### PR TITLE
implement expressions fully in sqlite.

### DIFF
--- a/NEW_PERSISTENCE_GUIDE.md
+++ b/NEW_PERSISTENCE_GUIDE.md
@@ -204,13 +204,35 @@ because there's no variant to check — it just asks "can JSON number 42 be read
 
 Also test `Option<T>` fields, null handling, and missing fields.
 
+### TryFrom<AnyType> for common types
+
+You also need `TryFrom<AnyType>` implementations for scalar types and Records.
+These are used later by `AssociatedExpression::get()` in Step 2, but they belong
+here because they're part of the type system:
+
+```rust
+// Scalars — extract single value from single-row results
+impl TryFrom<AnySqliteType> for i64 { ... }
+impl TryFrom<AnySqliteType> for String { ... }
+// etc.
+
+// Records — extract first row from result array
+impl TryFrom<AnySqliteType> for Record<AnySqliteType> { ... }
+impl TryFrom<AnySqliteType> for Record<serde_json::Value> { ... }
+```
+
+For scalars, if the result is a single-row, single-column array like `[{"COUNT(*)": 3}]`,
+extract the value automatically. For Records, extract the first row and wrap each
+field as an untyped `AnyType`.
+
 ### Step 1 conclusion
 
 At this point you should have:
 
 1. **Type impls** in `src/<backend>/types/` — the `vantage_type_system!` macro call,
-   trait implementations for each Rust type, `From` conversions on `AnyType`, and
-   variant detection in `TypeVariants::from_*()`.
+   trait implementations for each Rust type, `From` conversions on `AnyType`,
+   variant detection in `TypeVariants::from_*()`, and `TryFrom<AnyType>` for
+   scalars and Records.
 
 2. **Tests** in `tests/<backend>/1_types_round_trip.rs` covering:
    - In-memory `AnyType` round-trips for each supported type
@@ -255,147 +277,180 @@ Reading:  sqlx → Record<AnySqliteType> (untyped) → try_get / serde → Struc
 ```
 
 
-## Step 2: Implement ExprDataSource
+## Step 2: Make expressions work
 
-The expression system is how vantage builds and executes queries without knowing
-which database you're talking to. An `Expression<T>` is a template string with `{}`
-placeholders and a list of typed parameters. The type parameter `T` is your `AnyType`
-— this is what makes the type markers from Step 1 flow through to binding.
+With the type system in place, you can now use `Expression<AnySqliteType>` to build
+and execute queries. This step has two deliverables: a convenience macro and the
+`ExprDataSource` trait implementation.
 
-### Create a vendor-specific expression macro
+### The vendor macro
 
-Each backend defines a convenience macro that produces `Expression<AnyType>`. Vantage
-already ships `surreal_expr!` for SurrealDB. For SQLite, we define `sqlite_expr!`:
-
-```rust
-#[macro_export]
-macro_rules! sqlite_expr {
-    ($template:expr) => {
-        Expression::<AnySqliteType>::new($template, vec![])
-    };
-    ($template:expr, $($param:tt),*) => {
-        Expression::<AnySqliteType>::new(
-            $template,
-            vec![ $(vantage_expressions::expr_param!($param)),* ]
-        )
-    };
-}
-```
-
-The `expr_param!` helper handles the three kinds of parameters:
-- bare value like `42i64` → `ExpressiveEnum::Scalar(42i64.into())`
-- parenthesized expression like `(sub_expr)` → `ExpressiveEnum::Nested(sub_expr.expr())`
-- braced deferred like `{deferred_fn}` → `ExpressiveEnum::Deferred(...)`
-
-Now building expressions is clean:
+Define a macro that produces `Expression<YourAnyType>`. SurrealDB has `surreal_expr!`,
+we create `sqlite_expr!`:
 
 ```rust
-// Simple query — parameters carry type markers automatically
 let expr = sqlite_expr!("SELECT * FROM product WHERE price > {}", 100i64);
