### PR TITLE
clean up ssurrealdb operations

### DIFF
--- a/NEW_PERSISTENCE_GUIDE.md
+++ b/NEW_PERSISTENCE_GUIDE.md
@@ -837,9 +837,9 @@ both messages and the source chain is available via `std::error::Error::source()
 
 ### Implement Operation for your column type
 
-The `Operation` trait (from `vantage-table`) gives columns `.eq()` and `.in_()` methods for building
-conditions. The trait provides default implementations using standard SQL syntax, so for most
-backends you just need an empty impl:
+The `Operation` trait (from `vantage-table`) gives columns `.eq()`, `.ne()`, `.gt()`, `.gte()`,
+`.lt()`, `.lte()`, and `.in_()` methods for building conditions. The trait provides default
+implementations using standard SQL syntax, so for most backends you just need an empty impl:
 
 ```rust
 use vantage_table::operation::Operation;
@@ -847,11 +847,14 @@ use vantage_table::operation::Operation;
 impl Operation<AnySqliteType> for Column<AnySqliteType> {}
 ```
 
-The defaults use `"{} = {}"` and `"{} IN ({})"` templates. Backends with non-SQL evaluation (like
-CSV's in-memory filtering) can override these with their own implementations.
+The defaults use standard SQL templates (`"{} = {}"`, `"{} != {}"`, `"{} > {}"`, etc.). Backends
+with non-SQL evaluation (like CSV's in-memory filtering) can override these with their own
+implementations.
 
-The `eq()` method accepts `impl Into<YourAnyType>`, so you can pass native Rust values directly —
-`false`, `42`, `"hello"` — without wrapping them.
+All methods accept `impl Expressive<YourAnyType>`, so you can pass native Rust values (`false`,
+`42`, `"hello"`), other columns (`table["other_field"]`), or full expressions. This requires your
+scalar types to implement `Expressive<YourAnyType>` — the same impls you added in Step 1 for the
+vendor macro.
 
 ### Testing conditions
 

--- a/NEW_PERSISTENCE_GUIDE.md
+++ b/NEW_PERSISTENCE_GUIDE.md
@@ -835,21 +835,12 @@ let data = std::fs::read("config.json")
 This chains errors — the original `io::Error` is preserved as the source, so `Display` renders
 both messages and the source chain is available via `std::error::Error::source()`.
 
-### Implement Operation for your column type
+### Operation trait — condition building
 
-The `Operation` trait (from `vantage-table`) gives columns `.eq()`, `.ne()`, `.gt()`, `.gte()`,
-`.lt()`, `.lte()`, and `.in_()` methods for building conditions. The trait provides default
-implementations using standard SQL syntax, so for most backends you just need an empty impl:
-
-```rust
-use vantage_table::operation::Operation;
-
-impl Operation<AnySqliteType> for Column<AnySqliteType> {}
-```
-
-The defaults use standard SQL templates (`"{} = {}"`, `"{} != {}"`, `"{} > {}"`, etc.). Backends
-with non-SQL evaluation (like CSV's in-memory filtering) can override these with their own
-implementations.
+The `Operation` trait (from `vantage-table`) provides `.eq()`, `.ne()`, `.gt()`, `.gte()`,
+`.lt()`, `.lte()`, and `.in_()` methods for building conditions. It has a **blanket implementation**
+for all `Expressive<T>` types, so your columns get these methods automatically — no explicit impl
+needed.
 
 All methods accept `impl Expressive<YourAnyType>`, so you can pass native Rust values (`false`,
 `42`, `"hello"`), other columns (`table["other_field"]`), or full expressions. This requires your

--- a/README.md
+++ b/README.md
@@ -49,15 +49,16 @@ Vantage offers the following features out of the box:
 With all of the fundamental blocks and interfaces in place, Vantage can be extended in several ways.
 First - persistence implementation:
 
-- [`vantage-surrealdb`](vantage-surrealdb/README.md) - Implements all interfaces to interact with
-  this powerful multi-modal database with support for custom types, schemaless tables, graph-based
-  queries and live tables. Brings `SurrealSelect`, `SurrealColumn` types and also makes use of
-  `SurrealType` that include Geospatial, 128-bit `Decimal` and other advanced types. Built on
+- [`vantage-surrealdb`](vantage-surrealdb/README.md) - Full implementation for SurrealDB with
+  custom types, graph-based queries, CRUD, relationships, and aggregations. Built on
   [`surreal-client`](surreal-client/README.md).
-
-- `vantage-csv` - CSV file persistence with full read/write support and custom type system.
-- `vantage-redb` - Implementation for Redb embedded database, providing some basic features. Perfect
-  as a local cache.
+- [`vantage-sql`](vantage-sql/README.md) - SQLite implementation (via sqlx) with full CRUD,
+  relationships, aggregations, and query builder with JOINs, window functions, and CTEs.
+- `vantage-csv` - CSV file persistence with read support, conditions, relationships, and custom
+  type system. No query builder (conditions are evaluated in-memory).
+- [`vantage-api-pool`](vantage-api-pool/README.md) - High-performance REST API client pool with
+  auto-pagination, prefetching, and rate limiting. Read-only `TableSource` over paginated APIs.
+- `vantage-api-client` - Simple REST API client implementing read-only `TableSource`.
 
 On the other end, Vantage offers some adapters. Those would work with `Table` / `AnyTable` and
 implement generic UI or API component:
@@ -72,14 +73,14 @@ implement generic UI or API component:
 
 Vantage `0.3` is the current version. Recent additions:
 
-- **Full type system overhaul** - Custom type systems per datasource (`SurrealType`, `CsvType`) with
-  `vantage_type_system!` macro
+- **Full type system overhaul** - Custom type systems per datasource (`SurrealType`, `SqliteType`,
+  `CsvType`) with `vantage_type_system!` macro
+- **SQLite backend** - Full implementation with query builder, JOINs, window functions, CTEs
 - **Cross-database integration** - `AnyTable::from_table()` wraps any datasource for generic code
 - **Binary CBOR support** - SurrealDB client uses binary CBOR for improved performance
 - **References** - Traverse between `Table<Client>` into `Table<Order>`, even across databases
-- **Expressions** - Table columns can be calculated based on subqueries and references
-- **Full SurrealDB protocol support** - SelectableDataSource, TableQuerySource, TableExprSource
-- **Multi-source CLI** - Same `handle_commands` function works with CSV and SurrealDB
+- **Generic Operation trait** - Blanket `eq`/`ne`/`gt`/`lt`/`in_` for all `Expressive` types
+- **Multi-source CLI** - Same `handle_commands` function works with CSV, SQLite, and SurrealDB
 
 Features planned for next release:
 
@@ -641,9 +642,7 @@ API response for `GET /orders?client_id=2&page=1`
 
 Work-in-progress features for the next release:
 
-- [`vantage-sql`](vantage-sql/README.md) - Implementation utilising SQLx and providing support for
-  MySQL, PostgreSQL and SQLite.
-- [`vantage-mongodb`](vantage-mongodb/README.md) - Implementation for MongoDB database.
+- **PostgreSQL / MySQL** - Extend `vantage-sql` beyond SQLite using sqlx's multi-database support.
 - **Live Tables** - Mutexed tables with real-time updates and CDC integration.
 
 ## Roadmap
@@ -651,12 +650,9 @@ Work-in-progress features for the next release:
 Vantage needs a bit more work. Large number of features is already implemented, but some notable
 features are still missing:
 
-- Joins - were present in 0.2, but not yet implemented in 0.3 (read and write)
-- Aggregate columns - were in 0.2, partially implemented in 0.3 (count/sum/max/min work)
-- Column hooks - allowing field mappings and custom calculation is still TODO.
-- Condition propagation in references (WHERE clauses for related queries)
-- SQL testing - most tests so far were done with SurrealDB. We should give SQL more love.
-- Graph relations - implement hasMany support for Graph databases
+- Joins - present in SQLite query builder, not yet in SurrealDB 0.3 table layer
+- Column hooks - allowing field mappings and custom calculation is still TODO
+- Graph relations - implement hasMany support for SurrealDB graph edges
 - Implement some RestAPI adaptors (e.g. GitLab)
 - Aggregators (grouping queries) for SQL and SurrealDB
 
@@ -674,8 +670,18 @@ If you like what you see so far - reach out to me on BlueSky:
 
 ## Current status
 
-Vantage `0.3` is under active development. SurrealDB and CSV backends are fully functional with
-CRUD, aggregation, pagination, and type-erased `AnyTable` support.
+Vantage `0.3` is under active development. The table below shows implementation progress for each
+backend, measured against the steps in the
+[Persistence Guide](NEW_PERSISTENCE_GUIDE.md):
+
+| Step | Feature | SurrealDB | SQLite | CSV | REST API |
+|------|---------|-----------|--------|-----|----------|
+| 1 | Type system (`vantage_type_system!`, type markers) | Full | Full | Full | serde (Path A) |
+| 2 | Expressions (`ExprDataSource`, `defer()`, vendor macro) | Full | Full | In-memory eval | Minimal |
+| 3 | Query builder (`Selectable`, `SelectableDataSource`) | Full | Full (JOINs, CTEs, window fn) | -- | -- |
+| 4 | Table abstraction (`TableSource`, CRUD, aggregates) | Full | Full | Read-only | Read-only |
+| 5 | Relationships (`with_one`, `with_many`, `get_ref_as`) | Full | Full | Full | -- |
+| 6 | Multi-backend (`AnyTable`, CLI) | Full | Full | Full | Full |
 
 ## Author
 

--- a/bakery_model3/src/bakery.rs
+++ b/bakery_model3/src/bakery.rs
@@ -20,10 +20,14 @@ impl Bakery {
     }
 
     pub fn surreal_table(db: SurrealDB) -> Table<SurrealDB, Bakery> {
+        let db2 = db.clone();
         Table::new("bakery", db)
             .with_id_column("id")
             .with_column_of::<String>("name")
             .with_column_of::<i64>("profit_margin")
+            .with_many("products", "bakery", move || {
+                crate::Product::surreal_table(db2.clone())
+            })
     }
 
     pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Bakery> {

--- a/bakery_model3/src/client.rs
+++ b/bakery_model3/src/client.rs
@@ -36,12 +36,16 @@ impl Client {
     }
 
     pub fn surreal_table(db: SurrealDB) -> Table<SurrealDB, Client> {
+        let db2 = db.clone();
         Table::new("client", db)
             .with_id_column("id")
             .with_column_of::<String>("name")
             .with_column_of::<String>("email")
             .with_column_of::<String>("contact_details")
             .with_column_of::<bool>("is_paying_client")
+            .with_one("bakery", "bakery", move || {
+                Bakery::surreal_table(db2.clone())
+            })
     }
 
     pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Client> {

--- a/bakery_model3/src/product.rs
+++ b/bakery_model3/src/product.rs
@@ -26,12 +26,17 @@ impl Product {
     }
 
     pub fn surreal_table(db: SurrealDB) -> Table<SurrealDB, Product> {
+        let db2 = db.clone();
         Table::new("product", db)
             .with_id_column("id")
             .with_column_of::<String>("name")
             .with_column_of::<i64>("calories")
             .with_column_of::<i64>("price")
             .with_column_of::<bool>("is_deleted")
+            .with_column_of::<String>("bakery") // record link, used for relationships
+            .with_one("bakery", "bakery", move || {
+                Bakery::surreal_table(db2.clone())
+            })
     }
 
     pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Product> {

--- a/vantage-csv/src/condition.rs
+++ b/vantage-csv/src/condition.rs
@@ -65,7 +65,10 @@ pub(crate) async fn apply_condition(
                 })
                 .collect())
         }
-        _ => Ok(records), // Unknown operation, skip
+        other => Err(vantage_core::error!(
+            "Unsupported CSV condition operator",
+            template = other.to_string()
+        )),
     }
 }
 

--- a/vantage-csv/src/operation.rs
+++ b/vantage-csv/src/operation.rs
@@ -1,38 +1,8 @@
-//! CSV implementation of the generic Operation trait.
+//! CSV condition operation constants.
 //!
-//! Implements `eq()` and `in_()` for `Column<AnyCsvType>`,
-//! which is the column type used by CSV tables (accessed via `table["field"]`).
+//! Template markers for condition operations. CSV's in-memory evaluator
+//! matches on these to know which operation to apply. These match the
+//! default templates in `Operation<T>`.
 
-/// Template markers for condition operations.
-/// CSV's in-memory evaluator matches on these to know which operation to apply.
 pub const OP_EQ: &str = "{} = {}";
 pub const OP_IN: &str = "{} IN ({})";
-
-use vantage_expressions::traits::expressive::ExpressiveEnum;
-use vantage_expressions::{Expression, Expressive};
-use vantage_table::column::core::Column;
-use vantage_table::operation::Operation;
-
-use crate::type_system::AnyCsvType;
-
-impl Operation<AnyCsvType> for Column<AnyCsvType> {
-    fn eq(&self, value: impl Into<AnyCsvType>) -> Expression<AnyCsvType> {
-        Expression::new(
-            OP_EQ,
-            vec![
-                ExpressiveEnum::Nested(self.expr()),
-                ExpressiveEnum::Scalar(value.into()),
-            ],
-        )
-    }
-
-    fn in_(&self, values: Expression<AnyCsvType>) -> Expression<AnyCsvType> {
-        Expression::new(
-            OP_IN,
-            vec![
-                ExpressiveEnum::Nested(self.expr()),
-                ExpressiveEnum::Nested(values),
-            ],
-        )
-    }
-}

--- a/vantage-csv/src/type_system.rs
+++ b/vantage-csv/src/type_system.rs
@@ -192,6 +192,15 @@ macro_rules! impl_expressive_for_csv_scalar {
 
 impl_expressive_for_csv_scalar!(i64, f64, bool, String);
 
+impl Expressive<AnyCsvType> for &str {
+    fn expr(&self) -> Expression<AnyCsvType> {
+        Expression::new(
+            "{}",
+            vec![ExpressiveEnum::Scalar(AnyCsvType::new(self.to_string()))],
+        )
+    }
+}
+
 impl Expressive<AnyCsvType> for AnyCsvType {
     fn expr(&self) -> Expression<AnyCsvType> {
         Expression::new("{}", vec![ExpressiveEnum::Scalar(self.clone())])

--- a/vantage-csv/src/type_system.rs
+++ b/vantage-csv/src/type_system.rs
@@ -172,6 +172,32 @@ impl From<bool> for AnyCsvType {
     }
 }
 
+// Expressive impls — allows passing scalars directly to Operation methods (eq, gt, etc.)
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+macro_rules! impl_expressive_for_csv_scalar {
+    ($($ty:ty),*) => {
+        $(
+            impl Expressive<AnyCsvType> for $ty {
+                fn expr(&self) -> Expression<AnyCsvType> {
+                    Expression::new(
+                        "{}",
+                        vec![ExpressiveEnum::Scalar(AnyCsvType::new_ref(self))],
+                    )
+                }
+            }
+        )*
+    };
+}
+
+impl_expressive_for_csv_scalar!(i64, f64, bool, String);
+
+impl Expressive<AnyCsvType> for AnyCsvType {
+    fn expr(&self) -> Expression<AnyCsvType> {
+        Expression::new("{}", vec![ExpressiveEnum::Scalar(self.clone())])
+    }
+}
+
 impl From<serde_json::Value> for AnyCsvType {
     fn from(v: serde_json::Value) -> Self {
         match v {

--- a/vantage-sql/src/sqlite/operation.rs
+++ b/vantage-sql/src/sqlite/operation.rs
@@ -1,6 +1,2 @@
-use vantage_table::column::core::Column;
-use vantage_table::operation::Operation;
-
-use super::types::AnySqliteType;
-
-impl Operation<AnySqliteType> for Column<AnySqliteType> {}
+// SQLite columns get Operation<AnySqliteType> via the blanket impl
+// in vantage-table. No explicit impl needed.

--- a/vantage-surrealdb/src/operation.rs
+++ b/vantage-surrealdb/src/operation.rs
@@ -1,24 +1,36 @@
-//! SurrealDB operations for expressions
+//! SurrealDB-specific operations for expressions.
 //!
-//! This module provides operations that extend expressions with SurrealDB-specific functionality.
+//! Common comparison methods (eq, ne, gt, gte, lt, lte, in_) are provided by the
+//! generic `Operation<T>` trait from vantage-table, which has a blanket impl for
+//! all `Expressive<T>` types. This module adds SurrealDB-specific operations:
+//! graph traversal (rref/lref), subtraction, CONTAINS, and a SurrealDB-flavored
+//! IN (without parentheses).
 
 use vantage_expressions::Expressive;
 
 use crate::{AnySurrealType, Expr, identifier::Identifier, surreal_expr};
 
-/// Extension trait to add reference traversal and comparison methods to expressions
+/// SurrealDB-specific operations: graph traversal, CONTAINS, subtraction,
+/// and parenthesis-free IN.
+///
+/// For standard comparisons (eq, ne, gt, gte, lt, lte), use `Operation<T>`
+/// from `vantage_table::operation` — it's blanket-implemented for all
+/// `Expressive<T>` types.
 pub trait RefOperation: Expressive<AnySurrealType> {
+    /// Right-side graph traversal: `self->reference->table`
     fn rref(&self, reference: impl Into<String>, table: impl Into<String>) -> Expr;
+    /// Left-side graph traversal: `self<-reference<-table`
     fn lref(&self, reference: impl Into<String>, table: impl Into<String>) -> Expr;
-    fn eq(&self, other: impl Expressive<AnySurrealType>) -> Expr;
-    fn ne(&self, other: impl Expressive<AnySurrealType>) -> Expr;
-    fn gt(&self, other: impl Expressive<AnySurrealType>) -> Expr;
-    fn gte(&self, other: impl Expressive<AnySurrealType>) -> Expr;
-    fn lt(&self, other: impl Expressive<AnySurrealType>) -> Expr;
-    fn lte(&self, other: impl Expressive<AnySurrealType>) -> Expr;
+    /// Subtraction: `self - other`
     fn sub(&self, other: impl Expressive<AnySurrealType>) -> Expr;
+    /// SurrealDB CONTAINS operator: `self CONTAINS other`
     fn contains_(&self, other: impl Expressive<AnySurrealType>) -> Expr;
-    fn in_(&self, other: impl Expressive<AnySurrealType>) -> Expr;
+    /// SurrealDB IN without parentheses: `self IN other`
+    ///
+    /// SurrealDB uses `value IN array` syntax where the right side can be
+    /// a graph traversal or array literal — no parentheses needed.
+    /// SQL backends should use `Operation::in_()` which adds parens for subqueries.
+    fn surreal_in(&self, other: impl Expressive<AnySurrealType>) -> Expr;
 }
 
 impl<T> RefOperation for T
@@ -43,30 +55,6 @@ where
         )
     }
 
-    fn eq(&self, other: impl Expressive<AnySurrealType>) -> Expr {
-        surreal_expr!("{} = {}", (self), (other))
-    }
-
-    fn ne(&self, other: impl Expressive<AnySurrealType>) -> Expr {
-        surreal_expr!("{} != {}", (self), (other))
-    }
-
-    fn gt(&self, other: impl Expressive<AnySurrealType>) -> Expr {
-        surreal_expr!("{} > {}", (self), (other))
-    }
-
-    fn gte(&self, other: impl Expressive<AnySurrealType>) -> Expr {
-        surreal_expr!("{} >= {}", (self), (other))
-    }
-
-    fn lt(&self, other: impl Expressive<AnySurrealType>) -> Expr {
-        surreal_expr!("{} < {}", (self), (other))
-    }
-
-    fn lte(&self, other: impl Expressive<AnySurrealType>) -> Expr {
-        surreal_expr!("{} <= {}", (self), (other))
-    }
-
     fn sub(&self, other: impl Expressive<AnySurrealType>) -> Expr {
         surreal_expr!("{} - {}", (self), (other))
     }
@@ -75,7 +63,7 @@ where
         surreal_expr!("{} CONTAINS {}", (self), (other))
     }
 
-    fn in_(&self, other: impl Expressive<AnySurrealType>) -> Expr {
+    fn surreal_in(&self, other: impl Expressive<AnySurrealType>) -> Expr {
         surreal_expr!("{} IN {}", (self), (other))
     }
 }
@@ -158,11 +146,15 @@ mod tests {
 
     #[test]
     fn test_comparison_operations() {
+        use vantage_table::operation::Operation;
+
         let field = surreal_expr!("age");
 
+        // eq comes from generic Operation<T>
         let eq_scalar = field.eq(25i64);
         assert_eq!(eq_scalar.preview(), "age = 25");
 
+        // sub is SurrealDB-specific
         let sub_result = field.sub(10i64);
         assert_eq!(sub_result.preview(), "age - 10");
 
@@ -170,9 +162,10 @@ mod tests {
         let contains_result = tags_field.contains_("bakery".to_string());
         assert_eq!(contains_result.preview(), r#"tags CONTAINS "bakery""#);
 
+        // surreal_in — paren-free SurrealDB syntax
         let status_field = surreal_expr!("status");
         let values_expr = surreal_expr!(r#"["active", "pending"]"#);
-        let in_result = status_field.in_(values_expr);
+        let in_result = status_field.surreal_in(values_expr);
         assert_eq!(in_result.preview(), r#"status IN ["active", "pending"]"#);
     }
 }

--- a/vantage-surrealdb/src/surrealdb/impls/base.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/base.rs
@@ -39,17 +39,10 @@ impl SurrealDB {
                     params.insert(param_name, s.clone());
                 }
                 vantage_expressions::ExpressiveEnum::Deferred(_) => {
-                    // Deferred expressions get parameterized as null for now
-                    param_counter += 1;
-                    let param_name = format!("_arg{}", param_counter);
-                    query.push_str(&format!("${}", param_name));
-                    panic!("deffered shouldn't be here!");
-                    // params.insert(param_name, Value::Null);
+                    unreachable!("Deferred params should be resolved before prepare_query");
                 }
                 vantage_expressions::ExpressiveEnum::Nested(_) => {
-                    // Nested expressions get rendered directly into the query
-                    panic!("neshed should have been flatened!");
-                    // query.push_str(&nested.preview());
+                    unreachable!("Nested params should be flattened before prepare_query");
                 }
             }
 

--- a/vantage-surrealdb/src/surrealdb/impls/expr_data_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/expr_data_source.rs
@@ -1,12 +1,35 @@
 use vantage_core::{Context, Result};
-use vantage_expressions::{DeferredFn, ExprDataSource, Expression};
+use vantage_expressions::{DeferredFn, ExprDataSource, Expression, ExpressiveEnum};
 
 use crate::{AnySurrealType, SurrealType, surrealdb::SurrealDB};
 
+/// Resolve all Deferred parameters in an expression by calling them.
+async fn resolve_deferred(expr: &Expression<AnySurrealType>) -> Result<Expression<AnySurrealType>> {
+    let mut resolved_params = Vec::new();
+
+    for param in &expr.parameters {
+        match param {
+            ExpressiveEnum::Deferred(deferred_fn) => {
+                let result = deferred_fn.call().await?;
+                resolved_params.push(result);
+            }
+            ExpressiveEnum::Nested(inner) => {
+                let resolved_inner = Box::pin(resolve_deferred(inner)).await?;
+                resolved_params.push(ExpressiveEnum::Nested(resolved_inner));
+            }
+            other => {
+                resolved_params.push(other.clone());
+            }
+        }
+    }
+
+    Ok(Expression::new(expr.template.clone(), resolved_params))
+}
+
 impl ExprDataSource<AnySurrealType> for SurrealDB {
-    // TODO: this implementation is too crude, might need to make it more elegant
     async fn execute(&self, expr: &Expression<AnySurrealType>) -> Result<AnySurrealType> {
-        let (query_str, params) = self.prepare_query(expr);
+        let resolved = resolve_deferred(expr).await?;
+        let (query_str, params) = self.prepare_query(&resolved);
         let params_cbor = params.to_cbor();
         let client = self.inner.lock().await;
         let result = client

--- a/vantage-surrealdb/src/types/mod.rs
+++ b/vantage-surrealdb/src/types/mod.rs
@@ -308,17 +308,27 @@ impl TryFrom<AnySurrealType> for Record<AnySurrealType> {
                 .ok_or_else(|| vantage_core::error!("Expected map in array result"))?,
             _ => return Err(vantage_core::error!("Expected map or array result")),
         };
-        Ok(map
-            .into_iter()
-            .filter_map(|(k, v)| {
+        map.into_iter()
+            .map(|(k, v)| {
                 let key = match k {
                     ciborium::Value::Text(s) => s,
-                    _ => return None,
+                    other => {
+                        return Err(vantage_core::error!(
+                            "Expected text key in record conversion",
+                            key = format!("{:?}", other)
+                        ))
+                    }
                 };
-                let val = AnySurrealType::from_cbor(&v)?;
-                Some((key, val))
+                let val = AnySurrealType::from_cbor(&v).ok_or_else(|| {
+                    vantage_core::error!(
+                        "Failed to convert record value from CBOR",
+                        key = key.clone(),
+                        value = format!("{:?}", v)
+                    )
+                })?;
+                Ok((key, val))
             })
-            .collect())
+            .collect()
     }
 }
 

--- a/vantage-surrealdb/src/types/mod.rs
+++ b/vantage-surrealdb/src/types/mod.rs
@@ -316,7 +316,7 @@ impl TryFrom<AnySurrealType> for Record<AnySurrealType> {
                         return Err(vantage_core::error!(
                             "Expected text key in record conversion",
                             key = format!("{:?}", other)
-                        ))
+                        ));
                     }
                 };
                 let val = AnySurrealType::from_cbor(&v).ok_or_else(|| {

--- a/vantage-surrealdb/src/types/mod.rs
+++ b/vantage-surrealdb/src/types/mod.rs
@@ -4,7 +4,7 @@
 //! It defines the core SurrealType trait and AnySurrealType for type-erased operations.
 
 use vantage_core::VantageError;
-use vantage_types::{TerminalRender, vantage_type_system};
+use vantage_types::{Record, TerminalRender, vantage_type_system};
 
 // Generate the SurrealDB type system
 vantage_type_system! {
@@ -290,6 +290,35 @@ impl TryFrom<AnySurrealType> for Vec<AnySurrealType> {
                 value = format!("{}", val)
             )
         })
+    }
+}
+
+impl TryFrom<AnySurrealType> for Record<AnySurrealType> {
+    type Error = VantageError;
+    fn try_from(val: AnySurrealType) -> Result<Self, Self::Error> {
+        let value = val.into_value();
+        let map = match value {
+            ciborium::Value::Map(m) => m,
+            ciborium::Value::Array(arr) => arr
+                .into_iter()
+                .find_map(|v| match v {
+                    ciborium::Value::Map(m) => Some(m),
+                    _ => None,
+                })
+                .ok_or_else(|| vantage_core::error!("Expected map in array result"))?,
+            _ => return Err(vantage_core::error!("Expected map or array result")),
+        };
+        Ok(map
+            .into_iter()
+            .filter_map(|(k, v)| {
+                let key = match k {
+                    ciborium::Value::Text(s) => s,
+                    _ => return None,
+                };
+                let val = AnySurrealType::from_cbor(&v)?;
+                Some((key, val))
+            })
+            .collect())
     }
 }
 

--- a/vantage-surrealdb/tests/5_references.rs
+++ b/vantage-surrealdb/tests/5_references.rs
@@ -1,0 +1,65 @@
+//! Test 5: Relationship traversal — with_one, with_many, get_ref_as.
+//!
+//! Uses the pre-populated SurrealDB v2 bakery database.
+//! Requires: `cd scripts && ./ingress.sh` to populate.
+
+use bakery_model3::{Bakery, Client, Product, SurrealConnection, SurrealDB};
+use vantage_dataset::ReadableDataSet;
+use vantage_surrealdb::surreal_expr;
+
+async fn get_db() -> SurrealDB {
+    let client = SurrealConnection::dsn("cbor://root:root@localhost:8000/bakery/v2")
+        .expect("Invalid DSN")
+        .connect()
+        .await
+        .expect("Failed to connect to SurrealDB — run scripts/ingress.sh first");
+    SurrealDB::new(client)
+}
+
+/// Traverse has_many: bakery → products
+#[tokio::test]
+async fn test_has_many_products_for_bakery() {
+    let db = get_db().await;
+    let bakery = Bakery::surreal_table(db.clone());
+
+    let products = bakery.get_ref_as::<SurrealDB, Product>("products").unwrap();
+
+    let product_list = products.list().await.unwrap();
+    // v2 has 5 products all belonging to hill_valley bakery
+    assert_eq!(product_list.len(), 5);
+}
+
+/// Traverse has_one: product → bakery
+#[tokio::test]
+async fn test_has_one_bakery_for_product() {
+    let db = get_db().await;
+    let mut products = Product::surreal_table(db.clone());
+    products.add_condition(surreal_expr!("name = {}", "Flux Capacitor Cupcake"));
+
+    let bakery = products.get_ref_as::<SurrealDB, Bakery>("bakery").unwrap();
+
+    let bakery_list = bakery.list().await.unwrap();
+    assert_eq!(bakery_list.len(), 1);
+    assert_eq!(
+        bakery_list.values().next().unwrap().name,
+        "Hill Valley Bakery"
+    );
+}
+
+/// Traverse has_one: client → bakery (with condition)
+#[tokio::test]
+async fn test_has_one_bakery_for_paying_clients() {
+    let db = get_db().await;
+    let mut clients = Client::surreal_table(db.clone());
+    clients.add_condition(surreal_expr!("is_paying_client = {}", true));
+
+    let bakery = clients.get_ref_as::<SurrealDB, Bakery>("bakery").unwrap();
+
+    let bakery_list = bakery.list().await.unwrap();
+    // Both paying clients (Marty, Doc) belong to the same bakery
+    assert_eq!(bakery_list.len(), 1);
+    assert_eq!(
+        bakery_list.values().next().unwrap().name,
+        "Hill Valley Bakery"
+    );
+}

--- a/vantage-surrealdb/tests/graph_traversal.rs
+++ b/vantage-surrealdb/tests/graph_traversal.rs
@@ -142,7 +142,8 @@ async fn query10_low_stock_products() {
         .field("name")
         .with_expression(surreal_expr!("inventory.stock"), None)
         .with_where(
-            Thing::new("bakery", "hill_valley").in_(surreal_expr!("").lref("owns", "bakery")),
+            Thing::new("bakery", "hill_valley")
+                .surreal_in(surreal_expr!("").lref("owns", "bakery")),
         )
         .with_where(surreal_expr!("inventory.stock < {}", 20i64))
         .with_where(surreal_expr!("is_deleted = {}", false))
@@ -253,7 +254,8 @@ fn render_query10() {
         .field("name")
         .with_expression(surreal_expr!("inventory.stock"), None)
         .with_where(
-            Thing::new("bakery", "hill_valley").in_(surreal_expr!("").lref("owns", "bakery")),
+            Thing::new("bakery", "hill_valley")
+                .surreal_in(surreal_expr!("").lref("owns", "bakery")),
         )
         .with_where(surreal_expr!("inventory.stock < {}", 20i64))
         .with_where(surreal_expr!("is_deleted = {}", false));

--- a/vantage-surrealdb/tests/select.rs
+++ b/vantage-surrealdb/tests/select.rs
@@ -12,6 +12,7 @@ use vantage_surrealdb::{
     surrealdb::SurrealDB,
     thing::Thing,
 };
+use vantage_table::operation::Operation;
 
 fn snip(str: &str) -> String {
     str.split_whitespace()
@@ -201,7 +202,7 @@ fn query11() {
                 .with_source("product")
                 .with_condition(
                     Thing::new("bakery", "hill_valley")
-                        .in_(surreal_expr!("").lref("owns", "bakery")),
+                        .surreal_in(surreal_expr!("").lref("owns", "bakery")),
                 )
                 .with_condition(Identifier::new("is_deleted").eq(false))
                 .expr(),

--- a/vantage-surrealdb/tests/statements.rs
+++ b/vantage-surrealdb/tests/statements.rs
@@ -7,10 +7,10 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use vantage_expressions::{ExprDataSource, Expressive, Selectable};
 use vantage_surrealdb::field::Field;
-use vantage_surrealdb::operation::RefOperation;
 use vantage_surrealdb::statements::delete::SurrealDelete;
 use vantage_surrealdb::statements::insert::SurrealInsert;
 use vantage_surrealdb::statements::select::SurrealSelect;
+use vantage_table::operation::Operation;
 
 use vantage_surrealdb::statements::update::SurrealUpdate;
 use vantage_surrealdb::surreal_expr;

--- a/vantage-surrealdb/tests/table_source_read.rs
+++ b/vantage-surrealdb/tests/table_source_read.rs
@@ -27,7 +27,7 @@ async fn test_build_select_basic() {
     let select = table.select();
     assert_eq!(
         select.preview(),
-        "SELECT id, name, calories, price, is_deleted FROM product"
+        "SELECT id, name, calories, price, is_deleted, bakery FROM product"
     );
 }
 
@@ -39,7 +39,7 @@ async fn test_build_select_with_condition() {
     let select = table.select();
     assert_eq!(
         select.preview(),
-        "SELECT id, name, calories, price, is_deleted FROM product WHERE active = true"
+        "SELECT id, name, calories, price, is_deleted, bakery FROM product WHERE active = true"
     );
 }
 

--- a/vantage-table/src/operation.rs
+++ b/vantage-table/src/operation.rs
@@ -13,24 +13,82 @@ use vantage_expressions::{Expression, Expressive};
 /// Backends like CSV override these with structured parameters for in-memory evaluation.
 pub trait Operation<T>: Expressive<T> {
     /// Creates an equality condition: field = value
-    fn eq(&self, value: impl Into<T>) -> Expression<T> {
+    fn eq(&self, value: impl Expressive<T>) -> Expression<T> {
         Expression::new(
             "{} = {}",
             vec![
                 ExpressiveEnum::Nested(self.expr()),
-                ExpressiveEnum::Scalar(value.into()),
+                ExpressiveEnum::Nested(value.expr()),
+            ],
+        )
+    }
+
+    /// Creates a not-equal condition: field != value
+    fn ne(&self, value: impl Expressive<T>) -> Expression<T> {
+        Expression::new(
+            "{} != {}",
+            vec![
+                ExpressiveEnum::Nested(self.expr()),
+                ExpressiveEnum::Nested(value.expr()),
+            ],
+        )
+    }
+
+    /// Creates a greater-than condition: field > value
+    fn gt(&self, value: impl Expressive<T>) -> Expression<T> {
+        Expression::new(
+            "{} > {}",
+            vec![
+                ExpressiveEnum::Nested(self.expr()),
+                ExpressiveEnum::Nested(value.expr()),
+            ],
+        )
+    }
+
+    /// Creates a greater-than-or-equal condition: field >= value
+    fn gte(&self, value: impl Expressive<T>) -> Expression<T> {
+        Expression::new(
+            "{} >= {}",
+            vec![
+                ExpressiveEnum::Nested(self.expr()),
+                ExpressiveEnum::Nested(value.expr()),
+            ],
+        )
+    }
+
+    /// Creates a less-than condition: field < value
+    fn lt(&self, value: impl Expressive<T>) -> Expression<T> {
+        Expression::new(
+            "{} < {}",
+            vec![
+                ExpressiveEnum::Nested(self.expr()),
+                ExpressiveEnum::Nested(value.expr()),
+            ],
+        )
+    }
+
+    /// Creates a less-than-or-equal condition: field <= value
+    fn lte(&self, value: impl Expressive<T>) -> Expression<T> {
+        Expression::new(
+            "{} <= {}",
+            vec![
+                ExpressiveEnum::Nested(self.expr()),
+                ExpressiveEnum::Nested(value.expr()),
             ],
         )
     }
 
     /// Creates a membership condition: field IN (values_expression)
-    fn in_(&self, values: Expression<T>) -> Expression<T> {
+    fn in_(&self, values: impl Expressive<T>) -> Expression<T> {
         Expression::new(
             "{} IN ({})",
             vec![
                 ExpressiveEnum::Nested(self.expr()),
-                ExpressiveEnum::Nested(values),
+                ExpressiveEnum::Nested(values.expr()),
             ],
         )
     }
 }
+
+/// Blanket implementation: any type that implements `Expressive<T>` gets `Operation<T>` for free.
+impl<T, S: Expressive<T>> Operation<T> for S {}

--- a/vantage-table/src/operation.rs
+++ b/vantage-table/src/operation.rs
@@ -1,16 +1,15 @@
-//! Generic operation trait for building conditions on table columns.
+//! Generic operation trait for building conditions from any `Expressive` type.
 //!
-//! Each persistence backend provides its own implementation.
-//! CSV uses structured parameters evaluated in memory.
-//! SQL/SurrealDB render as query syntax.
+//! A blanket impl provides `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, and `in_` for
+//! every type that implements `Expressive<T>`. This includes table columns, fields,
+//! scalar values, and expressions across all backends.
 
 use vantage_expressions::traits::expressive::ExpressiveEnum;
 use vantage_expressions::{Expression, Expressive};
 
