### PR TITLE
Added example "bakery_api" crate, also added some convenience methods incto dorm. AssociatedQuery now also stores entity type

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Build
         run: cargo build
       - name: Run tests
-        run: cargo test
+        run: cd dorm && cargo test
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,16 +65,87 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.86"
+name = "anstream"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "async-trait"
@@ -84,7 +155,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -100,6 +171,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "axum-macros",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +250,30 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+]
+
+[[package]]
+name = "bakery_api"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "bakery_model",
+ "clap",
+ "dorm",
+ "dotenv",
+ "env_logger",
+ "fake",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-test",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -197,7 +359,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "rustls 0.22.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.1",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -244,7 +406,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
  "syn_derive",
 ]
 
@@ -284,9 +446,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
@@ -322,6 +484,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,10 +540,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
+name = "core-foundation"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -377,7 +595,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -388,7 +606,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -406,6 +624,12 @@ dependencies = [
  "powerfmt",
  "serde",
 ]
+
+[[package]]
+name = "deunicode"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
 
 [[package]]
 name = "diff"
@@ -479,6 +703,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,10 +729,33 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -510,6 +763,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fake"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661cb0601b5f4050d1e65452c5b0ea555c0b3e88fb5ed7855906adc6c42523ef"
+dependencies = [
+ "deunicode",
+ "rand",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -606,7 +869,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -713,10 +976,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -845,10 +1124,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
-name = "hyper"
-version = "1.4.1"
+name = "httpdate"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -857,6 +1148,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -891,7 +1183,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls 0.22.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -909,7 +1201,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls 0.23.11",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -919,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -932,7 +1224,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -1032,7 +1323,7 @@ dependencies = [
  "socket2",
  "widestring",
  "windows-sys 0.48.0",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
@@ -1040,6 +1331,12 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -1126,6 +1423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,13 +1467,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1181,6 +1485,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1196,16 +1510,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1234,6 +1538,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1280,7 +1590,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1324,7 +1634,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1632,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1658,13 +1968,13 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.11",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
@@ -1673,7 +1983,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg 0.52.0",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1821,7 +2131,19 @@ dependencies = [
  "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.0.1",
 ]
 
 [[package]]
