### PR TITLE
add get_col / query_col and AssociatedQuery::glue()

### DIFF
--- a/bakery_model/examples/main.rs
+++ b/bakery_model/examples/main.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
 
     println!(
         "There are {} clients in this bakery.",
-        clients.count().get_one().await.unwrap()
+        clients.count().get_one_untyped().await.unwrap()
     );
 
     // Example 3: referencing products, but augmenting it with a join
@@ -51,7 +51,7 @@ async fn main() -> Result<()> {
         "There are {} stock in the inventory.",
         products_with_inventory
             .sum(products_with_inventory.stock().clone())
-            .get_one()
+            .get_one_untyped()
             .await
             .unwrap()
     );

--- a/dorm/src/dataset/readable.rs
+++ b/dorm/src/dataset/readable.rs
@@ -34,6 +34,9 @@ pub trait ReadableDataSet<E> {
     /// Fetch a single row only. This is similar to [`get_some`], but returns [`json::Map`].
     fn get_row_untyped(&self) -> impl Future<Output = Result<Map<String, Value>>>;
 
+    /// Fetch a column of single untyped value, return it as a `Vec<Value>`.
+    fn get_col_untyped(&self) -> impl Future<Output = Result<Vec<Value>>>;
+
     /// Fetch a single row and only one column. This makes sense if your DataSet is produced
     /// from fetching arbitrary set of columns, containing a single column only.
     ///

--- a/dorm/src/datasource/postgres.rs
+++ b/dorm/src/datasource/postgres.rs
@@ -3,6 +3,8 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
+use crate::dataset::ReadableDataSet;
+use crate::prelude::EmptyEntity;
 use crate::sql::chunk::Chunk;
 use crate::sql::expression::{Expression, ExpressionArc};
 use crate::sql::Query;
@@ -21,6 +23,13 @@ use tokio_postgres::Row;
 #[derive(Clone, Debug)]
 pub struct Postgres {
     client: Arc<Box<Client>>,
+}
+
+/// Postgres is equal to its clones.
+impl PartialEq for Postgres {
+    fn eq(&self, other: &Postgres) -> bool {
+        Arc::ptr_eq(&self.client, &other.client)
+    }
 }
 
 impl Postgres {
@@ -239,6 +248,14 @@ impl DataSource for Postgres {
         };
         Ok(res)
     }
+    async fn query_col(&self, query: &Query) -> Result<Vec<Value>> {
+        let res = self.query_raw(query).await?;
+        let res = res
+            .into_iter()
+            .filter_map(|v| Some(v.as_object()?.iter().next()?.1.clone()))
+            .collect();
+        Ok(res)
+    }
 }
 
 pub struct AssociatedExpressionArc<T: DataSource> {
@@ -271,6 +288,40 @@ impl<T: DataSource> AssociatedExpressionArc<T> {
     }
 }
 
+/// While [`Query`] does not generally associate with the [`DataSource`], it may be inconvenient
+/// to execute it. AssociatedQuery combines query with the datasource, allowing you to ealily
+/// pass it around and execute it.
+///
+/// ```
+/// let clients = Client::table();
+/// let client_count = clients.count();   // returns AssociatedQuery
+///
+/// let cnt: Value = client_count.get_one_untuped().await?;  // actually executes the query
+/// ```
+///
+/// AssociatedQuery can be used to make a link between DataSources:
+///
+/// ```
+/// let clients = Client::table();
+/// let client_code_query = clients.field_query(clients.code())?;
+/// // returns field query (SELECT code FROM client)
+///
+/// let orders = Order::table();
+/// let orders = orders.with_condition(
+///     orders.client_code().in(orders.glue(client_code_query).await?)
+/// );
+/// ```
+/// If Order and Client tables do share same [`DataSource`], the conditioun would be set as
+///  `WHERE (client_code IN (SELECT code FROM client))`, ultimatelly saving you from
+/// redundant query.
+///
+/// When datasources are different, [`glue()`] would execute `SELECT code FROM client`, fetch
+/// the results and use those as a vector of values in a condition clause:
+///  `WHERE (client_code IN [12, 13, 14])`
+///
+/// [`DataSource`]: crate::traits::datasource::DataSource
+/// [`glue()`]: Table::glue
+///
 #[derive(Debug, Clone)]
 pub struct AssociatedQuery<T: DataSource> {
     pub query: Query,
@@ -283,20 +334,89 @@ impl<T: DataSource> Deref for AssociatedQuery<T> {
         &self.query
     }
 }
