### PR TITLE
implement complex queries

### DIFF
--- a/NEW_PERSISTENCE_GUIDE.md
+++ b/NEW_PERSISTENCE_GUIDE.md
@@ -586,12 +586,14 @@ This approach has two advantages. First, you don't over-design — you only add 
 need. Second, every new feature ships with a test that proves it works against a real database, not
 just string comparison.
 
-As you proceed - you can add new structs, for example "CASE" can be implemented as SqliteCase. Make
-sure it implements `Expressive` and then it can be used inside your queries.
-
-The select builder does not require to validate query logic during build, it only need to render.
-Most methods will accept either scalar values or other expressions. A good time to look into
-ExpressiveOr and use it for argument types in your query builder.
+When your queries outgrow what the select struct offers directly, extract **primitives** and
+**nested structs** rather than bloating the builder. For example, `Identifier` (in
+`vantage-sql/src/primitives/`) handles qualified column names (`"u"."name"`) and aliases — it
+implements `Expressive<T>` so it plugs straight into expressions. Similarly, `SqliteSelectJoin`
+lives inside the select module and renders its own `INNER JOIN ... ON ...` clause. The select struct
+just holds a `Vec<SqliteSelectJoin>` and calls `render()` on each one. This pattern — small struct
+with `Expressive` impl, composed into the builder — scales to CASE, CTE, window specs, and anything
+else without the select struct growing unbounded.
 
 ### Other statements
 

--- a/vantage-expressions/src/expression/macros.rs
+++ b/vantage-expressions/src/expression/macros.rs
@@ -73,6 +73,7 @@ macro_rules! expr_param {
     // If expr implements Expressive, convert it to Expression first
     (($expr:expr)) => {
         $crate::traits::expressive::ExpressiveEnum::Nested({
+            #[allow(unused_imports)]
             use $crate::traits::expressive::Expressive;
             $expr.expr()
         })

--- a/vantage-expressions/src/mocks/select.rs
+++ b/vantage-expressions/src/mocks/select.rs
@@ -3,9 +3,11 @@
 //! This module provides a minimalistic mock implementation of the Selectable trait
 //! that uses the expr! macro pattern for building queries.
 
-use crate::traits::expressive::ExpressiveEnum;
+use crate::traits::expressive::{Expressive, ExpressiveEnum};
 use crate::traits::selectable::{Selectable, SourceRef};
 use crate::{Expression, expr};
+
+type Value = serde_json::Value;
 
 /// Minimalistic mock implementation of Selectable trait
 ///
@@ -141,25 +143,25 @@ impl Selectable<serde_json::Value> for MockSelect {
 
     fn add_expression(
         &mut self,
-        _expression: Expression<serde_json::Value>,
+        _expression: impl Expressive<Value>,
         _alias: Option<String>,
     ) {
-        panic!("You may only use field() wihis mock")
+        panic!("You may only use field() in this mock")
     }
 
-    fn add_where_condition(&mut self, condition: Expression<serde_json::Value>) {
-        self.where_conditions.push(condition);
+    fn add_where_condition(&mut self, condition: impl Expressive<Value>) {
+        self.where_conditions.push(condition.expr());
     }
 
     fn set_distinct(&mut self, distinct: bool) {
         self.distinct = distinct;
     }
 
-    fn add_order_by(&mut self, expression: Expression<serde_json::Value>, ascending: bool) {
-        self.order_by.push((expression, ascending));
+    fn add_order_by(&mut self, expression: impl Expressive<Value>, ascending: bool) {
+        self.order_by.push((expression.expr(), ascending));
     }
 
-    fn add_group_by(&mut self, _expression: Expression<serde_json::Value>) {
+    fn add_group_by(&mut self, _expression: impl Expressive<Value>) {
         // Not implemented in minimal version
     }
 
@@ -217,7 +219,7 @@ impl Selectable<serde_json::Value> for MockSelect {
         expr!("SELECT COUNT(*) FROM {}", source)
     }
 
-    fn as_sum(&self, column: Expression<serde_json::Value>) -> Expression<serde_json::Value> {
+    fn as_sum(&self, column: impl Expressive<Value>) -> Expression<Value> {
         let source = self.source.as_ref().unwrap().as_str();
         expr!("SELECT SUM({}) FROM {}", (column), source)
     }

--- a/vantage-expressions/src/traits/selectable.rs
+++ b/vantage-expressions/src/traits/selectable.rs
@@ -15,82 +15,39 @@ use crate::{Expression, ExpressiveEnum};
 /// The trait supports both mutable builder methods and fluent chainable methods.
 pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
     /// Sets the data source for the query (table name, subquery, etc.).
-    ///
-    /// Implementation should store the source and optionally an alias. The generated
-    /// query should include this in the FROM clause (SQL) or equivalent construct.
-    /// If called multiple times, behavior is implementation-defined (replace or join).
     fn set_source(&mut self, source: impl Into<SourceRef<T>>, alias: Option<String>);
 
     /// Adds a column name to the SELECT clause.
-    ///
-    /// Implementation should append this field to the list of selected columns.
-    /// Multiple calls should accumulate fields. The field will be rendered as-is
-    /// in the query (e.g., `SELECT field1, field2 FROM table`).
     fn add_field(&mut self, field: impl Into<String>);
 
     /// Adds a complex expression to the SELECT clause with optional alias.
-    ///
-    /// Implementation should append this expression to the selected fields.
-    /// If alias is provided, render as `expression AS alias`. This allows
-    /// calculated fields, function calls, or subqueries in the SELECT clause.
-    fn add_expression(&mut self, expression: Expression<T>, alias: Option<String>);
+    fn add_expression(&mut self, expression: impl Expressive<T>, alias: Option<String>);
 
     /// Adds a condition to the WHERE clause.
-    ///
-    /// Implementation should append this condition to existing WHERE conditions,
-    /// typically joining with AND. Multiple calls should accumulate conditions
-    /// (e.g., `WHERE cond1 AND cond2 AND cond3`).
-    fn add_where_condition(&mut self, condition: Expression<T>);
+    fn add_where_condition(&mut self, condition: impl Expressive<T>);
 
     /// Sets whether the query should return distinct results.
-    ///
-    /// Implementation should add DISTINCT keyword (or equivalent) to the query
-    /// when `distinct` is true, remove it when false. Should affect the entire
-    /// result set to eliminate duplicate rows.
     fn set_distinct(&mut self, distinct: bool);
 
     /// Adds an ORDER BY clause with direction.
-    ///
-    /// Implementation should append to existing ordering clauses. Multiple calls
-    /// should accumulate (e.g., `ORDER BY expr1 ASC, expr2 DESC`). The `ascending`
-    /// parameter controls sort direction (true = ASC, false = DESC).
-    fn add_order_by(&mut self, expression: Expression<T>, ascending: bool);
+    fn add_order_by(&mut self, expression: impl Expressive<T>, ascending: bool);
 
     /// Adds a GROUP BY clause.
-    ///
-    /// Implementation should append to existing GROUP BY expressions. Multiple
-    /// calls should accumulate (e.g., `GROUP BY expr1, expr2`). Used for
-    /// aggregation queries and typically requires aggregate functions in SELECT.
-    fn add_group_by(&mut self, expression: Expression<T>);
+    fn add_group_by(&mut self, expression: impl Expressive<T>);
 
     /// Sets LIMIT and OFFSET for result pagination.
-    ///
-    /// Implementation should configure result limiting. `limit` controls maximum
-    /// rows returned, `skip` controls how many rows to skip (offset). Both None
-    /// means no limit. Only limit means limit without offset.
     fn set_limit(&mut self, limit: Option<i64>, skip: Option<i64>);
 
     /// Removes all fields from the SELECT clause.
-    ///
-    /// Implementation should clear the field list, typically resulting in
-    /// SELECT * behavior if no fields remain.
     fn clear_fields(&mut self);
 
     /// Removes all WHERE conditions.
-    ///
-    /// Implementation should clear all WHERE clause conditions, resulting
-    /// in an unfiltered query.
     fn clear_where_conditions(&mut self);
 
     /// Removes all ORDER BY clauses.
-    ///
-    /// Implementation should clear ordering, resulting in database-default
-    /// result ordering.
     fn clear_order_by(&mut self);
 
     /// Removes all GROUP BY clauses.
-    ///
-    /// Implementation should clear grouping, converting back to non-aggregated query.
     fn clear_group_by(&mut self);
 
     /// Returns true if any fields have been added to SELECT clause.
@@ -115,18 +72,10 @@ pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
     fn get_skip(&self) -> Option<i64>;
 
     /// Creates a COUNT(*) expression from this query configuration.
-    ///
-    /// Implementation should generate a query that counts matching rows instead
-    /// of returning the actual data. Typically wraps the current query or
-    /// converts SELECT fields to COUNT(*).
     fn as_count(&self) -> Expression<T>;
 
     /// Creates a SUM(column) expression from this query configuration.
-    ///
-    /// Implementation should generate a query that sums the specified column
-    /// for all matching rows. Should preserve WHERE conditions but typically
-    /// ignore field selections.
-    fn as_sum(&self, column: Expression<T>) -> Expression<T>;
+    fn as_sum(&self, column: impl Expressive<T>) -> Expression<T>;
 
     // Default implementations for builder-style methods
 
@@ -149,7 +98,7 @@ pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
     }
 
     /// Builder pattern method identical to [`Self::add_where_condition`].
-    fn with_condition(mut self, condition: Expression<T>) -> Self
+    fn with_condition(mut self, condition: impl Expressive<T>) -> Self
     where
         Self: Sized,
     {
@@ -158,7 +107,7 @@ pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
     }
 
     /// Builder pattern method identical to [`Self::add_order_by`].
-    fn with_order(mut self, expression: Expression<T>, ascending: bool) -> Self
+    fn with_order(mut self, expression: impl Expressive<T>, ascending: bool) -> Self
     where
         Self: Sized,
     {
@@ -176,11 +125,29 @@ pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
     }
 
     /// Builder pattern method identical to [`Self::add_expression`].
-    fn with_expression(mut self, expression: Expression<T>, alias: Option<String>) -> Self
+    fn with_expression(mut self, expression: impl Expressive<T>, alias: Option<String>) -> Self
     where
         Self: Sized,
     {
         Self::add_expression(&mut self, expression, alias);
+        self
+    }
+
+    /// Builder pattern method identical to [`Self::add_group_by`].
+    fn with_group_by(mut self, expression: impl Expressive<T>) -> Self
+    where
+        Self: Sized,
+    {
+        Self::add_group_by(&mut self, expression);
+        self
+    }
+
+    /// Builder pattern method identical to [`Self::set_distinct`].
+    fn with_distinct(mut self, distinct: bool) -> Self
+    where
+        Self: Sized,
+    {
+        Self::set_distinct(&mut self, distinct);
         self
     }
 
@@ -195,11 +162,6 @@ pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
 }
 
 /// A flexible type for source references that can be converted from various types.
-///
-/// `SourceRef` wraps different source types (strings, expressions) into a unified
-/// format that can be used with the [`Selectable`] trait. It automatically converts
-/// table names, subqueries, and other source references into the appropriate
-/// [`ExpressiveEnum`] format for database-specific query builders.
 pub struct SourceRef<T>(ExpressiveEnum<T>);
 
 impl<T> SourceRef<T> {

--- a/vantage-sql/src/lib.rs
+++ b/vantage-sql/src/lib.rs
@@ -1,2 +1,4 @@
+pub mod primitives;
+
 #[cfg(feature = "sqlite")]
 pub mod sqlite;

--- a/vantage-sql/src/primitives/case.rs
+++ b/vantage-sql/src/primitives/case.rs
@@ -1,0 +1,85 @@
+use std::fmt::{Debug, Display};
+
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+/// SQL CASE expression: `CASE WHEN cond THEN val ... ELSE val END`.
+///
+/// # Examples
+///
+/// ```ignore
+/// Case::new()
+///     .when(sqlite_expr!("{} >= {}", (Identifier::new("salary")), 100000.0f64), sqlite_expr!("{}", "senior"))
+///     .when(sqlite_expr!("{} >= {}", (Identifier::new("salary")), 60000.0f64), sqlite_expr!("{}", "mid"))
+///     .else_(sqlite_expr!("{}", "intern"))
+///     .with_alias("band")
+/// ```
+#[derive(Debug, Clone)]
+pub struct Case<T: Debug + Display + Clone> {
+    branches: Vec<(Expression<T>, Expression<T>)>,
+    else_branch: Option<Expression<T>>,
+    alias: Option<String>,
+}
+
+impl<T: Debug + Display + Clone> Case<T> {
+    pub fn new() -> Self {
+        Self {
+            branches: Vec::new(),
+            else_branch: None,
+            alias: None,
+        }
+    }
+
+    pub fn when(mut self, condition: impl Expressive<T>, then: impl Expressive<T>) -> Self {
+        self.branches.push((condition.expr(), then.expr()));
+        self
+    }
+
+    pub fn else_(mut self, value: impl Expressive<T>) -> Self {
+        self.else_branch = Some(value.expr());
+        self
+    }
+
+    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
+        self.alias = Some(alias.into());
+        self
+    }
+}
+
+impl<T: Debug + Display + Clone> Expressive<T> for Case<T> {
+    fn expr(&self) -> Expression<T> {
+        let mut parts: Vec<Expression<T>> = Vec::new();
+        for (cond, then) in &self.branches {
+            parts.push(Expression::new(
+                " WHEN {} THEN {}",
+                vec![
+                    ExpressiveEnum::Nested(cond.clone()),
+                    ExpressiveEnum::Nested(then.clone()),
+                ],
+            ));
+        }
+
+        let branches_expr = Expression::from_vec(parts, "");
+
+        let base = match &self.else_branch {
+            Some(else_val) => Expression::new(
+                "CASE{} ELSE {} END",
+                vec![
+                    ExpressiveEnum::Nested(branches_expr),
+                    ExpressiveEnum::Nested(else_val.clone()),
+                ],
+            ),
+            None => Expression::new(
+                "CASE{} END",
+                vec![ExpressiveEnum::Nested(branches_expr)],
+            ),
+        };
+
+        match &self.alias {
+            Some(alias) => Expression::new(
+                format!("{{}} AS \"{}\"", alias),
+                vec![ExpressiveEnum::Nested(base)],
+            ),
+            None => base,
+        }
+    }
+}

--- a/vantage-sql/src/primitives/fx.rs
+++ b/vantage-sql/src/primitives/fx.rs
@@ -1,0 +1,62 @@
+use std::fmt::{Debug, Display};
+
+use vantage_core::util::IntoVec;
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+/// SQL function call: `NAME(arg1, arg2, ...)`.
+///
+/// The function name is automatically uppercased. Arguments are expressions
+/// that get rendered comma-separated inside the parentheses.
+///
+/// # Examples
+///
+/// ```ignore
+/// use vantage_sql::primitives::fx::Fx;
+///
+/// // Single arg: SUM("o"."total")
+/// Fx::new("sum", [Identifier::with_dot("o", "total").expr()])
+///
+/// // Multiple args: COALESCE(SUM("o"."total"), 0.0)
+/// Fx::new("coalesce", [
+///     Fx::new("sum", [Identifier::with_dot("o", "total").expr()]).expr(),
+///     sqlite_expr!("{}", 0.0f64),
+/// ])
+/// ```
+#[derive(Debug, Clone)]
+pub struct Fx<T: Debug + Display + Clone> {
+    name: String,
+    args: Vec<Expression<T>>,
+    alias: Option<String>,
+}
+
+impl<T: Debug + Display + Clone> Fx<T> {
+    pub fn new(name: impl Into<String>, args: impl IntoVec<Expression<T>>) -> Self {
+        Self {
+            name: name.into().to_uppercase(),
+            args: args.into_vec(),
+            alias: None,
+        }
+    }
+
+    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
+        self.alias = Some(alias.into());
+        self
+    }
+}
+
+impl<T: Debug + Display + Clone> Expressive<T> for Fx<T> {
+    fn expr(&self) -> Expression<T> {
+        let args_expr = Expression::from_vec(self.args.clone(), ", ");
+        let base = Expression::new(
+            format!("{}({{}})", self.name),
+            vec![ExpressiveEnum::Nested(args_expr)],
+        );
+        match &self.alias {
+            Some(alias) => Expression::new(
+                format!("{{}} AS \"{}\"", alias),
+                vec![ExpressiveEnum::Nested(base)],
+            ),
+            None => base,
+        }
+    }
+}

--- a/vantage-sql/src/primitives/identifier.rs
+++ b/vantage-sql/src/primitives/identifier.rs
@@ -1,0 +1,69 @@
+use vantage_expressions::{Expression, Expressive};
+
+/// SQL identifier with proper double-quote escaping and optional alias.
+///
+/// Handles single identifiers (`"name"`), qualified names (`"u"."name"`),
+/// and aliased expressions (`"name" AS "alias"`).
+///
+/// # Examples
+///
+/// ```ignore
+/// use vantage_sql::primitives::identifier::Identifier;
+///
+/// // Simple column
+/// let id = Identifier::new("name");            // "name"
+///
+/// // Qualified (table.column)
+/// let id = Identifier::with_dot("u", "name");  // "u"."name"
+///
+/// // With alias
+/// let id = Identifier::with_dot("d", "name")
+///     .with_alias("department_name");           // "d"."name" AS "department_name"
+/// ```
+#[derive(Debug, Clone)]
+pub struct Identifier {
+    parts: Vec<String>,
+    alias: Option<String>,
+}
+
+impl Identifier {
+    /// Single identifier: renders as `"name"`.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            parts: vec![name.into()],
+            alias: None,
+        }
+    }
+
+    /// Qualified identifier: renders as `"prefix"."name"`.
+    pub fn with_dot(prefix: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            parts: vec![prefix.into(), name.into()],
+            alias: None,
+        }
+    }
+
+    /// Adds an AS alias: `... AS "alias"`.
+    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
+        self.alias = Some(alias.into());
+        self
+    }
+
+    fn render_parts(&self) -> String {
+        self.parts
+            .iter()
+            .map(|p| format!("\"{}\"", p))
+            .collect::<Vec<_>>()
+            .join(".")
+    }
+}
+
+impl<T> Expressive<T> for Identifier {
+    fn expr(&self) -> Expression<T> {
+        let sql = match &self.alias {
+            Some(alias) => format!("{} AS \"{}\"", self.render_parts(), alias),
+            None => self.render_parts(),
+        };
+        Expression::new(sql, vec![])
+    }
+}

