### PR TITLE
Remove old indexmap support, use Record

### DIFF
--- a/vantage-types/Cargo.toml
+++ b/vantage-types/Cargo.toml
@@ -24,3 +24,11 @@ serde_json = "1.0.145"
 rust_decimal = "1.0"
 csv = "1.1"
 tokio = { version = "1.0", features = ["rt", "macros"] }
+
+[[example]]
+name = "test_serde_record"
+required-features = ["serde"]
+
+[[example]]
+name = "test_combined_conversions"
+required-features = ["serde"]

--- a/vantage-types/deprecated/record_conversions.rs
+++ b/vantage-types/deprecated/record_conversions.rs
@@ -1,0 +1,56 @@
+//! Deprecated macros for record conversions
+//!
+//! These macros depended on the old IndexMap-based persistence methods
+//! that were removed in favor of the simpler Record-based approach.
+//!
+//! This file is kept for reference but is not included in the main library.
+
+use paste::paste;
+
+/// Deprecated: Generate Into/TryFrom implementations for struct -> Record conversions
+///
+/// This macro used to generate conversions between structs and Record types
+/// using the old *Persistence trait methods. It's no longer needed since
+/// the #[persistence] macro now generates IntoRecord/TryFromRecord directly.
+///
+/// Use the IntoRecord/TryFromRecord traits directly instead:
+/// ```
+/// use vantage_types::{IntoRecord, TryFromRecord};
+///
+/// // Convert struct to record
+/// let record: Record<AnyType> = my_struct.into_record();
+///
+/// // Convert record back to struct
+/// let my_struct = MyStruct::from_record(record)?;
+/// ```
+#[macro_export]
+macro_rules! vantage_record_conversions {
+    ($struct_name:ty, $trait_name:ident, $value_type:ty) => {
+        paste! {
+            // Into implementations for specific struct
+            impl Into<vantage_types::Record<[<Any $trait_name>]>> for $struct_name {
+                fn into(self) -> vantage_types::Record<[<Any $trait_name>]> {
+                    // This would call the old to_*_map() method that no longer exists
+                    self.[<to_ $trait_name:lower _map>]().into()
+                }
+            }
+
+            impl Into<vantage_types::Record<$value_type>> for $struct_name {
+                fn into(self) -> vantage_types::Record<$value_type> {
+                    // This would call the old to_*_values() method that no longer exists
+                    self.[<to_ $trait_name:lower _values>]()
+                }
+            }
+
+            // TryFrom for reverse conversion
+            impl TryFrom<vantage_types::Record<[<Any $trait_name>]>> for $struct_name {
+                type Error = vantage_core::VantageError;
+
+                fn try_from(value: vantage_types::Record<[<Any $trait_name>]>) -> vantage_core::Result<Self> {
+                    // This would call the old from_*_map() method that no longer exists
+                    Self::[<from_ $trait_name:lower _map>](value.into_inner())
+                }
+            }
+        }
+    };
+}

