### PR TITLE
feat: Add set_fields to Query and implement with_set_field method

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,6 +50,13 @@ MVP:
 - [ ] Restore functionality of bakery example
 - [ ] Implement ability to include sub-queries based on related tables
 
+  0.0.5: Refactor internal crates
+
+- [x] Move ReadableDataSet and WritableDataSet to separate crate and document
+- [x] Implement WritableDataSet for Table (almost)
+- [ ] Implement todo in update() in WritableDataSet for Table
+- [ ] Continue through the docs - align crates with documentation
+
 Create integration test-suite for SQL testing
 
 - [x] Quality of life improvements - nextest and improved assert_eq
@@ -59,6 +66,7 @@ Create integration test-suite for SQL testing
 - [x] Populate Bakery tables for tests
 - [x] Seed some data into Bakery tests
 - [ ] Make use of Postgres snapshots in the tests
+- [ ] Add integration tests for update() and delete() for Table
 
 Control field queries
 

--- a/dorm/src/dataset/mod.rs
+++ b/dorm/src/dataset/mod.rs
@@ -1,0 +1,20 @@
+//! Datasets are like a Vec<E>, but E are stored remotely and only fetched when needed.
+//!
+//! When we operate with DataSet we do not know how many rows are in a DataSet.
+//! An example dataset could contain all the Orders placed by a client.
+//!
+//! There are two main traits for Datasets:
+//!  - [`ReadableDataSet`]: allows to read rows
+//!  - [`WritableDataSet`]: allows to update or delete rows
+//!
+//! The included implementation for Datasets are:
+//!  - [`Table`]: a table is a dataset that stores data in a SQL table and implements both [`ReadableDataSet`] and [`WritableDataSet`].
+//!  - [`Query`]: a generic SELECT query that can fetch data and therefore implements [`ReadableDataSet`].
+//!
+//! [`Table`]: super::table::Table
+//! [`Query`]: super::query::Query
+mod readable;
+pub use readable::ReadableDataSet;
+
+mod writable;
+pub use writable::WritableDataSet;

--- a/dorm/src/dataset/readable.rs
+++ b/dorm/src/dataset/readable.rs
@@ -1,0 +1,78 @@
+use std::future::Future;
+
+use crate::query::Query;
+use anyhow::Result;
+use serde::de::DeserializeOwned;
+use serde_json::{Map, Value};
+
+/// Represents a [`dataset`] that may be used to fetch data.
+/// The <E> type parameter represents a record type.
+///
+/// # Example of [`Table`] which implements ReadableDataSet
+/// ```
+/// for client in Client::table().get().await? {
+///     dbg(&client.name);
+/// }
+/// ```
+///
+/// [`dataset`]: super
+/// [`Table`]: crate::table::Table
+pub trait ReadableDataSet<E> {
+    /// Fetch all records from the dataset and return them as a [`Vec<E>`].
+    fn get(&self) -> impl Future<Output = Result<Vec<E>>>;
+
+    /// Fetch one record from the dataset and return it as a `Vec<Map<String, Value>>`
+    /// (where Map is [`serde_json::Map`])
+    ///
+    /// ```
+    /// for client in Client::table().get_all_untyped().await? {
+    ///     dbg!(&client["name"]?);
+    /// }
+    /// ```
+    fn get_all_untyped(&self) -> impl Future<Output = Result<Vec<Map<String, Value>>>>;
+
+    /// Fetch a single row only. This is similar to [`get_some`], but returns [`json::Map`].
+    fn get_row_untyped(&self) -> impl Future<Output = Result<Map<String, Value>>>;
+
+    /// Fetch a single row and only one column. This makes sense if your DataSet is produced
+    /// from fetching arbitrary set of columns, containing a single column only.
+    ///
+    /// ```
+    /// let client = Client::table();
+    /// let name_query = client.get_select_query_for_fields(["name"]);
+    ///
+    /// let name: Value = client.get_row_untyped(name_query).await?;
+    /// ```
+    fn get_one_untyped(&self) -> impl Future<Output = Result<Value>>;
+
+    /// Fetch some record if dataset has at least one record. Works well with Table::with_id().
+    ///
+    /// ```
+    /// let client = Client::table().with_id(1).get_some().await? else {
+    ///     return Err(anyhow::anyhow!("No client with id=1"));
+    /// };
+    /// dbg!(&client.name);
+    /// ```
+    fn get_some(&self) -> impl Future<Output = Result<Option<E>>>;
+
+    /// Fetch records into a vector of type `T` using [`serde_json::from_value`].
+    ///
+    /// ```
+    /// struct ClientNameOnly {
+    ///     name: String,
+    /// }
+    ///
+    /// for client in Client::table().get_as::<ClientNameOnly>().await? {
+    ///     dbg!(&client.name);
+    /// }
+    /// ```
+    ///
+    /// [`serde_json::from_value`]: serde_json::from_value
+    fn get_as<T: DeserializeOwned>(&self) -> impl Future<Output = Result<Vec<T>>>;
+
+    /// Fetch a single record into a type `T` using [`serde_json::from_value`].
+    fn get_some_as<T: DeserializeOwned>(&self) -> impl Future<Output = Result<Option<T>>>;
+
+    /// TODO: must go away from here, as dataset should not be aware of query
+    fn select_query(&self) -> Query;
+}