+
 impl<T: DataSource> AssociatedQuery<T> {
     pub fn new(query: Query, ds: T) -> Self {
         Self { query, ds }
     }
-    pub async fn fetch(&self) -> Result<Vec<serde_json::Map<String, Value>>> {
-        self.ds.query_fetch(&self.query).await
-    }
-    pub async fn get_one(&self) -> Result<Value> {
-        self.ds.query_one(&self.query).await
+
+    /// Presented with another AssociatedQuery - calculate if queries
+    /// are linked with the same or different [`DataSource`]s.
+    ///
+    /// The same - return expression as-is.
+    /// Different - execute the query and return the result as a vector of values.
+    async fn glue(&self, other: AssociatedQuery<T>) -> Result<Expression> {
+        if self.ds.eq(&other.ds) {
+            Ok(other.query.render_chunk())
+        } else {
+            let vals = other.get_col_untyped().await?;
+            let tpl = vec!["{}"; vals.len()].join(", ");
+            Ok(Expression::new(tpl, vals))
+        }
     }
 }
 impl<T: DataSource + Sync> Chunk for AssociatedQuery<T> {
     fn render_chunk(&self) -> Expression {
         self.query.render_chunk()
+    }
+}
+impl<T: DataSource + Sync> ReadableDataSet<EmptyEntity> for AssociatedQuery<T> {
+    async fn get_all_untyped(&self) -> Result<Vec<Map<String, Value>>> {
+        self.ds.query_fetch(&self.query).await
+    }
+
+    async fn get_row_untyped(&self) -> Result<Map<String, Value>> {
+        self.ds.query_row(&self.query).await
+    }
+
+    async fn get_one_untyped(&self) -> Result<Value> {
+        self.ds.query_one(&self.query).await
+    }
+
+    async fn get_col_untyped(&self) -> Result<Vec<Value>> {
+        self.ds.query_col(&self.query).await
+    }
+
+    async fn get(&self) -> Result<Vec<EmptyEntity>> {
+        let data = self.get_all_untyped().await?;
+        Ok(data
+            .into_iter()
+            .map(|row| serde_json::from_value(Value::Object(row)).unwrap())
+            .collect())
+    }
+
+    async fn get_as<T2: serde::de::DeserializeOwned>(&self) -> Result<Vec<T2>> {
+        let data = self.get_all_untyped().await?;
+        Ok(data
+            .into_iter()
+            .map(|row| serde_json::from_value(Value::Object(row)).unwrap())
+            .collect())
+    }
+
+    async fn get_some(&self) -> Result<Option<EmptyEntity>> {
+        let data = self.ds.query_fetch(&self.query).await?;
+        if data.len() > 0 {
+            let row = data[0].clone();
+            let row = serde_json::from_value(Value::Object(row)).unwrap();
+            Ok(Some(row))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn get_some_as<T2: serde::de::DeserializeOwned>(&self) -> Result<Option<T2>> {
+        let data = self.ds.query_fetch(&self.query).await?;
+        if data.len() > 0 {
+            let row = data[0].clone();
+            let row = serde_json::from_value(Value::Object(row)).unwrap();
+            Ok(Some(row))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn select_query(&self) -> Query {
+        self.query.clone()
     }
 }
 

--- a/dorm/src/mocks/datasource.rs
+++ b/dorm/src/mocks/datasource.rs
@@ -52,6 +52,15 @@ impl DataSource for MockDataSource {
     async fn query_row(&self, query: &Query) -> Result<Map<String, Value>> {
         todo!()
     }
+    async fn query_col(&self, query: &Query) -> Result<Vec<Value>> {
+        todo!()
+    }
+}
+
+impl PartialEq for MockDataSource {
+    fn eq(&self, other: &MockDataSource) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/dorm/src/sql/query.rs
+++ b/dorm/src/sql/query.rs
@@ -317,7 +317,7 @@ impl Chunk for Query {
 
 #[cfg(test)]
 mod tests {
-    use crate::expr;
+    use crate::{expr, sql::Operations};
     use serde_json::json;
 
     use super::*;
@@ -325,7 +325,7 @@ mod tests {
     #[test]
     fn test_where() {
         let expr1 = expr!("name = {}", "John");
-        let expr2 = expr!("age > {}", 30);
+        let expr2 = expr!("age").gt(30);
 
         let query = Query::new()
             .with_table("users", None)
@@ -336,7 +336,7 @@ mod tests {
 
         let (sql, params) = wher.render_chunk().split();
 
-        assert_eq!(sql, " WHERE name = {} AND age > {}");
+        assert_eq!(sql, " WHERE name = {} AND (age > {})");
         assert_eq!(params.len(), 2);
         assert_eq!(params[0], Value::String("John".to_string()));
         assert_eq!(params[1], Value::Number(30.into()));

--- a/dorm/src/table/with_fetching.rs
+++ b/dorm/src/table/with_fetching.rs
@@ -26,6 +26,11 @@ impl<T: DataSource, E: Entity> ReadableDataSet<E> for Table<T, E> {
         self.data_source.query_row(&query).await
     }
 
+    async fn get_col_untyped(&self) -> Result<Vec<Value>> {
+        let query = self.select_query();
+        self.data_source.query_col(&query).await
+    }
+
     async fn get_one_untyped(&self) -> Result<Value> {
         let query = self.select_query();
         self.data_source.query_one(&query).await

--- a/dorm/src/traits/datasource.rs
+++ b/dorm/src/traits/datasource.rs
@@ -4,7 +4,7 @@ use crate::sql::Query;
 use anyhow::Result;
 use serde_json::{Map, Value};
 
-pub trait DataSource: Clone + Send + Sync + std::fmt::Debug + 'static {
+pub trait DataSource: Clone + Send + PartialEq + Sync + std::fmt::Debug + 'static {
     // Provided with an arbitrary query, fetch the results and return (Value = arbytrary )
     async fn query_fetch(&self, query: &Query) -> Result<Vec<Map<String, Value>>>;
 
@@ -16,4 +16,5 @@ pub trait DataSource: Clone + Send + Sync + std::fmt::Debug + 'static {
 
     async fn query_one(&self, query: &Query) -> Result<Value>;
     async fn query_row(&self, query: &Query) -> Result<Map<String, Value>>;
+    async fn query_col(&self, query: &Query) -> Result<Vec<Value>>;
 }


### PR DESCRIPTION
 - Implemented ReadableDataSet for AssociatedQuery
 - Added `query_col` and `get_col_untyped` for querying a single column (such as `select id from client`).
 - Added AssociatedQuery::glue to import another query into ours as expression - as a safety mechanism in case two queries are associated with a different DataSources.
 - Also added PartialEq as DataSource dependency allowing us to compare datasources.