### PR TITLE
feat: Add update_with method to Table implementation

### DIFF
--- a/dorm/src/dataset/writable.rs
+++ b/dorm/src/dataset/writable.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use std::future::Future;
 
 /// Represents a [`dataset`] that may can add or modify records.
@@ -30,6 +31,10 @@ pub trait WritableDataSet<E> {
     /// peter_orders.update(|orders| orders.qty += 1).await?;
     /// ```
     fn update<F>(&self, f: F) -> impl Future<Output = Result<()>>;
+
+    fn update_with<F, E2>(&self, values: E2) -> impl Future<Output = Result<()>>
+    where
+        E2: Serialize + Clone;
 
     /// Delete all records in the DataSet. When working with Table, it's important to set a condition
     /// if you only want to delete some records.

--- a/dorm/src/table/with_updates.rs
+++ b/dorm/src/table/with_updates.rs
@@ -18,6 +18,25 @@ impl<T: DataSource, E: Entity> WritableDataSet<E> for Table<T, E> {
         todo!()
     }
 
+    async fn update_with<F, T2>(&self, values: T2) -> Result<()>
+    where
+        T2: Serialize + Clone,
+    {
+        // ensure that T2 does not specify ID field
+        let Value::Object(values_map) = serde_json::to_value(values.clone()).unwrap() else {
+            return Err(anyhow::anyhow!("T2 must be a struct"));
+        };
+
+        if let Some(ref id_field) = self.id_field {
+            if values_map.get(id_field).is_some() {
+                return Err(anyhow::anyhow!("T2 must not specify ID field"));
+            }
+        }
+
+        let query = self.get_update_query(values);
+        self.data_source.query_exec(&query).await
+    }
+
     async fn delete(&self) -> Result<()> {
         let query = self.get_empty_query().with_type(QueryType::Delete);
         self.data_source.query_exec(&query).await


### PR DESCRIPTION
Table::update_with(struct)  can be used to set all matching record to a specified values

Well - something like this should be possible:

```rust
struct Disabled { 
    is_enabled: bool;
    disabled_on: timestamp;
}
let disabled = { is_enabled: false, disabled_on: now() };
Client::table().add_condition(Client::table().balance().lt(0.into()).update_with(disabled)).await?;
```