--- a/vantage-sql/src/primitives/iif.rs
+++ b/vantage-sql/src/primitives/iif.rs
@@ -1,0 +1,63 @@
+use std::fmt::{Debug, Display};
+
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+/// SQL IIF(condition, true_val, false_val) expression.
+///
+/// # Examples
+///
+/// ```ignore
+/// Iif::new(
+///     sqlite_expr!("{} = {}", (Identifier::new("role")), "admin"),
+///     sqlite_expr!("{}", "Yes"),
+///     sqlite_expr!("{}", "No"),
+/// ).with_alias("is_admin")
+/// ```
+#[derive(Debug, Clone)]
+pub struct Iif<T: Debug + Display + Clone> {
+    condition: Expression<T>,
+    true_val: Expression<T>,
+    false_val: Expression<T>,
+    alias: Option<String>,
+}
+
+impl<T: Debug + Display + Clone> Iif<T> {
+    pub fn new(
+        condition: impl Expressive<T>,
+        true_val: impl Expressive<T>,
+        false_val: impl Expressive<T>,
+    ) -> Self {
+        Self {
+            condition: condition.expr(),
+            true_val: true_val.expr(),
+            false_val: false_val.expr(),
+            alias: None,
+        }
+    }
+
+    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
+        self.alias = Some(alias.into());
+        self
+    }
+}
+
+impl<T: Debug + Display + Clone> Expressive<T> for Iif<T> {
+    fn expr(&self) -> Expression<T> {
+        let base = Expression::new(
+            "IIF({}, {}, {})",
+            vec![
+                ExpressiveEnum::Nested(self.condition.clone()),
+                ExpressiveEnum::Nested(self.true_val.clone()),
+                ExpressiveEnum::Nested(self.false_val.clone()),
+            ],
+        );
+
+        match &self.alias {
+            Some(alias) => Expression::new(
+                format!("{{}} AS \"{}\"", alias),
+                vec![ExpressiveEnum::Nested(base)],
+            ),
+            None => base,
+        }
+    }
+}

--- a/vantage-sql/src/primitives/mod.rs
+++ b/vantage-sql/src/primitives/mod.rs
@@ -1,0 +1,6 @@
+pub mod case;
+pub mod fx;
+pub mod identifier;
+pub mod iif;
+pub mod select;
+pub mod union;

--- a/vantage-sql/src/primitives/select/mod.rs
+++ b/vantage-sql/src/primitives/select/mod.rs
@@ -1,0 +1,1 @@
+pub mod window;

--- a/vantage-sql/src/primitives/select/window.rs
+++ b/vantage-sql/src/primitives/select/window.rs
@@ -1,0 +1,132 @@
+use std::fmt::{Debug, Display};
+
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+/// SQL window specification for window functions.
+///
+/// # Examples
+///
+/// ```ignore
+/// let win = Window::new()
+///     .partition_by(Identifier::with_dot("u", "department_id"))
+///     .order_by(Identifier::with_dot("u", "salary"), false);
+///
+/// // Inline: SUM(u.salary) OVER (PARTITION BY ... ORDER BY ... DESC)
+/// win.apply(Fx::new("sum", [Identifier::with_dot("u", "salary").expr()]))
+///
+/// // Named reference: ROW_NUMBER() OVER win
+/// Window::named("win").apply(Fx::new("row_number", []))
+/// ```
+#[derive(Debug, Clone)]
+pub struct Window<T: Debug + Display + Clone> {
+    partition_by: Vec<Expression<T>>,
+    order_by: Vec<(Expression<T>, bool)>,
+    frame: Option<String>,
+    named_ref: Option<String>,
+}
+
+impl<T: Debug + Display + Clone> Window<T> {
+    pub fn new() -> Self {
+        Self {
+            partition_by: Vec::new(),
+            order_by: Vec::new(),
+            frame: None,
+            named_ref: None,
+        }
+    }
+
+    /// Reference a named window defined in WINDOW clause.
+    pub fn named(name: impl Into<String>) -> Self {
+        Self {
+            partition_by: Vec::new(),
+            order_by: Vec::new(),
+            frame: None,
+            named_ref: Some(name.into()),
+        }
+    }
+
+    pub fn partition_by(mut self, expr: impl Expressive<T>) -> Self {
+        self.partition_by.push(expr.expr());
+        self
+    }
+
+    pub fn order_by(mut self, expr: impl Expressive<T>, ascending: bool) -> Self {
+        self.order_by.push((expr.expr(), ascending));
+        self
+    }
+
+    pub fn rows(mut self, from: &str, to: &str) -> Self {
+        self.frame = Some(format!("ROWS BETWEEN {} AND {}", from, to));
+        self
+    }
+
+    pub fn range(mut self, from: &str, to: &str) -> Self {
+        self.frame = Some(format!("RANGE BETWEEN {} AND {}", from, to));
+        self
+    }
+
+    /// Apply a function over this window: `expr OVER (spec)` or `expr OVER name`.
+    pub fn apply(&self, func: impl Expressive<T>) -> Expression<T> {
+        Expression::new(
+            "{} OVER {}",
+            vec![
+                ExpressiveEnum::Nested(func.expr()),
+                ExpressiveEnum::Nested(self.spec_expr()),
+            ],
+        )
+    }
+
+    /// Render the window spec — either a named reference or inline `(...)`.
+    fn spec_expr(&self) -> Expression<T> {
+        if let Some(name) = &self.named_ref {
+            return Expression::new(name.clone(), vec![]);
+        }
+
+        let mut parts: Vec<Expression<T>> = Vec::new();
+
+        if !self.partition_by.is_empty() {
+            parts.push(Expression::new(
+                "PARTITION BY {}",
+                vec![ExpressiveEnum::Nested(Expression::from_vec(
+                    self.partition_by.clone(),
+                    ", ",
+                ))],
+            ));
+        }
+
+        if !self.order_by.is_empty() {
+            let order_parts: Vec<Expression<T>> = self
+                .order_by
+                .iter()
+                .map(|(expr, asc)| {
+                    if *asc {
+                        expr.clone()
+                    } else {
+                        Expression::new(
+                            "{} DESC",
+                            vec![ExpressiveEnum::Nested(expr.clone())],
+                        )
+                    }
+                })
+                .collect();
+            parts.push(Expression::new(
+                "ORDER BY {}",
+                vec![ExpressiveEnum::Nested(Expression::from_vec(
+                    order_parts, ", ",
+                ))],
+            ));
+        }
+
+        if let Some(frame) = &self.frame {
+            parts.push(Expression::new(frame.clone(), vec![]));
+        }
+
+        let inner = Expression::from_vec(parts, " ");
+        Expression::new("({})", vec![ExpressiveEnum::Nested(inner)])
+    }
+
+    /// Render just the definition part (for WINDOW clause): `(PARTITION BY ... ORDER BY ...)`
+    pub fn definition(&self) -> Expression<T> {
+        self.spec_expr()
+    }
+}

