### PR TITLE
Properly implement "Record" in vantage-types

### DIFF
--- a/vantage-types/Cargo.toml
+++ b/vantage-types/Cargo.toml
@@ -22,3 +22,5 @@ serde = { version = "1.0", features = ["derive"] }
 url = { version = "2.5", features = ["serde"] }
 serde_json = "1.0.145"
 rust_decimal = "1.0"
+csv = "1.1"
+tokio = { version = "1.0", features = ["rt", "macros"] }

--- a/vantage-types/examples/test_combined_conversions.rs
+++ b/vantage-types/examples/test_combined_conversions.rs
@@ -1,0 +1,197 @@
+use serde::{Deserialize, Serialize};
+use vantage_types::prelude::*;
+use vantage_types::vantage_type_system;
+
+// Define a type system
+vantage_type_system! {
+    type_trait: MyType,
+    method_name: my_value,
+    value_type: String,
+    type_variants: [Text, Number]
+}
+
+impl MyType for String {
+    type Target = MyTypeTextMarker;
+
+    fn to_my_value(&self) -> String {
+        self.clone()
+    }
+
+    fn from_my_value(value: String) -> Option<Self> {
+        Some(value)
+    }
+}
+
+impl MyType for i32 {
+    type Target = MyTypeNumberMarker;
+
+    fn to_my_value(&self) -> String {
+        self.to_string()
+    }
+
+    fn from_my_value(value: String) -> Option<Self> {
+        value.parse().ok()
+    }
+}
+
+impl MyTypeVariants {
+    pub fn from_my_value(value: &String) -> Option<Self> {
+        if value.parse::<i32>().is_ok() {
+            Some(MyTypeVariants::Number)
+        } else {
+            Some(MyTypeVariants::Text)
+        }
+    }
+}
+
+// Struct with persistence macro (uses type system)
+#[persistence(MyType)]
+struct TypeSystemStruct {
+    name: String,
+    count: i32,
+}
+
+// Plain struct with serde (uses JSON)
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct SerdeStruct {
+    title: String,
+    active: bool,
+    score: f64,
+}
+
+fn main() {
+    println!("=== Testing Combined Type System + Serde Conversions ===\n");
+
+    // Create test data
+    let ts_struct = TypeSystemStruct {
+        name: "Test Item".to_string(),
+        count: 42,
+    };
+
+    let serde_struct = SerdeStruct {
+        title: "Example".to_string(),
+        active: true,
+        score: 95.5,
+    };
+
+    // Test 1: Type system struct conversions
+    println!("1. Type System Struct Conversions:");
+    println!(
+        "   Original: name={}, count={}",
+        ts_struct.name, ts_struct.count
+    );
+
+    // TypeSystemStruct -> Record<AnyMyType>
+    let ts_any_record: Record<AnyMyType> = ts_struct.into_record();
+    println!("   ✅ TypeSystemStruct -> Record<AnyMyType>");
+
+    // Record<AnyMyType> -> Record<String> (via blanket)
+    let ts_string_record: Record<String> = ts_any_record.clone().into_record();
+    println!("   ✅ Record<AnyMyType> -> Record<String>");
+    println!("   String record: {:?}", ts_string_record);
+
+    // Round trip back
+    let ts_any_back: Record<AnyMyType> = Record::try_from_record(&ts_string_record).unwrap();
+    let ts_back: TypeSystemStruct = TypeSystemStruct::try_from_record(&ts_any_back).unwrap();
+    println!(
+        "   ✅ Round trip: name={}, count={}",
+        ts_back.name, ts_back.count
+    );
+
+    println!();
+
+    // Test 2: Serde struct conversions
+    println!("2. Serde Struct Conversions:");
+    println!("   Original: {:?}", serde_struct);
+
+    // SerdeStruct -> Record<serde_json::Value> (via blanket serde impl)
+    let serde_json_record: Record<serde_json::Value> = serde_struct.into_record();
+    println!("   ✅ SerdeStruct -> Record<serde_json::Value>");
+    println!("   JSON record: {:?}", serde_json_record);
+
+    // Round trip back
+    let serde_back: SerdeStruct = SerdeStruct::try_from_record(&serde_json_record).unwrap();
+    println!("   ✅ Round trip: {:?}", serde_back);
+
+    println!();
+
+    // Test 3: Cross-conversion via String
+    println!("3. Cross-Conversion via String:");
+
+    // Create a simple struct that implements both
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[persistence(MyType)]
+    struct HybridStruct {
+        label: String,
+        value: String,
+    }
+
+    let hybrid = HybridStruct {
+        label: "test".to_string(),
+        value: "123".to_string(),
+    };
+
+    println!("   Original hybrid: {:?}", hybrid);
+
+    // Path 1: via Type System
+    let hybrid_any: Record<AnyMyType> = hybrid.into_record();
+    let hybrid_string_via_ts: Record<String> = hybrid_any.into_record();
+    println!("   ✅ HybridStruct -> Record<AnyMyType> -> Record<String>");
+    println!("   Via type system: {:?}", hybrid_string_via_ts);
+
+    // Path 2: via Serde
+    let hybrid2 = HybridStruct {
+        label: "test".to_string(),
+        value: "123".to_string(),
+    };
+    let hybrid_json: Record<serde_json::Value> = hybrid2.into_record();
+
+    // Convert serde_json::Value to String (need manual conversion for this)
+    let hybrid_string_via_serde: Record<String> = hybrid_json
+        .into_iter()
+        .map(|(k, v)| {
+            let string_val = match v {
+                serde_json::Value::String(s) => s,
+                serde_json::Value::Number(n) => n.to_string(),
+                serde_json::Value::Bool(b) => b.to_string(),
+                _ => "null".to_string(),
+            };
+            (k, string_val)
+        })
+        .collect();
+
+    println!("   ✅ HybridStruct -> Record<serde_json::Value> -> Record<String>");
+    println!("   Via serde: {:?}", hybrid_string_via_serde);
+
+    println!();
+
+    // Test 4: Demonstrate flexibility
+    println!("4. Flexibility Test - Multiple Conversion Paths:");
+
+    let flexible_struct = HybridStruct {
+        label: "flexible".to_string(),
+        value: "999".to_string(),
+    };
+
+    // Show that the same struct can go through different conversion paths
+    let path1: Record<AnyMyType> = flexible_struct.into_record(); // Type system path
+    let path2 = HybridStruct {
+        label: "flexible".to_string(),
+        value: "999".to_string(),
+    };
+    let path2_record: Record<serde_json::Value> = path2.into_record(); // Serde path
+
+    println!("   Same struct, different paths:");
+    println!("   Type system path: {:?}", path1);
+    println!("   Serde path: {:?}", path2_record);
+
+    // Both can convert to strings
+    let path1_strings: Record<String> = path1.into_record();
+    println!("   Both end up as Record<String>: {:?}", path1_strings);
+
+    println!("\n🎉 All combined conversions work perfectly!");
+    println!("   - Type system conversions via persistence macro");
+    println!("   - Automatic serde conversions via blanket impls");
+    println!("   - Cross-compatibility through common types");
+    println!("   - Multiple conversion paths for flexible structs");
+}

