### PR TITLE
finishing touch - add sqlite to cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "vantage-csv",
  "vantage-dataset",
  "vantage-expressions",
+ "vantage-sql",
  "vantage-surrealdb",
  "vantage-table",
  "vantage-types",

--- a/NEW_PERSISTENCE_GUIDE.md
+++ b/NEW_PERSISTENCE_GUIDE.md
@@ -927,18 +927,92 @@ let id = table.insert_return_id(&item).await.unwrap();
 let fetched = table.get(id).await.unwrap();
 ```
 
-## Step 5: Relationships and joins at the Table level
+## Step 5: Relationships
 
-Implement `has_one`, `has_many`, and `belongs_to` on your Table so that related entities can be
-traversed and queried through the `Table` API without manual JOIN construction.
+Tables can declare relationships using `with_one` and `with_many`, then traverse them at runtime
+with `get_ref_as`. The relationship system is provided by `vantage-table` — your backend just
+needs `column_table_values_expr` implemented to make it work.
 
-## Step 6: Transactions and error handling
+Implement `column_table_values_expr` — it builds a subquery for a single column respecting current
+conditions. For SQL backends this is a `SELECT "col" FROM "table" WHERE ...` expression.
 
-Wrap your connection pool's transaction API so that multiple operations can be grouped atomically,
-and map database-specific errors into `vantage_core::VantageError` for consistent error handling
-across backends.
+Define relationships when constructing tables — `with_one` for foreign-key-to-parent,
+`with_many` for parent-to-children. Then traverse:
 
-## Step 7: Schema introspection (optional)
+```rust
+let mut clients = client_table(db);
+clients.add_condition(sqlite_expr!("{} = {}", (clients["is_paying_client"]), true));
 
