### PR TITLE
draft implementation of hooks and soft-delete

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -45,6 +45,7 @@ MVP:
 - [x] Add "Entity" concept into Table
 - [x] Add example on how to use traits for augmenting Table of specific Entity
 - [x] Implement rendering of QueryType::Update so that we could update records
+- [ ] Refine "AnyTable" concept, so that we can use table as dyn without (if we want)
 - [ ] Check on "Join", they should allow for Entity mutation (joined table associated with a different entity)
 - [x] Implement has_one and has_many in a correct way, moving functionality to Related Reference
 - [ ] Implement Unrelated Reference (when ref leads to a table with different Data Source)

--- a/dorm/src/sql/table.rs
+++ b/dorm/src/sql/table.rs
@@ -136,6 +136,8 @@ mod with_updates;
 
 mod with_fetching;
 
+// mod extensions;
+
 impl<T: DataSource + Clone, E: Entity> Clone for Table<T, E> {
     fn clone(&self) -> Self {
         Table {

--- a/dorm/src/sql/table/extensions/mod.rs
+++ b/dorm/src/sql/table/extensions/mod.rs
@@ -1,0 +1,47 @@
+//! Table extensions
+//!
+//! Table extensions are a way to add additional functionality to a table. They
+//! are implemented as a trait, and can be added to a table using the
+//! [`Table::with_extension()`] method.
+
+use std::sync::Arc;
+
+use crate::{prelude::Entity, sql::Query, traits::datasource::DataSource};
+
+use super::{AnyTable, Table};
+
+trait TableExtension {
+    fn init(&self, _table: Arc<Box<dyn AnyTable>>) {}
+    fn before_select_query(&self, _table: Arc<Box<dyn AnyTable>>, query: Query) -> Query {
+        query
+    }
+    fn before_delete_query(&self, _table: Arc<Box<dyn AnyTable>>, query: Query) -> Query {
+        query
+    }
+}
+
+struct Hooks {
+    hooks: Vec<Box<dyn TableExtension>>,
+}
+impl Hooks {
+    pub fn new() -> Self {
+        Hooks { hooks: vec![] }
+    }
+    /// Add new hook to the table
+    pub fn add_hook(&mut self, table: Arc<Box<dyn AnyTable>>, hook: Box<dyn TableExtension>) {
+        hook.init(table);
+        self.hooks.push(hook);
+    }
+
+    pub fn before_select_query(&self, table: Arc<Box<dyn AnyTable>>, mut query: Query) -> Query {
+        for hook in self.hooks.iter() {
+            query = hook.before_select_query(table.clone(), query);
+        }
+        query
+    }
+}
+
+mod soft_delete;
+
+use indexmap::IndexMap;
+pub use soft_delete::SoftDelete;

--- a/dorm/src/sql/table/extensions/soft_delete.rs
+++ b/dorm/src/sql/table/extensions/soft_delete.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+
+use serde_json::json;
+
+use crate::{
+    prelude::{AnyTable, Entity, Table},
+    sql::{Field, Operations, Query},
+    traits::datasource::DataSource,
+};
+
+use super::TableExtension;
+
+pub struct SoftDelete {
+    soft_delete_field: String,
+}
+
+impl SoftDelete {
+    fn new(soft_delete_field: &str) -> Self {
+        SoftDelete {
+            soft_delete_field: soft_delete_field.to_string(),
+        }
+    }
+    fn is_deleted(&self, table: Arc<Box<dyn AnyTable>>) -> Arc<Field> {
+        table.get_field(&self.soft_delete_field).unwrap()
+    }
+}
+
+impl TableExtension for SoftDelete {
+    /// When selecting records, exclude deleted records
+    fn before_select_query(&self, table: Arc<Box<dyn AnyTable>>, query: Query) -> Query {
+        query.with_condition(self.is_deleted(table).eq(&false))
+    }
+    /// When deleting records, mark them as deleted instead
+    fn before_delete_query(&self, _table: Arc<Box<dyn AnyTable>>, query: Query) -> Query {
+        query
+            .with_type(crate::sql::query::QueryType::Update)
+            .with_set_field(&self.soft_delete_field, json!(true))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        mocks::datasource::MockDataSource,
+        prelude::{Chunk, Operations},
+        sql::table::extensions::Hooks,
+    };
+
+    #[tokio::test]
+    async fn test_soft_delete() {
+        let data =
+            json!([{ "name": "John", "surname": "Doe"}, { "name": "Jane", "surname": "Doe"}]);
+        let data_source = MockDataSource::new(&data);
+
+        let mut table = Table::new("users", data_source.clone())
+            .with_field("name")
+            .with_field("surname");
+
+        let table: Arc<Box<dyn AnyTable>> = Arc::new(Box::new(table));
+
+        let mut ext = Hooks::new();
+        ext.add_hook(table, Box::new(SoftDelete::new("is_deleted")));
+
+        table.add_condition(table.get_field("name").unwrap().eq(&"John".to_string()));
+
+        let query = table.get_select_query();
+        let query = ext.before_select_query(Arc::new(Box::new(table)), query);
+
+        let result = query.render_chunk().split();
+
+        assert_eq!(
+            result.0,
+            "SELECT name, surname FROM users WHERE (name = {}) AND (is_deleted = {})"
+        );
+        assert_eq!(result.1[0], json!("John"));
+        assert_eq!(result.1[1], json!(false));
+    }
+}


### PR DESCRIPTION
Nothing changed, but added a draft implementation for table extensions. Few candidates:

 - soft_delete - change select queries and delete actions
 - join - can probably be implemented as table extensions, as we will have multiple join types.

Having a proper table extensions would also allow 3rd parties to create new mechanisms to interact with table internal. We needs two things:
 - ability to add more methods into table through a trait.
 - ability to tweak queries or introduce callbacks