--- a/vantage-types/examples/test_serde_record.rs
+++ b/vantage-types/examples/test_serde_record.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use vantage_types::prelude::*;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 struct Person {
     name: String,
     age: u32,
@@ -9,7 +9,7 @@ struct Person {
     is_active: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 struct Company {
     name: String,
     employees: u32,
@@ -37,17 +37,17 @@ fn main() {
     println!("Original company: {:?}", company);
 
     // Test: Person -> Record<serde_json::Value>
-    let person_record: Record<serde_json::Value> = person.into_record();
+    let person_record: Record<serde_json::Value> = person.clone().into_record();
     println!("\nPerson -> Record<serde_json::Value>: SUCCESS");
     println!("Person record: {:?}", person_record);
 
     // Test: Company -> Record<serde_json::Value>
-    let company_record: Record<serde_json::Value> = company.into_record();
+    let company_record: Record<serde_json::Value> = company.clone().into_record();
     println!("\nCompany -> Record<serde_json::Value>: SUCCESS");
     println!("Company record: {:?}", company_record);
 
     // Test reverse conversion: Record<serde_json::Value> -> Person
-    let person_back: Result<Person, _> = Person::try_from_record(&person_record);
+    let person_back: Result<Person, _> = Person::from_record(person_record.clone());
     match person_back {
         Ok(p) => {
             println!("\nRecord<serde_json::Value> -> Person: SUCCESS");
@@ -69,7 +69,7 @@ fn main() {
     }
 
     // Test reverse conversion: Record<serde_json::Value> -> Company
-    let company_back: Result<Company, _> = Company::try_from_record(&company_record);
+    let company_back: Result<Company, _> = Company::from_record(company_record.clone());
     match company_back {
         Ok(c) => {
             println!("\nRecord<serde_json::Value> -> Company: SUCCESS");
@@ -90,7 +90,7 @@ fn main() {
     }
 
     // Test with nested structures
-    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
     struct Department {
         name: String,
         head: Person,
@@ -112,10 +112,10 @@ fn main() {
     println!("Original department: {:?}", department);
 
     // Department -> Record<serde_json::Value> -> Department
-    let dept_record: Record<serde_json::Value> = department.into_record();
+    let dept_record: Record<serde_json::Value> = department.clone().into_record();
     println!("\nDepartment -> Record<serde_json::Value>: SUCCESS");
 
-    let dept_back: Result<Department, _> = Department::try_from_record(&dept_record);
+    let dept_back: Result<Department, _> = Department::from_record(dept_record);
     match dept_back {
         Ok(d) => {
             println!("Record<serde_json::Value> -> Department: SUCCESS");

--- a/vantage-types/persistence/Cargo.toml
+++ b/vantage-types/persistence/Cargo.toml
@@ -13,4 +13,3 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
-vantage-core = { path = "../../vantage-core" }

--- a/vantage-types/src/type_system.rs
+++ b/vantage-types/src/type_system.rs
@@ -130,35 +130,3 @@ macro_rules! vantage_type_system {
         }
     };
 }
-
-/// Adds Into/From implementations for specific structs with Record conversions
-///
-/// Use this for specific struct types to avoid orphan rules
-#[macro_export]
-macro_rules! vantage_record_conversions {
-    ($struct_name:ty, $trait_name:ident, $value_type:ty) => {
-        paste::paste! {
-            // Into implementations for specific struct
-            impl Into<vantage_types::Record<[<Any $trait_name>]>> for $struct_name {
-                fn into(self) -> vantage_types::Record<[<Any $trait_name>]> {
-                    self.[<to_ $trait_name:lower _record>]()
-                }
-            }
-
-            impl Into<vantage_types::Record<$value_type>> for $struct_name {
-                fn into(self) -> vantage_types::Record<$value_type> {
-                    self.[<to_ $trait_name:lower _values>]()
-                }
-            }
-
-            // TryFrom for reverse conversion
-            impl TryFrom<vantage_types::Record<[<Any $trait_name>]>> for $struct_name {
-                type Error = vantage_core::VantageError;
-
-                fn try_from(value: vantage_types::Record<[<Any $trait_name>]>) -> vantage_core::Result<Self> {
-                    Self::[<from_ $trait_name:lower _record>](value)
-                }
-            }
-        }
-    };
-}

--- a/vantage-types/tests/optionals.rs
+++ b/vantage-types/tests/optionals.rs
@@ -1,5 +1,5 @@
 use url::Url;
-use vantage_types::{persistence, vantage_type_system};
+use vantage_types::{persistence, vantage_type_system, IntoRecord, TryFromRecord};
 
 // Generate Type3 system using the macro with None type for optionals
 vantage_type_system! {
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_record_with_optionals() {
-        #[derive(PartialEq, Eq, Debug)]
+        #[derive(PartialEq, Eq, Debug, Clone)]
         #[persistence(Type3)]
         struct UserRecord {
             name: String,
@@ -175,8 +175,8 @@ mod tests {
             email: Email::new("john", "example.com"),
         };
 
-        let values = record_with_nick.to_type3_map();
-        let restored = UserRecord::from_type3_map(values).unwrap();
+        let values: vantage_types::Record<AnyType3> = record_with_nick.clone().into_record();
+        let restored = UserRecord::from_record(values).unwrap();
         assert_eq!(record_with_nick, restored);
 
         // Test with None nickname
@@ -186,7 +186,7 @@ mod tests {
             email: Email::new("jane", "example.com"),
         };
 
-        let values_none = record_no_nick.to_type3_map();
+        let values_none: vantage_types::Record<AnyType3> = record_no_nick.clone().into_record();
         let cborize = values_none
             .into_iter()
             .map(|(k, v)| (k, v.value().clone()))
@@ -198,7 +198,7 @@ mod tests {
         );
 
         // Test round-trip with None
-        let restored_none = UserRecord::from_type3_map(cborize).unwrap();
+        let restored_none = UserRecord::from_record(cborize.into()).unwrap();
         assert_eq!(record_no_nick, restored_none);
     }
 }

--- a/vantage-types/tests/type3.rs
+++ b/vantage-types/tests/type3.rs
@@ -1,5 +1,5 @@
 use url::Url;
-use vantage_types::{persistence, vantage_type_system};
+use vantage_types::{persistence, vantage_type_system, IntoRecord, TryFromRecord};
 
 // Generate Type3 system using the macro
 vantage_type_system! {
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn test1_record() {
-        #[derive(PartialEq, Eq, Debug)]
+        #[derive(PartialEq, Eq, Debug, Clone)]
         #[persistence(Type3)]
         struct Record {
             name: String,
@@ -148,7 +148,7 @@ mod tests {
             email: Email::new("user", "example.com"),
         };
 
-        let values = record.to_type3_map();
+        let values: vantage_types::Record<AnyType3> = record.clone().into_record();
         assert_eq!(
             values.get("name").unwrap().type_variant(),
             Some(Type3Variants::String),
@@ -163,7 +163,7 @@ mod tests {
         );
 
         // Test round-trip conversion
-        let value = Record::from_type3_map(values).unwrap();
+        let value = Record::from_record(values).unwrap();
         assert_eq!(
             value,
             Record {


### PR DESCRIPTION
In `vantage-types`, every type system (`AnyType3`, `AnySurrealType`, `AnyPostgresType`, ...) used to come with its own pair of conversion methods — `to_type3_map()` / `from_type3_map()`, `to_surrealtype_map()` / `from_surrealtype_map()`, and so on. The `#[persistence]` macro generated them, each returning a bare `IndexMap`. After #124's `IntoRecord` / `TryFromRecord` traits covered the same ground generically, the per-system shape was duplicate work.

```rust
// before
let values: IndexMap<String, AnyType3> = user.to_type3_map();
let restored = User::from_type3_map(values).unwrap();

// after
let values: Record<AnyType3> = user.into_record();
let restored = User::from_record(values).unwrap();
```

`#[persistence]` now emits `IntoRecord` / `TryFromRecord` directly. `vantage_record_conversions!`, the glue between the two surfaces, moves to `deprecated/record_conversions.rs` as a stub so anyone hunting for the old name lands somewhere with a pointer.

`Record::from_serializable` / `to_deserializable` got inlined into the serde blanket impls — each had exactly one caller. Tests, examples, and the README pick up the new names across the same lines. One assertion in `decimal_json` flipped from `is_none()` to `is_err()` to match the new error path.