--- a/dorm/src/dataset/writable.rs
+++ b/dorm/src/dataset/writable.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+use std::future::Future;
+
+/// Represents a [`dataset`] that may can add or modify records.
+/// The <E> type parameter represents a record type.
+///
+/// # Example of [`Table`] which implements WritableDataSet
+/// ```
+/// Client::table().insert(Client { name: "John".to_string() }).await?;
+///
+/// let peter_orders = Client::table().with_id(1).ref_orders();
+/// peter_orders.update(|orders| orders.qty += 1).await?;
+/// ```
+///
+/// [`dataset`]: super
+/// [`Table`]: crate::table::Table
+pub trait WritableDataSet<E> {
+    /// Insert a new record into the DataSet.
+    ///
+    /// ```
+    /// Client::table().insert(Client { name: "John".to_string() }).await?;
+    /// ```
+    fn insert(&self, record: E) -> impl Future<Output = Result<()>>;
+
+    /// Update all records in the DataSet. When working with Table, it's important to set a condition
+    /// if you only want to update some records.
+    ///
+    /// ```
+    /// let peter_orders = Client::table().with_id(1).ref_orders();
+    /// peter_orders.update(|orders| orders.qty += 1).await?;
+    /// ```
+    fn update<F>(&self, f: F) -> impl Future<Output = Result<()>>;
+
+    /// Delete all records in the DataSet. When working with Table, it's important to set a condition
+    /// if you only want to delete some records.
+    ///
+    /// ```
+    /// let peter = Client::table().with_id(1);
+    /// peter.ref_orders().delete().await?;    // delete all orders of peter
+    /// peter.delete().await?;                 // delete peter
+    ///
+    /// ```
+    fn delete(&self) -> impl Future<Output = Result<()>>;
+}

--- a/dorm/src/lib.rs
+++ b/dorm/src/lib.rs
@@ -1,3 +1,6 @@
+// Define dataset traits
+pub mod dataset;
+
 mod condition;
 mod datasource;
 pub mod expression;
@@ -9,6 +12,6 @@ mod operations;
 pub mod prelude;
 pub mod query;
 mod reference;
-mod table;
+pub mod table;
 mod traits;
 mod uniqid;

--- a/dorm/src/prelude.rs
+++ b/dorm/src/prelude.rs
@@ -1,3 +1,4 @@
+pub use crate::dataset::ReadableDataSet;
 pub use crate::datasource::postgres::*;
 pub use crate::expr;
 pub use crate::expr_arc;