--- a/vantage-sql/src/primitives/union.rs
+++ b/vantage-sql/src/primitives/union.rs
@@ -1,0 +1,81 @@
+use std::fmt::{Debug, Display};
+
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+#[derive(Debug, Clone)]
+enum CompoundOp {
+    Union,
+    UnionAll,
+    Except,
+    Intersect,
+}
+
+impl CompoundOp {
+    fn as_str(&self) -> &'static str {
+        match self {
+            CompoundOp::Union => " UNION ",
+            CompoundOp::UnionAll => " UNION ALL ",
+            CompoundOp::Except => " EXCEPT ",
+            CompoundOp::Intersect => " INTERSECT ",
+        }
+    }
+}
+
+/// Compound query: combines multiple SELECT statements with UNION / UNION ALL / EXCEPT / INTERSECT.
+///
+/// # Examples
+///
+/// ```ignore
+/// Union::new(first_select)
+///     .union_all(second_select)
+///     .except(third_select)
+/// ```
+#[derive(Debug, Clone)]
+pub struct Union<T: Debug + Display + Clone> {
+    first: Expression<T>,
+    rest: Vec<(CompoundOp, Expression<T>)>,
+}
+
+impl<T: Debug + Display + Clone> Union<T> {
+    pub fn new(first: impl Expressive<T>) -> Self {
+        Self {
+            first: first.expr(),
+            rest: Vec::new(),
+        }
+    }
+
+    pub fn union(mut self, query: impl Expressive<T>) -> Self {
+        self.rest.push((CompoundOp::Union, query.expr()));
+        self
+    }
+
+    pub fn union_all(mut self, query: impl Expressive<T>) -> Self {
+        self.rest.push((CompoundOp::UnionAll, query.expr()));
+        self
+    }
+
+    pub fn except(mut self, query: impl Expressive<T>) -> Self {
+        self.rest.push((CompoundOp::Except, query.expr()));
+        self
+    }
+
+    pub fn intersect(mut self, query: impl Expressive<T>) -> Self {
+        self.rest.push((CompoundOp::Intersect, query.expr()));
+        self
+    }
+}
+
+impl<T: Debug + Display + Clone> Expressive<T> for Union<T> {
+    fn expr(&self) -> Expression<T> {
+        let mut params = vec![ExpressiveEnum::Nested(self.first.clone())];
+        let mut template = String::from("{}");
+
+        for (op, query) in &self.rest {
+            template.push_str(op.as_str());
+            template.push_str("{}");
+            params.push(ExpressiveEnum::Nested(query.clone()));
+        }
+
+        Expression::new(template, params)
+    }
+}

--- a/vantage-sql/src/sqlite/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/sqlite/statements/select/impls/selectable.rs
@@ -1,5 +1,5 @@
 use vantage_expressions::traits::selectable::{Selectable, SourceRef};