-
-// The 100i64 becomes AnySqliteType with Integer variant,
-// which bind_sqlite_value() uses to call query.bind(100i64)
 ```
 
-There's also `sql_expr!` which produces `Expression<serde_json::Value>` — the untyped
-variant. That's used by statement builders (Step 3) where types are inferred from
-context. For `ExprDataSource::execute()`, always use the typed variant.
+Under the hood, `100i64` gets wrapped as `AnySqliteType::new(100i64)` with variant
+`Integer`. When this expression hits the database, the bind layer knows to call
+`query.bind(100i64)` — not `query.bind("100")` or `query.bind(100.0)`.
 
-### Expressions compose
+The macro handles three kinds of parameters:
+- `42i64` → scalar with type marker
+- `(sub_expr)` → nested expression (composed into the template)
+- `{deferred}` → lazy evaluation (resolved at execution time)
 
-Expressions nest naturally. Each sub-expression keeps its own parameters with their
-type markers intact:
+### ExprDataSource
+
+Implement `DataSource` (marker) and `ExprDataSource<AnySqliteType>` on your DB struct.
+The `execute` method takes an expression, flattens nested sub-expressions, converts
+`{}` placeholders to your driver's syntax (`?N` for SQLite, `$N` for Postgres), binds
+parameters using type markers, and returns results.
+
+Results come back as `AnySqliteType` with `type_variant: None` — the database doesn't
+preserve our markers, so results are permissive (see Step 1). For SQLite that's
+especially natural since it doesn't distinguish boolean from integer on the wire.
+
+If the persistence layer you're implementing *does* preserve type information in
+responses (like SurrealDB with CBOR tags), set the correct `type_variant` when
+constructing result values in your `execute()` implementation. That way `try_get`
+enforces type boundaries on both sides of the round-trip.
+
+### Validating with INSERT expressions
+
+The best way to test this is INSERT + SELECT round-trips. A single insert exercises
+all the pieces — macro, parameter binding, type markers, and result parsing:
 
 ```rust
-// Build rows as nested expressions, each with typed parameters
-let row1 = sqlite_expr!("({}, {}, {})", "cupcake", 120i64, false);
-let row2 = sqlite_expr!("({}, {}, {})", "tart", 220i64, false);
+let insert = sqlite_expr!(
+    "INSERT INTO product (id, name, price, is_deleted) VALUES ({}, {}, {}, {})",
+    "cupcake", "Flux Cupcake", 120i64, false
+);
+db.execute(&insert).await?;
 
-// Combine into a single INSERT — Expression::from_vec joins with ", "
+let select = sqlite_expr!("SELECT * FROM product WHERE id = {}", "cupcake");
+let result = db.execute(&select).await?;
+```
+
+Nested expressions let you build multi-row inserts from composable parts:
+
+```rust
+let row1 = sqlite_expr!("({}, {}, {}, {})", "tart", "Time Tart", 220i64, false);
+let row2 = sqlite_expr!("({}, {}, {}, {})", "pie", "Sea Pie", 299i64, true);
+
+// Expression::from_vec joins sub-expressions with a delimiter
 let rows = Expression::from_vec(vec![row1, row2], ", ");
+
+// Nest into the INSERT — flattener resolves everything into a single query
 let insert = Expression::<AnySqliteType>::new(
-    "INSERT INTO product (name, price, is_deleted) VALUES {}",
+    "INSERT INTO product (id, name, price, is_deleted) VALUES {}",
     vec![ExpressiveEnum::Nested(rows)],
 );
-
 db.execute(&insert).await?;
 ```
 
-When executed, the `ExpressionFlattener` collapses all nesting into a flat template
-with only scalar parameters — safe for positional binding.
+The `ExpressionFlattener` collapses all nesting into one flat template with positional
+parameters — each one still carrying its type marker for correct binding.
 
-### What you need to implement
+### Deferring: cross-database value resolution
 
-Two traits on your DB struct:
+Sometimes a query on one database needs a value from another database. That's what
+`defer()` is for — it wraps a query as a closure that executes later, when the outer
+query runs.
+
+This is not a subquery. The deferred query runs first, produces a concrete value, and
+that value gets bound as a regular parameter in the outer query.
 
 ```rust
-impl DataSource for SqliteDB {}  // just a marker
+let (config_db, shop_db) = setup().await;
 
-impl ExprDataSource<AnySqliteType> for SqliteDB {
-    async fn execute(&self, expr: &Expression<AnySqliteType>) -> Result<AnySqliteType> {
-        // 1. Flatten nested expressions
-        // 2. Convert {} placeholders to your driver's bind syntax (?N for SQLite)
-        // 3. Bind the scalar parameters using type-aware bind_sqlite_value()
-        // 4. Execute and convert rows back to AnySqliteType
-    }
+// This doesn't execute yet — it's a closure
+let threshold_query = sqlite_expr!("SELECT value FROM config WHERE key = {}", "min_price");
+let deferred_threshold = config_db.defer(threshold_query);
 
-    fn defer(&self, expr: Expression<AnySqliteType>) -> DeferredFn<AnySqliteType> {
-        // Return a closure that calls execute() later — used for lazy evaluation
-    }
-}
+// Use the deferred value as a parameter in a different database
+let shop_query = Expression::<AnySqliteType>::new(
+    "SELECT name FROM product WHERE price >= {} ORDER BY price",
+    vec![ExpressiveEnum::Deferred(deferred_threshold)],
+);
+
+// When shop_db.execute() runs:
+// 1. Resolves the deferred → calls config_db, gets 150
+// 2. Replaces the Deferred param with Scalar(150)
+// 3. Flattens and binds: SELECT name FROM product WHERE price >= ?1
+let result = shop_db.execute(&shop_query).await?;
 ```
 
-The key helper is `prepare_typed_query` — it flattens the expression and converts
-`{}` placeholders to your driver's syntax:
+Your `execute()` implementation needs to resolve deferred parameters before flattening.
+Walk the parameter list, call `.call().await` on any `Deferred`, and leave `Scalar`
+and `Nested` untouched.
+
+The resolved value comes back as an untyped `AnySqliteType` (no variant marker), so
+it gets bound via JSON-inference. For SQLite this is fine — the loose type system
+handles it. For stricter databases, you may want `defer()` to preserve type
+information from the source query's result.
+
+### Reading query results
+
+So far we've been calling `db.execute(&expr).await` which returns `AnySqliteType`.
+For a SELECT query, that value wraps a JSON array of row objects. To work with
+individual rows, you convert into Records:
 
 ```rust
