### PR TITLE
Implement Query 2

### DIFF
--- a/vantage-expressions/src/protocol/selectable.rs
+++ b/vantage-expressions/src/protocol/selectable.rs
@@ -6,7 +6,7 @@ pub trait Selectable: Send + Sync + Debug {
     /// Specifies a source for a query. Depending on implementation, can be executed
     /// multiple times. If `source` is expression you might need to use alias.
     fn set_source(&mut self, source: impl Into<Expr>, alias: Option<String>);
-    fn add_field(&mut self, field: String);
+    fn add_field(&mut self, field: impl Into<String>);
     fn add_expression(&mut self, expression: OwnedExpression, alias: Option<String>);
     fn add_where_condition(&mut self, condition: OwnedExpression);
     fn set_distinct(&mut self, distinct: bool);

--- a/vantage-mongodb/src/query/select.rs
+++ b/vantage-mongodb/src/query/select.rs
@@ -1,5 +1,6 @@
 use crate::field::Field;
 use async_trait::async_trait;
+use serde_json::Value;
 use std::fmt::Debug;
 use vantage_expressions::{Expr, OwnedExpression, expr, protocol::selectable::Selectable};
 
@@ -183,8 +184,8 @@ impl Selectable for MongoSelect {
         self.source_alias = alias;
     }
 
-    fn add_field(&mut self, field: String) {
-        self.fields.push(Field::new_simple(field));
+    fn add_field(&mut self, field: impl Into<String>) {
+        self.fields.push(Field::new_simple(field.into()));
     }
 
     fn add_expression(&mut self, expression: OwnedExpression, alias: Option<String>) {

--- a/vantage-sql/src/select/mod.rs
+++ b/vantage-sql/src/select/mod.rs
@@ -359,7 +359,7 @@ impl Selectable for Select {
         self.from = vec![query_source];
     }
 
-    fn add_field(&mut self, field: String) {
+    fn add_field(&mut self, field: impl Into<String>) {
         self.fields.insert(None, Identifier::new(field).into());
     }
 

--- a/vantage-surrealdb/src/identifier.rs
+++ b/vantage-surrealdb/src/identifier.rs
@@ -36,6 +36,10 @@ impl Identifier {
         }
     }
 
+    pub fn dot(self, other: impl Into<String>) -> OwnedExpression {
+        expr!("{}.{}", self, Identifier::new(other.into()))
+    }
+
     /// Determines if identifier needs escaping
     ///
     /// doc wip

--- a/vantage-surrealdb/src/operation.rs
+++ b/vantage-surrealdb/src/operation.rs
@@ -2,7 +2,9 @@
 //!
 //! This module provides operations that extend expressions with SurrealDB-specific functionality.
 
-use vantage_expressions::{OwnedExpression, expr};
+use vantage_expressions::{Expr, OwnedExpression, expr};
+
+use crate::identifier::Identifier;
 
 /// Trait for types that can be converted to OwnedExpression
 pub trait Expressive: Into<OwnedExpression> {
@@ -35,6 +37,8 @@ pub trait RefOperation: Expressive {
     ///
     /// An expression that renders as "self<-reference<-table"
     fn lref(&self, reference: impl Into<String>, table: impl Into<String>) -> OwnedExpression;
+    fn alias(&self, alias: impl Into<String>) -> OwnedExpression;
+    fn eq(&self, other: impl Into<Expr>) -> OwnedExpression;
 }
 
 // Default implementations for RefOperation
@@ -58,6 +62,14 @@ where
             OwnedExpression::new(reference.into(), vec![]),
             OwnedExpression::new(table.into(), vec![])
         )
+    }
+
+    fn alias(&self, alias: impl Into<String>) -> OwnedExpression {
+        expr!("{} AS {}", self.expr(), Identifier::new(alias.into()))
+    }
+
+    fn eq(&self, other: impl Into<Expr>) -> OwnedExpression {
+        expr!("{} = {}", self.expr(), other.into())
     }
 }
 

--- a/vantage-surrealdb/src/select/field.rs
+++ b/vantage-surrealdb/src/select/field.rs
@@ -4,7 +4,7 @@
 
 use vantage_expressions::OwnedExpression;
 
-use crate::identifier::Identifier;
+use crate::{identifier::Identifier, operation::Expressive};
 
 /// Represents a database field
 ///
@@ -19,7 +19,7 @@ use crate::identifier::Identifier;
 /// let field = Field::new("user_name");
 /// ```
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Hash)]
 pub struct Field {
     field: String,
 }