-use vantage_expressions::{Expression, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
 use crate::sqlite::types::AnySqliteType;
 use crate::sqlite::statements::SqliteSelect;
@@ -12,7 +12,6 @@ impl Selectable<AnySqliteType> for SqliteSelect {
         let source_ref = source.into().into_expressive_enum();
         let expr = match (source_ref, alias) {
             (ExpressiveEnum::Scalar(val), None) => {
-                // Table name as string → quote it
                 Expression::new(
                     format!("\"{}\"", val.try_get::<String>().unwrap_or_default()),
                     vec![],
@@ -41,31 +40,32 @@ impl Selectable<AnySqliteType> for SqliteSelect {
             .push(Expression::new(format!("\"{}\"", field.into()), vec![]));
     }
 
-    fn add_expression(&mut self, expression: Expr, alias: Option<String>) {
+    fn add_expression(&mut self, expression: impl Expressive<AnySqliteType>, alias: Option<String>) {
+        let expr = expression.expr();
         let field = match alias {
             Some(a) => Expression::new(
                 format!("{{}} AS \"{}\"", a),
-                vec![ExpressiveEnum::Nested(expression)],
+                vec![ExpressiveEnum::Nested(expr)],
             ),
-            None => expression,
+            None => expr,
         };
         self.fields.push(field);
     }
 
-    fn add_where_condition(&mut self, condition: Expr) {
-        self.where_conditions.push(condition);
+    fn add_where_condition(&mut self, condition: impl Expressive<AnySqliteType>) {
+        self.where_conditions.push(condition.expr());
     }
 
     fn set_distinct(&mut self, distinct: bool) {
         self.distinct = distinct;
     }
 
-    fn add_order_by(&mut self, expression: Expr, ascending: bool) {
-        self.order_by.push((expression, ascending));
+    fn add_order_by(&mut self, expression: impl Expressive<AnySqliteType>, ascending: bool) {
+        self.order_by.push((expression.expr(), ascending));
     }
 
-    fn add_group_by(&mut self, expression: Expr) {
-        self.group_by.push(expression);
+    fn add_group_by(&mut self, expression: impl Expressive<AnySqliteType>) {
+        self.group_by.push(expression.expr());
     }
 
     fn set_limit(&mut self, limit: Option<i64>, skip: Option<i64>) {
@@ -125,12 +125,12 @@ impl Selectable<AnySqliteType> for SqliteSelect {
         count_select.render()
     }
 
-    fn as_sum(&self, column: Expr) -> Expr {
+    fn as_sum(&self, column: impl Expressive<AnySqliteType>) -> Expr {
         let mut sum_select = self.clone();
         sum_select.fields.clear();
         sum_select.fields.push(Expression::new(
             "SUM({})",
-            vec![ExpressiveEnum::Nested(column)],
+            vec![ExpressiveEnum::Nested(column.expr())],
         ));
         sum_select.order_by.clear();
         sum_select.render()

--- a/vantage-sql/src/sqlite/statements/select/join.rs
+++ b/vantage-sql/src/sqlite/statements/select/join.rs
@@ -1,0 +1,80 @@
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::sqlite::types::AnySqliteType;
+
+type Expr = Expression<AnySqliteType>;
+
+#[derive(Debug, Clone)]
+pub enum SqliteJoinType {
+    Inner,
+    Left,
+    Right,
+}
+
+impl SqliteJoinType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            SqliteJoinType::Inner => "INNER JOIN",
+            SqliteJoinType::Left => "LEFT JOIN",
+            SqliteJoinType::Right => "RIGHT JOIN",
+        }
+    }
+}
+
+/// A JOIN clause for SqliteSelect.
+#[derive(Debug, Clone)]
+pub struct SqliteSelectJoin {
+    join_type: SqliteJoinType,
+    table: Expr,
+    on_condition: Expr,
+}
+
+impl SqliteSelectJoin {
+    fn new(join_type: SqliteJoinType, table: Expr, on_condition: Expr) -> Self {
+        Self { join_type, table, on_condition }
+    }
+
+    fn table_expr(table: impl Into<String>, alias: impl Into<String>) -> Expr {
+        Expression::new(
+            format!("\"{}\" AS \"{}\"", table.into(), alias.into()),
+            vec![],
+        )
+    }
+
+    fn subquery_expr(subquery: impl Expressive<AnySqliteType>, alias: impl Into<String>) -> Expr {
+        Expression::new(
+            format!("({{}}) AS \"{}\"", alias.into()),
+            vec![ExpressiveEnum::Nested(subquery.expr())],
+        )
+    }
+
+    /// INNER JOIN on a named table.
+    pub fn inner(table: impl Into<String>, alias: impl Into<String>, on_condition: Expr) -> Self {
+        Self::new(SqliteJoinType::Inner, Self::table_expr(table, alias), on_condition)
+    }
+
+    /// LEFT JOIN on a named table.
+    pub fn left(table: impl Into<String>, alias: impl Into<String>, on_condition: Expr) -> Self {
+        Self::new(SqliteJoinType::Left, Self::table_expr(table, alias), on_condition)
+    }
+
+    /// INNER JOIN on a subquery/expression.
+    pub fn inner_expr(subquery: impl Expressive<AnySqliteType>, alias: impl Into<String>, on_condition: Expr) -> Self {
+        Self::new(SqliteJoinType::Inner, Self::subquery_expr(subquery, alias), on_condition)
+    }
+
+    /// LEFT JOIN on a subquery/expression.
+    pub fn left_expr(subquery: impl Expressive<AnySqliteType>, alias: impl Into<String>, on_condition: Expr) -> Self {
+        Self::new(SqliteJoinType::Left, Self::subquery_expr(subquery, alias), on_condition)
+    }
+
+    pub fn render(&self) -> Expr {
+        Expression::new(
+            format!(" {} {{}} ON {{}}", self.join_type.as_str()),
+            vec![
+                ExpressiveEnum::Nested(self.table.clone()),
+                ExpressiveEnum::Nested(self.on_condition.clone()),
+            ],
+        )
+    }
+}

--- a/vantage-sql/src/sqlite/statements/select/mod.rs
+++ b/vantage-sql/src/sqlite/statements/select/mod.rs
@@ -1,7 +1,10 @@
 mod impls;
+pub mod join;
 mod render;
 
+use crate::primitives::select::window::Window;
 use crate::sqlite::types::AnySqliteType;
+use join::SqliteSelectJoin;
 use vantage_expressions::Expression;
 
 type Expr = Expression<AnySqliteType>;
@@ -11,9 +14,13 @@ type Expr = Expression<AnySqliteType>;
 pub struct SqliteSelect {
     pub fields: Vec<Expr>,
     pub from: Vec<Expr>,
+    pub joins: Vec<SqliteSelectJoin>,
     pub where_conditions: Vec<Expr>,
     pub order_by: Vec<(Expr, bool)>,
     pub group_by: Vec<Expr>,
+    pub having: Vec<Expr>,
+    pub windows: Vec<(String, Window<AnySqliteType>)>,
+    pub ctes: Vec<(String, Expr, bool)>,
     pub distinct: bool,
     pub limit: Option<i64>,
     pub skip: Option<i64>,
@@ -24,13 +31,44 @@ impl SqliteSelect {
         Self {
             fields: Vec::new(),
             from: Vec::new(),
+            joins: Vec::new(),
             where_conditions: Vec::new(),
             order_by: Vec::new(),
             group_by: Vec::new(),
+            having: Vec::new(),
+            windows: Vec::new(),
+            ctes: Vec::new(),
             distinct: false,
             limit: None,
             skip: None,
         }
+    }
+
+    pub fn with_join(mut self, join: SqliteSelectJoin) -> Self {
+        self.joins.push(join);
+        self
+    }
+
+    pub fn add_having(&mut self, condition: impl vantage_expressions::Expressive<AnySqliteType>) {
+        self.having.push(condition.expr());
+    }
+
+    pub fn with_having(
+        mut self,
+        condition: impl vantage_expressions::Expressive<AnySqliteType>,
+    ) -> Self {
+        self.having.push(condition.expr());
+        self
+    }
+
+    pub fn with_window(mut self, name: impl Into<String>, window: Window<AnySqliteType>) -> Self {
+        self.windows.push((name.into(), window));
+        self
+    }
+
+    pub fn with_cte(mut self, name: impl Into<String>, query: impl vantage_expressions::Expressive<AnySqliteType>, recursive: bool) -> Self {
+        self.ctes.push((name.into(), query.expr(), recursive));
+        self
     }
 }
 

--- a/vantage-sql/src/sqlite/statements/select/render.rs
+++ b/vantage-sql/src/sqlite/statements/select/render.rs
@@ -4,6 +4,15 @@ use crate::sqlite::types::AnySqliteType;
 
 use super::{Expr, SqliteSelect};
 
+fn render_condition_list(conditions: &[Expr], keyword: &str) -> Expr {
+    if conditions.is_empty() {
+        Expression::new("", vec![])
+    } else {
+        let combined = Expression::from_vec(conditions.to_vec(), " AND ");
+        Expression::new(format!(" {} {{}}", keyword), vec![ExpressiveEnum::Nested(combined)])
+    }
+}
+
 impl SqliteSelect {
     fn render_fields(&self) -> Expr {
         if self.fields.is_empty() {
@@ -27,13 +36,21 @@ impl SqliteSelect {
         }
     }
 
-    fn render_where(&self) -> Expr {
-        if self.where_conditions.is_empty() {
+    fn render_joins(&self) -> Expr {
+        if self.joins.is_empty() {
             Expression::new("", vec![])
         } else {
-            let combined = Expression::from_vec(self.where_conditions.clone(), " AND ");
-            Expression::new(" WHERE {}", vec![ExpressiveEnum::Nested(combined)])
+            let parts: Vec<Expr> = self.joins.iter().map(|j| j.render()).collect();
+            Expression::from_vec(parts, "")
         }
+    }
+
+    fn render_where(&self) -> Expr {
+        render_condition_list(&self.where_conditions, "WHERE")
+    }
+
+    fn render_having(&self) -> Expr {
+        render_condition_list(&self.having, "HAVING")
     }
 
     fn render_group_by(&self) -> Expr {
@@ -46,6 +63,27 @@ impl SqliteSelect {
                     self.group_by.clone(),
                     ", ",
                 ))],
+            )
+        }
+    }
+
+    fn render_windows(&self) -> Expr {
+        if self.windows.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            let parts: Vec<Expr> = self
+                .windows
+                .iter()
+                .map(|(name, win)| {
+                    Expression::new(
+                        format!("{} AS {{}}", name),
+                        vec![ExpressiveEnum::Nested(win.definition())],
+                    )
+                })
+                .collect();
+            Expression::new(
+                " WINDOW {}",
+                vec![ExpressiveEnum::Nested(Expression::from_vec(parts, ", "))],
             )
         }
     }
@@ -96,17 +134,44 @@ impl SqliteSelect {
         }
     }
 
+    fn render_ctes(&self) -> Expr {
+        if self.ctes.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            let is_recursive = self.ctes.iter().any(|(_, _, r)| *r);
+            let parts: Vec<Expr> = self
+                .ctes
+                .iter()
+                .map(|(name, query, _)| {
+                    Expression::new(
+                        format!("{} AS ({{}})", name),
+                        vec![ExpressiveEnum::Nested(query.clone())],
+                    )
+                })
+                .collect();
+            let keyword = if is_recursive { "WITH RECURSIVE" } else { "WITH" };
+            Expression::new(
+                format!("{} {{}} ", keyword),
+                vec![ExpressiveEnum::Nested(Expression::from_vec(parts, ", "))],
+            )
+        }
+    }
+
     pub fn render(&self) -> Expr {
         Expression::new(
             format!(
-                "SELECT{} {{}}{{}}{{}}{{}}{{}}{{}}",
+                "{{}}SELECT{} {{}}{{}}{{}}{{}}{{}}{{}}{{}}{{}}{{}}",
                 if self.distinct { " DISTINCT" } else { "" }
             ),
             vec![
+                ExpressiveEnum::Nested(self.render_ctes()),
                 ExpressiveEnum::Nested(self.render_fields()),
                 ExpressiveEnum::Nested(self.render_from()),
+                ExpressiveEnum::Nested(self.render_joins()),
                 ExpressiveEnum::Nested(self.render_where()),
                 ExpressiveEnum::Nested(self.render_group_by()),
+                ExpressiveEnum::Nested(self.render_having()),
+                ExpressiveEnum::Nested(self.render_windows()),
                 ExpressiveEnum::Nested(self.render_order_by()),
                 ExpressiveEnum::Nested(self.render_limit()),
             ],

--- a/vantage-sql/tests/sqlite/3_complex_queries.rs
+++ b/vantage-sql/tests/sqlite/3_complex_queries.rs
@@ -1,8 +1,12 @@
 //! Test 3b: Complex SELECT queries against the v3 test database.
 //! Each query exercises specific SQL features through the Selectable trait.
 
+#![allow(dead_code)]
+
 use serde::Deserialize;
 use vantage_expressions::{ExprDataSource, Expressive, Selectable};
+use vantage_sql::primitives::identifier::Identifier;
+use vantage_sql::sqlite::statements::select::join::SqliteSelectJoin;
 use vantage_sql::sqlite::statements::SqliteSelect;
 use vantage_sql::sqlite::SqliteDB;
 use vantage_sql::sqlite_expr;
@@ -14,6 +18,27 @@ async fn get_db() -> SqliteDB {
     SqliteDB::connect(DB_PATH)
         .await
         .expect("Failed to connect to bakery.sqlite")
+}
+
+/// Checks that `select.preview()` matches `expected_sql`, then executes the
+/// query and returns deserialized rows.
+async fn check_and_run<T: for<'de> Deserialize<'de>>(
+    select: &SqliteSelect,
+    expected_sql: &str,
+) -> Vec<T> {
+    assert_eq!(select.preview(), expected_sql);
+
+    let db = get_db().await;
+    let result = db.execute(&select.expr()).await.unwrap();
+    let rows = result.into_value();
+    let arr = rows.as_array().unwrap();
+
+    let records: Vec<Record<serde_json::Value>> =
+        arr.iter().map(|v| v.clone().into()).collect();
+    records
+        .into_iter()
+        .map(|r| T::from_record(r).unwrap())
+        .collect()
 }
 
 // -- ---------------------------------------------------------------------------
@@ -34,75 +59,26 @@ struct UserBasic {
     email: String,
 }
 
-#[test]
-fn test_q1_render() {
-    let select = SqliteSelect::new()
-        .with_source("users")
-        .with_field("id")
-        .with_field("name")
-        .with_field("email")
-        .with_condition(sqlite_expr!("\"role\" = {}", "admin"))
-        .with_condition(sqlite_expr!("\"salary\" > {}", 50000.0f64))
-        .with_order(sqlite_expr!("\"name\""), true)
-        .with_limit(Some(10), Some(20));
-
-    assert_eq!(
-        select.preview(),
-        "SELECT \"id\", \"name\", \"email\" FROM \"users\" WHERE \"role\" = 'admin' AND \"salary\" > 50000.0 ORDER BY \"name\" LIMIT 10 OFFSET 20"
-    );
-}
-
 #[tokio::test]
-async fn test_q1_execute() {
-    let db = get_db().await;
+async fn test_q1() {
+    let users: Vec<UserBasic> = check_and_run(
+        &SqliteSelect::new()
+            .with_source("users")
+            .with_field("id")
+            .with_field("name")
+            .with_field("email")
+            .with_condition(sqlite_expr!("\"role\" = {}", "admin"))
+            .with_condition(sqlite_expr!("\"salary\" > {}", 50000.0f64))
+            .with_order(sqlite_expr!("\"name\""), true),
+        "SELECT \"id\", \"name\", \"email\" FROM \"users\" \
+         WHERE \"role\" = 'admin' AND \"salary\" > 50000.0 \
+         ORDER BY \"name\"",
+    )
+    .await;
 
-    // All admins earning > 50k, ordered by name
-    let select = SqliteSelect::new()
-        .with_source("users")
-        .with_field("id")
-        .with_field("name")
-        .with_field("email")
-        .with_condition(sqlite_expr!("\"role\" = {}", "admin"))
-        .with_condition(sqlite_expr!("\"salary\" > {}", 50000.0f64))
-        .with_order(sqlite_expr!("\"name\""), true);
-
-    let result = db.execute(&select.expr()).await.unwrap();
-    let rows = result.into_value();
-    let arr = rows.as_array().unwrap();
-
-    // v3 data: Alice (120k), Eve (110k), Leo (130k) — all admins > 50k
-    assert_eq!(arr.len(), 3);
-
-    let records: Vec<Record<serde_json::Value>> =
-        arr.iter().map(|v| v.clone().into()).collect();
-    let users: Vec<UserBasic> = records
-        .into_iter()
-        .map(|r| UserBasic::from_record(r).unwrap())
-        .collect();
-
-    // Ordered by name ASC
+    assert_eq!(users.len(), 3);
     assert_eq!(users[0].name, "Alice Chen");
-    assert_eq!(users[1].name, "Eve Johnson");
     assert_eq!(users[2].name, "Leo Russo");
-
-    // LIMIT 2 OFFSET 2 → only Leo
-    let select_page = SqliteSelect::new()
-        .with_source("users")
-        .with_field("id")
-        .with_field("name")
-        .with_field("email")
-        .with_condition(sqlite_expr!("\"role\" = {}", "admin"))
-        .with_condition(sqlite_expr!("\"salary\" > {}", 50000.0f64))
-        .with_order(sqlite_expr!("\"name\""), true)
-        .with_limit(Some(2), Some(2));
-
-    let record: Record<serde_json::Value> = db
-        .associate(select_page.expr())
-        .get()
-        .await
-        .unwrap();
-    let user: UserBasic = UserBasic::from_record(record).unwrap();
-    assert_eq!(user.name, "Leo Russo");
 }
 
 // -- ---------------------------------------------------------------------------
@@ -115,6 +91,59 @@ async fn test_q1_execute() {
 // INNER JOIN departments AS d ON d.id = u.department_id
 // WHERE u.salary >= 30000.0
 // ORDER BY d.name, u.name;
+
+#[derive(Debug, Deserialize)]
+struct UserWithDept {
+    id: i64,
+    name: String,
+    department_name: String,
+}
+
+#[tokio::test]
+async fn test_q2() {
+    let users: Vec<UserWithDept> = check_and_run(
+        &SqliteSelect::new()
+            .with_source_as("users", "u")
+            .with_expression(Identifier::with_dot("u", "id"), None)
+            .with_expression(Identifier::with_dot("u", "name"), None)
+            .with_expression(
+                Identifier::with_dot("d", "name").with_alias("department_name"),
+                None,
+            )
+            .with_join(SqliteSelectJoin::inner(
+                "departments",
+                "d",
+                sqlite_expr!(
+                    "{} = {}",
+                    (Identifier::with_dot("d", "id")),
+                    (Identifier::with_dot("u", "department_id"))
+                ),
+            ))
+            .with_condition(sqlite_expr!(
+                "{} >= {}",
+                (Identifier::with_dot("u", "salary")),
+                30000.0f64
+            ))
+            .with_order(Identifier::with_dot("d", "name"), true)
+            .with_order(Identifier::with_dot("u", "name"), true),
+        "SELECT \"u\".\"id\", \"u\".\"name\", \"d\".\"name\" AS \"department_name\" \
+         FROM \"users\" AS \"u\" \
+         INNER JOIN \"departments\" AS \"d\" ON \"d\".\"id\" = \"u\".\"department_id\" \
+         WHERE \"u\".\"salary\" >= 30000.0 \
+         ORDER BY \"d\".\"name\", \"u\".\"name\"",
+    )
+    .await;
+
+    assert_eq!(users.len(), 11);
+    assert_eq!(users[0].name, "Alice Chen");
+    assert_eq!(users[0].department_name, "Backend");
+    assert_eq!(users[1].name, "Bob Martinez");
+    assert_eq!(users[1].department_name, "Backend");
+    assert_eq!(users[2].name, "Iris Novak");
+    assert_eq!(users[2].department_name, "Design");
+    assert_eq!(users[10].name, "Jake Torres");
+    assert_eq!(users[10].department_name, "UX Research");
+}
 
 // -- ---------------------------------------------------------------------------
 // -- 3. LEFT JOIN with COALESCE and aggregate
@@ -129,6 +158,69 @@ async fn test_q1_execute() {
 // LEFT JOIN orders AS o ON o.user_id = u.id
 // GROUP BY u.id, u.name
 // ORDER BY total_spent DESC;
+
+#[derive(Debug, Deserialize)]
+struct UserSpend {
+    id: i64,
+    name: String,
+    total_spent: f64,
+}
+
+#[tokio::test]
+async fn test_q3() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let select = SqliteSelect::new()
+        .with_source_as("users", "u")
+        .with_expression(Identifier::with_dot("u", "id"), None)
+        .with_expression(Identifier::with_dot("u", "name"), None)
+        .with_expression(
+            Fx::new("coalesce", [
+                Fx::new("sum", [Identifier::with_dot("o", "total").expr()]).expr(),
+                sqlite_expr!("{}", 0.0f64),
+            ]),
+            Some("total_spent".into()),
+        )
+        .with_join(SqliteSelectJoin::left(
+            "orders",
+            "o",
+            sqlite_expr!(
+                "{} = {}",
+                (Identifier::with_dot("o", "user_id")),
+                (Identifier::with_dot("u", "id"))
+            ),
+        ))
+        .with_group_by(Identifier::with_dot("u", "id"))
+        .with_group_by(Identifier::with_dot("u", "name"))
+        .with_order(Identifier::new("total_spent"), false);
+
+    let users: Vec<UserSpend> = check_and_run(
+        &select,
+        "SELECT \"u\".\"id\", \"u\".\"name\", \
+         COALESCE(SUM(\"o\".\"total\"), 0.0) AS \"total_spent\" \
+         FROM \"users\" AS \"u\" \
+         LEFT JOIN \"orders\" AS \"o\" ON \"o\".\"user_id\" = \"u\".\"id\" \
+         GROUP BY \"u\".\"id\", \"u\".\"name\" \
+         ORDER BY \"total_spent\" DESC",
+    )
+    .await;
+
+    assert_eq!(users.len(), 12);
+
+    assert_eq!(users[0].name, "Eve Johnson");
+    assert_eq!(users[0].total_spent, 2000.0);
+    assert_eq!(users[1].name, "Leo Russo");
+    assert_eq!(users[1].total_spent, 625.0);
+    assert_eq!(users[2].name, "Bob Martinez");
+    assert_eq!(users[2].total_spent, 560.0);
+    assert_eq!(users[3].name, "Alice Chen");
+    assert_eq!(users[3].total_spent, 500.5);
+
+    // Users with no orders get 0.0
+    for user in &users[8..12] {
+        assert_eq!(user.total_spent, 0.0, "{} should have 0 spend", user.name);
+    }
+}
 
 // -- ---------------------------------------------------------------------------
 // -- 4. GROUP BY with HAVING and multiple aggregates
@@ -146,6 +238,49 @@ async fn test_q1_execute() {
 // HAVING COUNT(*) > 1 AND AVG(price) < 500.0
 // ORDER BY product_count DESC;
 
+#[derive(Debug, Deserialize)]
+struct CategoryStats {
+    category: String,
+    product_count: i64,
+    avg_price: f64,
+    cheapest: f64,
+    most_expensive: f64,
+}
+
+#[tokio::test]
+async fn test_q4() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let price = Identifier::new("price");
+    let stats: Vec<CategoryStats> = check_and_run(
+        &SqliteSelect::new()
+            .with_source("products")
+            .with_field("category")
+            .with_expression(Fx::new("count", [sqlite_expr!("*")]), Some("product_count".into()))
+            .with_expression(Fx::new("avg", [price.expr()]), Some("avg_price".into()))
+            .with_expression(Fx::new("min", [price.expr()]), Some("cheapest".into()))
+            .with_expression(Fx::new("max", [price.expr()]), Some("most_expensive".into()))
+            .with_group_by(Identifier::new("category"))
+            .with_having(sqlite_expr!("{} > {}", (Fx::new("count", [sqlite_expr!("*")])), 1i64))
+            .with_having(sqlite_expr!("{} < {}", (Fx::new("avg", [price.expr()])), 500.0f64))
+            .with_order(Identifier::new("product_count"), false),
+        "SELECT \"category\", COUNT(*) AS \"product_count\", AVG(\"price\") AS \"avg_price\", \
+         MIN(\"price\") AS \"cheapest\", MAX(\"price\") AS \"most_expensive\" \
+         FROM \"products\" \
+         GROUP BY \"category\" \
+         HAVING COUNT(*) > 1 AND AVG(\"price\") < 500.0 \
+         ORDER BY \"product_count\" DESC",
+    )
+    .await;
+
+    // electronics (7), then furniture (2) and stationery (2) in any order
+    assert_eq!(stats.len(), 3);
+    assert_eq!(stats[0].category, "electronics");
+    assert_eq!(stats[0].product_count, 7);
+    assert_eq!(stats[1].product_count, 2);
+    assert_eq!(stats[2].product_count, 2);
+}
+
 // -- ---------------------------------------------------------------------------
 // -- 5. Scalar subquery in SELECT + correlated EXISTS in WHERE
 // -- Features: subquery as column expr, correlated EXISTS, literal 1
@@ -162,6 +297,69 @@ async fn test_q1_execute() {
 // )
 // ORDER BY order_count DESC
 // LIMIT 20;
+
+#[derive(Debug, Deserialize)]
+struct UserOrderCount {
+    id: i64,
+    name: String,
+    order_count: i64,
+}
+
+#[tokio::test]
+async fn test_q5() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let user_id_match = sqlite_expr!(
+        "{} = {}",
+        (Identifier::with_dot("o", "user_id")),
+        (Identifier::with_dot("u", "id"))
+    );
+
+    let count_subquery = SqliteSelect::new()
+        .with_source_as("orders", "o")
+        .with_expression(Fx::new("count", [sqlite_expr!("*")]), None)
+        .with_condition(user_id_match.clone());
+
+    let exists_subquery = SqliteSelect::new()
+        .with_source_as("orders", "o")
+        .with_expression(sqlite_expr!("1"), None)
+        .with_condition(user_id_match)
+        .with_condition(sqlite_expr!(
+            "{} = {}",
+            (Identifier::with_dot("o", "status")),
+            "completed"
+        ));
+
+    let users: Vec<UserOrderCount> = check_and_run(
+        &SqliteSelect::new()
+            .with_source_as("users", "u")
+            .with_expression(Identifier::with_dot("u", "id"), None)
+            .with_expression(Identifier::with_dot("u", "name"), None)
+            .with_expression(
+                sqlite_expr!("({})", (count_subquery)),
+                Some("order_count".into()),
+            )
+            .with_condition(Fx::new("exists", [exists_subquery.expr()]))
+            .with_order(Identifier::new("order_count"), false)
+            .with_limit(Some(20), None),
+        concat!(
+            r#"SELECT "u"."id", "u"."name", "#,
+            r#"(SELECT COUNT(*) FROM "orders" AS "o" WHERE "o"."user_id" = "u"."id") AS "order_count" "#,
+            r#"FROM "users" AS "u" "#,
+            r#"WHERE EXISTS(SELECT 1 FROM "orders" AS "o" WHERE "o"."user_id" = "u"."id" AND "o"."status" = 'completed') "#,
+            r#"ORDER BY "order_count" DESC "#,
+            r#"LIMIT 20"#,
+        ),
+    )
+    .await;
+
+    // Users with completed orders: Alice(3 orders), Bob(1), Carol(1), Eve(1), Frank(1), Leo(1), Jake(1)
+    // But only those with status='completed': Alice(2), Bob(1), Carol(1), Eve(1), Frank(1), Leo(1), Jake(1)
+    assert_eq!(users.len(), 7);
+    // Alice has most orders (4 total), ordered DESC
+    assert_eq!(users[0].name, "Alice Chen");
+    assert_eq!(users[0].order_count, 4);
+}
 
 // -- ---------------------------------------------------------------------------
 // -- 6. Derived table (subquery in FROM)
@@ -181,6 +379,72 @@ async fn test_q1_execute() {
 // ) AS stats ON stats.user_id = u.id
 // WHERE stats.order_count >= 2
 // ORDER BY stats.avg_total DESC;
+
+#[derive(Debug, Deserialize)]
+struct UserOrderStats {
+    name: String,
+    order_count: i64,
+    avg_total: f64,
+}
+
+#[tokio::test]
+async fn test_q6() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let stats_subquery = SqliteSelect::new()
+        .with_source("orders")
+        .with_field("user_id")
+        .with_expression(Fx::new("count", [sqlite_expr!("*")]), Some("order_count".into()))
+        .with_expression(
+            Fx::new("avg", [Identifier::new("total").expr()]),
+            Some("avg_total".into()),
+        )
+        .with_condition(sqlite_expr!("{} != {}", (Identifier::new("status")), "cancelled"))
+        .with_group_by(Identifier::new("user_id"));
+
+    let users: Vec<UserOrderStats> = check_and_run(
+        &SqliteSelect::new()
+            .with_source_as("users", "u")
+            .with_expression(Identifier::with_dot("u", "name"), None)
+            .with_expression(Identifier::with_dot("stats", "order_count"), None)
+            .with_expression(Identifier::with_dot("stats", "avg_total"), None)
+            .with_join(SqliteSelectJoin::inner_expr(
+                stats_subquery,
+                "stats",
+                sqlite_expr!(
+                    "{} = {}",
+                    (Identifier::with_dot("stats", "user_id")),
+                    (Identifier::with_dot("u", "id"))
+                ),
+            ))
+            .with_condition(sqlite_expr!(
+                "{} >= {}",
+                (Identifier::with_dot("stats", "order_count")),
+                2i64
+            ))
+            .with_order(Identifier::with_dot("stats", "avg_total"), false),
+        concat!(
+            r#"SELECT "u"."name", "stats"."order_count", "stats"."avg_total" "#,
+            r#"FROM "users" AS "u" "#,
+            r#"INNER JOIN (SELECT "user_id", COUNT(*) AS "order_count", AVG("total") AS "avg_total" "#,
+            r#"FROM "orders" "#,
+            r#"WHERE "status" != 'cancelled' "#,
+            r#"GROUP BY "user_id") AS "stats" ON "stats"."user_id" = "u"."id" "#,
+            r#"WHERE "stats"."order_count" >= 2 "#,
+            r#"ORDER BY "stats"."avg_total" DESC"#,
+        ),
+    )
+    .await;
+
+    // Users with 2+ non-cancelled orders:
+    // Alice: 4 orders (250+125.5+75+50), Bob: 1 non-cancelled (500), Eve: 2 (1200+800),
+    // Carol: 2 (310+45), Leo: 2 (350+275)
+    // So: Alice(4), Eve(2), Carol(2), Leo(2)
+    assert_eq!(users.len(), 4);
+    // Ordered by avg_total DESC: Eve (1000), Leo (312.5), Alice (125.125), Carol (177.5)
+    assert_eq!(users[0].name, "Eve Johnson");
+    assert_eq!(users[0].order_count, 2);
+}
 
 // -- ---------------------------------------------------------------------------
 // -- 7. CASE expression, IIF, string concatenation, generated column read
@@ -202,6 +466,71 @@ async fn test_q1_execute() {
 // FROM users
 // ORDER BY salary DESC;
 
+#[derive(Debug, Deserialize)]
+struct UserBand {
+    id: i64,
+    name: String,
+    salary: f64,
+    band: String,
+    is_admin: String,
+    display_name: String,
+}
+
+#[tokio::test]
+async fn test_q7() {
+    use vantage_sql::primitives::case::Case;
+    use vantage_sql::primitives::iif::Iif;
+
+    let salary = Identifier::new("salary");
+
+    let users: Vec<UserBand> = check_and_run(
+        &SqliteSelect::new()
+            .with_source("users")
+            .with_field("id")
+            .with_field("name")
+            .with_field("salary")
+            .with_expression(
+                Case::new()
+                    .when(sqlite_expr!("{} >= {}", (salary.clone()), 100000.0f64), sqlite_expr!("{}", "senior"))
+                    .when(sqlite_expr!("{} >= {}", (salary.clone()), 60000.0f64), sqlite_expr!("{}", "mid"))
+                    .when(sqlite_expr!("{} >= {}", (salary.clone()), 30000.0f64), sqlite_expr!("{}", "junior"))
+                    .else_(sqlite_expr!("{}", "intern")),
+                Some("band".into()),
+            )
+            .with_expression(
+                Iif::new(
+                    sqlite_expr!("{} = {}", (Identifier::new("role")), "admin"),
+                    sqlite_expr!("{}", "Yes"),
+                    sqlite_expr!("{}", "No"),
+                ),
+                Some("is_admin".into()),
+            )
+            .with_field("display_name")
+            .with_order(Identifier::new("salary"), false),
+        "SELECT \"id\", \"name\", \"salary\", \
+         CASE WHEN \"salary\" >= 100000.0 THEN 'senior' WHEN \"salary\" >= 60000.0 THEN 'mid' \
+         WHEN \"salary\" >= 30000.0 THEN 'junior' ELSE 'intern' END AS \"band\", \
+         IIF(\"role\" = 'admin', 'Yes', 'No') AS \"is_admin\", \
+         \"display_name\" \
+         FROM \"users\" \
+         ORDER BY \"salary\" DESC",
+    )
+    .await;
+
+    assert_eq!(users.len(), 12);
+    // Leo: 130k → senior, admin
+    assert_eq!(users[0].name, "Leo Russo");
+    assert_eq!(users[0].band, "senior");
+    assert_eq!(users[0].is_admin, "Yes");
+    // Karen: 25k → intern
+    assert_eq!(users[11].name, "Karen Hill");
+    assert_eq!(users[11].band, "intern");
+    assert_eq!(users[11].is_admin, "No");
+    // display_name is generated: "name <email>"
+    assert!(users[0].display_name.contains("Leo Russo"));
+    assert!(users[0].display_name.contains("leo@example.com"));
+}
+
 // -- ---------------------------------------------------------------------------
 // -- 8. UNION ALL + EXCEPT compound select
 // -- Features: UNION ALL, EXCEPT, literal string column, IS NOT NULL
@@ -212,6 +541,73 @@ async fn test_q1_execute() {
 // SELECT id, name, 'department' AS source FROM departments WHERE budget IS NOT NULL
 // EXCEPT
 // SELECT id, name, 'department' AS source FROM departments WHERE budget = 0.0;
+
+#[derive(Debug, Deserialize)]
+struct NamedSource {
+    id: i64,
+    name: String,
+    source: String,
+}
+
+#[tokio::test]
+async fn test_q8() {
+    use vantage_sql::primitives::union::Union;
+
+    let admins = SqliteSelect::new()
+        .with_source("users")
+        .with_field("id")
+        .with_field("name")
+        .with_expression(sqlite_expr!("{}", "user"), Some("source".into()))
+        .with_condition(sqlite_expr!("{} = {}", (Identifier::new("role")), "admin"));
+
+    let depts_with_budget = SqliteSelect::new()
+        .with_source("departments")
+        .with_field("id")
+        .with_field("name")
+        .with_expression(sqlite_expr!("{}", "department"), Some("source".into()))
+        .with_condition(sqlite_expr!("{} IS NOT NULL", (Identifier::new("budget"))));
+
+    let depts_zero_budget = SqliteSelect::new()
+        .with_source("departments")
+        .with_field("id")
+        .with_field("name")
+        .with_expression(sqlite_expr!("{}", "department"), Some("source".into()))
+        .with_condition(sqlite_expr!("{} = {}", (Identifier::new("budget")), 0.0f64));
+
+    let compound = Union::new(admins)
+        .union_all(depts_with_budget)
+        .except(depts_zero_budget);
+
+    let db = get_db().await;
+    let result = db.execute(&compound.expr()).await.unwrap();
+    let rows = result.into_value();
+    let arr = rows.as_array().unwrap();
+
+    assert_eq!(
+        compound.preview(),
+        "SELECT \"id\", \"name\", 'user' AS \"source\" FROM \"users\" WHERE \"role\" = 'admin' \
+         UNION ALL \
+         SELECT \"id\", \"name\", 'department' AS \"source\" FROM \"departments\" WHERE \"budget\" IS NOT NULL \
+         EXCEPT \
+         SELECT \"id\", \"name\", 'department' AS \"source\" FROM \"departments\" WHERE \"budget\" = 0.0"
+    );
+
+    let records: Vec<Record<serde_json::Value>> =
+        arr.iter().map(|v| v.clone().into()).collect();
+    let rows: Vec<NamedSource> = records
+        .into_iter()
+        .map(|r| NamedSource::from_record(r).unwrap())
+        .collect();
+
+    // 3 admins + 8 departments with non-null budget, minus 0 with budget=0.0
+    // All departments have budget > 0 so EXCEPT removes nothing
+    assert_eq!(rows.len(), 11);
+
+    let user_count = rows.iter().filter(|r| r.source == "user").count();
+    let dept_count = rows.iter().filter(|r| r.source == "department").count();
+    assert_eq!(user_count, 3);
+    assert_eq!(dept_count, 8);
+}
 
 // -- ---------------------------------------------------------------------------
 // -- 9. Window functions — ROW_NUMBER, RANK, running SUM, named WINDOW
@@ -232,6 +628,75 @@ async fn test_q1_execute() {
 // FROM users AS u
 // WHERE u.department_id IS NOT NULL
 // WINDOW win AS (PARTITION BY u.department_id ORDER BY u.salary DESC);
+
+#[derive(Debug, Deserialize)]
+struct SalaryRanking {
+    department_id: i64,
+    name: String,
+    salary: f64,
+    row_num: i64,
+    salary_rank: i64,
+    running_total: f64,
+}
+
+#[tokio::test]
+async fn test_q9() {
+    use vantage_sql::primitives::fx::Fx;
+    use vantage_sql::primitives::select::window::Window;
+
+    let dept = Identifier::with_dot("u", "department_id");
+    let salary = Identifier::with_dot("u", "salary");
+
+    let rows: Vec<SalaryRanking> = check_and_run(
+        &SqliteSelect::new()
+            .with_source_as("users", "u")
+            .with_expression(dept.clone(), None)
+            .with_expression(Identifier::with_dot("u", "name"), None)
+            .with_expression(salary.clone(), None)
+            .with_expression(
+                Window::named("win").apply(Fx::new("row_number", vec![])),
+                Some("row_num".into()),
+            )
+            .with_expression(
+                Window::named("win").apply(Fx::new("rank", vec![])),
+                Some("salary_rank".into()),
+            )
+            .with_expression(
+                Window::new()
+                    .partition_by(dept.clone())
+                    .order_by(salary.clone(), false)
+                    .rows("UNBOUNDED PRECEDING", "CURRENT ROW")
+                    .apply(Fx::new("sum", [salary.expr()])),
+                Some("running_total".into()),
+            )
+            .with_condition(sqlite_expr!("{} IS NOT NULL", (dept)))
+            .with_window("win", Window::new()
+                .partition_by(dept.clone())
+                .order_by(salary.clone(), false)),
+        concat!(
+            r#"SELECT "u"."department_id", "u"."name", "u"."salary", "#,
+            r#"ROW_NUMBER() OVER win AS "row_num", "#,
+            r#"RANK() OVER win AS "salary_rank", "#,
+            r#"SUM("u"."salary") OVER (PARTITION BY "u"."department_id" ORDER BY "u"."salary" DESC "#,
+            r#"ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS "running_total" "#,
+            r#"FROM "users" AS "u" "#,
+            r#"WHERE "u"."department_id" IS NOT NULL "#,
+            r#"WINDOW win AS (PARTITION BY "u"."department_id" ORDER BY "u"."salary" DESC)"#,
+        ),
+    )
+    .await;
+
+    // 11 users with non-null department_id
+    assert_eq!(rows.len(), 11);
+    // First row in Backend (dept 2): Alice 120k, row_num=1, rank=1, running=120k
+    let backend: Vec<&SalaryRanking> = rows.iter().filter(|r| r.department_id == 2).collect();
+    assert_eq!(backend.len(), 2);
+    assert_eq!(backend[0].name, "Alice Chen");
+    assert_eq!(backend[0].row_num, 1);
+    assert_eq!(backend[0].running_total, 120000.0);
+    assert_eq!(backend[1].name, "Bob Martinez");
+    assert_eq!(backend[1].running_total, 215000.0); // 120k + 95k
+}
 
 // -- ---------------------------------------------------------------------------
 // -- 10. Non-recursive CTE — multiple WITH clauses, CTE referencing CTE
@@ -256,6 +721,66 @@ async fn test_q1_execute() {
 // ORDER BY t.revenue DESC
 // LIMIT 10;
 
+#[derive(Debug, Deserialize)]
+struct TopSpender {
+    name: String,
+    revenue: f64,
+}
+
+#[tokio::test]
+async fn test_q10() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let spenders: Vec<TopSpender> = check_and_run(
+        &SqliteSelect::new()
+            .with_cte("active_orders", SqliteSelect::new()
+                .with_source("orders")
+                .with_field("user_id")
+                .with_expression(Fx::new("count", [sqlite_expr!("*")]), Some("cnt".into()))
+                .with_expression(Fx::new("sum", [Identifier::new("total").expr()]), Some("revenue".into()))
+                .with_condition(sqlite_expr!("{} IN ({}, {})",
+                    (Identifier::new("status")), "completed", "shipped"))
+                .with_group_by(Identifier::new("user_id")), false)
+            .with_cte("top_spenders", SqliteSelect::new()
+                .with_source("active_orders")
+                .with_field("user_id")
+                .with_field("revenue")
+                .with_condition(sqlite_expr!("{} > {}", (Identifier::new("revenue")), 400.0f64)), false)
+            .with_source_as("top_spenders", "t")
+            .with_expression(Identifier::with_dot("u", "name"), None)
+            .with_expression(Identifier::with_dot("t", "revenue"), None)
+            .with_join(SqliteSelectJoin::inner("users", "u",
+                sqlite_expr!("{} = {}",
+                    (Identifier::with_dot("u", "id")),
+                    (Identifier::with_dot("t", "user_id")))))
+            .with_order(Identifier::with_dot("t", "revenue"), false)
+            .with_limit(Some(10), None),
+        concat!(
+            r#"WITH active_orders AS (SELECT "user_id", COUNT(*) AS "cnt", SUM("total") AS "revenue" "#,
+            r#"FROM "orders" "#,
+            r#"WHERE "status" IN ('completed', 'shipped') "#,
+            r#"GROUP BY "user_id"), "#,
+            r#"top_spenders AS (SELECT "user_id", "revenue" "#,
+            r#"FROM "active_orders" "#,
+            r#"WHERE "revenue" > 400.0) "#,
+            r#"SELECT "u"."name", "t"."revenue" "#,
+            r#"FROM "top_spenders" AS "t" "#,
+            r#"INNER JOIN "users" AS "u" ON "u"."id" = "t"."user_id" "#,
+            r#"ORDER BY "t"."revenue" DESC "#,
+            r#"LIMIT 10"#,
+        ),
+    )
+    .await;
+
+    // Users with completed+shipped revenue > 400:
+    // Eve: 2000, Leo: 625, Bob: 500, Alice: 450.5, Jake: 420
+    assert_eq!(spenders.len(), 5);
+    assert_eq!(spenders[0].name, "Eve Johnson");
+    assert_eq!(spenders[0].revenue, 2000.0);
+    assert_eq!(spenders[1].name, "Leo Russo");
+    assert_eq!(spenders[1].revenue, 625.0);
+}
+
 // -- ---------------------------------------------------------------------------
 // -- 11. Recursive CTE — hierarchical department tree
 // -- Features: WITH RECURSIVE, UNION ALL, self-referencing join, || concat, IS NULL
@@ -274,6 +799,76 @@ async fn test_q1_execute() {
 // FROM dept_tree
 // ORDER BY path;
 
+#[derive(Debug, Deserialize)]
+struct DeptTree {
+    id: i64,
+    name: String,
+    depth: i64,
+    path: String,
+}
+
+#[tokio::test]
+async fn test_q11() {
+    use vantage_sql::primitives::union::Union;
+
+    let base = SqliteSelect::new()
+        .with_source("departments")
+        .with_field("id")
+        .with_field("name")
+        .with_expression(sqlite_expr!("0"), None)
+        .with_expression(Identifier::new("name"), None)
+        .with_condition(sqlite_expr!("{} IS NULL", (Identifier::new("parent_id"))));
+
+    let recursive = SqliteSelect::new()
+        .with_source_as("departments", "d")
+        .with_expression(Identifier::with_dot("d", "id"), None)
+        .with_expression(Identifier::with_dot("d", "name"), None)
+        .with_expression(sqlite_expr!("{} + 1", (Identifier::with_dot("dt", "depth"))), None)
+        .with_expression(
+            sqlite_expr!("{} || ' > ' || {}", (Identifier::with_dot("dt", "path")), (Identifier::with_dot("d", "name"))),
+            None,
+        )
+        .with_join(SqliteSelectJoin::inner("dept_tree", "dt",
+            sqlite_expr!("{} = {}", (Identifier::with_dot("dt", "id")), (Identifier::with_dot("d", "parent_id")))));
+
+    let rows: Vec<DeptTree> = check_and_run(
+        &SqliteSelect::new()
+            .with_cte(
+                "dept_tree(id, name, depth, path)",
+                Union::new(base).union_all(recursive),
+                true,
+            )
+            .with_source("dept_tree")
+            .with_field("id")
+            .with_field("name")
+            .with_field("depth")
+            .with_field("path")
+            .with_order(Identifier::new("path"), true),
+        concat!(
+            r#"WITH RECURSIVE dept_tree(id, name, depth, path) AS "#,
+            r#"(SELECT "id", "name", 0, "name" FROM "departments" WHERE "parent_id" IS NULL "#,
+            r#"UNION ALL "#,
+            r#"SELECT "d"."id", "d"."name", "dt"."depth" + 1, "dt"."path" || ' > ' || "d"."name" "#,
+            r#"FROM "departments" AS "d" "#,
+            r#"INNER JOIN "dept_tree" AS "dt" ON "dt"."id" = "d"."parent_id") "#,
+            r#"SELECT "id", "name", "depth", "path" "#,
+            r#"FROM "dept_tree" "#,
+            r#"ORDER BY "path""#,
+        ),
+    )
+    .await;
+
+    // 8 departments total in the tree
+    assert_eq!(rows.len(), 8);
+    // Root nodes at depth 0
+    let roots: Vec<&DeptTree> = rows.iter().filter(|r| r.depth == 0).collect();
+    assert_eq!(roots.len(), 3); // Engineering, Sales, Design
+    // Check a nested path
+    let backend = rows.iter().find(|r| r.name == "Backend").unwrap();
+    assert_eq!(backend.depth, 1);
+    assert_eq!(backend.path, "Engineering > Backend");
+}
+
 // -- ---------------------------------------------------------------------------
 // -- 12. Multi-way JOIN through junction table + DISTINCT + LIKE + IN
 // -- Features: 3-table join, DISTINCT, LIKE pattern, IN list, many-to-many
@@ -288,6 +883,59 @@ async fn test_q1_execute() {
 //   AND p.stock > 0
 // ORDER BY p.price ASC
 // LIMIT 50;
+
+#[derive(Debug, Deserialize)]
+struct ProductMatch {
+    id: i64,
+    name: String,
+    price: f64,
+}
+
+#[tokio::test]
+async fn test_q12() {
+    let products: Vec<ProductMatch> = check_and_run(
+        &SqliteSelect::new()
+            .with_distinct(true)
+            .with_source_as("products", "p")
+            .with_expression(Identifier::with_dot("p", "id"), None)
+            .with_expression(Identifier::with_dot("p", "name"), None)
+            .with_expression(Identifier::with_dot("p", "price"), None)
+            .with_join(SqliteSelectJoin::inner("product_tags", "pt",
+                sqlite_expr!("{} = {}",
+                    (Identifier::with_dot("pt", "product_id")),
+                    (Identifier::with_dot("p", "id")))))
+            .with_join(SqliteSelectJoin::inner("tags", "t",
+                sqlite_expr!("{} = {}",
+                    (Identifier::with_dot("t", "id")),
+                    (Identifier::with_dot("pt", "tag_id")))))
+            .with_condition(sqlite_expr!("{} IN ({}, {}, {})",
+                (Identifier::with_dot("t", "name")),
+                "electronics", "sale", "featured"))
+            .with_condition(sqlite_expr!("{} LIKE {}",
+                (Identifier::with_dot("p", "name")), "%Pro%"))
+            .with_condition(sqlite_expr!("{} > {}",
+                (Identifier::with_dot("p", "stock")), 0i64))
+            .with_order(Identifier::with_dot("p", "price"), true)
+            .with_limit(Some(50), None),
+        concat!(
+            r#"SELECT DISTINCT "p"."id", "p"."name", "p"."price" "#,
+            r#"FROM "products" AS "p" "#,
+            r#"INNER JOIN "product_tags" AS "pt" ON "pt"."product_id" = "p"."id" "#,
+            r#"INNER JOIN "tags" AS "t" ON "t"."id" = "pt"."tag_id" "#,
+            r#"WHERE "t"."name" IN ('electronics', 'sale', 'featured') "#,
+            r#"AND "p"."name" LIKE '%Pro%' "#,
+            r#"AND "p"."stock" > 0 "#,
+            r#"ORDER BY "p"."price" "#,
+            r#"LIMIT 50"#,
+        ),
+    )
+    .await;
+
+    // Widget Pro (electronics, 29.99) and Gadget Pro Max (electronics, 99.99) match
+    assert_eq!(products.len(), 2);
+    assert_eq!(products[0].name, "Widget Pro");
+    assert_eq!(products[1].name, "Gadget Pro Max");
+}
 
 // -- ---------------------------------------------------------------------------
 // -- 13. JSON operators + BETWEEN + CAST + NULLIF
@@ -305,6 +953,75 @@ async fn test_q1_execute() {
 // WHERE CAST(metadata ->> '$.rating' AS REAL) BETWEEN 4.0 AND 5.0
 //   AND json_extract(metadata, '$.in_stock') = 1
 // ORDER BY rating DESC;
+
+#[derive(Debug, Deserialize)]
+struct ProductJson {
+    id: i64,
+    name: String,
+    color: String,
+    weight: f64,
+    rating: f64,
+    clean_category: Option<String>,
+}
+
+#[tokio::test]
+async fn test_q13() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let metadata = Identifier::new("metadata");
+    let products: Vec<ProductJson> = check_and_run(
+        &SqliteSelect::new()
+            .with_source("products")
+            .with_field("id")
+            .with_field("name")
+            .with_expression(
+                Fx::new("json_extract", [metadata.expr(), sqlite_expr!("{}", "$.color")]),
+                Some("color".into()),
+            )
+            .with_expression(
+                sqlite_expr!("{} ->> {}", (metadata.clone()), "$.weight_kg"),
+                Some("weight".into()),
+            )
+            .with_expression(
+                sqlite_expr!("CAST({} ->> {} AS REAL)", (metadata.clone()), "$.rating"),
+                Some("rating".into()),
+            )
+            .with_expression(
+                Fx::new("nullif", [Identifier::new("category").expr(), sqlite_expr!("{}", "uncategorized")]),
+                Some("clean_category".into()),
+            )
+            .with_condition(sqlite_expr!(
+                "CAST({} ->> {} AS REAL) BETWEEN {} AND {}",
+                (metadata.clone()), "$.rating", 4.0f64, 5.0f64
+            ))
+            .with_condition(sqlite_expr!(
+                "{} = {}",
+                (Fx::new("json_extract", [metadata.expr(), sqlite_expr!("{}", "$.in_stock")])),
+                1i64
+            ))
+            .with_order(Identifier::new("rating"), false),
+        concat!(
+            r#"SELECT "id", "name", "#,
+            r#"JSON_EXTRACT("metadata", '$.color') AS "color", "#,
+            r#""metadata" ->> '$.weight_kg' AS "weight", "#,
+            r#"CAST("metadata" ->> '$.rating' AS REAL) AS "rating", "#,
+            r#"NULLIF("category", 'uncategorized') AS "clean_category" "#,
+            r#"FROM "products" "#,
+            r#"WHERE CAST("metadata" ->> '$.rating' AS REAL) BETWEEN 4.0 AND 5.0 "#,
+            r#"AND JSON_EXTRACT("metadata", '$.in_stock') = 1 "#,
+            r#"ORDER BY "rating" DESC"#,
+        ),
+    )
+    .await;
+
+    // Products with rating 4.0-5.0 and in_stock=1
+    assert!(products.len() >= 5);
+    // Highest rated first
+    assert!(products[0].rating >= products[1].rating);
+    // Gadget Pro Max has rating 4.9
+    assert_eq!(products[0].name, "Gadget Pro Max");
+    assert_eq!(products[0].color, "silver");
+}
 
 // -- ---------------------------------------------------------------------------
 // -- 14. Date functions + ROUND + typeof + GROUP BY expression + HAVING
@@ -324,6 +1041,77 @@ async fn test_q1_execute() {
 // GROUP BY strftime('%Y-%m', o.created_at), d.name
 // HAVING SUM(o.total) > 100.0
 // ORDER BY month DESC, monthly_revenue DESC;
+
+#[derive(Debug, Deserialize)]
+struct MonthlyRevenue {
+    month: String,
+    department: String,
+    order_count: i64,
+    monthly_revenue: f64,
+    sum_type: String,
+}
+
+#[tokio::test]
+async fn test_q14() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let o_total = Identifier::with_dot("o", "total");
+    let sum_total = Fx::new("sum", [o_total.expr()]);
+    let month_expr = Fx::new("strftime", [
+        sqlite_expr!("{}", "%Y-%m"),
+        Identifier::with_dot("o", "created_at").expr(),
+    ]);
+
+    let rows: Vec<MonthlyRevenue> = check_and_run(
+        &SqliteSelect::new()
+            .with_source_as("orders", "o")
+            .with_expression(month_expr.clone(), Some("month".into()))
+            .with_expression(Identifier::with_dot("d", "name"), Some("department".into()))
+            .with_expression(
+                Fx::new("count", [Identifier::with_dot("o", "id").expr()]),
+                Some("order_count".into()),
+            )
+            .with_expression(
+                Fx::new("round", [sum_total.expr(), sqlite_expr!("{}", 2i64)]),
+                Some("monthly_revenue".into()),
+            )
+            .with_expression(
+                Fx::new("typeof", [sum_total.expr()]),
+                Some("sum_type".into()),
+            )
+            .with_join(SqliteSelectJoin::inner("users", "u",
+                sqlite_expr!("{} = {}", (Identifier::with_dot("u", "id")), (Identifier::with_dot("o", "user_id")))))
+            .with_join(SqliteSelectJoin::inner("departments", "d",
+                sqlite_expr!("{} = {}", (Identifier::with_dot("d", "id")), (Identifier::with_dot("u", "department_id")))))
+            .with_condition(sqlite_expr!("{} >= {}", (Identifier::with_dot("o", "created_at")), "2025-01-01"))
+            .with_group_by(month_expr)
+            .with_group_by(Identifier::with_dot("d", "name"))
+            .with_having(sqlite_expr!("{} > {}", (sum_total), 100.0f64))
+            .with_order(Identifier::new("month"), false)
+            .with_order(Identifier::new("monthly_revenue"), false),
+        concat!(
+            r#"SELECT STRFTIME('%Y-%m', "o"."created_at") AS "month", "#,
+            r#""d"."name" AS "department", "#,
+            r#"COUNT("o"."id") AS "order_count", "#,
+            r#"ROUND(SUM("o"."total"), 2) AS "monthly_revenue", "#,
+            r#"TYPEOF(SUM("o"."total")) AS "sum_type" "#,
+            r#"FROM "orders" AS "o" "#,
+            r#"INNER JOIN "users" AS "u" ON "u"."id" = "o"."user_id" "#,
+            r#"INNER JOIN "departments" AS "d" ON "d"."id" = "u"."department_id" "#,
+            r#"WHERE "o"."created_at" >= '2025-01-01' "#,
+            r#"GROUP BY STRFTIME('%Y-%m', "o"."created_at"), "d"."name" "#,
+            r#"HAVING SUM("o"."total") > 100.0 "#,
+            r#"ORDER BY "month" DESC, "monthly_revenue" DESC"#,
+        ),
+    )
+    .await;
+
+    assert!(!rows.is_empty());
+    // typeof returns the SQLite storage type
+    assert!(rows.iter().all(|r| r.sum_type == "real" || r.sum_type == "integer"));
+    // All rows have revenue > 100 (HAVING filter)
+    assert!(rows.iter().all(|r| r.monthly_revenue > 100.0));
+}
 
 // -- ---------------------------------------------------------------------------
 // -- 15. Window functions — FILTER, LAG, LEAD, FIRST_VALUE, NTH_VALUE
@@ -352,3 +1140,104 @@ async fn test_q1_execute() {
 // LEFT JOIN orders AS o ON o.user_id = u.id
 // WHERE u.department_id IS NOT NULL
 // ORDER BY u.department_id, u.salary DESC;
+
+#[derive(Debug, Deserialize)]
+struct UserWindowStats {
+    id: i64,
+    name: String,
+    salary: f64,
+    department_id: i64,
+    completed_count: i64,
+    prev_salary: Option<f64>,
+    next_salary: Option<f64>,
+    top_earner: String,
+    second_earner: Option<String>,
+}
+
+#[tokio::test]
+async fn test_q15() {
+    use vantage_sql::primitives::fx::Fx;
+    use vantage_sql::primitives::select::window::Window;
+
+    let dept = Identifier::with_dot("u", "department_id");
+    let salary = Identifier::with_dot("u", "salary");
+    let u_name = Identifier::with_dot("u", "name");
+
+    let dept_salary_win = Window::new()
+        .partition_by(dept.clone())
+        .order_by(salary.clone(), false);
+
+    let rows: Vec<UserWindowStats> = check_and_run(
+        &SqliteSelect::new()
+            .with_source_as("users", "u")
+            .with_expression(Identifier::with_dot("u", "id"), None)
+            .with_expression(u_name.clone(), None)
+            .with_expression(salary.clone(), None)
+            .with_expression(dept.clone(), None)
+            .with_expression(
+                sqlite_expr!(
+                    "COUNT(*) FILTER (WHERE {} = {}) OVER (PARTITION BY {})",
+                    (Identifier::with_dot("o", "status")), "completed",
+                    (Identifier::with_dot("u", "id"))
+                ),
+                Some("completed_count".into()),
+            )
+            .with_expression(
+                Window::new().order_by(salary.clone(), true)
+                    .apply(sqlite_expr!("LAG({}, 1)", (salary.clone()))),
+                Some("prev_salary".into()),
+            )
+            .with_expression(
+                Window::new().order_by(salary.clone(), true)
+                    .apply(sqlite_expr!("LEAD({}, 1)", (salary.clone()))),
+                Some("next_salary".into()),
+            )
+            .with_expression(
+                dept_salary_win.clone()
+                    .range("UNBOUNDED PRECEDING", "UNBOUNDED FOLLOWING")
+                    .apply(Fx::new("first_value", [u_name.expr()])),
+                Some("top_earner".into()),
+            )
+            .with_expression(
+                dept_salary_win.clone()
+                    .rows("UNBOUNDED PRECEDING", "UNBOUNDED FOLLOWING")
+                    .apply(Fx::new("nth_value", [u_name.expr(), sqlite_expr!("2")])),
+                Some("second_earner".into()),
+            )
+            .with_join(SqliteSelectJoin::left("orders", "o",
+                sqlite_expr!("{} = {}",
+                    (Identifier::with_dot("o", "user_id")),
+                    (Identifier::with_dot("u", "id")))))
+            .with_condition(sqlite_expr!("{} IS NOT NULL", (dept.clone())))
+            .with_order(dept, true)
+            .with_order(salary, false),
+        concat!(
+            r#"SELECT "u"."id", "u"."name", "u"."salary", "u"."department_id", "#,
+            r#"COUNT(*) FILTER (WHERE "o"."status" = 'completed') OVER (PARTITION BY "u"."id") AS "completed_count", "#,
+            r#"LAG("u"."salary", 1) OVER (ORDER BY "u"."salary") AS "prev_salary", "#,
+            r#"LEAD("u"."salary", 1) OVER (ORDER BY "u"."salary") AS "next_salary", "#,
+            r#"FIRST_VALUE("u"."name") OVER (PARTITION BY "u"."department_id" ORDER BY "u"."salary" DESC "#,
+            r#"RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "top_earner", "#,
+            r#"NTH_VALUE("u"."name", 2) OVER (PARTITION BY "u"."department_id" ORDER BY "u"."salary" DESC "#,
+            r#"ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "second_earner" "#,
+            r#"FROM "users" AS "u" "#,
+            r#"LEFT JOIN "orders" AS "o" ON "o"."user_id" = "u"."id" "#,
+            r#"WHERE "u"."department_id" IS NOT NULL "#,
+            r#"ORDER BY "u"."department_id", "u"."salary" DESC"#,
+        ),
+    )
+    .await;
+
+    // LEFT JOIN duplicates rows for users with multiple orders
+    assert!(!rows.is_empty());
+
+    // Backend dept (id=2): Alice (120k) is top earner
+    let alice = rows.iter().find(|r| r.name == "Alice Chen").unwrap();
+    assert_eq!(alice.department_id, 2);
+    assert_eq!(alice.top_earner, "Alice Chen");
+
+    // Hank Patel is sole member of Engineering (dept 1) — no second earner
+    let hank = rows.iter().find(|r| r.name == "Hank Patel").unwrap();
+    assert_eq!(hank.top_earner, "Hank Patel");
+    assert_eq!(hank.second_earner, None);
+}

--- a/vantage-sql/tests/sqlite/3_select.rs
+++ b/vantage-sql/tests/sqlite/3_select.rs
@@ -2,7 +2,6 @@
 //!
 //! All queries built using the Selectable trait methods, not custom builders.
 
-use serde::Deserialize;
 use vantage_expressions::{ExprDataSource, Expressive, Selectable};
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 #[allow(unused_imports)]


### PR DESCRIPTION
`vantage-sql` picks up enough SQL to express real queries, not just `SELECT … FROM t WHERE …`. Now in `vantage_sql::primitives`: `Identifier` (quoting + dotted paths + alias), `Fx` (function calls — uppercased, comma-joined args), `Case` / `Iif`, `Union` (with `union_all` / `except` / `intersect`), and `Window` (PARTITION BY / ORDER BY / `rows` / `range` frames, plus named-window references for the WINDOW clause). `SqliteSelect` gains matching builders: `with_join` (`SqliteSelectJoin::inner` / `left` / `*_expr` for subquery joins), `with_having`, `with_window`, and `with_cte` (the recursive flag bumps it to `WITH RECURSIVE`).

The fifteen queries in `vantage-sql/tests/sqlite/3_complex_queries.rs` are the brief — each one is a real shape (LEFT JOIN + COALESCE + GROUP BY, scalar subquery + correlated EXISTS, derived tables, ROW_NUMBER + RANK + running SUM with a named WINDOW, multi-CTE, recursive department-tree CTE, JSON operators with BETWEEN / CAST / NULLIF, window FILTER + LAG + LEAD), and each test asserts both the rendered SQL and the executed result against `bakery.sqlite`. This was the goal post-#163 (sqlite landed): prove the surface is enough to write the queries you actually write, not just the ones builders usually demo.

### Breaking change for custom `Selectable` impls

The methods on `vantage_expressions::Selectable` that took `Expression<T>` now take `impl Expressive<T>`: `add_expression`, `add_where_condition`, `add_order_by`, `add_group_by`, `as_sum`, plus the builder pairs `with_condition`, `with_order`, `with_expression`. Call sites passing an `Expression<T>` keep compiling — `Expression<T>: Expressive<T>`. If you implement `Selectable` for your own builder, change the signatures and add `.expr()` where you used to store the argument directly. Two new builder methods land while we're here: `with_group_by` and `with_distinct`.

### Still on `SqliteSelect`, not on the trait

`with_join`, `with_having`, `with_window`, and `with_cte` live on `SqliteSelect` directly because `Selectable` doesn't model joins, HAVING, named windows, or CTEs yet. Lifting them up is a separate question — the dialects diverge enough that designing the trait shape needs another pass. For now: write the cross-database parts through `Selectable`, drop down to the concrete `SqliteSelect` for the rest.