@@ -1836,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -1850,6 +2172,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
@@ -1885,7 +2213,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1893,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1903,33 +2244,44 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
+ "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -1941,7 +2293,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1983,7 +2335,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1995,6 +2347,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2085,7 +2446,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2096,7 +2457,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2118,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2136,14 +2497,23 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "tap"
@@ -2206,7 +2576,17 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -2257,32 +2637,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2345,6 +2724,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,37 +2768,73 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
 dependencies = [
  "futures-core",
  "futures-util",
- "pin-project",
+ "hdrhistogram",
+ "indexmap 2.2.6",
  "pin-project-lite",
+ "slab",
+ "sync_wrapper 0.1.2",
  "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower-test"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4546773ffeab9e4ea02b8872faa49bb616a80a7da66afc2f32688943f97efa7"
+dependencies = [
+ "futures-util",
+ "pin-project",
+ "tokio",
+ "tokio-test",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
-name = "tower-layer"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-
-[[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2414,22 +2842,48 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2496,10 +2950,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -2555,7 +3021,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -2589,7 +3055,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2668,6 +3134,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +3177,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2826,16 +3331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,7 +3362,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["dorm", "bakery_model"]
+members = ["dorm", "bakery_model", "bakery_api"]
 resolver = "2"

--- a/bakery_api/Cargo.toml
+++ b/bakery_api/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bakery_api"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.94"
+axum = { version = "0.7.9", features = ["macros"] }
+bakery_model = { path = "../bakery_model" }
+dorm = { path = "../dorm" }
+clap = { version = "4.5.23", features = ["derive", "env"] }
+dotenv = "0.15.0"
+env_logger = "0.11.5"
+fake = "3.0.1"
+http-body-util = "0.1.2"
+hyper = "1.5.1"
+hyper-util = { version = "0.1.10", features = ["http1"] }
+serde = { version = "1.0.215", features = ["derive"] }
+serde_json = "1.0.133"
+tokio = { version = "1.42.0", features = ["full"] }
+tower = { version = "0.5.1", features = ["full"] }
+tower-http = { version = "0.6.2", features = ["trace"] }
+
+tower-test = "0.4.0"
+tracing-subscriber = "0.3.19"

--- a/bakery_api/src/config.rs
+++ b/bakery_api/src/config.rs
@@ -1,0 +1,7 @@
+#[derive(clap::Parser)]
+pub struct Config {
+    #[clap(long, env, default_value = "3000")]
+    pub port: String,
+    #[clap(long, env, default_value = "127.0.0.1")]
+    pub host: String,
+}

--- a/bakery_api/src/lib.rs
+++ b/bakery_api/src/lib.rs
@@ -1,0 +1,45 @@
+use axum::http::StatusCode;
+use axum::{routing::*, Json, Router};
+use serde::{Deserialize, Serialize};
+
+pub mod orders;
+pub mod products;
+
+async fn root() -> &'static str {
+    "Hello, World!"
+}
+pub fn app() -> Router {
+    Router::new()
+        .route("/", get(root))
+        .route("/users", post(create_user))
+        .nest("/products", products::router_products())
+        .nest("/orders", orders::router_orders())
+}
+
+async fn create_user(
+    // this argument tells axum to parse the request body
+    // as JSON into a `CreateUser` type
+    Json(payload): Json<CreateUser>,
+) -> (StatusCode, Json<User>) {
+    // insert your application logic here
+    let user = User {
+        id: 1337,
+        username: payload.username,
+    };
+
+    // this will be converted into a JSON response
+    // with a status code of `201 Created`
+    (StatusCode::CREATED, Json(user))
+}
+// the input to our `create_user` handler
+#[derive(Deserialize)]
+struct CreateUser {
+    username: String,
+}
+
+// the output to our `create_user` handler
+#[derive(Serialize)]
+struct User {
+    id: u64,
+    username: String,
+}

--- a/bakery_api/src/main.rs
+++ b/bakery_api/src/main.rs
@@ -1,0 +1,48 @@
+use anyhow::Context;
+use bakery_api::app;
+use bakery_model::connect_postgres;
+use clap::Parser;
+use tower_http::trace::TraceLayer;
+
+mod config;
+mod products;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dotenv::dotenv().ok();
+
+    tracing_subscriber::fmt::init();
+
+    let config = config::Config::parse();
+    connect_postgres().await?;
+
+    println!("Listening on http://0.0.0.0:3000");
+
+    let listener = tokio::net::TcpListener::bind(format!("{}:{}", config.host, config.port))
+        .await
+        .unwrap();
+    axum::serve(listener, app().layer(TraceLayer::new_for_http()))
+        .await
+        .with_context(|| "Failed to serve")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+
+    #[tokio::test]
+    async fn test_hello() {
+        let app = app();
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), hyper::StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(&body[..], b"Hello, World!");
+    }
+}

--- a/bakery_api/src/orders.rs
+++ b/bakery_api/src/orders.rs
@@ -1,0 +1,88 @@
+use axum::{response::IntoResponse, routing::get, Json, Router};
+use bakery_model::*;
+use dorm::{prelude::*, sql::query::SqlQuery};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct OrderRequest {
+    client_id: i32,
+}
+
+#[derive(Deserialize)]
+struct Pagination {
+    #[serde(default)]
+    page: i64,
+    #[serde(default = "per_page_default")]
+    per_page: i64,
+}
+
+pub fn per_page_default() -> i64 {
+    10
+}
+
+pub fn router_orders() -> Router {
+    Router::new().route("/", get(list_orders))
+}
+
+async fn list_orders(
+    client: axum::extract::Query<OrderRequest>,
+    pager: axum::extract::Query<Pagination>,
+) -> impl IntoResponse {
+    let orders = Client::table()
+        .with_id(client.client_id.into())
+        .ref_orders();
+
+    let mut query = orders.query();
+
+    // Change the query to include pagination
+    query.add_limit(Some(pager.per_page));
+    if pager.page > 0 {
+        query.add_skip(Some(pager.per_page * pager.page));
+    }
+
+    // will serialize type of `Order` struct
+    Json(query.get().await.unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::app;
+
+    use axum::{body::Body, http::Request};
+    use bakery_model::connect_postgres;
+    use http_body_util::BodyExt;
+    use hyper::StatusCode;
+    use serde_json::{json, Value};
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+
+    #[tokio::test]
+    async fn list_orders() {
+        connect_postgres().await.unwrap();
+        let app = app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/orders?client_id=1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json_body: Value = serde_json::from_slice(&body).unwrap();
+
+        assert!(json_body.is_array());
+
+        assert_eq!(json_body.as_array().unwrap().len(), 1);
+
+        assert_eq!(
+            json_body,
+            json!([
+                {"id": 1, "client_id": 1, "client_name": "Marty McFly", "total": 893},
+            ])
+        );
+    }
+}

--- a/bakery_api/src/products.rs
+++ b/bakery_api/src/products.rs
@@ -1,0 +1,67 @@
+use axum::{response::IntoResponse, routing::get, Json, Router};
+use bakery_model::product::Product;
+use dorm::prelude::*;
+
+pub fn router_products() -> Router {
+    Router::new().route("/", get(list_products))
+}
+
+async fn list_products() -> impl IntoResponse {
+    // We will work with Product Set
+    let products = Product::table();
+
+    //
+    let data = products
+        .query_for_field_names(&["id", "name"])
+        .get_all_untyped()
+        .await
+        .unwrap();
+
+    Json(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::app;
+
+    use axum::{body::Body, http::Request};
+    use bakery_model::connect_postgres;
+    use http_body_util::BodyExt;
+    use hyper::StatusCode;
+    use serde_json::{json, Value};
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
+
+    #[tokio::test]
+    async fn list_products() {
+        connect_postgres().await.unwrap();
+        let app = app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/products")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json_body: Value = serde_json::from_slice(&body).unwrap();
+
+        assert!(json_body.is_array());
+
+        assert_eq!(
+            json_body,
+            json!([
+                {"id": 1, "name": "Flux Capacitor Cupcake"},
+                {"id": 2, "name": "DeLorean Doughnut"},
+                {"id": 3, "name": "Time Traveler Tart"},
+                {"id": 4, "name": "Enchantment Under the Sea Pie"},
+                {"id": 5, "name": "Hoverboard Cookies"},
+                {"id": 6, "name": "Nuclear Sandwich"}
+            ])
+        );
+    }
+}

--- a/bakery_model/schema-pg.sql
+++ b/bakery_model/schema-pg.sql
@@ -1,88 +1,110 @@
-
 DROP TABLE IF EXISTS order_line;
-DROP TABLE IF EXISTS ord;
-DROP TABLE IF EXISTS product;
-DROP TABLE IF EXISTS inventory;
-DROP TABLE IF EXISTS client;
-DROP TABLE IF EXISTS bakery;
 
+DROP TABLE IF EXISTS ord;
+
+DROP TABLE IF EXISTS product;
+
+DROP TABLE IF EXISTS inventory;
+
+DROP TABLE IF EXISTS client;
+
+DROP TABLE IF EXISTS bakery;
 
 -- Creating tables
 CREATE TABLE bakery (
-  id serial PRIMARY KEY,
-  name varchar(255) NOT NULL,
-  profit_margin int NOT NULL
+    id serial PRIMARY KEY,
+    name varchar(255) NOT NULL,
+    profit_margin int NOT NULL
 );
 
 CREATE TABLE client (
-  id serial PRIMARY KEY,
-  name varchar(255) NOT NULL,
-  contact_details varchar(255) NOT NULL,
-  is_paying_client BOOLEAN DEFAULT false NOT NULL,
-  bakery_id int NOT NULL
+    id serial PRIMARY KEY,
+    email varchar(255) UNIQUE NOT NULL,
+    name varchar(255) NOT NULL,
+    contact_details varchar(255) NOT NULL,
+    is_paying_client BOOLEAN DEFAULT false NOT NULL,
+    bakery_id int NOT NULL
 );
 
 CREATE TABLE inventory (
-  product_id int PRIMARY KEY,
-  stock int DEFAULT NULL
+    product_id int PRIMARY KEY,
+    stock int DEFAULT NULL
 );
 
 CREATE TABLE "ord" (
-  id serial,
-  product_id int NOT NULL,
-  client_id int NOT NULL,
-  is_deleted boolean DEFAULT false,
-  PRIMARY KEY (id, client_id)
+    id serial,
+    product_id int NOT NULL,
+    client_id int NOT NULL,
+    is_deleted boolean DEFAULT false,
+    PRIMARY KEY (id, client_id)
 );
 
 CREATE TABLE order_line (
-  id int,
-  order_id int DEFAULT NULL,
-  product_id int NOT NULL,
-  quantity int DEFAULT NULL,
-  price int DEFAULT NULL,
-  PRIMARY KEY (id, product_id)
+    id int,
+    order_id int DEFAULT NULL,
+    product_id int NOT NULL,
+    quantity int DEFAULT NULL,
+    price int DEFAULT NULL,
+    PRIMARY KEY (id, product_id)
 );
 
 CREATE TABLE product (
-  id serial PRIMARY KEY,
-  name varchar(255) NOT NULL,
-  calories int NOT NULL,
-  bakery_id int NOT NULL,
-  price int NOT NULL,
-  is_deleted boolean DEFAULT false
+    id serial PRIMARY KEY,
+    name varchar(255) NOT NULL,
+    calories int NOT NULL,
+    bakery_id int NOT NULL,
+    price int NOT NULL,
+    is_deleted boolean DEFAULT false
 );
 
 -- Insert data into tables
-INSERT INTO bakery (name, profit_margin) VALUES ('Hill Valley Bakery', 15);
+INSERT INTO
+    bakery (name, profit_margin)
+VALUES
+    ('Hill Valley Bakery', 15);
 
-INSERT INTO client (name, contact_details, is_paying_client, bakery_id) VALUES
-('Marty McFly', '555-1955', true, 1),
-('Doc Brown', '555-1885', true, 1),
-('Biff Tannen', '555-1955', false, 1);
+INSERT INTO
+    client (
+        name,
+        contact_details,
+        is_paying_client,
+        bakery_id
+    )
+VALUES
+    ('Marty McFly', '555-1955', true, 1),
+    ('Doc Brown', '555-1885', true, 1),
+    ('Biff Tannen', '555-1955', false, 1);
 
-INSERT INTO product (name, calories, bakery_id, price) VALUES
-('Flux Capacitor Cupcake', 300, 1, 120),
-('DeLorean Doughnut', 250, 1, 135),
-('Time Traveler Tart', 200, 1, 220),
-('Enchantment Under the Sea Pie', 350, 1, 299),
-('Hoverboard Cookies', 150, 1, 199);
+INSERT INTO
+    product (name, calories, bakery_id, price)
+VALUES
+    ('Flux Capacitor Cupcake', 300, 1, 120),
+    ('DeLorean Doughnut', 250, 1, 135),
+    ('Time Traveler Tart', 200, 1, 220),
+    ('Enchantment Under the Sea Pie', 350, 1, 299),
+    ('Hoverboard Cookies', 150, 1, 199);
 
-INSERT INTO inventory (product_id, stock) VALUES
-(1, 50),
-(2, 30),
-(3, 20),
-(4, 15),
-(5, 40);
+INSERT INTO
+    inventory (product_id, stock)
+VALUES
+    (1, 50),
+    (2, 30),
+    (3, 20),
+    (4, 15),
+    (5, 40);
 
-INSERT INTO "ord" (product_id, client_id) VALUES
-(1, 1),
-(2, 2),
-(3, 2);
+INSERT INTO
+    "ord" (product_id, client_id)
+VALUES
+    (1, 1),
+    (2, 2),
+    (3, 2);
 
-INSERT INTO order_line (id, order_id, product_id, quantity) VALUES
-(1, 1, 1, 3),
-(2, 1, 2, 1),
-(3, 1, 5, 2),
-(4, 2, 3, 1),
-(5, 3, 5, 5);
+INSERT INTO
+    order_line (id, order_id, product_id, quantity)
+VALUES
+    (1, 1, 1, 3),
+    (2, 1, 2, 1),
+    (3, 1, 5, 2),
+    (4, 2, 3, 1),
+    (5, 3, 5, 5);

--- a/bakery_model/src/client.rs
+++ b/bakery_model/src/client.rs
@@ -1,10 +1,7 @@
 use crate::{order::Order, postgres, Bakery};
 use dorm::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::{
-    ops::Deref,
-    sync::{Arc, OnceLock},
-};
+use std::sync::{Arc, OnceLock};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct Client {
@@ -23,6 +20,7 @@ impl Client {
             Table::new_with_entity("client", postgres())
                 .with_id_column("id")
                 .with_column("name")
+                .with_title_column("email")
                 .with_column("contact_details")
                 .with_column("is_paying_client")
                 .with_column("bakery_id")
@@ -38,6 +36,9 @@ impl Client {
 pub trait ClientTable: SqlTable {
     fn name(&self) -> Arc<Column> {
         self.get_column("name").unwrap()
+    }
+    fn email(&self) -> Arc<Column> {
+        self.get_column("email").unwrap()
     }
     fn contact_details(&self) -> Arc<Column> {
         self.get_column("contact_details").unwrap()

--- a/bakery_model/src/lib.rs
+++ b/bakery_model/src/lib.rs
@@ -30,13 +30,13 @@ static POSTGRESS: OnceLock<Postgres> = OnceLock::new();
 pub fn set_postgres(postgres: Postgres) -> Result<()> {
     POSTGRESS
         .set(postgres)
-        .map_err(|_| anyhow::anyhow!("Failed to set Postgres instance"))
+        .map_err(|e| anyhow::anyhow!("Failed to set Postgres instance: {:?}", e))
 }
 
 pub fn postgres() -> Postgres {
     POSTGRESS
         .get()
-        .expect("Postgres has not been initialized")
+        .expect("Postgres has not been initialized. use connect_postgress()")
         .clone()
 }
 

--- a/dorm/src/datasource/postgres.rs
+++ b/dorm/src/datasource/postgres.rs
@@ -7,6 +7,7 @@ use crate::dataset::ReadableDataSet;
 use crate::prelude::{EmptyEntity, Entity};
 use crate::sql::chunk::Chunk;
 use crate::sql::expression::{Expression, ExpressionArc};
+use crate::sql::query::SqlQuery;
 use crate::sql::Query;
 use crate::traits::datasource::DataSource;
 use anyhow::Context;
@@ -363,6 +364,22 @@ impl<T: DataSource, E: Entity> AssociatedQuery<T, E> {
             ds,
             _phantom: std::marker::PhantomData,
         }
+    }
+
+    pub fn with_skip(mut self, skip: i64) -> Self {
+        self.query.add_skip(Some(skip));
+        self
+    }
+
+    pub fn with_limit(mut self, limit: i64) -> Self {
+        self.query.add_limit(Some(limit));
+        self
+    }
+
+    pub fn with_skip_and_limit(mut self, skip: i64, limit: i64) -> Self {
+        self.query.add_limit(Some(limit));
+        self.query.add_skip(Some(skip));
+        self
     }
 
     /// Presented with another AssociatedQuery - calculate if queries

--- a/dorm/src/datasource/postgres.rs
+++ b/dorm/src/datasource/postgres.rs
@@ -1,16 +1,17 @@
 #![allow(dead_code)]
 
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use crate::dataset::ReadableDataSet;
-use crate::prelude::EmptyEntity;
+use crate::prelude::{EmptyEntity, Entity};
 use crate::sql::chunk::Chunk;
 use crate::sql::expression::{Expression, ExpressionArc};
 use crate::sql::Query;
 use crate::traits::datasource::DataSource;
 use anyhow::Context;
 use anyhow::{anyhow, Result};
+use futures::{pin_mut, TryStreamExt};
 use indexmap::IndexMap;
 use rust_decimal::Decimal;
 use serde_json::json;
@@ -114,22 +115,23 @@ impl Postgres {
         let params_tosql = query_rendered
             .params()
             .iter()
-            .map(|v| self.convert_value_tosql(v.clone()))
-            .collect::<Vec<_>>();
+            .map(|v| self.convert_value_tosql(v.clone()));
 
-        let params_tosql_refs = params_tosql
-            .iter()
-            .map(|b| b.as_ref())
-            .collect::<Vec<&(dyn ToSql + Sync)>>();
+        // let params_tosql_refs = params_tosql
+        //     .iter()
+        //     .map(|b| b.as_ref())
+        //     .collect::<Vec<&(dyn ToSql + Sync)>>();
 
         let result = self
             .client
-            .query(&query_rendered.sql_final(), params_tosql_refs.as_slice())
+            .query_raw(&query_rendered.sql_final(), params_tosql)
             .await
             .context(anyhow!("Error in query {}", query.preview()))?;
 
+        pin_mut!(result);
         let mut results = Vec::new();
-        for row in result {
+        while let Some(row) = result.try_next().await? {
+            // for row in result {
             results.push(self.convert_value_fromsql(row)?);
         }
 
@@ -335,22 +337,32 @@ impl<T: DataSource> AssociatedExpressionArc<T> {
 /// [`DataSource`]: crate::traits::datasource::DataSource
 /// [`glue()`]: Table::glue
 ///
-#[derive(Debug, Clone)]
-pub struct AssociatedQuery<T: DataSource> {
+#[derive(Clone)]
+pub struct AssociatedQuery<T: DataSource, E: Entity> {
     pub query: Query,
     pub ds: T,
+    pub _phantom: std::marker::PhantomData<E>,
 }
-impl<T: DataSource> Deref for AssociatedQuery<T> {
+impl<T: DataSource, E: Entity> Deref for AssociatedQuery<T, E> {
     type Target = Query;
 
     fn deref(&self) -> &Self::Target {
         &self.query
     }
 }
+impl<T: DataSource, E: Entity> DerefMut for AssociatedQuery<T, E> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.query
+    }
+}
 
-impl<T: DataSource> AssociatedQuery<T> {
+impl<T: DataSource, E: Entity> AssociatedQuery<T, E> {
     pub fn new(query: Query, ds: T) -> Self {
-        Self { query, ds }
+        Self {
+            query,
+            ds,
+            _phantom: std::marker::PhantomData,
+        }
     }
 
     /// Presented with another AssociatedQuery - calculate if queries
@@ -358,7 +370,7 @@ impl<T: DataSource> AssociatedQuery<T> {
     ///
     /// The same - return expression as-is.
     /// Different - execute the query and return the result as a vector of values.
-    async fn glue(&self, other: AssociatedQuery<T>) -> Result<Expression> {
+    async fn glue(&self, other: AssociatedQuery<T, E>) -> Result<Expression> {
         if self.ds.eq(&other.ds) {
             Ok(other.query.render_chunk())
         } else {
@@ -368,12 +380,20 @@ impl<T: DataSource> AssociatedQuery<T> {
         }
     }
 }
-impl<T: DataSource + Sync> Chunk for AssociatedQuery<T> {
+impl<D: DataSource + Sync, E: Entity> Chunk for AssociatedQuery<D, E> {
     fn render_chunk(&self) -> Expression {
         self.query.render_chunk()
     }
 }
-impl<T: DataSource + Sync> ReadableDataSet<EmptyEntity> for AssociatedQuery<T> {
+impl<D: DataSource, E: Entity> std::fmt::Debug for AssociatedQuery<D, E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AssociatedQuery")
+            .field("query", &self.query)
+            .field("ds", &self.ds)
+            .finish()
+    }
+}
+impl<T: DataSource + Sync, E: Entity> ReadableDataSet<E> for AssociatedQuery<T, E> {
     async fn get_all_untyped(&self) -> Result<Vec<Map<String, Value>>> {
         self.ds.query_fetch(&self.query).await
     }
@@ -390,7 +410,7 @@ impl<T: DataSource + Sync> ReadableDataSet<EmptyEntity> for AssociatedQuery<T> {
         self.ds.query_col(&self.query).await
     }
 
-    async fn get(&self) -> Result<Vec<EmptyEntity>> {
+    async fn get(&self) -> Result<Vec<E>> {
         let data = self.get_all_untyped().await?;
         Ok(data
             .into_iter()
@@ -406,7 +426,7 @@ impl<T: DataSource + Sync> ReadableDataSet<EmptyEntity> for AssociatedQuery<T> {
             .collect())
     }
 
-    async fn get_some(&self) -> Result<Option<EmptyEntity>> {
+    async fn get_some(&self) -> Result<Option<E>> {
         let data = self.ds.query_fetch(&self.query).await?;
         if data.len() > 0 {
             let row = data[0].clone();

--- a/dorm/src/sql/query/with_traits.rs
+++ b/dorm/src/sql/query/with_traits.rs
@@ -21,5 +21,7 @@ pub trait SqlQuery {
     fn add_join(&mut self, join: JoinQuery);
     fn add_group_by(&mut self, group_by: Expression);
     fn add_order_by(&mut self, order_by: Expression);
+    fn add_limit(&mut self, limit: Option<i64>);
+    fn add_skip(&mut self, skip: Option<i64>);
     fn set_field_value(&mut self, field: &str, value: Value);
 }

--- a/dorm/src/sql/table.rs
+++ b/dorm/src/sql/table.rs
@@ -81,7 +81,7 @@ pub trait AnyTable: Any + Send + Sync {
 ///
 ///
 pub trait RelatedTable<T: DataSource>: SqlTable {
-    fn column_query(&self, column: Arc<Column>) -> AssociatedQuery<T>;
+    fn column_query(&self, column: Arc<Column>) -> AssociatedQuery<T, EmptyEntity>;
     fn add_columns_into_query(&self, query: Query, alias_prefix: Option<&str>) -> Query;
     fn get_join(&self, table_alias: &str) -> Option<Arc<Join<T>>>;
 
@@ -210,7 +210,7 @@ impl<T: DataSource, E: Entity> AnyTable for Table<T, E> {
 }
 
 impl<T: DataSource, E: Entity> RelatedTable<T> for Table<T, E> {
-    fn column_query(&self, column: Arc<Column>) -> AssociatedQuery<T> {
+    fn column_query(&self, column: Arc<Column>) -> AssociatedQuery<T, EmptyEntity> {
         let query = self.get_empty_query().with_field(column.name(), column);
         AssociatedQuery::new(query, self.data_source.clone())
     }
@@ -411,7 +411,7 @@ impl<T: DataSource, E: Entity> Table<T, E> {
         self.data_source.query_fetch(&self.get_select_query()).await
     }
 
-    pub fn sum<C>(&self, column: C) -> AssociatedQuery<T>
+    pub fn sum<C>(&self, column: C) -> AssociatedQuery<T, EmptyEntity>
     where
         C: Chunk,
     {
@@ -422,7 +422,7 @@ impl<T: DataSource, E: Entity> Table<T, E> {
         AssociatedQuery::new(query, self.data_source.clone())
     }
 
-    pub fn count(&self) -> AssociatedQuery<T> {
+    pub fn count(&self) -> AssociatedQuery<T, EmptyEntity> {
         let mut query = self
             .get_empty_query()
             .with_field("count".to_string(), expr_arc!("COUNT(*)"));
@@ -454,7 +454,7 @@ pub trait TableDelegate<T: DataSource, E: Entity>: TableWithColumns {
     fn add_condition(&self, condition: Condition) -> Table<T, E> {
         self.table().clone().with_condition(condition)
     }
-    fn sum(&self, column: Arc<Column>) -> AssociatedQuery<T> {
+    fn sum(&self, column: Arc<Column>) -> AssociatedQuery<T, EmptyEntity> {
         self.table().sum(column)
     }
 }

--- a/dorm/src/sql/table/with_queries.rs
+++ b/dorm/src/sql/table/with_queries.rs
@@ -74,11 +74,34 @@ impl<T: DataSource, E: Entity> TableWithQueries for Table<T, E> {
 }
 
 impl<D: DataSource, E: Entity> Table<D, E> {
-    /// Obsolete: use get_select_query_for_field() instead
-    pub fn field_query(&self, field: Arc<Column>) -> AssociatedQuery<D> {
+    pub fn field_query(&self, field: Arc<Column>) -> AssociatedQuery<D, E> {
         // let query = self.get_select_query_for_field(field);
         let query = self.get_empty_query().with_field(field.name(), field);
         AssociatedQuery::new(query, self.data_source.clone())
+    }
+
+    pub fn query(&self) -> AssociatedQuery<D, E> {
+        AssociatedQuery::new(
+            self.get_select_query_for_struct(E::default()),
+            self.data_source.clone(),
+        )
+    }
+
+    pub fn query_for_fields(
+        &self,
+        fields: IndexMap<String, Arc<Box<dyn SqlField>>>,
+    ) -> AssociatedQuery<D, E> {
+        AssociatedQuery::new(
+            self.get_select_query_for_fields(fields),
+            self.data_source.clone(),
+        )
+    }
+
+    pub fn query_for_field_names(&self, field_names: &[&str]) -> AssociatedQuery<D, E> {
+        AssociatedQuery::new(
+            self.get_select_query_for_field_names(field_names),
+            self.data_source.clone(),
+        )
     }
 
     pub fn get_select_query_for_struct<R: Serialize>(&self, default: R) -> Query {


### PR DESCRIPTION
I'm starting a new pattern where

```
table.get_query_for_fields()
```

would return a `Query` but

```
table.query_for_fields
```

would return `AssociatedQuery` instead. As a result we can use either of the following:

```rust
    let data = products
        .query_for_field_names(&["id", "name"])
        .get_all_untyped()
        .await
        .unwrap();

    let data = products
        .get_all_untyped()  // defaults to all physical columns
        .await
        .unwrap();
```

while it seems that we are calling the same .get_all_untyped, in reality it is executed on a query first and on a table in the second example. The result is the same as expected, however different fields will appear in the response.

Associated query now also preserves the type so you can

```rust
let data = Orders::table().query().with_limit(10).get().await?; // Vec<Order>
```

## Axum

I have added `Axum` example and it turns pretty slick! Even worth mentioning in README.

```rust
async fn list_orders(
    client: axum::extract::Query<OrderRequest>,
    pager: axum::extract::Query<Pagination>,
) -> impl IntoResponse {
    let orders = Client::table()
        .with_id(client.client_id.into())
        .ref_orders();

    let mut query = orders.query();

    // Change the query to include pagination
    query.add_limit(Some(pager.per_page));
    if pager.page > 0 {
        query.add_skip(Some(pager.per_page * pager.page));
    }

    // will serialize type of `Order` struct
    Json(query.get().await.unwrap())
}
```
