### PR TITLE
Reimplement `with_condition` using `with_where_condition`

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ MVP:
 - [x] implement delete query
 - [x] implement operations: (field.eq(otherfield))
 - [x] implement parametric queries
-- [ ] reimplement "with_condition" into "with_where_condition" and "with_having_condition"
+- [x] reimplement "with_condition" into "with_where_condition" and "with_having_condition"
 
   0.0.2: Nested Query Building
 

--- a/dorm/src/sql/condition.rs
+++ b/dorm/src/sql/condition.rs
@@ -105,13 +105,6 @@ impl Chunk for Condition {
     }
 }
 
-// impl SqlChunk for &Condition {
-//     fn render_chunk(&self) -> Expression {
-//         let pr = self.value.as_ref().render_chunk();
-//         Expression::new(format!("{} {} {{}}", self.field, self.operation), vec![&pr]).render_chunk()
-//     }
-// }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/dorm/src/sql/query/parts.rs
+++ b/dorm/src/sql/query/parts.rs
@@ -92,11 +92,15 @@ impl QueryConditions {
 }
 impl Chunk for QueryConditions {
     fn render_chunk(&self) -> Expression {
-        let result = Expression::from_vec(self.conditions.clone(), " AND ");
-        match self.condition_type {
-            ConditionType::Where => expr_arc!("WHERE {}", result).render_chunk(),
-            ConditionType::Having => expr_arc!("HAVING {}", result).render_chunk(),
-            ConditionType::On => expr_arc!("ON {}", result).render_chunk(),
+        if self.conditions.is_empty() {
+            Expression::empty()
+        } else {
+            let result = Expression::from_vec(self.conditions.clone(), " AND ");
+            match self.condition_type {
+                ConditionType::Where => expr_arc!(" WHERE {}", result).render_chunk(),
+                ConditionType::Having => expr_arc!(" HAVING {}", result).render_chunk(),
+                ConditionType::On => expr_arc!("ON {}", result).render_chunk(),
+            }
         }
     }
 }
@@ -170,7 +174,7 @@ mod tests {
         };
         let result = conditions.render_chunk().split();
 
-        assert_eq!(result.0, "WHERE name = {} AND age > {}");
+        assert_eq!(result.0, " WHERE name = {} AND age > {}");
         assert_eq!(result.1.len(), 2);
         assert_eq!(result.1[0], Value::String("John".to_string()));
         assert_eq!(result.1[1], Value::Number(30.into()));
@@ -183,7 +187,7 @@ mod tests {
             .add_condition(expr!("age > {}", 30));
         let result = conditions.render_chunk().split();
 
-        assert_eq!(result.0, "HAVING name = {} AND age > {}");
+        assert_eq!(result.0, " HAVING name = {} AND age > {}");
         assert_eq!(result.1.len(), 2);
         assert_eq!(result.1[0], Value::String("John".to_string()));
         assert_eq!(result.1[1], Value::Number(30.into()));
@@ -201,7 +205,7 @@ mod tests {
 
         assert_eq!(
             result.0,
-            "HAVING ((name = sur.surname) OR (sur.surname = {}))"
+            " HAVING ((name = sur.surname) OR (sur.surname = {}))"
         );
         assert_eq!(result.1.len(), 1);
         assert_eq!(result.1[0], Value::Null);


### PR DESCRIPTION
A query does not really need to hold shared resources. The query is constructed and conditions are part of that query. Once query is complete, the queries shouldn't be changed anymore.

Conditions were implementing using Arc<Box<Chunk>>, which I thought is unnecessary and if rendered into expression right away, would be easier to handle.

The mechanism for `add_where_condition` was there before, so with this PR the refactor is complete now.

```rust
        let query = Query::new()
            .with_table("users", None)
            .with_condition(expr!("name = {}", "John"))    // pass expression
            .with_condition(expr!("age").gt(30));              // pass condition
```