### PR TITLE
implement table operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,7 +3236,6 @@ name = "vantage-sql"
 version = "0.4.0"
 dependencies = [
  "async-trait",
- "futures-core",
  "indexmap",
  "paste",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,6 +3235,8 @@ dependencies = [
 name = "vantage-sql"
 version = "0.4.0"
 dependencies = [
+ "async-trait",
+ "futures-core",
  "indexmap",
  "paste",
  "serde",
@@ -3242,7 +3244,9 @@ dependencies = [
  "sqlx",
  "tokio",
  "vantage-core",
+ "vantage-dataset",
  "vantage-expressions",
+ "vantage-table",
  "vantage-types",
 ]
 

--- a/NEW_PERSISTENCE_GUIDE.md
+++ b/NEW_PERSISTENCE_GUIDE.md
@@ -617,3 +617,328 @@ At this point you should have:
    - `as_count()` and `as_sum()` render correctly
    - Live execution against a test database — SELECT, COUNT, SUM, ORDER+LIMIT
    - Entity deserialization from live query results
+
+## Step 4: Table abstraction and entity CRUD
+
+The same entities get used hundreds of times across a codebase — constructing a query from scratch
+every single time is tedious and error-prone. Vantage offers `Table<>` as an abstraction over your
+entity definitions: it knows the table name, the columns, their types, and the ID field, so it can
+build queries for you.
+
+To use your persistence backend as a table source, you need to implement the `TableSource` trait.
+Most of the heavy-lifting is done by the `vantage-table` crate — your job is to implement
+`TableSource` trait methods.
+
+### Implement TableSource with placeholder methods
+
+Start by adding the required dependencies:
+
+```toml
+# in your backend's Cargo.toml
+vantage-table = { path = "../vantage-table" }
+async-trait = "0.1"
+futures-core = "0.3"
+```
+
+Create a new test file (e.g. `tests/<backend>/4_table_def.rs`) that defines a table and populates
+its columns. The columns rely on the type system you built in Step 1.
+
+The `TableSource` implementation also declares several associated types:
+
+- **`Column`** — the `Column` type supplied by `vantage-table` is good enough for most backends.
+- **`AnyType`** and **`Value`** — your type-erased value type from Step 1 (e.g. `AnySqliteType`).
+- **`Id`** — use `String` for SQL databases, or a custom type if your IDs have special structure
+  (e.g. SurrealDB's `Thing` which encodes `table:id`). Whatever you pick must be covered by your
+  type system.
+
+```rust
+use async_trait::async_trait;
+use vantage_table::column::core::{Column, ColumnType};
+use vantage_table::traits::table_source::TableSource;
+
+#[async_trait]
+impl TableSource for SqliteDB {
+    type Column<Type> = Column<Type> where Type: ColumnType;
+    type AnyType = AnySqliteType;
+    type Value = AnySqliteType;
+    type Id = String;
+    // ...
+}
+```
+
+Implement the following methods first — they're all straightforward delegations:
+
+- **Column management** — `create_column`, `to_any_column`, `convert_any_column`:
+
+```rust
+    fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
+        Column::new(name)
+    }
+
+    fn to_any_column<Type: ColumnType>(
+        &self,
+        column: Self::Column<Type>,
+    ) -> Self::Column<Self::AnyType> {
+        Column::from_column(column)
+    }
+
+    fn convert_any_column<Type: ColumnType>(
+        &self,
+        any_column: Self::Column<Self::AnyType>,
+    ) -> Option<Self::Column<Type>> {
+        Some(Column::from_column(any_column))
+    }
+```
+
+- **Expression factory** — `expr()`:
+
+```rust
+    fn expr(
+        &self,
+        template: impl Into<String>,
+        parameters: Vec<ExpressiveEnum<Self::Value>>,
+    ) -> Expression<Self::Value> {
+        Expression::new(template, parameters)
+    }
+```
+
+Every other method — should start as `todo!()`. You'll implement them incrementally in the following
+sections, driven by tests.
+
+### Define entity tables
+
+With `TableSource` in place, define your entity structs and table constructors. The pattern is the
+same across all backends — `#[entity(YourType)]` for the struct, plus a builder method that returns
+`Table<YourDB, Entity>`:
+
+```rust
+use vantage_sql::sqlite::{SqliteType, SqliteDB, AnySqliteType};
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+```
+
+Note that the entity struct does **not** include the `id` field — that's handled separately by
+`with_id_column()`, which registers the column and sets the table's ID field. The remaining columns
+are added with `with_column_of::<Type>()`, which creates typed columns via your
+`TableSource::create_column` implementation.
+
+### Verify with a query generation test
+
+Your first test should build a table, then call `table.select()`. Just like the Step 3 tests, you
+can use `preview()` to check the rendered SQL, and later execute it against a real database:
+
+```rust
+#[tokio::test]
+async fn test_product_select() {
+    let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+    let table = Product::sqlite_table(db);
+    let select = table.select();
+    assert_eq!(
+        select.preview(),
+        "SELECT \"id\", \"name\", \"calories\", \"price\", \
+         \"bakery_id\", \"is_deleted\", \"inventory_stock\" FROM \"product\""
+    );
+}
+```
+
+This works because `table.select()` (provided by `vantage-table`) calls your
+`SelectableDataSource::select()` to get a fresh SELECT builder, then applies the table name via
+`set_source()` and adds each registered column via `add_field()`. None of the `todo!()` methods are
+hit — only the column and expression infrastructure you already implemented.
+
+### Implement the read methods
+
+`Table<T, E>` implements two traits from `vantage-dataset` that provide read access:
+
+- **`ReadableValueSet`** — returns raw `Record<Value>` (untyped storage values):
+  - `list_values()` → all records as `IndexMap<Id, Record<Value>>`
+  - `get_value(id)` → single record by ID
+  - `get_some_value()` → one arbitrary record (or `None` if empty)
+
+- **`ReadableDataSet<E>`** — returns deserialized entities (calls `E::try_from_record()` for you):
+  - `list()` → all entities as `IndexMap<Id, E>`
+  - `get(id)` → single entity by ID
+  - `get_some()` → one arbitrary entity
+
+Both traits delegate to three `TableSource` methods: `list_table_values`, `get_table_value`, and
+`get_table_some_value`. The pattern is the same for all three:
+
+1. Get the id field name from `table.id_field()` (falls back to `"id"`)
+2. Build a SELECT using `table.select()` (which already applies columns, conditions, ordering)
+3. Execute via `self.execute(&select.expr())`
+4. Parse the result — split each row into an ID and a `Record`
+
+For `get_table_value`, add a WHERE condition on the id field. For `get_table_some_value`, set
+`LIMIT 1` and return the first row (or `None` if empty).
+
+Write tests for both `ReadableValueSet` and `ReadableDataSet` in separate files — import the traits
+from `vantage_dataset` and call `list_values()`, `get_value()`, `get_some_value()`, `list()`,
+`get()`, `get_some()` against your pre-populated test database. Keep these tests condition-free —
+conditions get their own test file next.
+
+### Error handling
+
+All `TableSource` methods return `vantage_core::Result<T>` (an alias for
+`Result<T, VantageError>`). Use the `error!` macro from `vantage_core` to create errors with
+structured context:
+
+```rust
+use vantage_core::error;
+
+// Simple error message
+return Err(error!("expected array result"));
+
+// With key = value context (NOT format args — the macro uses a different syntax)
+return Err(error!("row missing id field", field = id_field_name));
+
+// For database-specific errors, convert them with map_err
+let rows = query.fetch_all(self.pool()).await
+    .map_err(|e| error!("SQLite query failed", details = e.to_string()))?;
+```
+
+The macro automatically captures file, line, and column. The `key = value` pairs are stored as
+structured context, not interpolated into the message string.
+
+To wrap external errors with additional context, use the `Context` trait:
+
+```rust
+use vantage_core::Context;
+
+// Wraps the original error as the "source" of a new VantageError
+let data = std::fs::read("config.json")
+    .context(error!("failed to load config"))?;
+```
+
+This chains errors — the original `io::Error` is preserved as the source, so `Display` renders
+both messages and the source chain is available via `std::error::Error::source()`.
+
+### Implement Operation for your column type
+
+The `Operation` trait (from `vantage-table`) gives columns `.eq()` and `.in_()` methods for building
+conditions. The trait provides default implementations using standard SQL syntax, so for most
+backends you just need an empty impl:
+
+```rust
+use vantage_table::operation::Operation;
+
+impl Operation<AnySqliteType> for Column<AnySqliteType> {}
+```
+
+The defaults use `"{} = {}"` and `"{} IN ({})"` templates. Backends with non-SQL evaluation (like
+CSV's in-memory filtering) can override these with their own implementations.
+
+The `eq()` method accepts `impl Into<YourAnyType>`, so you can pass native Rust values directly —
+`false`, `42`, `"hello"` — without wrapping them.
+
+### Testing conditions
+
+`Table` carries conditions set via `add_condition()`, and `table.select()` applies them
+automatically as WHERE clauses. Test a few patterns:
+
+- **Custom expression** — pass columns as expression arguments via `table["field"]`:
+
+```rust
+let mut table = Product::sqlite_table(db);
+table.add_condition(sqlite_expr!("{} > {}", (table["price"]), 130));
+```
+
+- **Multiple conditions** — combined with AND, including field-to-field comparison:
+
+```rust
+let mut table = Product::sqlite_table(db);
+table.add_condition(sqlite_expr!("{} > {}", (table["price"]), 130));
+table.add_condition(sqlite_expr!("{} > {}", (table["price"]), (table["calories"])));
+```
+
+- **Operation::eq()** — the idiomatic way:
+
+```rust
+use vantage_table::operation::Operation;
+
+let mut table = Product::sqlite_table(db);
+table.add_condition(table["is_deleted"].eq(false));
+```
+
+### Implement aggregates
+
+Implement `get_count`, `get_sum`, `get_max`, and `get_min` in your `TableSource`. These build
+aggregate queries from `table.select()` and extract the scalar result. Once implemented, `Table`
+exposes them directly:
+
+```rust
+let table = Product::sqlite_table(db);
+assert_eq!(table.get_count().await.unwrap(), 5);
+assert_eq!(table.get_max(&table["price"]).await.unwrap().try_get::<i64>().unwrap(), 299);
+```
+
+### Implement write operations
+
+`Table` also implements `WritableDataSet` (insert, replace, patch, delete) and `InsertableDataSet`
+(insert with auto-generated ID). These delegate to six `TableSource` methods:
+
+- **`insert_table_value`** — INSERT with a known ID. Build an `SqliteInsert` with the id field and
+  record fields, execute, then read back via `get_table_value`.
+- **`replace_table_value`** — full replacement. For SQLite, use `INSERT OR REPLACE INTO`.
+- **`patch_table_value`** — partial update. Build an `SqliteUpdate` with only the provided fields
+  and a WHERE condition on the id field.
+- **`delete_table_value`** — DELETE with a WHERE condition on the id field.
+- **`delete_table_all_values`** — DELETE without conditions.
+- **`insert_table_return_id_value`** — INSERT without a known ID (auto-increment). Use
+  `RETURNING "id"` to get the generated ID back from the database.
+
+Test both `WritableValueSet` (raw records, no entity) and `WritableDataSet` (typed entities) using
+in-memory SQLite:
+
+```rust
+// WritableValueSet — no entity needed
+let rec = record(&[("name", "Gamma".into()), ("price", 30i64.into())]);
+table.insert_value(&"c".to_string(), &rec).await.unwrap();
+
+// WritableDataSet — typed entities
+let item = Item { name: "Gamma".into(), price: 30 };
+table.insert(&"c".to_string(), &item).await.unwrap();
+
+// InsertableDataSet — auto-generated ID
+let id = table.insert_return_id(&item).await.unwrap();
+let fetched = table.get(id).await.unwrap();
+```
+
+## Step 5: Relationships and joins at the Table level
+
+Implement `has_one`, `has_many`, and `belongs_to` on your Table so that related entities can be
+traversed and queried through the `Table` API without manual JOIN construction.
+
+## Step 6: Transactions and error handling
+
+Wrap your connection pool's transaction API so that multiple operations can be grouped atomically,
+and map database-specific errors into `vantage_core::VantageError` for consistent error handling
+across backends.
+
+## Step 7: Schema introspection (optional)
+
+Implement schema reading so that tables, columns, and types can be discovered at runtime — useful
+for migrations, admin UIs, and dynamic query building without compile-time entity structs.

--- a/NEW_PERSISTENCE_GUIDE.md
+++ b/NEW_PERSISTENCE_GUIDE.md
@@ -637,7 +637,6 @@ Start by adding the required dependencies:
 # in your backend's Cargo.toml
 vantage-table = { path = "../vantage-table" }
 async-trait = "0.1"
-futures-core = "0.3"
 ```
 
 Create a new test file (e.g. `tests/<backend>/4_table_def.rs`) that defines a table and populates
@@ -885,9 +884,10 @@ table.add_condition(table["is_deleted"].eq(false));
 
 ### Implement aggregates
 
-Implement `get_count`, `get_sum`, `get_max`, and `get_min` in your `TableSource`. These build
-aggregate queries from `table.select()` and extract the scalar result. Once implemented, `Table`
-exposes them directly:
+Implement `get_table_count`, `get_table_sum`, `get_table_max`, and `get_table_min` in your
+`TableSource`. These build aggregate queries from `table.select()` and extract the scalar result.
+Once implemented, `Table` exposes shorter `get_count`, `get_sum`, `get_max`, `get_min` methods
+directly:
 
 ```rust
 let table = Product::sqlite_table(db);

--- a/vantage-api-client/src/table_source.rs
+++ b/vantage-api-client/src/table_source.rs
@@ -9,7 +9,6 @@ use vantage_expressions::traits::datasource::DataSource;
 use vantage_expressions::traits::expressive::ExpressiveEnum;
 use vantage_table::column::core::{Column, ColumnType};
 use vantage_table::table::Table;
-use vantage_table::traits::table_like::TableLike;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
 
@@ -83,11 +82,14 @@ impl TableSource for RestApi {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr(
+    fn search_table_expr<E>(
         &self,
-        _table: &impl TableLike,
+        _table: &Table<Self, E>,
         search_value: &str,
-    ) -> Expression<Self::Value> {
+    ) -> Expression<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
         Expression::new(format!("SEARCH '{}'", search_value), vec![])
     }
 

--- a/vantage-api-client/src/table_source.rs
+++ b/vantage-api-client/src/table_source.rs
@@ -135,7 +135,7 @@ impl TableSource for RestApi {
         Ok(records.into_iter().next())
     }
 
-    async fn get_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
+    async fn get_table_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
     where
         E: Entity<Self::Value>,
         Self: Sized,
@@ -146,7 +146,7 @@ impl TableSource for RestApi {
         Ok(records.len() as i64)
     }
 
-    async fn get_sum<E>(
+    async fn get_table_sum<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,
@@ -158,7 +158,7 @@ impl TableSource for RestApi {
         Err(error!("Sum not implemented for API backend"))
     }
 
-    async fn get_max<E>(
+    async fn get_table_max<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,
@@ -170,7 +170,7 @@ impl TableSource for RestApi {
         Err(error!("Max not implemented for API backend"))
     }
 
-    async fn get_min<E>(
+    async fn get_table_min<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,

--- a/vantage-api-pool/src/pool_api.rs
+++ b/vantage-api-pool/src/pool_api.rs
@@ -194,7 +194,7 @@ impl TableSource for PoolApi {
         Ok(records.into_iter().next())
     }
 
-    async fn get_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
+    async fn get_table_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
     where
         E: Entity<Self::Value>,
         Self: Sized,
@@ -203,7 +203,7 @@ impl TableSource for PoolApi {
         Ok(records.len() as i64)
     }
 
-    async fn get_sum<E>(
+    async fn get_table_sum<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,
@@ -215,7 +215,7 @@ impl TableSource for PoolApi {
         Err(error!("Sum not implemented for API pool backend"))
     }
 
-    async fn get_max<E>(
+    async fn get_table_max<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,
@@ -227,7 +227,7 @@ impl TableSource for PoolApi {
         Err(error!("Max not implemented for API pool backend"))
     }
 
-    async fn get_min<E>(
+    async fn get_table_min<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,

--- a/vantage-api-pool/src/pool_api.rs
+++ b/vantage-api-pool/src/pool_api.rs
@@ -14,7 +14,6 @@ use vantage_expressions::traits::expressive::{DeferredFn, ExpressiveEnum};
 use vantage_expressions::Expression;
 use vantage_table::column::core::{Column, ColumnType};
 use vantage_table::table::Table;
-use vantage_table::traits::table_like::TableLike;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
 
@@ -120,11 +119,14 @@ impl TableSource for PoolApi {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr(
+    fn search_table_expr<E>(
         &self,
-        _table: &impl TableLike,
+        _table: &Table<Self, E>,
         search_value: &str,
-    ) -> Expression<Self::Value> {
+    ) -> Expression<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
         Expression::new(format!("SEARCH '{}'", search_value), vec![])
     }
 

--- a/vantage-csv/src/condition.rs
+++ b/vantage-csv/src/condition.rs
@@ -10,8 +10,8 @@ use vantage_expressions::Expression;
 use vantage_expressions::traits::expressive::ExpressiveEnum;
 use vantage_types::Record;
 
+use crate::operation::{OP_EQ, OP_IN};
 use crate::type_system::AnyCsvType;
-use vantage_table::operation::{OP_EQ, OP_IN};
 
 /// Evaluate a single condition expression against a set of records,
 /// returning only the records that match.

--- a/vantage-csv/src/operation.rs
+++ b/vantage-csv/src/operation.rs
@@ -3,7 +3,10 @@
 //! Implements `eq()` and `in_()` for `Column<AnyCsvType>`,
 //! which is the column type used by CSV tables (accessed via `table["field"]`).
 
-pub use vantage_table::operation::{OP_EQ, OP_IN};
+/// Template markers for condition operations.
+/// CSV's in-memory evaluator matches on these to know which operation to apply.
+pub const OP_EQ: &str = "{} = {}";
+pub const OP_IN: &str = "{} IN ({})";
 
 use vantage_expressions::traits::expressive::ExpressiveEnum;
 use vantage_expressions::{Expression, Expressive};
@@ -13,12 +16,12 @@ use vantage_table::operation::Operation;
 use crate::type_system::AnyCsvType;
 
 impl Operation<AnyCsvType> for Column<AnyCsvType> {
-    fn eq(&self, value: AnyCsvType) -> Expression<AnyCsvType> {
+    fn eq(&self, value: impl Into<AnyCsvType>) -> Expression<AnyCsvType> {
         Expression::new(
             OP_EQ,
             vec![
                 ExpressiveEnum::Nested(self.expr()),
-                ExpressiveEnum::Scalar(value),
+                ExpressiveEnum::Scalar(value.into()),
             ],
         )
     }

--- a/vantage-csv/src/table_source.rs
+++ b/vantage-csv/src/table_source.rs
@@ -8,7 +8,6 @@ use vantage_expressions::traits::datasource::DataSource;
 use vantage_expressions::traits::expressive::{DeferredFn, ExpressiveEnum};
 use vantage_table::column::core::{Column, ColumnType};
 use vantage_table::table::Table;
-use vantage_table::traits::table_like::TableLike;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
 
@@ -54,11 +53,14 @@ impl TableSource for Csv {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr(
+    fn search_table_expr<E>(
         &self,
-        _table: &impl TableLike,
+        _table: &Table<Self, E>,
         search_value: &str,
-    ) -> Expression<Self::Value> {
+    ) -> Expression<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
         Expression::new(format!("SEARCH '{}'", search_value), vec![])
     }
 

--- a/vantage-csv/src/table_source.rs
+++ b/vantage-csv/src/table_source.rs
@@ -107,7 +107,7 @@ impl TableSource for Csv {
         Ok(records.into_iter().next())
     }
 
-    async fn get_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
+    async fn get_table_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
     where
         E: Entity<Self::Value>,
         Self: Sized,
@@ -116,7 +116,7 @@ impl TableSource for Csv {
         Ok(records.len() as i64)
     }
 
-    async fn get_sum<E>(
+    async fn get_table_sum<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,
@@ -128,7 +128,7 @@ impl TableSource for Csv {
         Err(error!("Sum not implemented for CSV backend"))
     }
 
-    async fn get_max<E>(
+    async fn get_table_max<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,
@@ -140,7 +140,7 @@ impl TableSource for Csv {
         Err(error!("Max not implemented for CSV backend"))
     }
 
-    async fn get_min<E>(
+    async fn get_table_min<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,
@@ -393,7 +393,7 @@ mod tests {
         let csv = test_csv();
         let table = Table::<Csv, EmptyEntity>::new("product", csv);
 
-        let count = table.data_source().get_count(&table).await.unwrap();
+        let count = table.data_source().get_table_count(&table).await.unwrap();
         assert_eq!(count, 5);
     }
 

--- a/vantage-expressions/src/mocks/select.rs
+++ b/vantage-expressions/src/mocks/select.rs
@@ -219,6 +219,16 @@ impl Selectable<serde_json::Value> for MockSelect {
         let source = self.source.as_ref().unwrap().as_str();
         expr!("SELECT SUM({}) FROM {}", (column), source)
     }
+
+    fn as_max(&self, column: impl Expressive<Value>) -> Expression<Value> {
+        let source = self.source.as_ref().unwrap().as_str();
+        expr!("SELECT MAX({}) FROM {}", (column), source)
+    }
+
+    fn as_min(&self, column: impl Expressive<Value>) -> Expression<Value> {
+        let source = self.source.as_ref().unwrap().as_str();
+        expr!("SELECT MIN({}) FROM {}", (column), source)
+    }
 }
 
 impl From<MockSelect> for Expression<serde_json::Value> {

--- a/vantage-expressions/src/traits/selectable.rs
+++ b/vantage-expressions/src/traits/selectable.rs
@@ -77,6 +77,12 @@ pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
     /// Creates a SUM(column) expression from this query configuration.
     fn as_sum(&self, column: impl Expressive<T>) -> Expression<T>;
 
+    /// Creates a MAX(column) expression from this query configuration.
+    fn as_max(&self, column: impl Expressive<T>) -> Expression<T>;
+
+    /// Creates a MIN(column) expression from this query configuration.
+    fn as_min(&self, column: impl Expressive<T>) -> Expression<T>;
+
     // Default implementations for builder-style methods
 
     /// Builder pattern method identical to [`Self::set_source`] without alias.

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -24,7 +24,6 @@ paste = "1.0"
 vantage-dataset = { path = "../vantage-dataset" }
 vantage-table = { path = "../vantage-table" }
 async-trait = "0.1"
-futures-core = "0.3"
 sqlx = { version = "0.8", features = ["runtime-tokio"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -21,6 +21,10 @@ vantage-types = { path = "../vantage-types", features = ["serde"] }
 vantage-expressions = { path = "../vantage-expressions" }
 paste = "1.0"
 
+vantage-dataset = { path = "../vantage-dataset" }
+vantage-table = { path = "../vantage-table" }
+async-trait = "0.1"
+futures-core = "0.3"
 sqlx = { version = "0.8", features = ["runtime-tokio"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/vantage-sql/src/sqlite/impls/mod.rs
+++ b/vantage-sql/src/sqlite/impls/mod.rs
@@ -1,5 +1,6 @@
 pub mod expr_data_source;
 pub mod selectable_data_source;
+pub mod table_source;
 
 use vantage_expressions::traits::datasource::DataSource;
 

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -7,7 +7,6 @@ use vantage_expressions::traits::expressive::ExpressiveEnum;
 use vantage_expressions::{Expression, Expressive, Selectable};
 use vantage_table::column::core::{Column, ColumnType};
 use vantage_table::table::Table;
-use vantage_table::traits::table_like::TableLike;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
 
@@ -87,12 +86,32 @@ impl TableSource for SqliteDB {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr(
+    fn search_table_expr<E>(
         &self,
-        _table: &impl TableLike,
-        _search_value: &str,
-    ) -> Expression<Self::Value> {
-        todo!("search_table_expr")
+        table: &Table<Self, E>,
+        search_value: &str,
+    ) -> Expression<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        let pattern = format!("%{}%", search_value.replace('%', "\\%"));
+        let conditions: Vec<Expression<AnySqliteType>> = table
+            .columns()
+            .values()
+            .map(|col| {
+                Expression::new(
+                    format!("\"{}\" LIKE {{}}", col.name()),
+                    vec![ExpressiveEnum::Scalar(AnySqliteType::from(
+                        pattern.clone(),
+                    ))],
+                )
+            })
+            .collect();
+
+        if conditions.is_empty() {
+            return sqlite_expr!("0");
+        }
+        Expression::from_vec(conditions, " OR ")
     }
 
     async fn list_table_values<E>(
@@ -166,7 +185,7 @@ impl TableSource for SqliteDB {
         let result = self.aggregate(&select, "count", sqlite_expr!("*")).await?;
         result
             .try_get::<i64>()
-            .ok_or_else(|| error!("get_count: expected i64", result = format!("{}", result)))
+            .ok_or_else(|| error!("get_table_count: expected i64", result = format!("{}", result)))
     }
 
     async fn get_table_sum<E>(

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -101,9 +101,7 @@ impl TableSource for SqliteDB {
             .map(|col| {
                 Expression::new(
                     format!("\"{}\" LIKE {{}}", col.name()),
-                    vec![ExpressiveEnum::Scalar(AnySqliteType::from(
-                        pattern.clone(),
-                    ))],
+                    vec![ExpressiveEnum::Scalar(AnySqliteType::from(pattern.clone()))],
                 )
             })
             .collect();
@@ -183,9 +181,12 @@ impl TableSource for SqliteDB {
     {
         let select = table.select();
         let result = self.aggregate(&select, "count", sqlite_expr!("*")).await?;
-        result
-            .try_get::<i64>()
-            .ok_or_else(|| error!("get_table_count: expected i64", result = format!("{}", result)))
+        result.try_get::<i64>().ok_or_else(|| {
+            error!(
+                "get_table_count: expected i64",
+                result = format!("{}", result)
+            )
+        })
     }
 
     async fn get_table_sum<E>(

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -1,0 +1,351 @@
+use async_trait::async_trait;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_expressions::traits::associated_expressions::AssociatedExpression;
+use vantage_expressions::traits::datasource::ExprDataSource;
+use vantage_expressions::traits::expressive::ExpressiveEnum;
+use vantage_expressions::{Expression, Expressive, Selectable};
+use vantage_table::column::core::{Column, ColumnType};
+use vantage_table::table::Table;
+use vantage_table::traits::table_like::TableLike;
+use vantage_table::traits::table_source::TableSource;
+use vantage_types::{Entity, Record};
+
+use crate::sqlite::SqliteDB;
+use crate::sqlite::types::AnySqliteType;
+
+/// Parse the JSON array result from execute() into an IndexMap of id → Record.
+fn parse_rows(
+    result: AnySqliteType,
+    id_field_name: &str,
+) -> Result<IndexMap<String, Record<AnySqliteType>>> {
+    let arr = match result.into_value() {
+        serde_json::Value::Array(arr) => arr,
+        other => return Err(error!("expected array result", details = other.to_string())),
+    };
+
+    let mut records = IndexMap::new();
+    for item in arr {
+        let obj = match item {
+            serde_json::Value::Object(map) => map,
+            _ => continue,
+        };
+
+        let id = obj
+            .get(id_field_name)
+            .and_then(|v| match v {
+                serde_json::Value::String(s) => Some(s.clone()),
+                serde_json::Value::Number(n) => Some(n.to_string()),
+                _ => None,
+            })
+            .ok_or_else(|| error!("row missing id field", field = id_field_name))?;
+
+        let record: Record<AnySqliteType> = obj
+            .into_iter()
+            .map(|(k, v)| (k, AnySqliteType::untyped(v)))
+            .collect();
+
+        records.insert(id, record);
+    }
+
+    Ok(records)
+}
+
+#[async_trait]
+impl TableSource for SqliteDB {
+    type Column<Type>
+        = Column<Type>
+    where
+        Type: ColumnType;
+    type AnyType = AnySqliteType;
+    type Value = AnySqliteType;
+    type Id = String;
+
+    fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
+        Column::new(name)
+    }
+
+    fn to_any_column<Type: ColumnType>(
+        &self,
+        column: Self::Column<Type>,
+    ) -> Self::Column<Self::AnyType> {
+        Column::from_column(column)
+    }
+
+    fn convert_any_column<Type: ColumnType>(
+        &self,
+        any_column: Self::Column<Self::AnyType>,
+    ) -> Option<Self::Column<Type>> {
+        Some(Column::from_column(any_column))
+    }
+
+    fn expr(
+        &self,
+        template: impl Into<String>,
+        parameters: Vec<ExpressiveEnum<Self::Value>>,
+    ) -> Expression<Self::Value> {
+        Expression::new(template, parameters)
+    }
+
+    fn search_table_expr(
+        &self,
+        _table: &impl TableLike,
+        _search_value: &str,
+    ) -> Expression<Self::Value> {
+        todo!("search_table_expr")
+    }
+
+    async fn list_table_values<E>(
+        &self,
+        table: &Table<Self, E>,
+    ) -> Result<IndexMap<Self::Id, Record<Self::Value>>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let select = table.select();
+        let result = self.execute(&select.expr()).await?;
+
+        parse_rows(result, &id_field_name)
+    }
+
+    async fn get_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let condition = Expression::new(
+            format!("\"{}\" = {{}}", id_field_name),
+            vec![ExpressiveEnum::Scalar(AnySqliteType::from(id.clone()))],
+        );
+        let select = table.select().with_condition(condition);
+        let result = self.execute(&select.expr()).await?;
+
+        let mut rows = parse_rows(result, &id_field_name)?;
+        rows.swap_remove(id)
+            .ok_or_else(|| error!("get_table_value: no row found", id = id.clone()))
+    }
+
+    async fn get_table_some_value<E>(
+        &self,
+        table: &Table<Self, E>,
+    ) -> Result<Option<(Self::Id, Record<Self::Value>)>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let mut select = table.select();
+        select.set_limit(Some(1), None);
+        let result = self.execute(&select.expr()).await?;
+
+        let mut rows = parse_rows(result, &id_field_name)?;
+        Ok(rows.swap_remove_index(0))
+    }
+
+    async fn get_table_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
+    where
+        E: Entity<Self::Value>,
+    {
+        let select = table.select();
+        let result = self.aggregate(&select, "count", sqlite_expr!("*")).await?;
+        result
+            .try_get::<i64>()
+            .ok_or_else(|| error!("get_count: expected i64", result = format!("{}", result)))
+    }
+
+    async fn get_table_sum<E>(
+        &self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        self.aggregate(&table.select(), "sum", column.expr()).await
+    }
+
+    async fn get_table_max<E>(
+        &self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        self.aggregate(&table.select(), "max", column.expr()).await
+    }
+
+    async fn get_table_min<E>(
+        &self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        self.aggregate(&table.select(), "min", column.expr()).await
+    }
+
+    async fn insert_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        record: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let insert = crate::sqlite::statements::SqliteInsert::new(table.table_name())
+            .with_field(&id_field_name, AnySqliteType::from(id.clone()))
+            .with_record(record);
+        self.execute(&insert.expr()).await?;
+
+        self.get_table_value(table, id).await
+    }
+
+    async fn replace_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        record: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        // SQLite INSERT OR REPLACE handles both insert and update
+        let insert = crate::sqlite::statements::SqliteInsert::new(table.table_name())
+            .with_field(&id_field_name, AnySqliteType::from(id.clone()))
+            .with_record(record);
+        // Rewrite as INSERT OR REPLACE
+        let expr = insert.expr();
+        let replace_expr = Expression::new(
+            expr.template
+                .replacen("INSERT INTO", "INSERT OR REPLACE INTO", 1),
+            expr.parameters.clone(),
+        );
+        self.execute(&replace_expr).await?;
+
+        self.get_table_value(table, id).await
+    }
+
+    async fn patch_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        partial: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let id_condition = Expression::new(
+            format!("\"{}\" = {{}}", id_field_name),
+            vec![ExpressiveEnum::Scalar(AnySqliteType::from(id.clone()))],
+        );
+        let update = crate::sqlite::statements::SqliteUpdate::new(table.table_name())
+            .with_record(partial)
+            .with_condition(id_condition);
+        self.execute(&update.expr()).await?;
+
+        self.get_table_value(table, id).await
+    }
+
+    async fn delete_table_value<E>(&self, table: &Table<Self, E>, id: &Self::Id) -> Result<()>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let id_condition = Expression::new(
+            format!("\"{}\" = {{}}", id_field_name),
+            vec![ExpressiveEnum::Scalar(AnySqliteType::from(id.clone()))],
+        );
+        let delete = crate::sqlite::statements::SqliteDelete::new(table.table_name())
+            .with_condition(id_condition);
+        self.execute(&delete.expr()).await?;
+        Ok(())
+    }
+
+    async fn delete_table_all_values<E>(&self, table: &Table<Self, E>) -> Result<()>
+    where
+        E: Entity<Self::Value>,
+    {
+        let delete = crate::sqlite::statements::SqliteDelete::new(table.table_name());
+        self.execute(&delete.expr()).await?;
+        Ok(())
+    }
+
+    async fn insert_table_return_id_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        record: &Record<Self::Value>,
+    ) -> Result<Self::Id>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let insert =
+            crate::sqlite::statements::SqliteInsert::new(table.table_name()).with_record(record);
+
+        // Append RETURNING id_field to get the generated ID back
+        let base = insert.expr();
+        let returning = Expression::new(
+            format!("{} RETURNING \"{}\"", base.template, id_field_name),
+            base.parameters.clone(),
+        );
+        let result = self.execute(&returning).await?;
+        let mut rows = parse_rows(result, &id_field_name)?;
+        rows.swap_remove_index(0)
+            .map(|(id, _)| id)
+            .ok_or_else(|| error!("insert_table_return_id_value: no id returned"))
+    }
+
+    fn column_table_values_expr<'a, E, Type: ColumnType>(
+        &'a self,
+        _table: &Table<Self, E>,
+        _column: &Self::Column<Type>,
+    ) -> AssociatedExpression<'a, Self, Self::Value, Vec<Type>>
+    where
+        E: Entity<Self::Value> + 'static,
+        Self: ExprDataSource<Self::Value> + Sized,
+    {
+        todo!("column_table_values_expr")
+    }
+}

--- a/vantage-sql/src/sqlite/mod.rs
+++ b/vantage-sql/src/sqlite/mod.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 mod macros;
 pub mod impls;
+mod operation;
 mod row;
 pub mod statements;
 pub mod types;
@@ -23,5 +24,26 @@ impl SqliteDB {
 
     pub fn pool(&self) -> &SqlitePool {
         &self.pool
+    }
+
+    /// Execute an aggregate query (COUNT, SUM, MAX, MIN etc.) and return the scalar result.
+    pub async fn aggregate(
+        &self,
+        select: &statements::SqliteSelect,
+        func: &str,
+        column: impl vantage_expressions::Expressive<AnySqliteType>,
+    ) -> vantage_core::Result<AnySqliteType> {
+        use vantage_expressions::ExprDataSource;
+        let expr = select.as_aggregate(func, column);
+        let result = self.execute(&expr).await?;
+        Ok(match result.value() {
+            serde_json::Value::Array(arr) => arr
+                .first()
+                .and_then(|row| row.as_object())
+                .and_then(|obj| obj.values().next())
+                .map(|v| AnySqliteType::untyped(v.clone()))
+                .unwrap_or(result),
+            _ => result,
+        })
     }
 }

--- a/vantage-sql/src/sqlite/operation.rs
+++ b/vantage-sql/src/sqlite/operation.rs
@@ -1,0 +1,6 @@
+use vantage_table::column::core::Column;
+use vantage_table::operation::Operation;
+
+use super::types::AnySqliteType;
+
+impl Operation<AnySqliteType> for Column<AnySqliteType> {}

--- a/vantage-sql/src/sqlite/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/sqlite/statements/select/impls/selectable.rs
@@ -1,10 +1,21 @@
 use vantage_expressions::traits::selectable::{Selectable, SourceRef};
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
+use crate::primitives::fx::Fx;
 use crate::sqlite::statements::SqliteSelect;
 use crate::sqlite::types::AnySqliteType;
 
 type Expr = Expression<AnySqliteType>;
+
+impl SqliteSelect {
+    pub fn as_aggregate(&self, func: &str, column: impl Expressive<AnySqliteType>) -> Expr {
+        let mut s = self.clone();
+        s.clear_fields();
+        s.add_expression(Fx::new(func, [column.expr()]), None);
+        s.clear_order_by();
+        s.render()
+    }
+}
 
 impl Selectable<AnySqliteType> for SqliteSelect {
     fn set_source(&mut self, source: impl Into<SourceRef<AnySqliteType>>, alias: Option<String>) {
@@ -130,13 +141,14 @@ impl Selectable<AnySqliteType> for SqliteSelect {
     }
 
     fn as_sum(&self, column: impl Expressive<AnySqliteType>) -> Expr {
-        let mut sum_select = self.clone();
-        sum_select.fields.clear();
-        sum_select.fields.push(Expression::new(
-            "SUM({})",
-            vec![ExpressiveEnum::Nested(column.expr())],
-        ));
-        sum_select.order_by.clear();
-        sum_select.render()
+        self.as_aggregate("sum", column)
+    }
+
+    fn as_max(&self, column: impl Expressive<AnySqliteType>) -> Expr {
+        self.as_aggregate("max", column)
+    }
+
+    fn as_min(&self, column: impl Expressive<AnySqliteType>) -> Expr {
+        self.as_aggregate("min", column)
     }
 }

--- a/vantage-sql/tests/sqlite.rs
+++ b/vantage-sql/tests/sqlite.rs
@@ -1,19 +1,33 @@
 mod sqlite {
+    #[path = "4_aggregates.rs"]
+    mod aggregates;
     #[path = "2_associated.rs"]
     mod associated;
     mod bakery;
     #[path = "3_complex_queries.rs"]
     mod complex_queries;
+    #[path = "4_conditions.rs"]
+    mod conditions;
     #[path = "2_defer.rs"]
     mod defer;
+    #[path = "4_editable_data_set.rs"]
+    mod editable_data_set;
+    #[path = "4_editable_value_set.rs"]
+    mod editable_value_set;
     #[path = "2_expressions.rs"]
     mod expressions;
     #[path = "2_insert.rs"]
     mod insert;
+    #[path = "4_readable_data_set.rs"]
+    mod readable_data_set;
+    #[path = "4_readable_value_set.rs"]
+    mod readable_value_set;
     #[path = "2_records.rs"]
     mod records;
     #[path = "3_select.rs"]
     mod select;
+    #[path = "4_table_def.rs"]
+    mod table_def;
     #[path = "1_types_record.rs"]
     mod types_record;
     #[path = "1_types_round_trip.rs"]

--- a/vantage-sql/tests/sqlite/4_aggregates.rs
+++ b/vantage-sql/tests/sqlite/4_aggregates.rs
@@ -1,0 +1,80 @@
+//! Test 4: Aggregate operations — count, sum, max, min via Table methods.
+
+#[allow(unused_imports)]
+use vantage_sql::sqlite::SqliteType;
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_sql::sqlite_expr;
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+const DB_PATH: &str = "sqlite:../target/bakery.sqlite?mode=ro";
+
+async fn get_db() -> SqliteDB {
+    SqliteDB::connect(DB_PATH)
+        .await
+        .expect("Failed to connect to bakery.sqlite — run scripts/sqlite/ingress.sh first")
+}
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+#[tokio::test]
+async fn test_get_count() {
+    let db = get_db().await;
+    let table = Product::sqlite_table(db);
+    assert_eq!(table.get_count().await.unwrap(), 5);
+}
+
+#[tokio::test]
+async fn test_get_count_with_condition() {
+    let db = get_db().await;
+    let mut table = Product::sqlite_table(db);
+    table.add_condition(sqlite_expr!("{} > {}", (table["price"]), 150));
+    assert_eq!(table.get_count().await.unwrap(), 3); // time_tart (220), sea_pie (299), hover_cookies (199)
+}
+
+// prices: 120, 135, 220, 299, 199 → sum = 973
+#[tokio::test]
+async fn test_get_sum() {
+    let db = get_db().await;
+    let table = Product::sqlite_table(db);
+    let result = table.get_sum(&table["price"]).await.unwrap();
+    assert_eq!(result.try_get::<i64>().unwrap(), 973);
+}
+
+#[tokio::test]
+async fn test_get_max() {
+    let db = get_db().await;
+    let table = Product::sqlite_table(db);
+    let result = table.get_max(&table["price"]).await.unwrap();
+    assert_eq!(result.try_get::<i64>().unwrap(), 299);
+}
+
+#[tokio::test]
+async fn test_get_min() {
+    let db = get_db().await;
+    let table = Product::sqlite_table(db);
+    let result = table.get_min(&table["price"]).await.unwrap();
+    assert_eq!(result.try_get::<i64>().unwrap(), 120);
+}

--- a/vantage-sql/tests/sqlite/4_conditions.rs
+++ b/vantage-sql/tests/sqlite/4_conditions.rs
@@ -1,0 +1,98 @@
+//! Test 4: Table conditions — verify that conditions applied via add_condition()
+//! flow through to the generated SELECT and filter results correctly.
+
+#[allow(unused_imports)]
+use vantage_sql::sqlite::SqliteType;
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_sql::sqlite_expr;
+use vantage_table::operation::Operation;
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::ReadableDataSet;
+
+const DB_PATH: &str = "sqlite:../target/bakery.sqlite?mode=ro";
+
+async fn get_db() -> SqliteDB {
+    SqliteDB::connect(DB_PATH)
+        .await
+        .expect("Failed to connect to bakery.sqlite — run scripts/sqlite/ingress.sh first")
+}
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+/// Custom expression condition — columns passed as expression arguments
+#[tokio::test]
+async fn test_custom_expression_condition() {
+    let db = get_db().await;
+    let mut table = Product::sqlite_table(db);
+    table.add_condition(sqlite_expr!("{} > {}", (table["price"]), 130i64));
+
+    let products = table.list().await.unwrap();
+    assert_eq!(products.len(), 4); // all except flux_cupcake (120)
+    for (_id, p) in &products {
+        assert!(p.price > 130);
+    }
+}
+
+/// Multiple conditions combine with AND
+#[tokio::test]
+async fn test_multiple_conditions() {
+    let db = get_db().await;
+    let mut table = Product::sqlite_table(db);
+    // Products with price > 130 AND calories <= 250:
+    // delorean_donut (135, 250), time_tart (220, 200), hover_cookies (199, 150)
+    table.add_condition(sqlite_expr!("{} > {}", (table["price"]), 130i64));
+    table.add_condition(sqlite_expr!("{} <= {}", (table["calories"]), 250i64));
+
+    let products = table.list().await.unwrap();
+    assert_eq!(products.len(), 3);
+    for (_id, p) in &products {
+        assert!(p.price > 130);
+        assert!(p.calories <= 250);
+    }
+}
+
+/// Operation::eq() on table column — the idiomatic way to build conditions
+#[tokio::test]
+async fn test_operation_eq() {
+    let db = get_db().await;
+    let mut table = Product::sqlite_table(db);
+    table.add_condition(table["is_deleted"].eq(false));
+
+    let products = table.list().await.unwrap();
+    assert_eq!(products.len(), 5); // all products have is_deleted = false
+}
+
+/// Condition that matches nothing returns empty
+#[tokio::test]
+async fn test_condition_no_matches() {
+    let db = get_db().await;
+    let mut table = Product::sqlite_table(db);
+    table.add_condition(sqlite_expr!("{} > {}", (table["price"]), 999));
+
+    let products = table.list().await.unwrap();
+    assert!(products.is_empty());
+}

--- a/vantage-sql/tests/sqlite/4_editable_data_set.rs
+++ b/vantage-sql/tests/sqlite/4_editable_data_set.rs
@@ -1,0 +1,150 @@
+//! Test 4: WritableDataSet and InsertableDataSet for Table<SqliteDB, Entity>.
+//!
+//! Uses in-memory SQLite with a typed entity.
+
+#[allow(unused_imports)]
+use vantage_sql::sqlite::SqliteType;
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::{InsertableDataSet, ReadableDataSet, WritableDataSet};
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Item {
+    name: String,
+    price: i64,
+}
+
+impl Item {
+    fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Item> {
+        Table::new("item", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("price")
+    }
+}
+
+async fn setup() -> (SqliteDB, Table<SqliteDB, Item>) {
+    let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+
+    sqlx::query(
+        "CREATE TABLE item (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            price INTEGER NOT NULL
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query("INSERT INTO item VALUES ('a', 'Alpha', 10), ('b', 'Beta', 20)")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    let table = Item::sqlite_table(db.clone());
+    (db, table)
+}
+
+// ── WritableDataSet ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_insert() {
+    let (_db, table) = setup().await;
+
+    let item = Item {
+        name: "Gamma".into(),
+        price: 30,
+    };
+    let result = table.insert(&"c".to_string(), &item).await.unwrap();
+    assert_eq!(result.name, "Gamma");
+    assert_eq!(result.price, 30);
+
+    let fetched = table.get("c").await.unwrap();
+    assert_eq!(fetched.name, "Gamma");
+}
+
+#[tokio::test]
+async fn test_replace() {
+    let (_db, table) = setup().await;
+
+    let item = Item {
+        name: "Alpha Replaced".into(),
+        price: 99,
+    };
+    table.replace(&"a".to_string(), &item).await.unwrap();
+
+    let fetched = table.get("a").await.unwrap();
+    assert_eq!(fetched.name, "Alpha Replaced");
+    assert_eq!(fetched.price, 99);
+}
+
+#[tokio::test]
+async fn test_patch() {
+    let (_db, table) = setup().await;
+
+    let partial = Item {
+        name: "".into(),
+        price: 55,
+    };
+    table.patch(&"a".to_string(), &partial).await.unwrap();
+
+    let fetched = table.get("a").await.unwrap();
+    assert_eq!(fetched.price, 55);
+}
+
+#[tokio::test]
+async fn test_delete() {
+    let (_db, table) = setup().await;
+
+    table.delete(&"a".to_string()).await.unwrap();
+
+    let all = table.list().await.unwrap();
+    assert_eq!(all.len(), 1);
+    assert!(!all.contains_key("a"));
+}
+
+#[tokio::test]
+async fn test_delete_all() {
+    let (_db, table) = setup().await;
+
+    table.delete_all().await.unwrap();
+    assert!(table.list().await.unwrap().is_empty());
+}
+
+// ── InsertableDataSet ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_insert_return_id() {
+    let (db, _) = setup().await;
+
+    sqlx::query(
+        "CREATE TABLE auto_item (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            price INTEGER NOT NULL
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let table = Table::<SqliteDB, Item>::new("auto_item", db)
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price");
+
+    let item = Item {
+        name: "Auto".into(),
+        price: 42,
+    };
+    let id = table.insert_return_id(&item).await.unwrap();
+    assert!(!id.is_empty());
+
+    let fetched = table.get(id).await.unwrap();
+    assert_eq!(fetched.name, "Auto");
+    assert_eq!(fetched.price, 42);
+}

--- a/vantage-sql/tests/sqlite/4_editable_value_set.rs
+++ b/vantage-sql/tests/sqlite/4_editable_value_set.rs
@@ -1,0 +1,141 @@
+//! Test 4: WritableValueSet and InsertableValueSet for Table<SqliteDB, Entity>.
+//!
+//! Uses in-memory SQLite — no entity deserialization, operates on raw Records.
+
+#[allow(unused_imports)]
+use vantage_sql::sqlite::SqliteType;
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+
+use vantage_dataset::{InsertableValueSet, ReadableValueSet, WritableValueSet};
+
+async fn setup() -> (SqliteDB, Table<SqliteDB, EmptyEntity>) {
+    let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+
+    sqlx::query(
+        "CREATE TABLE item (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            price INTEGER NOT NULL
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query("INSERT INTO item VALUES ('a', 'Alpha', 10), ('b', 'Beta', 20)")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    let table = Table::<SqliteDB, EmptyEntity>::new("item", db.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price");
+
+    (db, table)
+}
+
+fn record(fields: &[(&str, AnySqliteType)]) -> Record<AnySqliteType> {
+    fields
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect()
+}
+
+// ── WritableValueSet ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_insert_value() {
+    let (_db, table) = setup().await;
+
+    let rec = record(&[("name", "Gamma".into()), ("price", 30i64.into())]);
+    let result = table.insert_value(&"c".to_string(), &rec).await.unwrap();
+    assert_eq!(result["name"].try_get::<String>().unwrap(), "Gamma");
+
+    // Verify it's actually there
+    let fetched = table.get_value(&"c".to_string()).await.unwrap();
+    assert_eq!(fetched["price"].try_get::<i64>().unwrap(), 30);
+}
+
+#[tokio::test]
+async fn test_replace_value() {
+    let (_db, table) = setup().await;
+
+    let rec = record(&[("name", "Alpha Replaced".into()), ("price", 99i64.into())]);
+    table.replace_value(&"a".to_string(), &rec).await.unwrap();
+
+    let fetched = table.get_value(&"a".to_string()).await.unwrap();
+    assert_eq!(
+        fetched["name"].try_get::<String>().unwrap(),
+        "Alpha Replaced"
+    );
+    assert_eq!(fetched["price"].try_get::<i64>().unwrap(), 99);
+}
+
+#[tokio::test]
+async fn test_patch_value() {
+    let (_db, table) = setup().await;
+
+    // Patch only the price
+    let partial = record(&[("price", 55i64.into())]);
+    table.patch_value(&"a".to_string(), &partial).await.unwrap();
+
+    let fetched = table.get_value(&"a".to_string()).await.unwrap();
+    assert_eq!(fetched["name"].try_get::<String>().unwrap(), "Alpha"); // unchanged
+    assert_eq!(fetched["price"].try_get::<i64>().unwrap(), 55); // updated
+}
+
+#[tokio::test]
+async fn test_delete() {
+    let (_db, table) = setup().await;
+
+    table.delete(&"a".to_string()).await.unwrap();
+
+    let all = table.list_values().await.unwrap();
+    assert_eq!(all.len(), 1);
+    assert!(!all.contains_key("a"));
+}
+
+#[tokio::test]
+async fn test_delete_all() {
+    let (_db, table) = setup().await;
+
+    table.delete_all().await.unwrap();
+
+    let all = table.list_values().await.unwrap();
+    assert!(all.is_empty());
+}
+
+// ── InsertableValueSet ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_insert_return_id_value() {
+    let (db, _) = setup().await;
+
+    // Use a table with INTEGER PRIMARY KEY AUTOINCREMENT for auto-generated IDs
+    sqlx::query(
+        "CREATE TABLE log_entry (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            message TEXT NOT NULL
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let table = Table::<SqliteDB, EmptyEntity>::new("log_entry", db)
+        .with_id_column("id")
+        .with_column_of::<String>("message");
+
+    let rec = record(&[("message", "hello world".into())]);
+    let id = table.insert_return_id_value(&rec).await.unwrap();
+    assert!(!id.is_empty());
+
+    let fetched = table.get_value(&id).await.unwrap();
+    assert_eq!(
+        fetched["message"].try_get::<String>().unwrap(),
+        "hello world"
+    );
+}

--- a/vantage-sql/tests/sqlite/4_readable_data_set.rs
+++ b/vantage-sql/tests/sqlite/4_readable_data_set.rs
@@ -1,0 +1,83 @@
+//! Test 4: ReadableDataSet for Table<SqliteDB, Entity>.
+//!
+//! Tests list, get, and get_some with entity deserialization against bakery.sqlite.
+
+#[allow(unused_imports)]
+use vantage_sql::sqlite::SqliteType;
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::ReadableDataSet;
+
+const DB_PATH: &str = "sqlite:../target/bakery.sqlite?mode=ro";
+
+async fn get_db() -> SqliteDB {
+    SqliteDB::connect(DB_PATH)
+        .await
+        .expect("Failed to connect to bakery.sqlite — run scripts/sqlite/ingress.sh first")
+}
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+#[tokio::test]
+async fn test_list_products() {
+    let db = get_db().await;
+    let table = Product::sqlite_table(db);
+
+    let products = table.list().await.unwrap();
+    assert_eq!(products.len(), 5);
+
+    let cupcake = &products["flux_cupcake"];
+    assert_eq!(cupcake.name, "Flux Capacitor Cupcake");
+    assert_eq!(cupcake.price, 120);
+    assert_eq!(cupcake.calories, 300);
+    assert!(!cupcake.is_deleted);
+}
+
+#[tokio::test]
+async fn test_get_product() {
+    let db = get_db().await;
+    let table = Product::sqlite_table(db);
+
+    let product = table.get("delorean_donut").await.unwrap();
+    assert_eq!(product.name, "DeLorean Doughnut");
+    assert_eq!(product.price, 135);
+    assert_eq!(product.calories, 250);
+}
+
+#[tokio::test]
+async fn test_get_some_product() {
+    let db = get_db().await;
+    let table = Product::sqlite_table(db);
+
+    let result = table.get_some().await.unwrap();
+    assert!(result.is_some());
+
+    let (id, product) = result.unwrap();
+    assert!(!id.is_empty());
+    assert!(!product.name.is_empty());
+    assert!(product.price > 0);
+}

--- a/vantage-sql/tests/sqlite/4_readable_value_set.rs
+++ b/vantage-sql/tests/sqlite/4_readable_value_set.rs
@@ -1,0 +1,93 @@
+//! Test 4: ReadableValueSet for Table<SqliteDB, Entity>.
+//!
+//! Tests list_values, get_value, and get_some_value against bakery.sqlite.
+
+#[allow(unused_imports)]
+use vantage_sql::sqlite::SqliteType;
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::ReadableValueSet;
+
+const DB_PATH: &str = "sqlite:../target/bakery.sqlite?mode=ro";
+
+async fn get_db() -> SqliteDB {
+    SqliteDB::connect(DB_PATH)
+        .await
+        .expect("Failed to connect to bakery.sqlite — run scripts/sqlite/ingress.sh first")
+}
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+#[tokio::test]
+async fn test_list_values_products() {
+    let db = get_db().await;
+    let table = Product::sqlite_table(db);
+
+    let values = table.list_values().await.unwrap();
+    assert_eq!(values.len(), 5);
+
+    assert!(values.contains_key("flux_cupcake"));
+    assert!(values.contains_key("delorean_donut"));
+
+    let cupcake = &values["flux_cupcake"];
+    assert_eq!(
+        cupcake["name"].try_get::<String>(),
+        Some("Flux Capacitor Cupcake".to_string())
+    );
+    assert_eq!(cupcake["price"].try_get::<i64>(), Some(120));
+}
+
+#[tokio::test]
+async fn test_get_value_product() {
+    let db = get_db().await;
+    let table = Product::sqlite_table(db);
+
+    let record = table
+        .get_value(&"delorean_donut".to_string())
+        .await
+        .unwrap();
+    assert_eq!(
+        record["name"].try_get::<String>(),
+        Some("DeLorean Doughnut".to_string())
+    );
+    assert_eq!(record["price"].try_get::<i64>(), Some(135));
+    assert_eq!(record["calories"].try_get::<i64>(), Some(250));
+}
+
+#[tokio::test]
+async fn test_get_some_value_product() {
+    let db = get_db().await;
+    let table = Product::sqlite_table(db);
+
+    let result = table.get_some_value().await.unwrap();
+    assert!(result.is_some());
+
+    let (id, record) = result.unwrap();
+    assert!(!id.is_empty());
+    assert!(record.get("name").is_some());
+    assert!(record.get("price").is_some());
+}

--- a/vantage-sql/tests/sqlite/4_table_def.rs
+++ b/vantage-sql/tests/sqlite/4_table_def.rs
@@ -1,0 +1,45 @@
+//! Test 4: Table definition and query generation via TableSource.
+//!
+//! Verifies that `Table<SqliteDB, Entity>` builds correct SELECT queries
+//! using column definitions and the Selectable trait.
+
+#[allow(unused_imports)]
+use vantage_sql::sqlite::SqliteType;
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+#[tokio::test]
+async fn test_product_select() {
+    let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+    let table = Product::sqlite_table(db);
+    let select = table.select();
+    assert_eq!(
+        select.preview(),
+        "SELECT \"id\", \"name\", \"calories\", \"price\", \"bakery_id\", \"is_deleted\", \"inventory_stock\" FROM \"product\""
+    );
+}

--- a/vantage-surrealdb/src/statements/select/impls/selectable.rs
+++ b/vantage-surrealdb/src/statements/select/impls/selectable.rs
@@ -103,4 +103,12 @@ impl<T: QueryResult> Selectable<AnySurrealType> for SurrealSelect<T> {
     fn as_sum(&self, column: impl Expressive<AnySurrealType>) -> Expr {
         Sum::new(column.expr()).into()
     }
+
+    fn as_max(&self, column: impl Expressive<AnySurrealType>) -> Expr {
+        Fx::new("math::max", vec![column.expr()]).into()
+    }
+
+    fn as_min(&self, column: impl Expressive<AnySurrealType>) -> Expr {
+        Fx::new("math::min", vec![column.expr()]).into()
+    }
 }

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -224,7 +224,7 @@ impl TableSource for SurrealDB {
         }
     }
 
-    async fn get_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
+    async fn get_table_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
     where
         E: Entity<Self::Value>,
     {
@@ -237,7 +237,7 @@ impl TableSource for SurrealDB {
         })
     }
 
-    async fn get_sum<E>(
+    async fn get_table_sum<E>(
         &self,
         table: &Table<Self, E>,
         column: &Self::Column<Self::AnyType>,
@@ -251,7 +251,7 @@ impl TableSource for SurrealDB {
         self.execute(&sum_query.expr()).await
     }
 
-    async fn get_max<E>(
+    async fn get_table_max<E>(
         &self,
         table: &Table<Self, E>,
         column: &Self::Column<Self::AnyType>,
@@ -265,7 +265,7 @@ impl TableSource for SurrealDB {
         self.execute(&max_query.expr()).await
     }
 
-    async fn get_min<E>(
+    async fn get_table_min<E>(
         &self,
         table: &Table<Self, E>,
         column: &Self::Column<Self::AnyType>,

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -10,8 +10,6 @@ use vantage_expressions::{Expression, Expressive};
 use vantage_table::column::core::{Column, ColumnType};
 
 use vantage_table::table::Table;
-
-use vantage_table::traits::table_like::TableLike;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
 
@@ -110,12 +108,15 @@ impl TableSource for SurrealDB {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr(
+    fn search_table_expr<E>(
         &self,
-        _table: &impl TableLike,
+        _table: &Table<Self, E>,
         search_value: &str,
-    ) -> Expression<Self::Value> {
-        // TODO: iterate searchable columns once TableLike exposes them
+    ) -> Expression<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        // TODO: iterate searchable columns
         Expression::new(
             "SEARCH {}",
             vec![ExpressiveEnum::Scalar(AnySurrealType::new(

--- a/vantage-surrealdb/tests/table_source_read.rs
+++ b/vantage-surrealdb/tests/table_source_read.rs
@@ -63,7 +63,7 @@ async fn test_build_select_count_query() {
 async fn test_get_count_products() {
     let db = get_db().await;
     let table = Product::surreal_table(db.clone());
-    let count = db.get_count(&table).await.unwrap();
+    let count = db.get_table_count(&table).await.unwrap();
     assert_eq!(count, 5);
 }
 
@@ -71,7 +71,7 @@ async fn test_get_count_products() {
 async fn test_get_count_clients() {
     let db = get_db().await;
     let table = Client::surreal_table(db.clone());
-    let count = db.get_count(&table).await.unwrap();
+    let count = db.get_table_count(&table).await.unwrap();
     assert_eq!(count, 3);
 }
 
@@ -80,7 +80,7 @@ async fn test_get_count_with_condition() {
     let db = get_db().await;
     let table = Client::surreal_table(db.clone())
         .with_condition(surreal_expr!("is_paying_client = {}", true));
-    let count = db.get_count(&table).await.unwrap();
+    let count = db.get_table_count(&table).await.unwrap();
     assert_eq!(count, 2);
 }
 
@@ -88,7 +88,7 @@ async fn test_get_count_with_condition() {
 async fn test_get_count_orders() {
     let db = get_db().await;
     let table = Order::surreal_table(db.clone());
-    let count = db.get_count(&table).await.unwrap();
+    let count = db.get_table_count(&table).await.unwrap();
     assert_eq!(count, 3);
 }
 
@@ -99,7 +99,7 @@ async fn test_get_sum_product_prices() {
     let db = get_db().await;
     let table = Product::surreal_table(db.clone());
     let col = Column::<AnySurrealType>::new("price");
-    let result = db.get_sum(&table, &col).await.unwrap();
+    let result = db.get_table_sum(&table, &col).await.unwrap();
     assert_eq!(result.try_get::<i64>().unwrap(), 973);
 }
 
@@ -108,7 +108,7 @@ async fn test_get_max_product_price() {
     let db = get_db().await;
     let table = Product::surreal_table(db.clone());
     let col = Column::<AnySurrealType>::new("price");
-    let result = db.get_max(&table, &col).await.unwrap();
+    let result = db.get_table_max(&table, &col).await.unwrap();
     assert_eq!(result.try_get::<i64>().unwrap(), 299);
 }
 
@@ -117,7 +117,7 @@ async fn test_get_min_product_price() {
     let db = get_db().await;
     let table = Product::surreal_table(db.clone());
     let col = Column::<AnySurrealType>::new("price");
-    let result = db.get_min(&table, &col).await.unwrap();
+    let result = db.get_table_min(&table, &col).await.unwrap();
     assert_eq!(result.try_get::<i64>().unwrap(), 120);
 }
 
@@ -128,7 +128,7 @@ async fn test_get_sum_with_condition() {
     let table =
         Product::surreal_table(db.clone()).with_condition(surreal_expr!("calories <= {}", 200));
     let col = Column::<AnySurrealType>::new("price");
-    let result = db.get_sum(&table, &col).await.unwrap();
+    let result = db.get_table_sum(&table, &col).await.unwrap();
     assert_eq!(result.try_get::<i64>().unwrap(), 419);
 }
 

--- a/vantage-surrealdb/tests/table_source_write.rs
+++ b/vantage-surrealdb/tests/table_source_write.rs
@@ -63,7 +63,7 @@ async fn test_insert_table_value() {
     );
 
     // Verify via direct read
-    let count = table.data_source().get_count(&table).await.unwrap();
+    let count = table.data_source().get_table_count(&table).await.unwrap();
     assert_eq!(count, 1);
 
     db.execute(&surreal_expr!("DELETE tw_insert")).await.ok();
@@ -140,7 +140,7 @@ async fn test_replace_table_value() {
     );
 
     // Verify only 1 record
-    let count = table.data_source().get_count(&table).await.unwrap();
+    let count = table.data_source().get_table_count(&table).await.unwrap();
     assert_eq!(count, 1);
 
     db.execute(&surreal_expr!("DELETE tw_replace")).await.ok();
@@ -210,7 +210,10 @@ async fn test_delete_table_value() {
         .await
         .unwrap();
 
-    assert_eq!(table.data_source().get_count(&table).await.unwrap(), 2);
+    assert_eq!(
+        table.data_source().get_table_count(&table).await.unwrap(),
+        2
+    );
 
     table
         .data_source()
@@ -218,7 +221,10 @@ async fn test_delete_table_value() {
         .await
         .expect("delete_table_value failed");
 
-    assert_eq!(table.data_source().get_count(&table).await.unwrap(), 1);
+    assert_eq!(
+        table.data_source().get_table_count(&table).await.unwrap(),
+        1
+    );
 
     // Deleted record should not be fetchable
     let remaining = table.data_source().list_table_values(&table).await.unwrap();
@@ -246,7 +252,10 @@ async fn test_delete_table_all_values() {
             .unwrap();
     }
 
-    assert_eq!(table.data_source().get_count(&table).await.unwrap(), 5);
+    assert_eq!(
+        table.data_source().get_table_count(&table).await.unwrap(),
+        5
+    );
 
     table
         .data_source()
@@ -254,7 +263,10 @@ async fn test_delete_table_all_values() {
         .await
         .expect("delete_table_all_values failed");
 
-    assert_eq!(table.data_source().get_count(&table).await.unwrap(), 0);
+    assert_eq!(
+        table.data_source().get_table_count(&table).await.unwrap(),
+        0
+    );
 }
 
 // -- round-trip: insert → read → patch → read → delete --
@@ -335,7 +347,10 @@ async fn test_full_crud_lifecycle() {
         .await
         .unwrap();
 
-    assert_eq!(table.data_source().get_count(&table).await.unwrap(), 0);
+    assert_eq!(
+        table.data_source().get_table_count(&table).await.unwrap(),
+        0
+    );
 
     db.execute(&surreal_expr!("DELETE tw_crud")).await.ok();
 }

--- a/vantage-table/src/any.rs
+++ b/vantage-table/src/any.rs
@@ -485,7 +485,7 @@ where
     }
 
     async fn get_count(&self) -> Result<i64> {
-        self.inner.data_source().get_count(&self.inner).await
+        self.inner.data_source().get_table_count(&self.inner).await
     }
 }
 

--- a/vantage-table/src/mocks/mock_table_source.rs
+++ b/vantage-table/src/mocks/mock_table_source.rs
@@ -26,7 +26,7 @@ use crate::mocks::mock_type_system::AnyMockType;
 use crate::traits::table_expr_source::TableExprSource;
 use crate::{
     table::Table,
-    traits::{column_like::ColumnLike, table_like::TableLike, table_source::TableSource},
+    traits::{column_like::ColumnLike, table_source::TableSource},
 };
 
 #[derive(Clone)]
@@ -154,18 +154,15 @@ impl TableSource for MockTableSource {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr(
+    fn search_table_expr<E>(
         &self,
-        _table: &impl TableLike,
+        _table: &Table<Self, E>,
         search_value: &str,
-    ) -> Expression<Self::Value> {
-        // Mock implementation: search in "name" field if it exists
-        // Simple mock - search in name field if exists (mock implementation)
-        if true {
-            expr_any!("name LIKE '%{}%'", search_value)
-        } else {
-            panic!("Mock can only search column `name` as fulltext search")
-        }
+    ) -> Expression<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        expr_any!("name LIKE '%{}%'", search_value)
     }
 
     async fn list_table_values<E>(

--- a/vantage-table/src/mocks/mock_table_source.rs
+++ b/vantage-table/src/mocks/mock_table_source.rs
@@ -205,7 +205,7 @@ impl TableSource for MockTableSource {
         im_table.get_some_value().await
     }
 
-    async fn get_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
+    async fn get_table_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
     where
         E: Entity,
         Self: Sized,
@@ -216,7 +216,7 @@ impl TableSource for MockTableSource {
         }
     }
 
-    async fn get_sum<E>(
+    async fn get_table_sum<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,
@@ -230,7 +230,7 @@ impl TableSource for MockTableSource {
         ))
     }
 
-    async fn get_max<E>(
+    async fn get_table_max<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,
@@ -244,7 +244,7 @@ impl TableSource for MockTableSource {
         ))
     }
 
-    async fn get_min<E>(
+    async fn get_table_min<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,
@@ -556,7 +556,7 @@ mod tests {
 
         let table =
             Table::<MockTableSource, TestUser>::new("users", mock).into_entity::<TestUser>();
-        let count = table.data_source().get_count(&table).await.unwrap();
+        let count = table.data_source().get_table_count(&table).await.unwrap();
         assert_eq!(count, 2);
     }
 }

--- a/vantage-table/src/operation.rs
+++ b/vantage-table/src/operation.rs
@@ -4,21 +4,33 @@
 //! CSV uses structured parameters evaluated in memory.
 //! SQL/SurrealDB render as query syntax.
 
+use vantage_expressions::traits::expressive::ExpressiveEnum;
 use vantage_expressions::{Expression, Expressive};
-
-/// Template markers for condition operations.
-/// Backends match on these in their condition evaluators.
-pub const OP_EQ: &str = "{} = {}";
-pub const OP_IN: &str = "{} IN ({})";
 
 /// Trait for building condition expressions from column references.
 ///
-/// Each backend implements this for its column types. The trait defines
-/// the interface; backends provide the implementation.
+/// Provides default implementations using standard SQL syntax.
+/// Backends like CSV override these with structured parameters for in-memory evaluation.
 pub trait Operation<T>: Expressive<T> {
     /// Creates an equality condition: field = value
-    fn eq(&self, value: T) -> Expression<T>;
+    fn eq(&self, value: impl Into<T>) -> Expression<T> {
+        Expression::new(
+            "{} = {}",
+            vec![
+                ExpressiveEnum::Nested(self.expr()),
+                ExpressiveEnum::Scalar(value.into()),
+            ],
+        )
+    }
 
     /// Creates a membership condition: field IN (values_expression)
-    fn in_(&self, values: Expression<T>) -> Expression<T>;
+    fn in_(&self, values: Expression<T>) -> Expression<T> {
+        Expression::new(
+            "{} IN ({})",
+            vec![
+                ExpressiveEnum::Nested(self.expr()),
+                ExpressiveEnum::Nested(values),
+            ],
+        )
+    }
 }

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -52,22 +52,22 @@ where
     }
     /// Get count of records in the table
     pub async fn get_count(&self) -> Result<i64> {
-        self.data_source.get_count(self).await
+        self.data_source.get_table_count(self).await
     }
 
     /// Get sum of a column in the table
     pub async fn get_sum(&self, column: &T::Column<T::AnyType>) -> Result<T::Value> {
-        self.data_source.get_sum(self, column).await
+        self.data_source.get_table_sum(self, column).await
     }
 
     /// Get max of a column in the table
     pub async fn get_max(&self, column: &T::Column<T::AnyType>) -> Result<T::Value> {
-        self.data_source.get_max(self, column).await
+        self.data_source.get_table_max(self, column).await
     }
 
     /// Get min of a column in the table
     pub async fn get_min(&self, column: &T::Column<T::AnyType>) -> Result<T::Value> {
-        self.data_source.get_min(self, column).await
+        self.data_source.get_table_min(self, column).await
     }
 
     /// Create a count query expression (does not execute)

--- a/vantage-table/src/table/impls/table_like.rs
+++ b/vantage-table/src/table/impls/table_like.rs
@@ -85,6 +85,6 @@ where
     }
 
     async fn get_count(&self) -> Result<i64> {
-        self.data_source().get_count(self).await
+        self.data_source().get_table_count(self).await
     }
 }

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -95,13 +95,13 @@ pub trait TableSource: DataSource + Clone + 'static {
         Self: Sized;
 
     /// Get count of records in the table
-    async fn get_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
+    async fn get_table_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
     where
         E: Entity<Self::Value>,
         Self: Sized;
 
     /// Get sum of a column in the table (returns native value type)
-    async fn get_sum<E>(
+    async fn get_table_sum<E>(
         &self,
         table: &Table<Self, E>,
         column: &Self::Column<Self::AnyType>,
@@ -111,7 +111,7 @@ pub trait TableSource: DataSource + Clone + 'static {
         Self: Sized;
 
     /// Get maximum value of a column in the table (returns native value type)
-    async fn get_max<E>(
+    async fn get_table_max<E>(
         &self,
         table: &Table<Self, E>,
         column: &Self::Column<Self::AnyType>,
@@ -121,7 +121,7 @@ pub trait TableSource: DataSource + Clone + 'static {
         Self: Sized;
 
     /// Get minimum value of a column in the table (returns native value type)
-    async fn get_min<E>(
+    async fn get_table_min<E>(
         &self,
         table: &Table<Self, E>,
         column: &Self::Column<Self::AnyType>,

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -16,7 +16,7 @@ use vantage_types::{Entity, Record};
 use crate::{
     column::core::ColumnType,
     table::Table,
-    traits::{column_like::ColumnLike, table_like::TableLike},
+    traits::column_like::ColumnLike,
 };
 
 /// Trait for table data sources that defines column type separate from execution
@@ -60,11 +60,14 @@ pub trait TableSource: DataSource + Clone + 'static {
     /// - MongoDB: `{ field: { $regex: 'value', $options: 'i' } }`
     ///
     /// The implementation should search across appropriate fields in the table.
-    fn search_table_expr(
+    fn search_table_expr<E>(
         &self,
-        table: &impl TableLike,
+        table: &Table<Self, E>,
         search_value: &str,
-    ) -> Expression<Self::Value>;
+    ) -> Expression<Self::Value>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized;
 
     /// Get all data from a table as Record values with IDs (for ReadableValueSet implementation)
     async fn list_table_values<E>(

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -13,11 +13,7 @@ use vantage_expressions::{
 };
 use vantage_types::{Entity, Record};
 
-use crate::{
-    column::core::ColumnType,
-    table::Table,
-    traits::column_like::ColumnLike,
-};
+use crate::{column::core::ColumnType, table::Table, traits::column_like::ColumnLike};
 
 /// Trait for table data sources that defines column type separate from execution
 /// TableSource represents a data source that can create and manage tables

--- a/vantage-table/tests/column_type_system.rs
+++ b/vantage-table/tests/column_type_system.rs
@@ -349,7 +349,7 @@ impl TableSource for Type3TableSource {
         }
     }
 
-    async fn get_count<E>(&self, _table: &Table<Self, E>) -> Result<i64>
+    async fn get_table_count<E>(&self, _table: &Table<Self, E>) -> Result<i64>
     where
         E: Entity<Self::Value>,
         Self: Sized,
@@ -357,7 +357,7 @@ impl TableSource for Type3TableSource {
         Ok(self.data.len() as i64)
     }
 
-    async fn get_sum<E>(
+    async fn get_table_sum<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,
@@ -371,7 +371,7 @@ impl TableSource for Type3TableSource {
         ))
     }
 
-    async fn get_max<E>(
+    async fn get_table_max<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,
@@ -385,7 +385,7 @@ impl TableSource for Type3TableSource {
         ))
     }
 
-    async fn get_min<E>(
+    async fn get_table_min<E>(
         &self,
         _table: &Table<Self, E>,
         _column: &Self::Column<Self::AnyType>,

--- a/vantage-table/tests/column_type_system.rs
+++ b/vantage-table/tests/column_type_system.rs
@@ -39,7 +39,6 @@ use vantage_table::column::core::ColumnType;
 use vantage_table::column::flags::ColumnFlag;
 use vantage_table::table::Table;
 use vantage_table::traits::column_like::ColumnLike;
-use vantage_table::traits::table_like::TableLike;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record, vantage_type_system};
 
@@ -285,12 +284,14 @@ impl TableSource for Type3TableSource {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr(
+    fn search_table_expr<E>(
         &self,
-        _table: &impl TableLike,
+        _table: &Table<Self, E>,
         search_value: &str,
-    ) -> Expression<Self::Value> {
-        // Simple mock - search in name field if exists
+    ) -> Expression<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
         Expression::new(
             "name CONTAINS {}",
             vec![ExpressiveEnum::Scalar(ciborium::Value::Text(


### PR DESCRIPTION
`vantage-sql` finally has a working SQLite `TableSource`, so `Table<SqliteDB, Entity>` now does everything `Table<SurrealDB, _>` and `Table<CsvDataSource, _>` already did — `list`/`get`/`insert`/`replace`/`patch`/`delete`, conditions, aggregates (`get_count`/`get_sum`/`get_max`/`get_min`), and auto-increment IDs via `RETURNING`.

```rust
#[entity(SqliteType)]
#[derive(Debug, Clone, PartialEq, Default)]
struct Product { name: String, price: i64, is_deleted: bool }

let db = SqliteDB::connect("sqlite::memory:").await?;
let table = Table::new("product", db)
    .with_id_column("id")
    .with_column_of::<String>("name")
    .with_column_of::<i64>("price")
    .with_column_of::<bool>("is_deleted");

let mut t = table.clone();
t.add_condition(t["is_deleted"].eq(false));   // <- now takes `impl Into<T>`
let cheap = t.list().await?;
```

### If you implement TableSource yourself

Four methods got the `_table_` prefix to match the rest of the trait — pure rename, no signature change otherwise:

- `get_count` → `get_table_count`
- `get_sum` → `get_table_sum`
- `get_max` → `get_table_max`
- `get_min` → `get_table_min`

`search_table_expr` swaps `&impl TableLike` for `&Table<Self, E>` so it can read columns through the concrete table type — `TableLike` couldn't expose them generically without dragging the value type into yet another supertrait. `Selectable` impls now also need `as_max` / `as_min` next to the existing `as_count` / `as_sum`.

### eq() takes Into<T> now

`Operation::eq()` accepts `impl Into<T>`, so `column.eq(false)` and `column.eq(42)` work without wrapping in `AnySqliteType::new(...)`. The trait also ships default impls of `eq` / `in_` using standard SQL templates, which lets most backends collapse to:

```rust
impl Operation<AnySqliteType> for Column<AnySqliteType> {}
```

CSV still overrides them because its in-memory evaluator pattern-matches on the template constants.

### A guide, since this is the second time

`NEW_PERSISTENCE_GUIDE.md` walks the SQLite implementation end-to-end as a template — type system, expression macro, `Selectable`, `TableSource`, the WHERE/aggregate/write surface. Tests live under `vantage-sql/tests/sqlite/4_*.rs` (one file per trait surface) and double as a copyable example for the next backend.