-/// Trait for building condition expressions from column references.
+/// Trait for building condition expressions.
 ///
-/// Provides default implementations using standard SQL syntax.
-/// Backends like CSV override these with structured parameters for in-memory evaluation.
+/// Blanket-implemented for all `Expressive<T>` types using standard SQL templates.
 pub trait Operation<T>: Expressive<T> {
     /// Creates an equality condition: field = value
     fn eq(&self, value: impl Expressive<T>) -> Expression<T> {

--- a/vantage-types/examples/test_traits.rs
+++ b/vantage-types/examples/test_traits.rs
@@ -34,9 +34,9 @@ fn main() {
     println!("Into conversion: {}", value);
     assert_eq!(value, "hello");
 
-    // Test TryFrom: String -> AnySimpleType
-    let any_type2: AnySimpleType = "world".to_string().try_into().unwrap();
-    println!("TryFrom conversion: {:?}", any_type2.value());
+    // Test From: String -> AnySimpleType
+    let any_type2: AnySimpleType = "world".to_string().into();
+    println!("From conversion: {:?}", any_type2.value());
     assert_eq!(any_type2.value(), "world");
     assert_eq!(any_type2.type_variant(), Some(SimpleTypeVariants::Text));
 

--- a/vantage-types/tests/simple_traits_test.rs
+++ b/vantage-types/tests/simple_traits_test.rs
@@ -60,7 +60,7 @@ mod tests {
         assert_eq!(value, "hello");
 
         // ValueType -> AnyType
-        let any_type2: AnyTestType = "world".to_string().try_into().unwrap();
+        let any_type2: AnyTestType = "world".to_string().into();
         assert_eq!(any_type2.value(), "world");
         assert_eq!(any_type2.type_variant(), Some(TestTypeVariants::Text));
     }


### PR DESCRIPTION
SurrealDB users: `column.in_(...)` no longer means what it did. The paren-free `value IN array` form moved to `surreal_in`. The plain `in_` is now the SQL-style `IN (...)` from `Operation`, which works across every backend.

### One Operation trait for every backend

`vantage-table::Operation<T>` now has a blanket impl over every `Expressive<T>`, with the full set: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in_`. Argument type relaxed from `impl Into<T>` to `impl Expressive<T>`, so columns, scalars, and full expressions all flow through the same call.

For backend authors, dropping your per-column `impl Operation<MyType> for Column<MyType>` is the whole adoption story — SQLite is now a two-line comment. CSV keeps its `OP_EQ` / `OP_IN` template constants because it still pattern-matches on them at evaluation time, but the impl block is gone.

### SurrealDB-only operators

`RefOperation` shed every operator that had a generic equivalent. What remains is genuinely Surreal-shaped: `rref`/`lref` for graph traversal, `sub`, `contains_`, and `surreal_in` (no parens — for `value IN ->edge->table`). Reach for `Operation::in_` when you want SQL-style `IN (...)` with a subquery.

### Deferred params actually resolve now

`SurrealDB::execute` was handing `Deferred` parameters straight to `prepare_query`, which then `panic!`'d on them. It now walks the expression tree first via `resolve_deferred` and awaits each one before flattening. The two `panic!` branches in `prepare_query` are now `unreachable!` — if either fires, something upstream is wrong. CSV's condition evaluator also stopped silently passing all rows on an unknown operator and now returns an error. Plus a new `5_references.rs` exercising `with_one`/`with_many` against the bakery model.