--- a/vantage-types/examples/test_persistence.rs
+++ b/vantage-types/examples/test_persistence.rs
@@ -1,0 +1,93 @@
+use vantage_types::{vantage_type_system, IntoRecord, Record, TryFromRecord};
+use vantage_types_persistence::persistence;
+
+vantage_type_system! {
+    type_trait: TestType,
+    method_name: test_value,
+    value_type: String,
+    type_variants: [Text]
+}
+
+impl TestType for String {
+    type Target = TestTypeTextMarker;
+
+    fn to_test_value(&self) -> String {
+        self.clone()
+    }
+
+    fn from_test_value(value: String) -> Option<Self> {
+        Some(value)
+    }
+}
+
+impl TestTypeVariants {
+    pub fn from_test_value(_value: &String) -> Option<Self> {
+        Some(TestTypeVariants::Text)
+    }
+}
+
+#[persistence(TestType)]
+struct MyStruct {
+    name: String,
+    city: String,
+}
+
+fn main() {
+    // Create a struct
+    let my_struct = MyStruct {
+        name: "Alice".to_string(),
+        city: "Paris".to_string(),
+    };
+
+    println!(
+        "Original struct: name={}, city={}",
+        my_struct.name, my_struct.city
+    );
+
+    // Test: MyStruct -> Record<AnyTestType> using into_record()
+    let any_record: Record<AnyTestType> = my_struct.into_record();
+    println!("MyStruct -> Record<AnyTestType>: SUCCESS");
+    println!("Record<AnyTestType>: {:?}", any_record);
+
+    // Test: Record<AnyTestType> -> Record<String> using blanket implementation
+    let string_record: Record<String> = any_record.clone().into_record();
+    println!("Record<AnyTestType> -> Record<String>: SUCCESS");
+    println!("Record<String>: {:?}", string_record);
+
+    // Test reverse: Record<AnyTestType> -> MyStruct using from_record()
+    let back_to_struct: MyStruct = MyStruct::from_record(any_record).unwrap();
+    println!("Record<AnyTestType> -> MyStruct: SUCCESS");
+    println!(
+        "Reconstructed struct: name={}, city={}",
+        back_to_struct.name, back_to_struct.city
+    );
+
+    // Test full round trip: MyStruct -> Record<String> -> MyStruct
+    let original = MyStruct {
+        name: "Bob".to_string(),
+        city: "London".to_string(),
+    };
+
+    // MyStruct -> Record<AnyTestType> -> Record<String>
+    let any_record: Record<AnyTestType> = original.into_record();
+    let string_via_any: Record<String> = any_record.into_record();
+
+    // Record<String> -> Record<AnyTestType> -> MyStruct
+    let any_record_back: Record<AnyTestType> = Record::from_record(string_via_any).unwrap();
+    let round_trip_result: Result<MyStruct, _> = MyStruct::from_record(any_record_back);
+
+    match round_trip_result {
+        Ok(reconstructed) => {
+            println!("Full round trip: SUCCESS");
+            println!(
+                "Final result: name={}, city={}",
+                reconstructed.name, reconstructed.city
+            );
+        }
+        Err(e) => {
+            println!("Full round trip: FAILED - {:?}", e);
+        }
+    }
+
+    println!("All persistence conversions work correctly!");
+}