-fn prepare_typed_query(expr: &Expression<AnySqliteType>) -> (String, Vec<AnySqliteType>) {
-    let flattener = ExpressionFlattener::new();
-    let flattened = flattener.flatten(expr);
-    // Walk the template, replace each {} with ?1, ?2, ...
-    // Collect scalar AnySqliteType values in order
-    (sql_string, params)
-}
-```
+let result = db.execute(&sqlite_expr!("SELECT * FROM product")).await?;
 
-Each database driver has its own placeholder syntax. SQLite and MySQL use `?N`,
-Postgres uses `$N`, SurrealDB uses `$_argN`. The flattener doesn't care — it just
-gives you a flat list of scalars and a template.
-
-Then the bind step uses the type markers from Step 1:
-
-```rust
-fn bind_sqlite_value(query, value: &AnySqliteType) -> ... {
-    match value.type_variant() {
-        Some(SqliteTypeVariants::Integer) => query.bind(value.as_i64()),
-        Some(SqliteTypeVariants::Text) => query.bind(value.as_str()),
-        Some(SqliteTypeVariants::Real) => query.bind(value.as_f64()),
-        // ...
-    }
-}
-```
-
-### Reading results back
-
-`ExprDataSource::execute()` returns an `AnySqliteType`. For queries that return rows,
-this wraps a JSON array of objects. To get typed structs out:
-
-```rust
-let result = db.execute(&sqlite_expr!("SELECT * FROM product WHERE id = {}", "cupcake")).await?;
-
-// Unwrap the array
-let rows = match result.into_value() {
-    serde_json::Value::Array(arr) => arr,
-    _ => panic!("expected array"),
+// Result is AnySqliteType wrapping [{"id":"a","name":"Cheap","price":50}, ...]
+// Convert to records manually:
+let rows: Vec<JsonValue> = match result.into_value() {
+    JsonValue::Array(arr) => arr,
+    _ => panic!("expected rows"),
 };
+let record: Record<JsonValue> = rows[0].clone().into();
+```
 
-// Each row → Record → struct via serde
-let record: Record<serde_json::Value> = rows[0].clone().into();
+That works but it's verbose. The `TryFrom<AnyType>` impls from Step 1 make this
+cleaner through `AssociatedExpression`. When you call `db.associate::<R>(expr)`,
+you get an expression that knows its return type — `.get()` executes and converts
+in one step:
+
+```rust
+// Scalar — extracts single value from single-row result
+let count = db.associate::<i64>(sqlite_expr!("SELECT COUNT(*) FROM product"));
+assert_eq!(count.get().await?, 3);
+
+// Record — extracts first row
+let record: Record<JsonValue> = db
+    .associate(sqlite_expr!("SELECT * FROM product WHERE id = {}", "c"))
+    .get().await?;
+```
+
+From a Record, you can deserialize into a struct. For the `#[entity]` path:
+
+```rust
+#[entity(SqliteType)]
+struct Product { id: String, name: String, price: i64 }
+
+let record: Record<AnySqliteType> = db
+    .associate(sqlite_expr!("SELECT * FROM product WHERE id = {}", "c"))
+    .get().await?;
+let product = Product::from_record(record)?;
+```
+
+Or for the serde path with `Record<JsonValue>`:
+
+```rust
+#[derive(Deserialize)]
+struct Product { id: String, name: String, price: i64 }
+
+let record: Record<JsonValue> = db
+    .associate(sqlite_expr!("SELECT * FROM product WHERE id = {}", "c"))
+    .get().await?;
 let product: Product = Product::from_record(record)?;
 ```
 
-Remember the asymmetry from Step 1: writing uses `AnySqliteType` (type-aware binding),
-reading returns `Record<serde_json::Value>` (struct validates types via serde).
+Testing the failure modes (missing fields, NULL into required field, wrong types)
+can help spot issues in your implementation.
 
 ### Step 2 conclusion
 
@@ -408,8 +463,8 @@ At this point you should have:
    `ExprDataSource<AnyType>` with `execute()` and `defer()`.
 
 3. **Tests** in `tests/<backend>/2_*.rs` covering:
-   - SELECT with parameterized queries (each type)
    - INSERT with typed parameters, read back and verify
-   - Nested expressions (compose sub-expressions, execute as one query)
+   - Multi-row INSERT using nested expressions and `from_vec`
    - Type marker verification (bool binds as bool, not as string "true")
-   - Empty result sets
+   - Cross-database deferred value resolution
+   - AssociatedExpression with scalar, Record, and entity results

--- a/vantage-sql/src/sqlite/impls/expr_data_source.rs
+++ b/vantage-sql/src/sqlite/impls/expr_data_source.rs
@@ -1,6 +1,6 @@
 use serde_json::Value as JsonValue;
 use vantage_expressions::traits::expressive::DeferredFn;
-use vantage_expressions::{Expression, ExpressionFlattener, Flatten};
+use vantage_expressions::{ExpressiveEnum, Expression, ExpressionFlattener, Flatten};
 
 use crate::sqlite::types::AnySqliteType;
 use crate::sqlite::SqliteDB;
@@ -11,8 +11,13 @@ impl vantage_expressions::ExprDataSource<AnySqliteType> for SqliteDB {
         &self,
         expr: &Expression<AnySqliteType>,
     ) -> vantage_core::Result<AnySqliteType> {
-        let (sql, params) = prepare_typed_query(expr);
+        // 1. Resolve deferred parameters (async — may call other databases)
+        let resolved = resolve_deferred(expr).await?;
 
+        // 2. Flatten nested expressions + convert {} to ?N
+        let (sql, params) = prepare_typed_query(&resolved);
+
+        // 3. Bind and execute
         let mut query = sqlx::query(&sql);
         for value in &params {
             query = bind_sqlite_value(query, value);
@@ -23,13 +28,11 @@ impl vantage_expressions::ExprDataSource<AnySqliteType> for SqliteDB {
             .await
             .map_err(|e| vantage_core::error!("SQLite query failed", details = e.to_string()))?;
 
-        // Each row becomes a Record<AnySqliteType> (marker-less values).
-        // We wrap the whole result as a JSON array → AnySqliteType with type_variant: None.
+        // 4. Convert rows to AnySqliteType (untyped — type_variant: None)
         let arr: Vec<JsonValue> = rows
             .iter()
             .map(|row| {
                 let record = row_to_record(row);
-                // Convert Record<AnySqliteType> → JSON object by extracting inner values
                 let json_map: serde_json::Map<String, JsonValue> = record
                     .into_iter()
                     .map(|(k, v)| (k, v.into_value()))
@@ -39,8 +42,6 @@ impl vantage_expressions::ExprDataSource<AnySqliteType> for SqliteDB {
             .collect();
 
         let json_arr = JsonValue::Array(arr);
-        // from_json on an array → type_variant: None (not in our variant list)
-        // This is intentional — the result is an opaque container, not a typed value.
         Ok(AnySqliteType::from_json(&json_arr)
             .expect("JSON array should always convert to AnySqliteType"))
     }
@@ -51,10 +52,46 @@ impl vantage_expressions::ExprDataSource<AnySqliteType> for SqliteDB {
             let db = db.clone();
             let expr = expr.clone();
             Box::pin(async move {
-                vantage_expressions::ExprDataSource::execute(&db, &expr).await
+                let result = vantage_expressions::ExprDataSource::execute(&db, &expr).await?;
+                // execute() returns rows as a JSON array. For use as a deferred
+                // parameter (scalar subquery), extract the first column of the
+                // first row. If the result is empty or not an array, return as-is.
+                let scalar = match result.value() {
+                    serde_json::Value::Array(arr) => {
+                        arr.first()
+                            .and_then(|row| row.as_object())
+                            .and_then(|obj| obj.values().next())
+                            .map(|v| AnySqliteType::untyped(v.clone()))
+                            .unwrap_or(result)
+                    }
+                    _ => result,
+                };
+                Ok(scalar)
             })
         })
     }
+}
+
+/// Resolve all Deferred parameters in an expression by calling them.
+/// Deferred closures may execute queries on other databases.
+async fn resolve_deferred(
+    expr: &Expression<AnySqliteType>,
+) -> vantage_core::Result<Expression<AnySqliteType>> {
+    let mut resolved_params = Vec::new();
+
+    for param in &expr.parameters {
+        match param {
+            ExpressiveEnum::Deferred(deferred_fn) => {
+                let result = deferred_fn.call().await?;
+                resolved_params.push(result);
+            }
+            other => {
+                resolved_params.push(other.clone());
+            }
+        }
+    }
+
+    Ok(Expression::new(expr.template.clone(), resolved_params))
 }
 
 /// Flatten an Expression<AnySqliteType> and convert `{}` placeholders to `?N`.
@@ -73,16 +110,16 @@ fn prepare_typed_query(
 
     for (i, param) in flattened.parameters.iter().enumerate() {
         match param {
-            vantage_expressions::ExpressiveEnum::Scalar(value) => {
+            ExpressiveEnum::Scalar(value) => {
                 param_counter += 1;
                 sql.push_str(&format!("?{}", param_counter));
                 params.push(value.clone());
             }
-            vantage_expressions::ExpressiveEnum::Nested(_) => {
+            ExpressiveEnum::Nested(_) => {
                 panic!("nested expression should have been flattened");
             }
-            vantage_expressions::ExpressiveEnum::Deferred(_) => {
-                panic!("deferred expression should have been resolved");
+            ExpressiveEnum::Deferred(_) => {
+                panic!("deferred expression should have been resolved before prepare");
             }
         }
 

--- a/vantage-sql/src/sqlite/row.rs
+++ b/vantage-sql/src/sqlite/row.rs
@@ -22,7 +22,9 @@ pub(crate) fn bind_sqlite_value<'q>(
 ) -> sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
     let json = value.value();
     match value.type_variant() {
-        Some(SqliteTypeVariants::Null) | None => query.bind(None::<String>),
+        Some(SqliteTypeVariants::Null) => query.bind(None::<String>),
+        // Untyped values (from deferred results, database reads) — infer from JSON
+        None => bind_by_json(query, json),
         Some(SqliteTypeVariants::Bool) => {
             match json {
                 JsonValue::Number(n) => query.bind(n.as_i64().unwrap_or(0) != 0),
@@ -60,6 +62,29 @@ pub(crate) fn bind_sqlite_value<'q>(
                 .unwrap_or("");
             query.bind(s)
         }
+    }
+}
+
+/// Bind a JSON value without type variant — infers the bind type from the value itself.
+/// Used for untyped values (deferred results, database reads).
+fn bind_by_json<'q>(
+    query: sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>>,
+    json: &'q JsonValue,
+) -> sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
+    match json {
+        JsonValue::Null => query.bind(None::<String>),
+        JsonValue::Bool(b) => query.bind(*b),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                query.bind(i)
+            } else if let Some(f) = n.as_f64() {
+                query.bind(f)
+            } else {
+                query.bind(n.to_string())
+            }
+        }
+        JsonValue::String(s) => query.bind(s.as_str()),
+        other => query.bind(other.to_string()),
     }
 }
 

--- a/vantage-sql/src/sqlite/types/value.rs
+++ b/vantage-sql/src/sqlite/types/value.rs
@@ -89,6 +89,87 @@ impl Expressive<AnySqliteType> for &str {
     }
 }
 
+// TryFrom<AnySqliteType> impls — enables AssociatedExpression::get()
+//
+// If the value is a single-row, single-column result (common for COUNT, MAX, etc.),
+// extracts the scalar automatically. Otherwise falls back to try_get.
+macro_rules! impl_try_from_sqlite {
+    ($($ty:ty),*) => {
+        $(
+            impl TryFrom<AnySqliteType> for $ty {
+                type Error = vantage_core::VantageError;
+                fn try_from(val: AnySqliteType) -> Result<Self, Self::Error> {
+                    // Try direct extraction first
+                    if let Some(v) = val.try_get::<$ty>() {
+                        return Ok(v);
+                    }
+                    // If result is [{col: value}], extract the scalar
+                    if let serde_json::Value::Array(arr) = val.value() {
+                        if arr.len() == 1 {
+                            if let Some(obj) = arr[0].as_object() {
+                                if obj.len() == 1 {
+                                    let inner = AnySqliteType::untyped(
+                                        obj.values().next().unwrap().clone()
+                                    );
+                                    if let Some(v) = inner.try_get::<$ty>() {
+                                        return Ok(v);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(vantage_core::error!(
+                        "Cannot convert AnySqliteType to target type",
+                        target = std::any::type_name::<$ty>(),
+                        value = format!("{}", val)
+                    ))
+                }
+            }
+        )*
+    };
+}
+
+impl_try_from_sqlite!(i64, i32, f64, bool, String);
+
+/// Extract first row from a result array as a JSON object.
+/// Used by TryFrom impls for Record and serde structs.
+fn extract_first_row(val: &AnySqliteType) -> Option<serde_json::Value> {
+    match val.value() {
+        serde_json::Value::Array(arr) => arr.first().cloned(),
+        // Already a single object (shouldn't happen from execute, but handle it)
+        obj @ serde_json::Value::Object(_) => Some(obj.clone()),
+        _ => None,
+    }
+}
+
+impl TryFrom<AnySqliteType> for vantage_types::Record<serde_json::Value> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnySqliteType) -> Result<Self, Self::Error> {
+        let row = extract_first_row(&val).ok_or_else(|| {
+            vantage_core::error!("Expected row result", value = format!("{}", val))
+        })?;
+        Ok(row.into())
+    }
+}
+
+impl TryFrom<AnySqliteType> for vantage_types::Record<AnySqliteType> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnySqliteType) -> Result<Self, Self::Error> {
+        let row = extract_first_row(&val).ok_or_else(|| {
+            vantage_core::error!("Expected row result", value = format!("{}", val))
+        })?;
+        // Convert JSON object → Record<AnySqliteType> with untyped values
+        match row {
+            serde_json::Value::Object(map) => {
+                Ok(map.into_iter()
+                    .map(|(k, v)| (k, AnySqliteType::untyped(v)))
+                    .collect())
+            }
+            _ => Err(vantage_core::error!("Expected object row", value = format!("{:?}", row))),
+        }
+    }
+}
+
 impl Expressive<AnySqliteType> for AnySqliteType {
     fn expr(&self) -> Expression<AnySqliteType> {
         Expression::new(

--- a/vantage-sql/tests/sqlite.rs
+++ b/vantage-sql/tests/sqlite.rs
@@ -7,6 +7,12 @@ mod sqlite {
     mod expressions;
     #[path = "2_insert.rs"]
     mod insert;
+    #[path = "2_defer.rs"]
+    mod defer;
+    #[path = "2_records.rs"]
+    mod records;
+    #[path = "2_associated.rs"]
+    mod associated;
     mod bakery;
     mod statements;
 }

--- a/vantage-sql/tests/sqlite/2_associated.rs
+++ b/vantage-sql/tests/sqlite/2_associated.rs
@@ -1,0 +1,100 @@
+//! Test 2d: AssociatedExpression — expressions with a known return type.
+//!
+//! Call .get() to execute and get a typed result. Works out of the box
+//! once ExprDataSource and TryFrom<AnySqliteType> are in place.
+
+use vantage_expressions::ExprDataSource;
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+#[allow(unused_imports)]
+use vantage_sql::sqlite::SqliteType;
+use vantage_sql::sqlite_expr;
+use vantage_types::{Record, TryFromRecord, entity};
+
+async fn setup() -> SqliteDB {
+    let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+
+    sqlx::query(
+        "CREATE TABLE product (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            price INTEGER NOT NULL
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let insert = sqlite_expr!(
+        "INSERT INTO product VALUES ({}, {}, {}), ({}, {}, {}), ({}, {}, {})",
+        "a", "Cheap", 50i64,
+        "b", "Mid", 150i64,
+        "c", "Expensive", 300i64
+    );
+    db.execute(&insert).await.unwrap();
+
+    db
+}
+
+#[entity(SqliteType)]
+struct Product {
+    id: String,
+    name: String,
+    price: i64,
+}
+
+#[tokio::test]
+async fn test_associated_scalar() {
+    let db = setup().await;
+
+    let associated = db.associate::<i64>(sqlite_expr!("SELECT COUNT(*) FROM product"));
+    assert_eq!(associated.get().await.unwrap(), 3);
+}
+
+#[tokio::test]
+async fn test_associated_record() {
+    let db = setup().await;
+
+    let associated = db.associate::<Record<AnySqliteType>>(
+        sqlite_expr!("SELECT name, price FROM product WHERE id = {}", "a"),
+    );
+    let record = associated.get().await.unwrap();
+    assert_eq!(record["name"].try_get::<String>(), Some("Cheap".to_string()));
+    assert_eq!(record["price"].try_get::<i64>(), Some(50));
+}
+
+#[tokio::test]
+async fn test_associated_entity() {
+    let db = setup().await;
+
+    let associated = db.associate::<Record<AnySqliteType>>(
+        sqlite_expr!("SELECT id, name, price FROM product WHERE id = {}", "c"),
+    );
+    let record = associated.get().await.unwrap();
+    let product = Product::from_record(record).unwrap();
+    assert_eq!(product.id, "c");
+    assert_eq!(product.name, "Expensive");
+    assert_eq!(product.price, 300);
+}
+
+// serde path: Record<JsonValue> + #[derive(Deserialize)]
+#[tokio::test]
+async fn test_associated_entity_serde() {
+    let db = setup().await;
+
+    #[derive(serde::Deserialize)]
+    struct ProductSerde {
+        id: String,
+        name: String,
+        price: i64,
+    }
+
+    let record: Record<serde_json::Value> = db
+        .associate(sqlite_expr!("SELECT id, name, price FROM product WHERE id = {}", "b"))
+        .get()
+        .await
+        .unwrap();
+    let product: ProductSerde = ProductSerde::from_record(record).unwrap();
+    assert_eq!(product.id, "b");
+    assert_eq!(product.name, "Mid");
+    assert_eq!(product.price, 150);
+}

--- a/vantage-sql/tests/sqlite/2_defer.rs
+++ b/vantage-sql/tests/sqlite/2_defer.rs
@@ -1,0 +1,100 @@
+//! Test 2b: Deferred expressions — cross-database value resolution.
+//!
+//! A deferred expression runs a query on one database at execution time,
+//! and the resulting value gets placed as a parameter in another database's
+//! query. This is NOT a subquery — the deferred query executes first,
+//! produces a concrete value, and that value gets bound into the outer query.
+
+use serde_json::Value as JsonValue;
+use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_sql::sqlite_expr;
+
+fn rows(result: AnySqliteType) -> Vec<JsonValue> {
+    match result.into_value() {
+        JsonValue::Array(arr) => arr,
+        other => panic!("expected array, got: {:?}", other),
+    }
+}
+
+async fn setup() -> (SqliteDB, SqliteDB) {
+    let config_db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+    let shop_db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+
+    // Config database: stores thresholds
+    sqlx::query("CREATE TABLE config (key TEXT PRIMARY KEY, value INTEGER NOT NULL)")
+        .execute(config_db.pool())
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO config VALUES ('min_price', 150)")
+        .execute(config_db.pool())
+        .await
+        .unwrap();
+
+    // Shop database: stores products
+    sqlx::query(
+        "CREATE TABLE product (id TEXT PRIMARY KEY, name TEXT NOT NULL, price INTEGER NOT NULL)",
+    )
+    .execute(shop_db.pool())
+    .await
+    .unwrap();
+
+    let insert = sqlite_expr!(
+        "INSERT INTO product VALUES ({}, {}, {}), ({}, {}, {}), ({}, {}, {})",
+        "a", "Cheap Thing", 50i64,
+        "b", "Mid Thing", 150i64,
+        "c", "Expensive Thing", 300i64
+    );
+    shop_db.execute(&insert).await.unwrap();
+
+    (config_db, shop_db)
+}
+
+// ── defer() resolves a value from one DB, binds it into another ────────────
+
+#[tokio::test]
+async fn test_cross_database_deferred() {
+    let (config_db, shop_db) = setup().await;
+
+    // defer() on config_db: at execution time, runs the query and extracts
+    // the scalar value (150). That value gets bound into the shop_db query.
+    let threshold_query = sqlite_expr!("SELECT value FROM config WHERE key = {}", "min_price");
+    let deferred_threshold = config_db.defer(threshold_query);
+
+    let shop_query = Expression::<AnySqliteType>::new(
+        "SELECT name FROM product WHERE price >= {} ORDER BY price",
+        vec![ExpressiveEnum::Deferred(deferred_threshold)],
+    );
+
+    // shop_db.execute() resolves the deferred first (calls config_db),
+    // gets 150, then runs: SELECT name FROM product WHERE price >= 150
+    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0]["name"], "Mid Thing");
+    assert_eq!(result[1]["name"], "Expensive Thing");
+}
+
+// ── Deferred mixed with regular scalar parameters ──────────────────────────
+
+#[tokio::test]
+async fn test_deferred_mixed_with_scalars() {
+    let (config_db, shop_db) = setup().await;
+
+    let threshold_query = sqlite_expr!("SELECT value FROM config WHERE key = {}", "min_price");
+    let deferred_threshold = config_db.defer(threshold_query);
+
+    let shop_query = Expression::<AnySqliteType>::new(
+        "SELECT name FROM product WHERE price >= {} AND name != {} ORDER BY price",
+        vec![
+            ExpressiveEnum::Deferred(deferred_threshold),
+            ExpressiveEnum::Scalar(AnySqliteType::new("Mid Thing".to_string())),
+        ],
+    );
+
+    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+
+    // 150 threshold, excluding "Mid Thing" → only "Expensive Thing"
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0]["name"], "Expensive Thing");
+}

--- a/vantage-sql/tests/sqlite/2_records.rs
+++ b/vantage-sql/tests/sqlite/2_records.rs
@@ -1,0 +1,157 @@
+//! Test 2c: SELECT into Record and deserialize into structs.
+//!
+//! Uses associate::<Record<JsonValue>> and TryFromRecord to verify
+//! the full pipeline. Includes failure cases for field mismatches.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use vantage_expressions::ExprDataSource;
+use vantage_sql::sqlite::SqliteDB;
+use vantage_sql::sqlite_expr;
+use vantage_types::{Record, TryFromRecord};
+
+async fn setup() -> SqliteDB {
+    let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+
+    sqlx::query(
+        "CREATE TABLE product (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            price INTEGER NOT NULL,
+            calories INTEGER NOT NULL,
+            weight REAL,
+            is_deleted BOOLEAN NOT NULL DEFAULT 0,
+            description TEXT
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let insert = sqlite_expr!(
+        "INSERT INTO product VALUES ({}, {}, {}, {}, {}, {}, {}), ({}, {}, {}, {}, {}, {}, {})",
+        "cupcake", "Flux Cupcake", 120i64, 300i64, 0.25f64, false, "A tasty cupcake",
+        "tart", "Time Tart", 220i64, 200i64, 0.15f64, true, "tart"
+    );
+    db.execute(&insert).await.unwrap();
+
+    sqlx::query("INSERT INTO product (id, name, price, calories, is_deleted) VALUES ('plain', 'Plain Bread', 50, 150, 0)")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    db
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+struct Product {
+    id: String,
+    name: String,
+    price: i64,
+    calories: i64,
+    weight: Option<f64>,
+    is_deleted: bool,
+    description: Option<String>,
+}
+
+#[tokio::test]
+async fn test_select_single_record_into_entity() {
+    let db = setup().await;
+
+    let record: Record<JsonValue> = db
+        .associate(sqlite_expr!("SELECT * FROM product WHERE id = {}", "cupcake"))
+        .get()
+        .await
+        .unwrap();
+
+    let product: Product = Product::from_record(record).unwrap();
+    assert_eq!(product.name, "Flux Cupcake");
+    assert_eq!(product.price, 120);
+    assert!((product.weight.unwrap() - 0.25).abs() < f64::EPSILON);
+    assert_eq!(product.description, Some("A tasty cupcake".to_string()));
+    assert!(!product.is_deleted);
+}
+
+#[tokio::test]
+async fn test_null_into_optional_field() {
+    let db = setup().await;
+
+    let record: Record<JsonValue> = db
+        .associate(sqlite_expr!("SELECT name, price, weight, description FROM product WHERE id = {}", "plain"))
+        .get()
+        .await
+        .unwrap();
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct ProductOptional {
+        name: String,
+        price: i64,
+        weight: Option<f64>,
+        description: Option<String>,
+    }
+
+    let product: ProductOptional = ProductOptional::from_record(record).unwrap();
+    assert_eq!(product.name, "Plain Bread");
+    assert_eq!(product.weight, None);
+    assert_eq!(product.description, None);
+}
+
+#[tokio::test]
+async fn test_missing_field_fails() {
+    let db = setup().await;
+
+    let record: Record<JsonValue> = db
+        .associate(sqlite_expr!("SELECT * FROM product WHERE id = {}", "cupcake"))
+        .get()
+        .await
+        .unwrap();
+
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    struct ProductWithRating {
+        name: String,
+        rating: f64, // doesn't exist
+    }
+
+    assert!(ProductWithRating::from_record(record).is_err());
+}
+
+#[tokio::test]
+async fn test_null_into_required_field_fails() {
+    let db = setup().await;
+
+    let record: Record<JsonValue> = db
+        .associate(sqlite_expr!("SELECT name, weight FROM product WHERE id = {}", "plain"))
+        .get()
+        .await
+        .unwrap();
+
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    struct Strict {
+        name: String,
+        weight: f64, // NOT Option — plain has NULL here
+    }
+
+    assert!(Strict::from_record(record).is_err());
+}
+
+#[tokio::test]
+async fn test_wrong_field_type_fails() {
+    let db = setup().await;
+
+    let record: Record<JsonValue> = db
+        .associate(sqlite_expr!("SELECT name, price FROM product WHERE id = {}", "cupcake"))
+        .get()
+        .await
+        .unwrap();
+
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    struct WrongTypes {
+        name: i64,     // TEXT in DB
+        price: String, // INTEGER in DB
+    }
+
+    assert!(WrongTypes::from_record(record).is_err());
+}


### PR DESCRIPTION
In `vantage-sql/sqlite`, PR #163 landed the type system (`AnySqliteType`, the variant table, `From` impls) but expressions weren't actually executable yet. This finishes Step 2 of `NEW_PERSISTENCE_GUIDE.md`: `SqliteDB` now resolves deferred parameters, binds untyped values from result sets and cross-database `defer()` payloads, and exposes `db.associate::<T>(expr).get()` for typed scalar / `Record` / entity reads.

Nothing here breaks a vantage user's code — `vantage-sql` is still pre-release, listed under "What's coming next" in the README. If you're already poking at it, the surfaces (`sqlite_expr!`, `SqliteDB::execute` / `defer` / `associate`) match the equivalent SurrealDB ones.

```rust
let count = db.associate::<i64>(sqlite_expr!("SELECT COUNT(*) FROM product"));
assert_eq!(count.get().await?, 3);

// cross-DB: threshold from config_db, query on shop_db, single await
let deferred = config_db.defer(sqlite_expr!("SELECT value FROM config WHERE key = {}", "min_price"));
shop_db.execute(&Expression::<AnySqliteType>::new(
    "SELECT name FROM product WHERE price >= {}",
    vec![ExpressiveEnum::Deferred(deferred)],
)).await?;
```

### Why deferred values come back untyped

SQLite's storage classes don't separate `BOOL` from `INTEGER`, so query results carry `type_variant: None`. Rather than guess a marker, `bind_sqlite_value` grew a JSON-shape inference path (`bind_by_json`) for any value the database hands back — including `defer()` results from a stricter persistence. For Postgres or SurrealDB you'll want `execute()` to preserve the source variant; the trait surface allows it, SQLite just doesn't need it.

### Still missing for SQLite

Step 3 — `Selectable` integration so `Table<E, SqliteDB>` actually compiles — is next. The `statements` module is in the tree but not wired through `SelectSource`.