-Implement schema reading so that tables, columns, and types can be discovered at runtime — useful
-for migrations, admin UIs, and dynamic query building without compile-time entity structs.
+let orders = clients.get_ref_as::<SqliteDB, ClientOrder>("orders").unwrap();
+
+// The generated query includes the subquery:
+// SELECT ... FROM "client_order"
+//   WHERE client_id IN (SELECT "id" FROM "client" WHERE is_paying_client = 1)
+assert_eq!(orders.list().await.unwrap().len(), 3);
+```
+
+## Step 6: Using tables in a multi-backend application
+
+At this point your backend works — you can define tables, query data, and traverse relationships.
+But a real application typically has a *model crate* that defines entities once and offers table
+constructors for each backend. That's `bakery_model3` in the Vantage repo. The final piece is
+`AnyTable`, which lets you treat tables from different backends uniformly.
+
+### AnyTable: the type-erased wrapper
+
+`AnyTable` erases the backend and entity types behind a uniform `serde_json::Value`-based interface.
+This is what makes it possible to write generic UI, CLI, or API code that doesn't care which database
+is behind it.
+
+There are two ways to create one:
+
+```rust
+// 1. If your backend already uses serde_json::Value (rare):
+let any = AnyTable::new(my_table);
+
+// 2. For backends with custom value types (the common case):
+let any = AnyTable::from_table(Product::sqlite_table(db));
+```
+
+`from_table` works as long as your `AnyType` implements `Into<serde_json::Value>` and
+`From<serde_json::Value>`. The `vantage_type_system!` macro generates the `Into` conversion
+automatically, and after Step 1 your backend should have the `From` direction covered too.
+
+### Building a multi-source CLI
+
+The CLI example in `bakery_model3/examples/cli.rs` shows the pattern. A `build_table` function
+matches on the user's chosen source, calls the right entity constructor, and wraps it with
+`AnyTable::from_table()`. Once you have an `AnyTable`, all commands are backend-agnostic —
+`list_values()`, `get_count()`, `get_some_value()`, `insert_value()`, and `delete()` all work
+identically regardless of which database is behind it.
+
+Because the values flow through as `serde_json::Value`, the CLI renderer can inspect types at
+runtime — booleans like `is_deleted` display as `true`/`false` with color highlighting, numbers
+stay numeric, and nulls render cleanly. Your type system work in Step 1 ensures these values
+arrive with the right JSON type rather than everything being a string.
+
+Try it out:
+
+```bash
+# List products from CSV
+cargo run --example cli -- csv product list
+
+# Same thing from SQLite
+cargo run --example cli -- sqlite product list
+
+# Count bakeries in SurrealDB
+cargo run --example cli -- surreal bakery count
+
+# Get a single product record
+cargo run --example cli -- sqlite product get
+
+# Insert a new record
+cargo run --example cli -- surreal bakery add myid '{"name":"Test","profit_margin":10}'
+
+# Delete a record
+cargo run --example cli -- surreal bakery delete myid
+```
+
+That's the payoff of implementing a proper type system and `TableSource` — one line of
+`AnyTable::from_table()` bridges the gap between your backend's native types and a uniform
+JSON-based interface.

--- a/bakery_model3/Cargo.toml
+++ b/bakery_model3/Cargo.toml
@@ -10,8 +10,10 @@ vantage-csv = { path = "../vantage-csv" }
 vantage-expressions = { path = "../vantage-expressions" }
 vantage-dataset = { path = "../vantage-dataset" }
 vantage-types = { path = "../vantage-types" }
+vantage-sql = { path = "../vantage-sql" }
 vantage-surrealdb = { path = "../vantage-surrealdb" }
 surreal-client = { path = "../surreal-client", features = ["decimal"] }
+serde_json = "1"
 indexmap = "2.0"
 tokio = { version = "1.48", features = ["full"] }
 clap = "4.5"

--- a/bakery_model3/examples/cli.rs
+++ b/bakery_model3/examples/cli.rs
@@ -130,10 +130,7 @@ async fn build_table(
             let db = SqliteDB::connect("sqlite:target/bakery.sqlite")
                 .await
                 .map_err(|e| {
-                    vantage_core::error!(
-                        "Failed to connect to SQLite",
-                        details = e.to_string()
-                    )
+                    vantage_core::error!("Failed to connect to SQLite", details = e.to_string())
                 })?;
             let table = match entity_name {
                 "bakery" => AnyTable::from_table(Bakery::sqlite_table(db)),

--- a/bakery_model3/examples/cli.rs
+++ b/bakery_model3/examples/cli.rs
@@ -2,7 +2,7 @@
 //!
 //! Usage: db [--debug] <source> <entity> [command ...]
 //!
-//! Sources: csv, surreal
+//! Sources: csv, surreal, sqlite
 //! Entities: bakery, client, product, order
 //!
 //! Commands:
@@ -45,7 +45,7 @@ async fn run() -> vantage_core::Result<()> {
         )
         .arg(
             Arg::new("source")
-                .help("Data source: csv, surreal")
+                .help("Data source: csv, surreal, sqlite")
                 .required(true),
         )
         .arg(
@@ -126,8 +126,29 @@ async fn build_table(
             };
             Ok(Some(table))
         }
+        "sqlite" => {
+            let db = SqliteDB::connect("sqlite:target/bakery.sqlite")
+                .await
+                .map_err(|e| {
+                    vantage_core::error!(
+                        "Failed to connect to SQLite",
+                        details = e.to_string()
+                    )
+                })?;
+            let table = match entity_name {
+                "bakery" => AnyTable::from_table(Bakery::sqlite_table(db)),
+                "client" => AnyTable::from_table(Client::sqlite_table(db)),
+                "product" => AnyTable::from_table(Product::sqlite_table(db)),
+                "order" => AnyTable::from_table(Order::sqlite_table(db)),
+                _ => {
+                    println!("Unknown entity: {}", entity_name);
+                    return Ok(None);
+                }
+            };
+            Ok(Some(table))
+        }
         _ => {
-            println!("Unknown source: {}. Use: csv, surreal", source);
+            println!("Unknown source: {}. Use: csv, surreal, sqlite", source);
             Ok(None)
         }
     }
@@ -137,7 +158,7 @@ fn print_usage() {
     println!();
     println!("Usage: db [--debug] <source> <entity> <command>");
     println!();
-    println!("Sources: csv, surreal");
+    println!("Sources: csv, surreal, sqlite");
     println!();
     println!("Commands:");
     println!("  list              List all records");

--- a/bakery_model3/src/animal.rs
+++ b/bakery_model3/src/animal.rs
@@ -1,4 +1,6 @@
+use serde_json::Value as JsonValue;
 use vantage_csv::{CsvType, type_system::CsvTypeAnimalMarker};
+use vantage_sql::sqlite::{SqliteType, types::SqliteTypeTextMarker};
 use vantage_surrealdb::types::SurrealTypeStringMarker;
 use vantage_surrealdb::{CborValue, SurrealType};
 use vantage_types::TerminalRender;
@@ -61,6 +63,21 @@ impl CsvType for Animal {
 
     fn from_csv_string(value: String) -> Option<Self> {
         value.parse().ok()
+    }
+}
+
+impl SqliteType for Animal {
+    type Target = SqliteTypeTextMarker;
+
+    fn to_json(&self) -> JsonValue {
+        JsonValue::String(self.as_str().to_string())
+    }
+
+    fn from_json(value: JsonValue) -> Option<Self> {
+        match value {
+            JsonValue::String(s) => s.parse().ok(),
+            _ => None,
+        }
     }
 }
 

--- a/bakery_model3/src/bakery.rs
+++ b/bakery_model3/src/bakery.rs
@@ -1,10 +1,11 @@
 use vantage_csv::{AnyCsvType, Csv};
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_surrealdb::types::AnySurrealType;
 use vantage_table::table::Table;
 use vantage_types::entity;
 
-#[entity(CsvType, SurrealType)]
+#[entity(CsvType, SurrealType, SqliteType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Bakery {
     pub name: String,
@@ -17,10 +18,15 @@ impl Bakery {
             .with_column_of::<String>("name")
             .with_column_of::<i64>("profit_margin")
     }
-}
 
-impl Bakery {
     pub fn surreal_table(db: SurrealDB) -> Table<SurrealDB, Bakery> {
+        Table::new("bakery", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("profit_margin")
+    }
+
+    pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Bakery> {
         Table::new("bakery", db)
             .with_id_column("id")
             .with_column_of::<String>("name")

--- a/bakery_model3/src/client.rs
+++ b/bakery_model3/src/client.rs
@@ -1,4 +1,5 @@
 use vantage_csv::{AnyCsvType, Csv};
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_surrealdb::types::AnySurrealType;
 use vantage_table::table::Table;
@@ -6,7 +7,7 @@ use vantage_types::entity;
 
 use crate::{Bakery, Order};
 
-#[entity(CsvType, SurrealType)]
+#[entity(CsvType, SurrealType, SqliteType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Client {
     pub name: String,
@@ -41,5 +42,23 @@ impl Client {
             .with_column_of::<String>("email")
             .with_column_of::<String>("contact_details")
             .with_column_of::<bool>("is_paying_client")
+    }
+
+    pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Client> {
+        let db2 = db.clone();
+        let db3 = db.clone();
+        Table::new("client", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<String>("email")
+            .with_column_of::<String>("contact_details")
+            .with_column_of::<bool>("is_paying_client")
+            .with_column_of::<String>("bakery_id")
+            .with_one("bakery", "bakery_id", move || {
+                Bakery::sqlite_table(db2.clone())
+            })
+            .with_many("orders", "client_id", move || {
+                Order::sqlite_table(db3.clone())
+            })
     }
 }

--- a/bakery_model3/src/lib.rs
+++ b/bakery_model3/src/lib.rs
@@ -1,4 +1,5 @@
 pub use vantage_csv::{AnyCsvType, Csv, CsvType};
+pub use vantage_sql::sqlite::{AnySqliteType, SqliteDB, SqliteType};
 
 pub mod animal;
 pub mod bakery;

--- a/bakery_model3/src/order.rs
+++ b/bakery_model3/src/order.rs
@@ -1,4 +1,5 @@
 use vantage_csv::{AnyCsvType, Csv};
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_surrealdb::types::AnySurrealType;
 use vantage_table::table::Table;
@@ -6,7 +7,7 @@ use vantage_types::entity;
 
 use crate::Client;
 
-#[entity(CsvType, SurrealType)]
+#[entity(CsvType, SurrealType, SqliteType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Order {
     pub client_id: Option<String>,
@@ -32,5 +33,16 @@ impl Order {
         Table::new("order", db)
             .with_id_column("id")
             .with_column_of::<bool>("is_deleted")
+    }
+
+    pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Order> {
+        let db2 = db.clone();
+        Table::new("client_order", db)
+            .with_id_column("id")
+            .with_column_of::<String>("client_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_one("client", "client_id", move || {
+                Client::sqlite_table(db2.clone())
+            })
     }
 }

--- a/bakery_model3/src/product.rs
+++ b/bakery_model3/src/product.rs
@@ -7,7 +7,6 @@ use vantage_types::entity;
 
 use crate::Bakery;
 
-
 #[entity(CsvType, SurrealType, SqliteType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Product {

--- a/bakery_model3/src/product.rs
+++ b/bakery_model3/src/product.rs
@@ -1,19 +1,20 @@
 use vantage_csv::{AnyCsvType, Csv};
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_surrealdb::types::AnySurrealType;
 use vantage_table::table::Table;
 use vantage_types::entity;
 
-use crate::animal::Animal;
+use crate::Bakery;
 
-#[entity(CsvType, SurrealType)]
+
+#[entity(CsvType, SurrealType, SqliteType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Product {
     pub name: String,
     pub calories: i64,
     pub price: i64,
     pub is_deleted: bool,
-    pub sticker: Option<Animal>,
 }
 
 impl Product {
@@ -23,7 +24,6 @@ impl Product {
             .with_column_of::<i64>("calories")
             .with_column_of::<i64>("price")
             .with_column_of::<bool>("is_deleted")
-            .with_column_of::<Option<Animal>>("sticker")
     }
 
     pub fn surreal_table(db: SurrealDB) -> Table<SurrealDB, Product> {
@@ -33,5 +33,18 @@ impl Product {
             .with_column_of::<i64>("calories")
             .with_column_of::<i64>("price")
             .with_column_of::<bool>("is_deleted")
+    }
+
+    pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Product> {
+        let db2 = db.clone();
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<bool>("is_deleted")
+            .with_one("bakery", "bakery_id", move || {
+                Bakery::sqlite_table(db2.clone())
+            })
     }
 }

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -359,13 +359,21 @@ impl TableSource for SqliteDB {
 
     fn column_table_values_expr<'a, E, Type: ColumnType>(
         &'a self,
-        _table: &Table<Self, E>,
-        _column: &Self::Column<Type>,
+        table: &Table<Self, E>,
+        column: &Self::Column<Type>,
     ) -> AssociatedExpression<'a, Self, Self::Value, Vec<Type>>
     where
         E: Entity<Self::Value> + 'static,
         Self: ExprDataSource<Self::Value> + Sized,
     {
-        todo!("column_table_values_expr")
+        // Build a subquery: SELECT "column" FROM "table" WHERE ...
+        let mut select = table.select();
+        select.clear_fields();
+        select.clear_order_by();
+        select.add_field(column.name());
+
+        // Render as a nested subquery expression
+        let subquery = select.expr();
+        AssociatedExpression::new(subquery, self)
     }
 }

--- a/vantage-sql/tests/sqlite.rs
+++ b/vantage-sql/tests/sqlite.rs
@@ -24,6 +24,8 @@ mod sqlite {
     mod readable_value_set;
     #[path = "2_records.rs"]
     mod records;
+    #[path = "5_references.rs"]
+    mod references;
     #[path = "3_select.rs"]
     mod select;
     #[path = "4_table_def.rs"]
@@ -32,6 +34,4 @@ mod sqlite {
     mod types_record;
     #[path = "1_types_round_trip.rs"]
     mod types_round_trip;
-    #[path = "5_references.rs"]
-    mod references;
 }

--- a/vantage-sql/tests/sqlite.rs
+++ b/vantage-sql/tests/sqlite.rs
@@ -32,4 +32,6 @@ mod sqlite {
     mod types_record;
     #[path = "1_types_round_trip.rs"]
     mod types_round_trip;
+    #[path = "5_references.rs"]
+    mod references;
 }

--- a/vantage-sql/tests/sqlite/5_references.rs
+++ b/vantage-sql/tests/sqlite/5_references.rs
@@ -1,0 +1,134 @@
+//! Test 5: Relationship traversal — with_one, with_many, get_ref_as.
+//!
+//! Uses the pre-populated bakery.sqlite database.
+
+#[allow(unused_imports)]
+use vantage_sql::sqlite::SqliteType;
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_sql::sqlite_expr;
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::ReadableDataSet;
+
+const DB_PATH: &str = "sqlite:../target/bakery.sqlite?mode=ro";
+
+async fn get_db() -> SqliteDB {
+    SqliteDB::connect(DB_PATH)
+        .await
+        .expect("Failed to connect to bakery.sqlite — run scripts/sqlite/ingress.sh first")
+}
+
+// ── Entity definitions ─────────────────────────────────────────────────────
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Client {
+    name: String,
+    email: String,
+    contact_details: String,
+    is_paying_client: bool,
+    bakery_id: String,
+}
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct ClientOrder {
+    bakery_id: String,
+    client_id: String,
+    is_deleted: bool,
+}
+
+// ── Table constructors with relationships ──────────────────────────────────
+
+fn client_table(db: SqliteDB) -> Table<SqliteDB, Client> {
+    let db2 = db.clone();
+    Table::new("client", db)
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<String>("email")
+        .with_column_of::<String>("contact_details")
+        .with_column_of::<bool>("is_paying_client")
+        .with_column_of::<String>("bakery_id")
+        .with_many("orders", "client_id", move || order_table(db2.clone()))
+}
+
+fn order_table(db: SqliteDB) -> Table<SqliteDB, ClientOrder> {
+    let db2 = db.clone();
+    Table::new("client_order", db)
+        .with_id_column("id")
+        .with_column_of::<String>("bakery_id")
+        .with_column_of::<String>("client_id")
+        .with_column_of::<bool>("is_deleted")
+        .with_one("client", "client_id", move || client_table(db2.clone()))
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+/// Traverse has_many: paying clients → their orders
+#[tokio::test]
+async fn test_has_many_orders_for_paying_clients() {
+    let db = get_db().await;
+    let mut clients = client_table(db.clone());
+    clients.add_condition(sqlite_expr!("{} = {}", (clients["is_paying_client"]), true));
+
+    let orders = clients
+        .get_ref_as::<SqliteDB, ClientOrder>("orders")
+        .unwrap();
+
+    let preview = orders.select().preview();
+    assert_eq!(
+        preview,
+        "SELECT \"id\", \"bakery_id\", \"client_id\", \"is_deleted\" FROM \"client_order\" \
+         WHERE client_id IN (SELECT \"id\" FROM \"client\" WHERE is_paying_client = 1)"
+    );
+
+    let order_list = orders.list().await.unwrap();
+    // Marty has 1 order, Doc has 2 orders → 3 total
+    assert_eq!(order_list.len(), 3);
+}
+
+/// Traverse has_many: single client → orders
+#[tokio::test]
+async fn test_has_many_orders_for_single_client() {
+    let db = get_db().await;
+    let mut clients = client_table(db.clone());
+    clients.add_condition(sqlite_expr!("{} = {}", (clients["name"]), "Doc Brown"));
+
+    let orders = clients
+        .get_ref_as::<SqliteDB, ClientOrder>("orders")
+        .unwrap();
+
+    let preview = orders.select().preview();
+    assert_eq!(
+        preview,
+        "SELECT \"id\", \"bakery_id\", \"client_id\", \"is_deleted\" FROM \"client_order\" \
+         WHERE client_id IN (SELECT \"id\" FROM \"client\" WHERE name = 'Doc Brown')"
+    );
+
+    let order_list = orders.list().await.unwrap();
+    assert_eq!(order_list.len(), 2);
+}
+
+/// Traverse has_one: order → client
+#[tokio::test]
+async fn test_has_one_client_for_order() {
+    let db = get_db().await;
+    let mut orders = order_table(db.clone());
+    orders.add_condition(sqlite_expr!("{} = {}", (orders["id"]), "order1"));
+
+    let client = orders
+        .get_ref_as::<SqliteDB, Client>("client")
+        .unwrap();
+
+    let preview = client.select().preview();
+    assert_eq!(
+        preview,
+        "SELECT \"id\", \"name\", \"email\", \"contact_details\", \"is_paying_client\", \"bakery_id\" \
+         FROM \"client\" WHERE id IN (SELECT \"client_id\" FROM \"client_order\" WHERE id = 'order1')"
+    );
+
+    let client_list = client.list().await.unwrap();
+    assert_eq!(client_list.len(), 1);
+    assert_eq!(client_list.values().next().unwrap().name, "Marty McFly");
+}

--- a/vantage-sql/tests/sqlite/5_references.rs
+++ b/vantage-sql/tests/sqlite/5_references.rs
@@ -117,9 +117,7 @@ async fn test_has_one_client_for_order() {
     let mut orders = order_table(db.clone());
     orders.add_condition(sqlite_expr!("{} = {}", (orders["id"]), "order1"));
 
-    let client = orders
-        .get_ref_as::<SqliteDB, Client>("client")
-        .unwrap();
+    let client = orders.get_ref_as::<SqliteDB, Client>("client").unwrap();
 
     let preview = client.select().preview();
     assert_eq!(

--- a/vantage-types/src/type_system.rs
+++ b/vantage-types/src/type_system.rs
@@ -102,11 +102,9 @@ macro_rules! vantage_type_system {
                 }
             }
 
-            impl TryFrom<$value_type> for [<Any $trait_name>] {
-                type Error = vantage_core::VantageError;
-
-                fn try_from(value: $value_type) -> vantage_core::Result<Self> {
-                    Self::[<from_ $method_name>](&value).ok_or_else(|| vantage_core::error!("Failed to convert value to type"))
+            impl From<$value_type> for [<Any $trait_name>] {
+                fn from(value: $value_type) -> Self {
+                    Self::[<from_ $method_name>](&value).expect("Failed to convert value to type")
                 }
             }
 


### PR DESCRIPTION
`bakery_model3`'s CLI example gets a third source. `cargo run --example cli -- sqlite product list` now does the same thing as the `csv` and `surreal` variants — `list`, `count`, `get`, `add`, `delete`, all of it.

What was actually missing wasn't the CLI plumbing — it was relationship traversal on SQLite. `column_table_values_expr` is now implemented, so `with_one` / `with_many` / `get_ref_as` work end-to-end:

```rust
let mut clients = client_table(db);
clients.add_condition(sqlite_expr!("{} = {}", (clients["is_paying_client"]), true));
let orders = clients.get_ref_as::<SqliteDB, ClientOrder>("orders").unwrap();
// SELECT ... FROM "client_order"
//   WHERE client_id IN (SELECT "id" FROM "client" WHERE is_paying_client = 1)
```

Tests under `vantage-sql/tests/sqlite/5_references.rs` cover both directions and round-trip the generated SQL.

### Macro change — only matters if you implement your own backend

`vantage_type_system!` used to emit `TryFrom<Value> for AnyFooType` (returning `Result`). It now emits `From<Value>` and panics on a malformed value. This is what lets `AnyTable::from_table(Product::sqlite_table(db))` compile — the bound is `Into<Value> + From<Value>`, not `TryFrom`. If you wrote `AnyMyType::try_from(v)?` in your own backend, swap to `AnyMyType::from(v)` and validate upstream.

### Animal sticker, briefly demoted

`Product::sticker: Option<Animal>` is gone. Custom-typed columns aren't in the SQLite type system yet, and keeping the column broke the cross-source CLI (csv and surreal had it; sqlite couldn't). Adding `Option<CustomEnum>` support to `SqliteType` is the right fix — separate PR.

`NEW_PERSISTENCE_GUIDE.md` Steps 5–6 are also rewritten around the actual relationship and `AnyTable` story instead of the old transactions/schema-introspection placeholders.