### PR TITLE
rm-branch-5

### DIFF
--- a/vantage-surrealdb/src/identifier.rs
+++ b/vantage-surrealdb/src/identifier.rs
@@ -4,6 +4,8 @@
 
 use vantage_expressions::{IntoExpressive, OwnedExpression, expr};
 
+use crate::operation::Expressive;
+
 /// SurrealDB identifier with automatic escaping
 ///
 /// doc wip
@@ -58,16 +60,29 @@ impl Identifier {
 
 impl Into<OwnedExpression> for Identifier {
     fn into(self) -> OwnedExpression {
-        if self.needs_escaping() {
-            expr!(format!("⟨{}⟩", self.identifier))
-        } else {
-            expr!(self.identifier)
-        }
+        self.expr()
     }
 }
 
 impl From<Identifier> for IntoExpressive<OwnedExpression> {
     fn from(id: Identifier) -> Self {
         IntoExpressive::nested(id.into())
+    }
+}
+
+impl Expressive for Identifier {
+    fn expr(&self) -> OwnedExpression {
+        if self.needs_escaping() {
+            expr!(format!("⟨{}⟩", self.identifier))
+        } else {
+            expr!(self.identifier.clone())
+        }
+    }
+}
+
+pub struct Parent {}
+impl Parent {
+    pub fn new() -> Identifier {
+        Identifier::new("$parent")
     }
 }

--- a/vantage-surrealdb/src/operation.rs
+++ b/vantage-surrealdb/src/operation.rs
@@ -40,6 +40,8 @@ pub trait RefOperation: Expressive {
     fn alias(&self, alias: impl Into<String>) -> OwnedExpression;
     fn eq(&self, other: impl Into<Expr>) -> OwnedExpression;
     fn sub(&self, other: impl Into<Expr>) -> OwnedExpression;
+    fn contains(&self, other: impl Into<Expr>) -> OwnedExpression;
+    fn in_(&self, other: impl Into<Expr>) -> OwnedExpression;
 }
 
 // Default implementations for RefOperation
@@ -75,6 +77,14 @@ where
 
     fn sub(&self, other: impl Into<Expr>) -> OwnedExpression {
         expr!("{} - {}", self.expr(), other.into())
+    }
+
+    fn contains(&self, other: impl Into<Expr>) -> OwnedExpression {
+        expr!("{} CONTAINS {}", self.expr(), other.into())
+    }
+
+    fn in_(&self, other: impl Into<Expr>) -> OwnedExpression {
+        expr!("{} IN {}", self.expr(), other.into())
     }
 }
 

--- a/vantage-surrealdb/src/protocol.rs
+++ b/vantage-surrealdb/src/protocol.rs
@@ -6,11 +6,4 @@
 ///
 /// doc wip
 ///
-/// # Examples
-///
-/// ```rust
-/// use vantage_surrealdb::protocol::Query;
-///
-/// // doc wip
-/// ```
 pub trait SurrealQueriable {}

--- a/vantage-surrealdb/src/select/mod.rs
+++ b/vantage-surrealdb/src/select/mod.rs
@@ -121,6 +121,15 @@ impl SurrealSelect {
         self.add_where_condition(condition);
         self
     }
+
+    pub fn with_order(mut self, field_or_expr: impl Into<Expr>, ascending: bool) -> Self {
+        self.add_order_by(field_or_expr, ascending);
+        self
+    }
+    pub fn with_value(mut self) -> Self {
+        self.single_value = true;
+        self
+    }
 }
 
 impl<T> SurrealSelect<T> {


### PR DESCRIPTION
Added:
 * operator `expr.in_(expr)`
 * query.with_order()
 * query.with_value() // returns single value
 * Parent::new()  - returns Identifier::new("$parent")

New mega-query possible now:

```rust
let select = SurrealSelect::new()
    .with_order("product_name", true)
    .with_condition(expr!("total_items_ordered > current_inventory"))
    .with_source(
        SurrealSelect::new()
            .with_expression(
                Identifier::new("name").into(),
                Some("product_name".to_string()),
            )
            .with_expression(
                Identifier::new("inventory").dot("stock"),
                Some("current_inventory".to_string()),
            )
            .with_expression(
                Sum::new(
                    SurrealSelect::new()
                        .with_value()
                        .with_expression(
                            Sum::new(expr!("lines[WHERE product = $parent.id].quantity"))
                                .into(),
                            None,
                        )
                        .with_source("order")
                        .with_condition(
                            Identifier::new("lines")
                                .dot("product")
                                .contains(Parent::new().dot("id")),
                        )
                        .expr(),
                )
                .into(),
                Some("total_items_ordered".to_string()),
            )
            .with_source("product")
            .with_condition(
                Thing::new("bakery", "hill_valley").in_(expr!("").lref("owns", "bakery")),
            )
            .with_condition(Identifier::new("is_deleted").eq(false))
            .expr(),
    );
```

Resulting in

```sql
SELECT * FROM (
    SELECT
        name AS product_name,
        inventory.stock AS current_inventory,
        math::sum(
            SELECT VALUE math::sum(
                lines[WHERE product = $parent.id].quantity
            )
            FROM order
            WHERE lines.product CONTAINS $parent.id
        ) AS total_items_ordered
    FROM product
    WHERE bakery:hill_valley IN <-owns<-bakery
        AND is_deleted = false
) WHERE total_items_ordered > current_inventory
ORDER BY product_name"
```