@@ -41,6 +41,12 @@ impl Field {
 
 impl Into<OwnedExpression> for Field {
     fn into(self) -> OwnedExpression {
-        Identifier::new(self.field).into()
+        self.expr()
+    }
+}
+
+impl Expressive for Field {
+    fn expr(&self) -> OwnedExpression {
+        Identifier::new(self.field.clone()).into()
     }
 }

--- a/vantage-surrealdb/src/select/mod.rs
+++ b/vantage-surrealdb/src/select/mod.rs
@@ -9,6 +9,7 @@ pub mod target;
 
 use field::Field;
 use select_field::SelectField;
+use serde_json::Value;
 use target::Target;
 
 use crate::identifier::Identifier;
@@ -211,14 +212,14 @@ impl Into<OwnedExpression> for SurrealSelect {
 impl Selectable for SurrealSelect {
     fn set_source(&mut self, source: impl Into<Expr>, _alias: Option<String>) {
         let source_expr = match source.into() {
-            Expr::Scalar(serde_json::Value::String(s)) => Identifier::new(s).into(),
+            Expr::Scalar(Value::String(s)) => Identifier::new(s).into(),
             other => expr!("({})", other),
         };
         self.from = vec![Target::new(source_expr)];
     }
 
-    fn add_field(&mut self, field: String) {
-        self.fields.push(SelectField::new(Field::new(field)));
+    fn add_field(&mut self, field: impl Into<String>) {
+        self.fields.push(SelectField::new(Identifier::new(field)));
     }
 
     fn add_expression(&mut self, expression: OwnedExpression, alias: Option<String>) {
@@ -239,7 +240,7 @@ impl Selectable for SurrealSelect {
 
     fn add_order_by(&mut self, field_or_expr: impl Into<Expr>, ascending: bool) {
         let expression = match field_or_expr.into() {
-            Expr::Scalar(serde_json::Value::String(s)) => Identifier::new(s).into(),
+            Expr::Scalar(Value::String(s)) => Identifier::new(s).into(),
             other => expr!("{}", other),
         };
 

--- a/vantage-surrealdb/tests/select.rs
+++ b/vantage-surrealdb/tests/select.rs
@@ -1,5 +1,10 @@
 use vantage_expressions::{expr, protocol::selectable::Selectable};
-use vantage_surrealdb::{operation::RefOperation, select::SurrealSelect, thing::Thing};
+use vantage_surrealdb::{
+    identifier::Identifier,
+    operation::RefOperation,
+    select::{SurrealSelect, field::Field},
+    thing::Thing,
+};
 
 #[test]
 fn query01() {
@@ -37,6 +42,27 @@ fn query01() {
 
 #[test]
 fn query02() {}
+
+#[test]
+fn query03() {
+    let mut select = SurrealSelect::new();
+
+    select.add_field("name");
+    select.add_field("price");
+    select.add_expression(
+        Identifier::new("inventory").dot("stock"),
+        Some("stock".to_string()),
+    );
+
+    select.set_source("product", None);
+    select.add_where_condition(Field::new("is_deleted").eq(false));
+
+    let result = select.preview();
+    assert_eq!(
+        result,
+        "SELECT name, price, inventory.stock AS stock FROM product WHERE is_deleted = false"
+    );
+}
 
 #[test]
 fn test_set_source_accepts_string_and_expression() {


### PR DESCRIPTION
Added support for dot():

```rust
select.add_expression(
    Identifier::new("inventory").dot("stock"),
    Some("stock".to_string()),
);
```

Also eq():

```rust
select.add_where_condition(Field::new("is_deleted").eq(false));
```

And Identifier::alias():

```rust
Identifier::new("inventory").dot("stock").alias("inventory_stock")
```

Although it's not needed as we add identifiers with dot as expression.