--- a/vantage-types/examples/test_serde_record.rs
+++ b/vantage-types/examples/test_serde_record.rs
@@ -1,0 +1,131 @@
+use serde::{Deserialize, Serialize};
+use vantage_types::prelude::*;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Person {
+    name: String,
+    age: u32,
+    city: String,
+    is_active: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+struct Company {
+    name: String,
+    employees: u32,
+    founded: u32,
+}
+
+fn main() {
+    println!("=== Testing Serde Record Conversions ===\n");
+
+    // Create test data
+    let person = Person {
+        name: "Alice Johnson".to_string(),
+        age: 30,
+        city: "New York".to_string(),
+        is_active: true,
+    };
+
+    let company = Company {
+        name: "TechCorp".to_string(),
+        employees: 150,
+        founded: 2010,
+    };
+
+    println!("Original person: {:?}", person);
+    println!("Original company: {:?}", company);
+
+    // Test: Person -> Record<serde_json::Value>
+    let person_record: Record<serde_json::Value> = person.into_record();
+    println!("\nPerson -> Record<serde_json::Value>: SUCCESS");
+    println!("Person record: {:?}", person_record);
+
+    // Test: Company -> Record<serde_json::Value>
+    let company_record: Record<serde_json::Value> = company.into_record();
+    println!("\nCompany -> Record<serde_json::Value>: SUCCESS");
+    println!("Company record: {:?}", company_record);
+
+    // Test reverse conversion: Record<serde_json::Value> -> Person
+    let person_back: Result<Person, _> = Person::try_from_record(&person_record);
+    match person_back {
+        Ok(p) => {
+            println!("\nRecord<serde_json::Value> -> Person: SUCCESS");
+            println!("Reconstructed person: {:?}", p);
+            assert_eq!(
+                p,
+                Person {
+                    name: "Alice Johnson".to_string(),
+                    age: 30,
+                    city: "New York".to_string(),
+                    is_active: true,
+                }
+            );
+            println!("✅ Person round-trip successful!");
+        }
+        Err(e) => {
+            println!("Record<serde_json::Value> -> Person: FAILED - {:?}", e);
+        }
+    }
+
+    // Test reverse conversion: Record<serde_json::Value> -> Company
+    let company_back: Result<Company, _> = Company::try_from_record(&company_record);
+    match company_back {
+        Ok(c) => {
+            println!("\nRecord<serde_json::Value> -> Company: SUCCESS");
+            println!("Reconstructed company: {:?}", c);
+            assert_eq!(
+                c,
+                Company {
+                    name: "TechCorp".to_string(),
+                    employees: 150,
+                    founded: 2010,
+                }
+            );
+            println!("✅ Company round-trip successful!");
+        }
+        Err(e) => {
+            println!("Record<serde_json::Value> -> Company: FAILED - {:?}", e);
+        }
+    }
+
+    // Test with nested structures
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Department {
+        name: String,
+        head: Person,
+        budget: f64,
+    }
+
+    let department = Department {
+        name: "Engineering".to_string(),
+        head: Person {
+            name: "Bob Smith".to_string(),
+            age: 45,
+            city: "San Francisco".to_string(),
+            is_active: true,
+        },
+        budget: 500000.0,
+    };
+
+    println!("\n=== Testing Nested Structures ===");
+    println!("Original department: {:?}", department);
+
+    // Department -> Record<serde_json::Value> -> Department
+    let dept_record: Record<serde_json::Value> = department.into_record();
+    println!("\nDepartment -> Record<serde_json::Value>: SUCCESS");
+
+    let dept_back: Result<Department, _> = Department::try_from_record(&dept_record);
+    match dept_back {
+        Ok(d) => {
+            println!("Record<serde_json::Value> -> Department: SUCCESS");
+            println!("Reconstructed department: {:?}", d);
+            println!("✅ Nested structure round-trip successful!");
+        }
+        Err(e) => {
+            println!("Nested structure conversion: FAILED - {:?}", e);
+        }
+    }
+
+    println!("\n🎉 All automatic serde Record conversions work correctly!");
+}

--- a/vantage-types/examples/test_traits.rs
+++ b/vantage-types/examples/test_traits.rs
@@ -1,0 +1,80 @@
+use vantage_types::{vantage_type_system, IntoRecord, Record, TryFromRecord};
+
+vantage_type_system! {
+    type_trait: SimpleType,
+    method_name: simple,
+    value_type: String,
+    type_variants: [Text]
+}
+
+impl SimpleType for String {
+    type Target = SimpleTypeTextMarker;
+
+    fn to_simple(&self) -> String {
+        self.clone()
+    }
+
+    fn from_simple(value: String) -> Option<Self> {
+        Some(value)
+    }
+}
+
+impl SimpleTypeVariants {
+    pub fn from_simple(_value: &String) -> Option<Self> {
+        Some(SimpleTypeVariants::Text)
+    }
+}
+
+fn main() {
+    let text = String::from("hello");
+    let any_type = AnySimpleType::new(text.clone());
+
+    // Test Into: AnySimpleType -> String
+    let value: String = any_type.clone().into();
+    println!("Into conversion: {}", value);
+    assert_eq!(value, "hello");
+
+    // Test TryFrom: String -> AnySimpleType
+    let any_type2: AnySimpleType = "world".to_string().try_into().unwrap();
+    println!("TryFrom conversion: {:?}", any_type2.value());
+    assert_eq!(any_type2.value(), "world");
+    assert_eq!(any_type2.type_variant(), Some(SimpleTypeVariants::Text));
+
+    // Test that AnySimpleType no longer implements SimpleType trait
+    println!("\n--- Testing AnySimpleType (trait implementation removed) ---");
+    let any_simple = AnySimpleType::new("test".to_string());
+    println!("AnySimpleType created with value: {:?}", any_simple.value());
+    // Note: can no longer call .to_simple() or .from_simple() since trait impl was removed
+
+    // Test Record conversions
+    println!("\n--- Testing Record conversions ---");
+
+    // Create Record<AnySimpleType>
+    let mut any_record: Record<AnySimpleType> = Record::new();
+    any_record.insert("name".to_string(), AnySimpleType::new("Alice".to_string()));
+    any_record.insert("city".to_string(), AnySimpleType::new("Paris".to_string()));
+
+    println!("Original Record<AnySimpleType>: {:?}", any_record);
+
+    // Try: Record<AnySimpleType> -> Record<String> using into_record()
+    let string_record: Record<String> = any_record.clone().into_record();
+    println!("Record<AnySimpleType> -> Record<String> conversion: SUCCESS");
+    println!("Converted record: {:?}", string_record);
+
+    // Try reverse: Record<String> -> Record<AnySimpleType> using from_record()
+    let back_to_any: Result<Record<AnySimpleType>, _> = Record::from_record(string_record);
+    match back_to_any {
+        Ok(any_rec) => {
+            println!("Record<String> -> Record<AnySimpleType> conversion: SUCCESS");
+            println!("Round-trip record: {:?}", any_rec);
+        }
+        Err(e) => {
+            println!(
+                "Record<String> -> Record<AnySimpleType> conversion: FAILED - {:?}",
+                e
+            );
+        }
+    }
+
+    println!("Record conversions work correctly even without AnyType trait implementation!");
+}

--- a/vantage-types/persistence/Cargo.toml
+++ b/vantage-types/persistence/Cargo.toml
@@ -13,3 +13,4 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
+vantage-core = { path = "../../vantage-core" }

--- a/vantage-types/src/lib.rs
+++ b/vantage-types/src/lib.rs
@@ -2,11 +2,11 @@
 pub use vantage_types_persistence::{persistence, persistence_serde};
 
 // Include type_system module with regular macros
+pub mod prelude;
 pub mod record;
 pub mod type_system;
 
-// Re-export Record type at crate root
-pub use record::Record;
+pub use record::{IntoRecord, Record, TryFromRecord};
 
 /// Entity trait with conversion requirements and default Value type
 ///

--- a/vantage-types/src/prelude.rs
+++ b/vantage-types/src/prelude.rs
@@ -1,0 +1,20 @@
+//! Prelude module for vantage-types
+//!
+//! This module re-exports commonly used traits and types for convenient importing.
+//!
+//! # Example
+//! ```rust
+//! use vantage_types::prelude::*;
+//! ```
+
+// Re-export core types
+pub use crate::record::{IntoRecord, Record, TryFromRecord};
+
+// Re-export macros
+pub use crate::vantage_type_system;
+
+// Re-export proc-macros
+pub use vantage_types_persistence::{persistence, persistence_serde};
+
+#[cfg(feature = "serde")]
+pub use crate::Entity;

--- a/vantage-types/tests/decimal_json.rs
+++ b/vantage-types/tests/decimal_json.rs
@@ -164,7 +164,7 @@ mod tests {
 
         // Attempt to restore as StringRecord should fail
         let failed_restore = StringRecord::from_mytype_map(storage_map);
-        assert!(failed_restore.is_none());
+        assert!(failed_restore.is_err());
     }
 
     #[test]

--- a/vantage-types/tests/readme_tests.rs
+++ b/vantage-types/tests/readme_tests.rs
@@ -1,0 +1,668 @@
+use indexmap::IndexMap;
+use rust_decimal::Decimal;
+
+use vantage_types::vantage_type_system;
+use vantage_types_persistence::persistence;
+
+// Basic example - single field value
+vantage_type_system! {
+    type_trait: Type3,
+    method_name: cbor,
+    value_type: ciborium::Value,
+    type_variants: [String, Email]
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Email {
+    pub name: String,
+    pub domain: String,
+}
+
+impl Email {
+    pub fn new(name: &str, domain: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            domain: domain.to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for Email {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}@{}", self.name, self.domain)
+    }
+}
+
+impl Type3 for String {
+    type Target = Type3StringMarker;
+
+    fn to_cbor(&self) -> ciborium::Value {
+        ciborium::Value::Text(self.clone())
+    }
+
+    fn from_cbor(cbor: ciborium::Value) -> Option<Self> {
+        match cbor {
+            ciborium::Value::Text(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+impl Type3 for Email {
+    type Target = Type3EmailMarker;
+
+    fn to_cbor(&self) -> ciborium::value::Value {
+        let array = vec![
+            ciborium::value::Value::Text(self.name.clone()),
+            ciborium::value::Value::Text(self.domain.clone()),
+        ];
+        ciborium::value::Value::Tag(1000, Box::new(ciborium::value::Value::Array(array)))
+    }
+
+    fn from_cbor(cbor: ciborium::value::Value) -> Option<Self> {
+        let ciborium::value::Value::Tag(1000, boxed_value) = cbor else {
+            return None;
+        };
+        let ciborium::value::Value::Array(arr) = boxed_value.as_ref() else {
+            return None;
+        };
+        let name = match arr.get(0)? {
+            ciborium::value::Value::Text(s) => s,
+            _ => return None,
+        };
+        let domain = match arr.get(1)? {
+            ciborium::value::Value::Text(s) => s,
+            _ => return None,
+        };
+        Some(Email::new(name, domain))
+    }
+}
+
+impl Type3Variants {
+    pub fn from_cbor(value: &ciborium::Value) -> Option<Self> {
+        match value {
+            ciborium::Value::Text(_) => Some(Type3Variants::String),
+            ciborium::Value::Tag(1000, _) => Some(Type3Variants::Email),
+            _ => None,
+        }
+    }
+}
+
+// Typed record example
+#[derive(Debug, PartialEq)]
+#[persistence(Type3)]
+struct User {
+    name: String,
+    email: Email,
+}
+
+// Type System Generation example
+vantage_type_system! {
+    type_trait: MyType,
+    method_name: json,
+    value_type: serde_json::Value,
+    type_variants: [Int, Float, Decimal]
+}
+
+impl MyType for i32 {
+    type Target = MyTypeIntMarker;
+
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::Value::Number((*self).into())
+    }
+
+    fn from_json(value: serde_json::Value) -> Option<Self> {
+        match value {
+            serde_json::Value::Number(n) if n.is_i64() => Some(n.as_i64()? as i32),
+            _ => None,
+        }
+    }
+}
+
+impl MyType for f64 {
+    type Target = MyTypeFloatMarker;
+
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::Value::Number(
+            serde_json::Number::from_f64(*self).unwrap_or_else(|| serde_json::Number::from(0)),
+        )
+    }
+
+    fn from_json(value: serde_json::Value) -> Option<Self> {
+        match value {
+            serde_json::Value::Number(n) if n.is_f64() => n.as_f64(),
+            _ => None,
+        }
+    }
+}
+
+impl MyType for Decimal {
+    type Target = MyTypeDecimalMarker;
+
+    fn to_json(&self) -> serde_json::Value {
+        // Store decimal as {"decimal": "decimal_string"} to avoid precision loss
+        serde_json::json!({"decimal": self.to_string()})
+    }
+
+    fn from_json(value: serde_json::Value) -> Option<Self> {
+        match value {
+            serde_json::Value::Object(obj) => {
+                if let Some(serde_json::Value::String(decimal_str)) = obj.get("decimal") {
+                    decimal_str.parse().ok()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+impl MyTypeVariants {
+    pub fn from_json(value: &serde_json::Value) -> Option<Self> {
+        match value {
+            serde_json::Value::Number(n) if n.is_i64() => Some(MyTypeVariants::Int),
+            serde_json::Value::Number(n) if n.is_f64() => Some(MyTypeVariants::Float),
+            serde_json::Value::Object(obj) => {
+                if obj.contains_key("decimal") {
+                    Some(MyTypeVariants::Decimal)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+// Optional Values example
+vantage_type_system! {
+    type_trait: OptionalType,
+    method_name: cbor_opt,
+    value_type: ciborium::Value,
+    type_variants: [String, Email, Null]
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Null;
+
+impl OptionalType for Null {
+    type Target = OptionalTypeNullMarker;
+
+    fn to_cbor_opt(&self) -> ciborium::Value {
+        ciborium::Value::Tag(6, Box::new(ciborium::Value::Null))
+    }
+
+    fn from_cbor_opt(cbor: ciborium::Value) -> Option<Self> {
+        match cbor {
+            ciborium::Value::Tag(6, _) => Some(Null),
+            _ => None,
+        }
+    }
+}
+
+impl OptionalType for String {
+    type Target = OptionalTypeStringMarker;
+
+    fn to_cbor_opt(&self) -> ciborium::Value {
+        ciborium::Value::Text(self.clone())
+    }
+
+    fn from_cbor_opt(value: ciborium::Value) -> Option<Self> {
+        match value {
+            ciborium::Value::Text(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+impl OptionalType for Email {
+    type Target = OptionalTypeEmailMarker;
+
+    fn to_cbor_opt(&self) -> ciborium::value::Value {
+        let array = vec![
+            ciborium::value::Value::Text(self.name.clone()),
+            ciborium::value::Value::Text(self.domain.clone()),
+        ];
+        ciborium::value::Value::Tag(1000, Box::new(ciborium::value::Value::Array(array)))
+    }
+
+    fn from_cbor_opt(cbor: ciborium::value::Value) -> Option<Self> {
+        let ciborium::value::Value::Tag(1000, boxed_value) = cbor else {
+            return None;
+        };
+        let ciborium::value::Value::Array(arr) = boxed_value.as_ref() else {
+            return None;
+        };
+        let name = match arr.get(0)? {
+            ciborium::value::Value::Text(s) => s,
+            _ => return None,
+        };
+        let domain = match arr.get(1)? {
+            ciborium::value::Value::Text(s) => s,
+            _ => return None,
+        };
+        Some(Email::new(name, domain))
+    }
+}
+
+impl OptionalType for Option<String> {
+    type Target = OptionalTypeNullMarker;
+
+    fn to_cbor_opt(&self) -> ciborium::Value {
+        match self {
+            Some(s) => ciborium::Value::Text(s.clone()),
+            None => ciborium::Value::Tag(6, Box::new(ciborium::Value::Null)),
+        }
+    }
+
+    fn from_cbor_opt(cbor: ciborium::Value) -> Option<Self> {
+        match cbor {
+            ciborium::Value::Tag(6, _) => Some(None),
+            ciborium::Value::Text(s) => Some(Some(s)),
+            _ => None,
+        }
+    }
+}
+
+impl OptionalTypeVariants {
+    pub fn from_cbor_opt(value: &ciborium::Value) -> Option<Self> {
+        match value {
+            ciborium::Value::Text(_) => Some(OptionalTypeVariants::String),
+            ciborium::Value::Tag(1000, _) => Some(OptionalTypeVariants::Email),
+            ciborium::Value::Tag(6, _) => None, // Null values bypass variant check
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+#[persistence(OptionalType)]
+struct Document {
+    title: String,
+    subtitle: Option<String>,
+    author: Email,
+    published: bool,
+}
+
+impl OptionalType for bool {
+    type Target = OptionalTypeNullMarker; // Using Null marker for simplicity
+
+    fn to_cbor_opt(&self) -> ciborium::Value {
+        ciborium::Value::Bool(*self)
+    }
+
+    fn from_cbor_opt(value: ciborium::Value) -> Option<Self> {
+        match value {
+            ciborium::Value::Bool(b) => Some(b),
+            _ => None,
+        }
+    }
+}
+
+// Cross-Database Type Systems
+vantage_type_system! {
+    type_trait: SurrealType,
+    method_name: cbor_surreal,
+    value_type: ciborium::Value,
+    type_variants: [String, Decimal, RId]
+}
+
+vantage_type_system! {
+    type_trait: PostgresType,
+    method_name: json_pg,
+    value_type: serde_json::Value,
+    type_variants: [String, Decimal, Uuid]
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct RId(String);
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Uuid(String);
+
+impl SurrealType for String {
+    type Target = SurrealTypeStringMarker;
+
+    fn to_cbor_surreal(&self) -> ciborium::Value {
+        ciborium::Value::Text(self.clone())
+    }
+
+    fn from_cbor_surreal(value: ciborium::Value) -> Option<Self> {
+        match value {
+            ciborium::Value::Text(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+impl SurrealType for Decimal {
+    type Target = SurrealTypeDecimalMarker;
+
+    fn to_cbor_surreal(&self) -> ciborium::Value {
+        ciborium::Value::Tag(200, Box::new(ciborium::Value::Text(self.to_string())))
+    }
+
+    fn from_cbor_surreal(value: ciborium::Value) -> Option<Self> {
+        match value {
+            ciborium::Value::Tag(200, boxed) => {
+                if let ciborium::Value::Text(s) = boxed.as_ref() {
+                    s.parse().ok()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+impl PostgresType for String {
+    type Target = PostgresTypeStringMarker;
+
+    fn to_json_pg(&self) -> serde_json::Value {
+        serde_json::Value::String(self.clone())
+    }
+
+    fn from_json_pg(value: serde_json::Value) -> Option<Self> {
+        match value {
+            serde_json::Value::String(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+impl PostgresType for Decimal {
+    type Target = PostgresTypeDecimalMarker;
+
+    fn to_json_pg(&self) -> serde_json::Value {
+        serde_json::json!({"decimal": self.to_string()})
+    }
+
+    fn from_json_pg(value: serde_json::Value) -> Option<Self> {
+        match value {
+            serde_json::Value::Object(obj) => {
+                if let Some(serde_json::Value::String(decimal_str)) = obj.get("decimal") {
+                    decimal_str.parse().ok()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+impl SurrealTypeVariants {
+    pub fn from_cbor_surreal(value: &ciborium::Value) -> Option<Self> {
+        match value {
+            ciborium::Value::Text(_) => Some(SurrealTypeVariants::String),
+            ciborium::Value::Tag(200, _) => Some(SurrealTypeVariants::Decimal),
+            _ => None,
+        }
+    }
+}
+
+impl PostgresTypeVariants {
+    pub fn from_json_pg(value: &serde_json::Value) -> Option<Self> {
+        match value {
+            serde_json::Value::String(_) => Some(PostgresTypeVariants::String),
+            serde_json::Value::Object(obj) if obj.contains_key("decimal") => {
+                Some(PostgresTypeVariants::Decimal)
+            }
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+#[persistence(SurrealType)]
+#[persistence(PostgresType)]
+struct CrossDbUser {
+    name: String,
+    balance: Decimal,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_single_field_value() {
+        // AnyType3 can store either String or Email
+        let field_value = AnyType3::new(String::from("Hello, World!"));
+
+        // Back to string:
+        let hello: String = field_value.try_get().unwrap();
+        assert_eq!(hello, "Hello, World!");
+
+        // This would fail, because type is important!
+        let hello_fail: Option<Email> = field_value.try_get::<Email>();
+        assert!(hello_fail.is_none());
+    }
+
+    #[test]
+    fn test_typed_record_example() {
+        let user = User {
+            name: "John Doe".to_string(),
+            email: Email::new("john", "example.com"),
+        };
+
+        // Convert to type-erased format for generic processing:
+        let values: IndexMap<String, AnyType3> = user.to_type3_map();
+
+        // Restore back when reading from database:
+        let restored = User::from_type3_map(values).unwrap();
+        assert_eq!(user, restored);
+    }
+
+    #[test]
+    fn test_custom_decimal_implementation() {
+        let decimal = Decimal::from_str_exact("1234.5678").unwrap();
+        let _any_decimal = AnyMyType::new(decimal.clone());
+
+        // Test serialization
+        let json_value = decimal.to_json();
+        let expected = serde_json::json!({"decimal": "1234.5678"});
+        assert_eq!(json_value, expected);
+
+        // Test deserialization
+        let restored = Decimal::from_json(json_value).unwrap();
+        assert_eq!(decimal, restored);
+
+        // Test variant detection
+        let variant = MyTypeVariants::from_json(&expected);
+        assert_eq!(variant, Some(MyTypeVariants::Decimal));
+    }
+
+    #[test]
+    fn test_optional_values() {
+        let doc = Document {
+            title: "My Article".to_string(),
+            subtitle: Some("A comprehensive guide".to_string()),
+            author: Email::new("author", "blog.com"),
+            published: true,
+        };
+
+        // Automatic conversion to storage format
+        let storage_map: IndexMap<String, AnyOptionalType> = doc.to_optionaltype_map();
+
+        // Each field is stored as AnyOptionalType with proper type information
+        assert!(storage_map.contains_key("title"));
+        assert!(storage_map.contains_key("subtitle"));
+        assert!(storage_map.contains_key("author"));
+        assert!(storage_map.contains_key("published"));
+
+        // Test with None subtitle
+        let doc_no_subtitle = Document {
+            title: "Another Article".to_string(),
+            subtitle: None,
+            author: Email::new("author", "blog.com"),
+            published: false,
+        };
+
+        let storage_none = doc_no_subtitle.to_optionaltype_map();
+        // For None values, just check the field exists
+        assert!(storage_none.contains_key("subtitle"));
+
+        // Perfect round-trip conversion
+        let restored = Document::from_optionaltype_map(storage_map).unwrap();
+        assert_eq!(doc, restored);
+    }
+
+    #[test]
+    fn test_cross_database_type_systems() {
+        let user = CrossDbUser {
+            name: "John Doe".to_string(),
+            balance: Decimal::from_str_exact("1234.56").unwrap(),
+        };
+
+        // Store to both formats
+        let surreal_storage = user.to_surrealtype_map();
+        let postgres_storage = user.to_postgrestype_map();
+
+        // Both can be restored perfectly
+        let from_surreal = CrossDbUser::from_surrealtype_map(surreal_storage).unwrap();
+        let from_postgres = CrossDbUser::from_postgrestype_map(postgres_storage).unwrap();
+
+        assert_eq!(user, from_surreal);
+        assert_eq!(user, from_postgres);
+    }
+
+    #[tokio::test]
+    async fn test_csv_examples() {
+        // CSV persistence engine example
+        vantage_type_system! {
+            type_trait: CsvType,
+            method_name: csv_string,
+            value_type: String,
+            type_variants: [Text]
+        }
+        use vantage_core::{Context, Result};
+        use vantage_types::{IntoRecord, Record, TryFromRecord};
+
+        impl CsvType for String {
+            type Target = CsvTypeTextMarker;
+
+            fn to_csv_string(&self) -> String {
+                self.clone()
+            }
+
+            fn from_csv_string(value: String) -> Option<Self> {
+                Some(value)
+            }
+        }
+
+        impl CsvType for Email {
+            type Target = CsvTypeTextMarker;
+
+            fn to_csv_string(&self) -> String {
+                format!("{}@{}", self.name, self.domain)
+            }
+
+            fn from_csv_string(value: String) -> Option<Self> {
+                let parts: Vec<&str> = value.split('@').collect();
+                if parts.len() == 2 {
+                    Some(Email {
+                        name: parts[0].to_string(),
+                        domain: parts[1].to_string(),
+                    })
+                } else {
+                    None
+                }
+            }
+        }
+
+        impl CsvTypeVariants {
+            pub fn from_csv_string(_value: &String) -> Option<Self> {
+                Some(CsvTypeVariants::Text)
+            }
+        }
+
+        #[derive(Debug, PartialEq)]
+        #[persistence(CsvType)]
+        struct User {
+            name: String,
+            email: Email,
+        }
+        // Layer 1: Low-level persistence operations (hardcoded for testing)
+        async fn actually_read_csv_contents(
+        ) -> std::result::Result<Vec<IndexMap<String, String>>, std::io::Error> {
+            let mut result = Vec::new();
+
+            let mut record1 = IndexMap::new();
+            record1.insert("name".to_string(), "Alice".to_string());
+            record1.insert("email".to_string(), "alice@paris.com".to_string());
+
+            let mut record2 = IndexMap::new();
+            record2.insert("name".to_string(), "Bob".to_string());
+            record2.insert("email".to_string(), "bob@london.com".to_string());
+
+            result.push(record1);
+            result.push(record2);
+
+            Ok(result)
+        }
+
+        async fn actually_insert_csv_record(
+            _data: IndexMap<String, String>,
+        ) -> std::result::Result<(), std::io::Error> {
+            // In real implementation, this would write to CSV file
+            Ok(())
+        }
+
+        // Layer 2: Vantage type system integration
+        async fn read_csv_contents() -> Result<Vec<Record<AnyCsvType>>> {
+            // convert error into VantageError
+            let contents = actually_read_csv_contents()
+                .await
+                .context("Failed to read CSV contents")?;
+
+            // Convert each row into Record<AnyCsvType>
+            Ok(contents
+                .into_iter()
+                .map(|row| {
+                    let record = Record::from_indexmap(row); // Record<String>
+                    Record::<AnyCsvType>::try_from_record(&record).unwrap() // convert to Record<AnyCsvType>
+                })
+                .collect())
+        }
+
+        async fn insert_csv_record<T>(record: T) -> Result<()>
+        where
+            T: IntoRecord<AnyCsvType>,
+        {
+            let vantage_record = record.into_record();
+
+            // Convetr to underlying value type
+            let string_record: Record<String> = vantage_record.into_record();
+
+            // Convert Record<AnyCsvType> into IndexMap<String, String>
+            let indexmap = string_record.into_inner();
+
+            // Convert error into VantageError
+            actually_insert_csv_record(indexmap)
+                .await
+                .context("Failed to insert CSV record")
+        }
+
+        let _ = insert_csv_record(User {
+            name: "John Doe".to_string(),
+            email: Email::new("john", "example.com"),
+        })
+        .await;
+
+        let records = read_csv_contents().await.unwrap();
+        for record in records {
+            let user: User = User::try_from_record(&record).unwrap();
+            println!("User: {} ({})", user.name, user.email);
+
+            // alternatively:
+            println!(
+                "User: {} ({})",
+                record["name"].value(),
+                record["email"].value()
+            );
+        }
+    }
+}

--- a/vantage-types/tests/simple_traits_test.rs
+++ b/vantage-types/tests/simple_traits_test.rs
@@ -1,0 +1,108 @@
+use vantage_types::{vantage_type_system, IntoRecord, Record, TryFromRecord};
+
+vantage_type_system! {
+    type_trait: TestType,
+    method_name: test_value,
+    value_type: String,
+    type_variants: [Text, Label]
+}
+
+impl TestType for String {
+    type Target = TestTypeTextMarker;
+
+    fn to_test_value(&self) -> String {
+        self.clone()
+    }
+
+    fn from_test_value(value: String) -> Option<Self> {
+        Some(value)
+    }
+}
+
+struct Label(String);
+
+impl TestType for Label {
+    type Target = TestTypeLabelMarker;
+
+    fn to_test_value(&self) -> String {
+        format!("label:{}", self.0)
+    }
+
+    fn from_test_value(value: String) -> Option<Self> {
+        if value.starts_with("label:") {
+            Some(Label(value[6..].to_string()))
+        } else {
+            None
+        }
+    }
+}
+
+impl TestTypeVariants {
+    pub fn from_test_value(value: &String) -> Option<Self> {
+        if value.starts_with("label:") {
+            Some(TestTypeVariants::Label)
+        } else {
+            Some(TestTypeVariants::Text)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_individual_conversions() {
+        // Test String conversions
+        let text = String::from("hello");
+        let any_type = AnyTestType::new(text.clone());
+
+        // AnyType -> ValueType
+        let value: String = any_type.clone().into();
+        assert_eq!(value, "hello");
+
+        // ValueType -> AnyType
+        let any_type2: AnyTestType = "world".to_string().try_into().unwrap();
+        assert_eq!(any_type2.value(), "world");
+        assert_eq!(any_type2.type_variant(), Some(TestTypeVariants::Text));
+    }
+
+    #[test]
+    fn test_record_conversions() {
+        // Create Record<AnyTestType>
+        let mut any_record: Record<AnyTestType> = Record::new();
+        any_record.insert("name".to_string(), AnyTestType::new("Alice".to_string()));
+        any_record.insert(
+            "label".to_string(),
+            AnyTestType::new(Label("important".to_string())),
+        );
+
+        // Record<AnyTestType> -> Record<String>
+        let string_record: Record<String> = any_record.clone().into_record();
+        assert_eq!(string_record.get("name").unwrap(), "Alice");
+        assert_eq!(string_record.get("label").unwrap(), "label:important");
+
+        // Record<String> -> Record<AnyTestType>
+        let back_to_any: Record<AnyTestType> = Record::from_record(string_record).unwrap();
+
+        let name_any = back_to_any.get("name").unwrap();
+        assert_eq!(name_any.value(), "Alice");
+        assert_eq!(name_any.type_variant(), Some(TestTypeVariants::Text));
+
+        let label_any = back_to_any.get("label").unwrap();
+        assert_eq!(label_any.value(), "label:important");
+        assert_eq!(label_any.type_variant(), Some(TestTypeVariants::Label));
+    }
+
+    #[test]
+    fn test_record_conversion_error_handling() {
+        // Create a Record<String> that can't convert back to AnyTestType
+        let mut string_record: Record<String> = Record::new();
+        string_record.insert("valid".to_string(), "hello".to_string());
+        string_record.insert("invalid".to_string(), "".to_string()); // Empty string might fail conversion
+
+        // This should still work since our implementations are permissive
+        let result: Result<Record<AnyTestType>, _> = Record::from_record(string_record);
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
Deserialising a `Record` and missing a field looked the same as feeding it the wrong type — both collapsed to `None`. No way to tell which, no error to bubble up. Every persistence backend was lossy at the boundary.

Two new traits fix it. `IntoRecord<T>` and `TryFromRecord<T>` carry blanket impls so `Record<T> -> Record<U>` works whenever `T: Into<U>` (or `T: TryFrom<U>`). Conversions return `vantage_core::Result<Self>` with a real `error!("Missing field", field = ...)`, and a serde blanket gives `Record<serde_json::Value>` for free.

```rust
async fn insert_csv_record<T: IntoRecord<AnyCsvType>>(record: T) -> Result<()> {
    let r: Record<String> = record.into_record().into_record();
    actually_insert_csv_record(r.into_inner()).await.context("...")
}
```

### Macros

`#[persistence]` now emits both traits alongside the existing `*Persistence` trait. `vantage_type_system!` gains `From<AnyT> for ValueType` and `TryFrom<ValueType> for AnyT`, so the blanket conversions cover any user-defined type system. The serde-detour helpers (`to_cbor_value`, `from_cbor_value`, ...) it used to generate are gone — scaffolding from before `Record::from_serializable` existed.

### Knock-ons

A new `vantage_types::prelude` re-exports the traits and macros. The README grows a CSV-engine walkthrough exercising the round-trip end-to-end, and `tests/readme_tests.rs` keeps it honest.

One downstream change: `decimal_json`'s "should fail to restore" assertion flipped from `is_none()` to `is_err()`.