@@ -8,7 +9,6 @@ pub use crate::operations::Operations;
 pub use crate::table::TableDelegate;
 pub use crate::traits::any::AnyTable;
 pub use crate::traits::any::RelatedTable;
-pub use crate::traits::dataset::ReadableDataSet;
 pub use crate::traits::entity::{EmptyEntity, Entity};
 pub use crate::traits::sql_chunk::SqlChunk;
 pub use crate::{query::JoinQuery, query::Query, table::Table};

--- a/dorm/src/table/mod.rs
+++ b/dorm/src/table/mod.rs
@@ -45,6 +45,7 @@ mod with_fields;
 mod with_joins;
 mod with_queries;
 mod with_refs;
+mod with_updates;
 
 impl<T: DataSource + Clone, E: Entity> Clone for Table<T, E> {
     fn clone(&self) -> Self {

--- a/dorm/src/table/with_fetching.rs
+++ b/dorm/src/table/with_fetching.rs
@@ -1,6 +1,6 @@
+use crate::dataset::ReadableDataSet;
 use crate::query::Query;
 use crate::table::Table;
-use crate::traits::dataset::ReadableDataSet;
 use crate::traits::datasource::DataSource;
 use crate::traits::entity::Entity;
 use anyhow::Result;

--- a/dorm/src/table/with_updates.rs
+++ b/dorm/src/table/with_updates.rs
@@ -1,0 +1,25 @@
+use crate::{
+    dataset::WritableDataSet, prelude::Entity, query::QueryType, traits::datasource::DataSource,
+};
+
+use super::Table;
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::{json, Map, Value};
+
+// You should be able to insert and delete data in a table
+impl<T: DataSource, E: Entity> WritableDataSet<E> for Table<T, E> {
+    async fn insert(&self, record: E) -> Result<()> {
+        let query = self.get_insert_query(record);
+        self.data_source.query_exec(&query).await
+    }
+
+    async fn update<F>(&self, f: F) -> Result<()> {
+        todo!()
+    }
+
+    async fn delete(&self) -> Result<()> {
+        let query = self.get_empty_query().with_type(QueryType::Delete);
+        self.data_source.query_exec(&query).await
+    }
+}

--- a/dorm/src/traits/dataset.rs
+++ b/dorm/src/traits/dataset.rs
@@ -1,24 +1,3 @@
-use std::future::Future;
-
-use crate::query::Query;
-use anyhow::Result;
-use serde::de::DeserializeOwned;
-use serde_json::{Map, Value};
-
-// Represents a dataset that may fetch all or some data
-pub trait ReadableDataSet<E> {
-    fn select_query(&self) -> Query;
-    fn get_all_untyped(&self) -> impl Future<Output = Result<Vec<Map<String, Value>>>>;
-    fn get_row_untyped(&self) -> impl Future<Output = Result<Map<String, Value>>>;
-    fn get_one_untyped(&self) -> impl Future<Output = Result<Value>>;
-
-    fn get(&self) -> impl Future<Output = Result<Vec<E>>>;
-    fn get_some(&self) -> impl Future<Output = Result<Option<E>>>;
-
-    fn get_as<T: DeserializeOwned>(&self) -> impl Future<Output = Result<Vec<T>>>;
-    fn get_some_as<T: DeserializeOwned>(&self) -> impl Future<Output = Result<Option<T>>>;
-}
-
 // // Represents a dataset that may also be modified through a query
 // pub trait WritableDataSet: ReadableDataSet {
 //     fn insert_query(&self) -> Query;


### PR DESCRIPTION
Now that we have a better idea of what our interface should be - I'm starting to refactor concepts into individual crates. For instance "dorm::dataset" defines `ReadableDataSet` and `WritableDataSet`, which are then implemented by `Table` and perhaps other things. I don't see why `Query` wouldn't be implementing `ReadableDataSet`.

 - [x] Refactored Query to properly construct INSERT queries (but not update queries yet)
 - [x] Thorough documentation of dataset module 