### PR TITLE
implement postgresql

### DIFF
--- a/.github/workflows/postgres.yaml
+++ b/.github/workflows/postgres.yaml
@@ -1,33 +1,31 @@
-name: Vantage v0.2 and Integration Tests
+name: PostgreSQL Tests
 
 on:
   pull_request:
     branches: ["main"]
     paths:
-      - "vantage/**"
-      - "bakery_model/**"
-      - "bakery_api/**"
+      - "vantage-sql/**"
+      - "bakery_model3/**"
       - ".github/workflows/postgres.yaml"
 
 env:
   CARGO_TERM_COLOR: always
-  TESTCONTAINER_DOCKER_NETWORK: tomodachi-testcontainers
 
 jobs:
-  vantage-v02:
+  test:
     runs-on: ubuntu-latest
 
     services:
       postgres:
-        image: postgres:latest
+        image: postgres:17-alpine
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
+          POSTGRES_USER: vantage
+          POSTGRES_PASSWORD: vantage
+          POSTGRES_DB: vantage
         ports:
-          - 5432:5432
+          - 5433:5432
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U vantage -d vantage"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -37,48 +35,32 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          key: "vantage-v02"
-          workspaces: |
-            vantage -> target
-            bakery_model -> target
-            bakery_api -> target
+          key: "postgres-workspace-v01"
+          cache-workspace-crates: true
+          cache-all-crates: true
 
-      - name: Setup database schema
+      - name: Populate PostgreSQL database
         run: |
-          psql -h localhost -U postgres -d postgres -f bakery_model/schema-pg.sql
-        env:
-          PGPASSWORD: postgres
+          cd vantage-sql/scripts/postgres
+          for f in db/*.sql; do
+            echo "Loading $f..."
+            PGPASSWORD=vantage psql -h localhost -p 5433 -U vantage -d vantage -f "$f"
+          done
 
-      - name: Build vantage v0.2
-        working-directory: vantage
-        run: cargo build
+      - name: Build vantage-sql with postgres feature
+        run: cargo build -p vantage-sql --features postgres
 
-      - name: Run vantage v0.2 tests
-        working-directory: vantage
-        run: cargo test
-        env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+      - name: Run vantage-sql postgres tests
+        run: cargo test -p vantage-sql --features postgres --test postgres
 
-      - name: Build bakery_model
-        working-directory: bakery_model
-        run: cargo build
-        env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+      - name: Run clippy on postgres code
+        run: cargo clippy -p vantage-sql --features "sqlite,postgres" --all-targets -- -D warnings
 
-      - name: Run bakery_model tests
-        working-directory: bakery_model
-        run: cargo test
-        env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+      - name: Build bakery_model3
+        run: cargo build -p bakery_model3
 
-      - name: Build bakery_api
-        working-directory: bakery_api
-        run: cargo build
-        env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
-
-      - name: Run bakery_api tests
-        working-directory: bakery_api
-        run: cargo test -- --test-threads=1
-        env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+      - name: Run bakery_model3 CLI smoke test
+        run: |
+          cargo run -p bakery_model3 --example cli -- postgres bakery list
+          cargo run -p bakery_model3 --example cli -- postgres product count
+          cargo run -p bakery_model3 --example cli -- postgres client list

--- a/POSTGRES_NOTES.md
+++ b/POSTGRES_NOTES.md
@@ -1,0 +1,137 @@
+# PostgreSQL Backend Implementation Notes
+
+## Overview
+
+PostgreSQL support is implemented as a feature-gated module (`postgres`) in the `vantage-sql` crate,
+following the same architecture as the existing SQLite backend. Enable with `--features postgres`.
+
+## Key Differences from SQLite
+
+### Type System
+
+PostgreSQL has a richer type system than SQLite. The variants defined are:
+
+| Variant | Rust types | PostgreSQL types |
+|---------|-----------|-----------------|
+| Null | - | NULL |
+| Bool | bool | BOOLEAN |
+| Int2 | i8, i16, u8 | SMALLINT |
+| Int4 | i32, u16 | INTEGER |
+| Int8 | i64, u32 | BIGINT |
+| Float4 | f32 | REAL |
+| Float8 | f64 | DOUBLE PRECISION |
+| Text | String, &str | TEXT, VARCHAR |
+| Bytea | Vec<u8> | BYTEA |
+
+Unlike SQLite where bool maps to Integer (0/1), PostgreSQL has native BOOLEAN. This means
+`AnyPostgresType::new(true)` stores `Value::Bool(true)` (not `Value::Number(1)`).
+
+Integer widths (Int2/Int4/Int8) are distinct variants — `AnyPostgresType::new(42i32)` gets
+variant `Int4`, which blocks `try_get::<i64>()` (Int4 ≠ Int8). Untyped values (from DB reads)
+bypass this check as expected.
+
+### Parameter Binding
+
+PostgreSQL uses `$1`, `$2`, ... for positional parameters (not `?1`, `?2` like SQLite).
+The `prepare_typed_query` function in `expr_data_source.rs` handles this conversion.
+
+### NUMERIC Type Handling
+
+PostgreSQL's `SUM()`, `AVG()` on integer columns return `NUMERIC`, which sqlx cannot decode
+without the `bigdecimal` or `rust_decimal` feature. The `as_aggregate` method wraps results
+with `CAST(... AS BIGINT)` to ensure decodability.
+
+The `pg_column_to_json` row reader also handles `NUMERIC` by trying i64/i32/f64 decoders
+in sequence.
+
+### UPSERT (replace)
+
+SQLite uses `INSERT OR REPLACE INTO`. PostgreSQL uses
+`INSERT ... ON CONFLICT (id) DO UPDATE SET col = EXCLUDED.col`.
+The `replace_table_value` method builds this automatically.
+
+### ID Type Handling
+
+When the table uses `SERIAL` (integer) IDs, the id string needs to be bound as an integer,
+not text. The `id_value()` helper parses the string id and creates the appropriate typed
+`AnyPostgresType` (Int8 for numeric ids, Text otherwise).
+
+### Search Expression
+
+`search_table_expr` uses `"col"::text LIKE $1` instead of just `"col" LIKE $1` to handle
+non-text columns (PostgreSQL doesn't implicitly cast to text for LIKE).
+
+## Docker Setup
+
+Tests require a running PostgreSQL instance. Scripts are in `scripts/postgres/`:
+
+```bash
+# Start PostgreSQL on port 5433 (avoids conflict with local postgres on 5432)
+./scripts/postgres/start.sh
+
+# Load bakery test data
+./scripts/postgres/ingress.sh
+
+# Stop
+./scripts/postgres/stop.sh
+```
+
+Port 5433 is used because many dev machines have a local PostgreSQL on 5432.
+
+## Test Structure
+
+All 84 tests follow the same pattern as SQLite:
+
+- `1_types_round_trip.rs` — 18 tests: AnyPostgresType in-memory round-trips
+- `1_types_record.rs` — 9 tests: Record<AnyPostgresType> typed/untyped
+- `2_expressions.rs` — 7 tests: ExprDataSource execute with parameters
+- `2_insert.rs` — 4 tests: INSERT with typed parameters
+- `2_records.rs` — 5 tests: SELECT into Record, entity deserialization
+- `2_defer.rs` — 3 tests: cross-database deferred expressions
+- `2_associated.rs` — 4 tests: AssociatedExpression with typed results
+- `3_select.rs` — 14 tests: PostgresSelect builder rendering + live execution
+- `4_table_def.rs` — 1 test: Table query generation
+- `4_readable_data_set.rs` — 3 tests: list, get, get_some
+- `4_conditions.rs` — 3 tests: custom conditions, field comparison, Operation::eq
+- `4_aggregates.rs` — 4 tests: COUNT, SUM, MAX, MIN
+- `4_editable_data_set.rs` — 6 tests: insert, replace, patch, delete, delete_all, insert_return_id
+- `5_references.rs` — 3 tests: has_many, has_one relationship traversal
+
+Each test that touches the database uses a unique table name to avoid race conditions
+from parallel test execution.
+
+## File Structure
+
+```
+vantage-sql/src/postgres/
+├── mod.rs          — PostgresDB struct with pool + aggregate method
+├── macros.rs       — postgres_expr! macro
+├── operation.rs    — blanket impl note
+├── row.rs          — bind_postgres_value + row_to_record
+├── types/
+│   ├── mod.rs      — vantage_type_system! macro + variant detection
+│   ├── bool.rs     — bool -> Bool variant
+│   ├── numbers.rs  — integer/float types
+│   ├── string.rs   — String/&str -> Text
+│   └── value.rs    — From, Display, Expressive, TryFrom impls
+├── impls/
+│   ├── mod.rs      — DataSource marker
+│   ├── expr_data_source.rs  — execute + defer + $N placeholder conversion
+│   ├── selectable_data_source.rs
+│   └── table_source.rs      — full TableSource implementation
+└── statements/
+    ├── mod.rs
+    ├── select/
+    │   ├── mod.rs       — PostgresSelect struct
+    │   ├── render.rs    — SQL rendering
+    │   ├── join.rs      — JOIN clause
+    │   └── impls/
+    │       ├── mod.rs
+    │       └── selectable.rs — Selectable trait impl + CAST aggregate
+    ├── insert/
+    │   ├── mod.rs, builder.rs, render.rs
+    ├── update/
+    │   ├── mod.rs, builder.rs, render.rs
+    └── delete/
+        ├── mod.rs, builder.rs, render.rs
+```

--- a/bakery_model3/Cargo.toml
+++ b/bakery_model3/Cargo.toml
@@ -10,7 +10,7 @@ vantage-csv = { path = "../vantage-csv" }
 vantage-expressions = { path = "../vantage-expressions" }
 vantage-dataset = { path = "../vantage-dataset" }
 vantage-types = { path = "../vantage-types" }
-vantage-sql = { path = "../vantage-sql" }
+vantage-sql = { path = "../vantage-sql", features = ["sqlite", "postgres"] }
 vantage-surrealdb = { path = "../vantage-surrealdb" }
 surreal-client = { path = "../surreal-client", features = ["decimal"] }
 serde_json = "1"

--- a/bakery_model3/examples/cli.rs
+++ b/bakery_model3/examples/cli.rs
@@ -2,7 +2,7 @@
 //!
 //! Usage: db [--debug] <source> <entity> [command ...]
 //!
-//! Sources: csv, surreal, sqlite
+//! Sources: csv, surreal, sqlite, postgres
 //! Entities: bakery, client, product, order
 //!
 //! Commands:
@@ -45,7 +45,7 @@ async fn run() -> vantage_core::Result<()> {
         )
         .arg(
             Arg::new("source")
-                .help("Data source: csv, surreal, sqlite")
+                .help("Data source: csv, surreal, sqlite, postgres")
                 .required(true),
         )
         .arg(
@@ -144,8 +144,29 @@ async fn build_table(
             };
             Ok(Some(table))
         }
+        "postgres" => {
+            let url = std::env::var("POSTGRES_URL")
+                .unwrap_or_else(|_| "postgres://vantage:vantage@localhost:5433/vantage".to_string());
+            let db = PostgresDB::connect(&url).await.map_err(|e| {
+                vantage_core::error!("Failed to connect to PostgreSQL", details = e.to_string())
+            })?;
+            let table = match entity_name {
+                "bakery" => AnyTable::from_table(Bakery::postgres_table(db)),
+                "client" => AnyTable::from_table(Client::postgres_table(db)),
+                "product" => AnyTable::from_table(Product::postgres_table(db)),
+                "order" => AnyTable::from_table(Order::postgres_table(db)),
+                _ => {
+                    println!("Unknown entity: {}", entity_name);
+                    return Ok(None);
+                }
+            };
+            Ok(Some(table))
+        }
         _ => {
-            println!("Unknown source: {}. Use: csv, surreal, sqlite", source);
+            println!(
+                "Unknown source: {}. Use: csv, surreal, sqlite, postgres",
+                source
+            );
             Ok(None)
         }
     }
@@ -155,7 +176,7 @@ fn print_usage() {
     println!();
     println!("Usage: db [--debug] <source> <entity> <command>");
     println!();
-    println!("Sources: csv, surreal, sqlite");
+    println!("Sources: csv, surreal, sqlite, postgres");
     println!();
     println!("Commands:");
     println!("  list              List all records");

--- a/bakery_model3/examples/cli.rs
+++ b/bakery_model3/examples/cli.rs
@@ -145,8 +145,9 @@ async fn build_table(
             Ok(Some(table))
         }
         "postgres" => {
-            let url = std::env::var("POSTGRES_URL")
-                .unwrap_or_else(|_| "postgres://vantage:vantage@localhost:5433/vantage".to_string());
+            let url = std::env::var("POSTGRES_URL").unwrap_or_else(|_| {
+                "postgres://vantage:vantage@localhost:5433/vantage".to_string()
+            });
             let db = PostgresDB::connect(&url).await.map_err(|e| {
                 vantage_core::error!("Failed to connect to PostgreSQL", details = e.to_string())
             })?;

--- a/bakery_model3/src/animal.rs
+++ b/bakery_model3/src/animal.rs
@@ -1,5 +1,6 @@
 use serde_json::Value as JsonValue;
 use vantage_csv::{CsvType, type_system::CsvTypeAnimalMarker};
+use vantage_sql::postgres::{PostgresType, types::PostgresTypeTextMarker};
 use vantage_sql::sqlite::{SqliteType, types::SqliteTypeTextMarker};
 use vantage_surrealdb::types::SurrealTypeStringMarker;
 use vantage_surrealdb::{CborValue, SurrealType};
@@ -68,6 +69,21 @@ impl CsvType for Animal {
 
 impl SqliteType for Animal {
     type Target = SqliteTypeTextMarker;
+
+    fn to_json(&self) -> JsonValue {
+        JsonValue::String(self.as_str().to_string())
+    }
+
+    fn from_json(value: JsonValue) -> Option<Self> {
+        match value {
+            JsonValue::String(s) => s.parse().ok(),
+            _ => None,
+        }
+    }
+}
+
+impl PostgresType for Animal {
+    type Target = PostgresTypeTextMarker;
 
     fn to_json(&self) -> JsonValue {
         JsonValue::String(self.as_str().to_string())

--- a/bakery_model3/src/bakery.rs
+++ b/bakery_model3/src/bakery.rs
@@ -1,11 +1,12 @@
 use vantage_csv::{AnyCsvType, Csv};
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_surrealdb::types::AnySurrealType;
 use vantage_table::table::Table;
 use vantage_types::entity;
 
-#[entity(CsvType, SurrealType, SqliteType)]
+#[entity(CsvType, SurrealType, SqliteType, PostgresType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Bakery {
     pub name: String,
@@ -31,6 +32,13 @@ impl Bakery {
     }
 
     pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Bakery> {
+        Table::new("bakery", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("profit_margin")
+    }
+
+    pub fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Bakery> {
         Table::new("bakery", db)
             .with_id_column("id")
             .with_column_of::<String>("name")

--- a/bakery_model3/src/bakery.rs
+++ b/bakery_model3/src/bakery.rs
@@ -1,5 +1,7 @@
 use vantage_csv::{AnyCsvType, Csv};
-use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+#[allow(unused_imports)]
+use vantage_sql::postgres::AnyPostgresType;
+use vantage_sql::postgres::PostgresDB;
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_surrealdb::types::AnySurrealType;

--- a/bakery_model3/src/client.rs
+++ b/bakery_model3/src/client.rs
@@ -1,4 +1,5 @@
 use vantage_csv::{AnyCsvType, Csv};
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_surrealdb::types::AnySurrealType;
@@ -7,7 +8,7 @@ use vantage_types::entity;
 
 use crate::{Bakery, Order};
 
-#[entity(CsvType, SurrealType, SqliteType)]
+#[entity(CsvType, SurrealType, SqliteType, PostgresType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Client {
     pub name: String,
@@ -63,6 +64,24 @@ impl Client {
             })
             .with_many("orders", "client_id", move || {
                 Order::sqlite_table(db3.clone())
+            })
+    }
+
+    pub fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Client> {
+        let db2 = db.clone();
+        let db3 = db.clone();
+        Table::new("client", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<String>("email")
+            .with_column_of::<String>("contact_details")
+            .with_column_of::<bool>("is_paying_client")
+            .with_column_of::<String>("bakery_id")
+            .with_one("bakery", "bakery_id", move || {
+                Bakery::postgres_table(db2.clone())
+            })
+            .with_many("orders", "client_id", move || {
+                Order::postgres_table(db3.clone())
             })
     }
 }

--- a/bakery_model3/src/client.rs
+++ b/bakery_model3/src/client.rs
@@ -1,5 +1,7 @@
 use vantage_csv::{AnyCsvType, Csv};
-use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+#[allow(unused_imports)]
+use vantage_sql::postgres::AnyPostgresType;
+use vantage_sql::postgres::PostgresDB;
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_surrealdb::types::AnySurrealType;

--- a/bakery_model3/src/lib.rs
+++ b/bakery_model3/src/lib.rs
@@ -1,4 +1,5 @@
 pub use vantage_csv::{AnyCsvType, Csv, CsvType};
+pub use vantage_sql::postgres::{AnyPostgresType, PostgresDB, PostgresType};
 pub use vantage_sql::sqlite::{AnySqliteType, SqliteDB, SqliteType};
 
 pub mod animal;

--- a/bakery_model3/src/order.rs
+++ b/bakery_model3/src/order.rs
@@ -1,4 +1,5 @@
 use vantage_csv::{AnyCsvType, Csv};
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_surrealdb::types::AnySurrealType;
@@ -7,7 +8,7 @@ use vantage_types::entity;
 
 use crate::Client;
 
-#[entity(CsvType, SurrealType, SqliteType)]
+#[entity(CsvType, SurrealType, SqliteType, PostgresType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Order {
     pub client_id: Option<String>,
@@ -43,6 +44,17 @@ impl Order {
             .with_column_of::<bool>("is_deleted")
             .with_one("client", "client_id", move || {
                 Client::sqlite_table(db2.clone())
+            })
+    }
+
+    pub fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Order> {
+        let db2 = db.clone();
+        Table::new("client_order", db)
+            .with_id_column("id")
+            .with_column_of::<String>("client_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_one("client", "client_id", move || {
+                Client::postgres_table(db2.clone())
             })
     }
 }

--- a/bakery_model3/src/order.rs
+++ b/bakery_model3/src/order.rs
@@ -1,5 +1,7 @@
 use vantage_csv::{AnyCsvType, Csv};
-use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+#[allow(unused_imports)]
+use vantage_sql::postgres::AnyPostgresType;
+use vantage_sql::postgres::PostgresDB;
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_surrealdb::types::AnySurrealType;

--- a/bakery_model3/src/product.rs
+++ b/bakery_model3/src/product.rs
@@ -1,12 +1,14 @@
 use vantage_csv::{AnyCsvType, Csv};
-use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+#[allow(unused_imports)]
+use vantage_sql::postgres::AnyPostgresType;
+use vantage_sql::postgres::PostgresDB;
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_surrealdb::types::AnySurrealType;
 use vantage_table::table::Table;
 use vantage_types::entity;
 
-use crate::Bakery;
+use crate::{Animal, Bakery};
 
 #[entity(CsvType, SurrealType, SqliteType, PostgresType)]
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -15,6 +17,7 @@ pub struct Product {
     pub calories: i64,
     pub price: i64,
     pub is_deleted: bool,
+    pub sticker: Option<Animal>,
 }
 
 impl Product {
@@ -24,6 +27,7 @@ impl Product {
             .with_column_of::<i64>("calories")
             .with_column_of::<i64>("price")
             .with_column_of::<bool>("is_deleted")
+            .with_column_of::<Option<Animal>>("sticker")
     }
 
     pub fn surreal_table(db: SurrealDB) -> Table<SurrealDB, Product> {
@@ -34,6 +38,7 @@ impl Product {
             .with_column_of::<i64>("calories")
             .with_column_of::<i64>("price")
             .with_column_of::<bool>("is_deleted")
+            .with_column_of::<Option<Animal>>("sticker")
             .with_column_of::<String>("bakery") // record link, used for relationships
             .with_one("bakery", "bakery", move || {
                 Bakery::surreal_table(db2.clone())
@@ -48,6 +53,7 @@ impl Product {
             .with_column_of::<i64>("calories")
             .with_column_of::<i64>("price")
             .with_column_of::<bool>("is_deleted")
+            .with_column_of::<Option<Animal>>("sticker")
             .with_one("bakery", "bakery_id", move || {
                 Bakery::sqlite_table(db2.clone())
             })
@@ -61,6 +67,7 @@ impl Product {
             .with_column_of::<i64>("calories")
             .with_column_of::<i64>("price")
             .with_column_of::<bool>("is_deleted")
+            .with_column_of::<Option<Animal>>("sticker")
             .with_one("bakery", "bakery_id", move || {
                 Bakery::postgres_table(db2.clone())
             })

--- a/bakery_model3/src/product.rs
+++ b/bakery_model3/src/product.rs
@@ -1,4 +1,5 @@
 use vantage_csv::{AnyCsvType, Csv};
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_surrealdb::types::AnySurrealType;
@@ -7,7 +8,7 @@ use vantage_types::entity;
 
 use crate::Bakery;
 
-#[entity(CsvType, SurrealType, SqliteType)]
+#[entity(CsvType, SurrealType, SqliteType, PostgresType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Product {
     pub name: String,
@@ -49,6 +50,19 @@ impl Product {
             .with_column_of::<bool>("is_deleted")
             .with_one("bakery", "bakery_id", move || {
                 Bakery::sqlite_table(db2.clone())
+            })
+    }
+
+    pub fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Product> {
+        let db2 = db.clone();
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<bool>("is_deleted")
+            .with_one("bakery", "bakery_id", move || {
+                Bakery::postgres_table(db2.clone())
             })
     }
 }

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -14,6 +14,7 @@ autoexamples = false
 [features]
 default = ["sqlite"]
 sqlite = ["sqlx/sqlite"]
+postgres = ["sqlx/postgres"]
 
 [dependencies]
 vantage-core = { path = "../vantage-core" }

--- a/vantage-sql/scripts/postgres/db/v2.sql
+++ b/vantage-sql/scripts/postgres/db/v2.sql
@@ -1,0 +1,86 @@
+-- Hill Valley Bakery Database - PostgreSQL Version
+-- Translated from SQLite v2.sql with PostgreSQL adaptations:
+-- - BOOLEAN is native (not 0/1)
+-- - BIGINT instead of INTEGER for numeric IDs where needed
+-- - SERIAL for auto-increment
+-- - timestamp for datetime
+
+CREATE TABLE IF NOT EXISTS bakery (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    profit_margin BIGINT NOT NULL CHECK (profit_margin >= 0 AND profit_margin <= 100)
+);
+
+CREATE TABLE IF NOT EXISTS client (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    contact_details TEXT NOT NULL,
+    is_paying_client BOOLEAN NOT NULL DEFAULT false,
+    balance DOUBLE PRECISION NOT NULL DEFAULT 0,
+    bakery_id TEXT NOT NULL REFERENCES bakery(id)
+);
+
+CREATE TABLE IF NOT EXISTS product (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    calories BIGINT NOT NULL CHECK (calories >= 0),
+    price BIGINT NOT NULL CHECK (price > 0),
+    bakery_id TEXT NOT NULL REFERENCES bakery(id),
+    is_deleted BOOLEAN NOT NULL DEFAULT false,
+    inventory_stock BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS client_order (
+    id TEXT PRIMARY KEY,
+    bakery_id TEXT NOT NULL REFERENCES bakery(id),
+    client_id TEXT NOT NULL REFERENCES client(id),
+    is_deleted BOOLEAN NOT NULL DEFAULT false,
+    created_at TEXT NOT NULL DEFAULT to_char(now(), 'YYYY-MM-DD"T"HH24:MI:SS')
+);
+
+CREATE TABLE IF NOT EXISTS order_line (
+    id SERIAL PRIMARY KEY,
+    order_id TEXT NOT NULL REFERENCES client_order(id),
+    product_id TEXT NOT NULL REFERENCES product(id),
+    quantity BIGINT NOT NULL CHECK (quantity > 0),
+    price BIGINT NOT NULL CHECK (price > 0)
+);
+
+-- Data
+
+INSERT INTO bakery (id, name, profit_margin)
+VALUES ('hill_valley', 'Hill Valley Bakery', 15)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO client (id, name, email, contact_details, is_paying_client, balance, bakery_id)
+VALUES
+    ('marty', 'Marty McFly', 'marty@gmail.com', '555-1955', true, 150.00, 'hill_valley'),
+    ('doc', 'Doc Brown', 'doc@brown.com', '555-1885', true, 500.50, 'hill_valley'),
+    ('biff', 'Biff Tannen', 'biff-3293@hotmail.com', '555-1955', false, -50.25, 'hill_valley')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock)
+VALUES
+    ('flux_cupcake', 'Flux Capacitor Cupcake', 300, 120, 'hill_valley', false, 50),
+    ('delorean_donut', 'DeLorean Doughnut', 250, 135, 'hill_valley', false, 30),
+    ('time_tart', 'Time Traveler Tart', 200, 220, 'hill_valley', false, 20),
+    ('sea_pie', 'Enchantment Under the Sea Pie', 350, 299, 'hill_valley', false, 15),
+    ('hover_cookies', 'Hoverboard Cookies', 150, 199, 'hill_valley', false, 40)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO client_order (id, bakery_id, client_id, is_deleted, created_at)
+VALUES
+    ('order1', 'hill_valley', 'marty', false, to_char(now(), 'YYYY-MM-DD"T"HH24:MI:SS')),
+    ('order2', 'hill_valley', 'doc', false, to_char(now(), 'YYYY-MM-DD"T"HH24:MI:SS')),
+    ('order3', 'hill_valley', 'doc', false, to_char(now(), 'YYYY-MM-DD"T"HH24:MI:SS'))
+ON CONFLICT DO NOTHING;
+
+INSERT INTO order_line (order_id, product_id, quantity, price)
+VALUES
+    ('order1', 'flux_cupcake', 3, 120),
+    ('order1', 'delorean_donut', 1, 135),
+    ('order1', 'hover_cookies', 2, 199),
+    ('order2', 'time_tart', 1, 220),
+    ('order3', 'hover_cookies', 500, 199)
+ON CONFLICT DO NOTHING;

--- a/vantage-sql/scripts/postgres/db/v2.sql
+++ b/vantage-sql/scripts/postgres/db/v2.sql
@@ -28,7 +28,8 @@ CREATE TABLE IF NOT EXISTS product (
     price BIGINT NOT NULL CHECK (price > 0),
     bakery_id TEXT NOT NULL REFERENCES bakery(id),
     is_deleted BOOLEAN NOT NULL DEFAULT false,
-    inventory_stock BIGINT NOT NULL DEFAULT 0
+    inventory_stock BIGINT NOT NULL DEFAULT 0,
+    sticker TEXT
 );
 
 CREATE TABLE IF NOT EXISTS client_order (
@@ -60,13 +61,13 @@ VALUES
     ('biff', 'Biff Tannen', 'biff-3293@hotmail.com', '555-1955', false, -50.25, 'hill_valley')
 ON CONFLICT DO NOTHING;
 
-INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock)
+INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock, sticker)
 VALUES
-    ('flux_cupcake', 'Flux Capacitor Cupcake', 300, 120, 'hill_valley', false, 50),
-    ('delorean_donut', 'DeLorean Doughnut', 250, 135, 'hill_valley', false, 30),
-    ('time_tart', 'Time Traveler Tart', 200, 220, 'hill_valley', false, 20),
-    ('sea_pie', 'Enchantment Under the Sea Pie', 350, 299, 'hill_valley', false, 15),
-    ('hover_cookies', 'Hoverboard Cookies', 150, 199, 'hill_valley', false, 40)
+    ('flux_cupcake', 'Flux Capacitor Cupcake', 300, 120, 'hill_valley', false, 50, 'cat'),
+    ('delorean_donut', 'DeLorean Doughnut', 250, 135, 'hill_valley', false, 30, 'dog'),
+    ('time_tart', 'Time Traveler Tart', 200, 220, 'hill_valley', false, 20, NULL),
+    ('sea_pie', 'Enchantment Under the Sea Pie', 350, 299, 'hill_valley', false, 15, 'pig'),
+    ('hover_cookies', 'Hoverboard Cookies', 150, 199, 'hill_valley', false, 40, 'chicken')
 ON CONFLICT DO NOTHING;
 
 INSERT INTO client_order (id, bakery_id, client_id, is_deleted, created_at)

--- a/vantage-sql/scripts/postgres/ingress.sh
+++ b/vantage-sql/scripts/postgres/ingress.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONTAINER_NAME="postgres-vantage"
+USER="vantage"
+DB="vantage"
+
+echo "Loading PostgreSQL data..."
+
+for db_file in "$SCRIPT_DIR"/db/*.sql; do
+    db_name=$(basename "$db_file" .sql)
+    echo "Loading $db_name..."
+    docker exec -i $CONTAINER_NAME psql -U $USER -d $DB < "$db_file"
+    echo "  done."
+done
+
+echo "PostgreSQL data loaded."

--- a/vantage-sql/scripts/postgres/start.sh
+++ b/vantage-sql/scripts/postgres/start.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+# Configuration
+CONTAINER_NAME="postgres-vantage"
+PORT="5433"
+USER="vantage"
+PASS="vantage"
+DB="vantage"
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+    echo "Error: Docker is not running. Please start Docker and try again."
+    exit 1
+fi
+
+# Stop existing container if running
+if docker ps -q -f name=$CONTAINER_NAME | grep -q .; then
+    echo "Stopping existing PostgreSQL container..."
+    docker stop $CONTAINER_NAME > /dev/null 2>&1 || true
+fi
+
+# Remove existing container
+if docker ps -aq -f name=$CONTAINER_NAME | grep -q .; then
+    echo "Removing existing PostgreSQL container..."
+    docker rm $CONTAINER_NAME > /dev/null 2>&1 || true
+fi
+
+echo "Starting PostgreSQL local instance..."
+echo "Container: $CONTAINER_NAME"
+echo "Port: $PORT"
+echo "Username: $USER"
+echo "Password: $PASS"
+echo "Database: $DB"
+
+# Start PostgreSQL container
+docker run -d \
+    --name $CONTAINER_NAME \
+    -p $PORT:5432 \
+    -e POSTGRES_USER=$USER \
+    -e POSTGRES_PASSWORD=$PASS \
+    -e POSTGRES_DB=$DB \
+    postgres:17-alpine
+
+# Wait for PostgreSQL to be ready
+echo "Waiting for PostgreSQL to start..."
+for i in $(seq 1 30); do
+    if docker exec $CONTAINER_NAME pg_isready -U $USER -d $DB > /dev/null 2>&1; then
+        echo "PostgreSQL is ready!"
+        break
+    fi
+    sleep 1
+done
+
+# Check if container is running
+if docker ps -q -f name=$CONTAINER_NAME | grep -q .; then
+    echo ""
+    echo "Connection details:"
+    echo "  URL: postgres://$USER:$PASS@localhost:$PORT/$DB"
+    echo ""
+    echo "To connect with psql:"
+    echo "  docker exec -it $CONTAINER_NAME psql -U $USER -d $DB"
+    echo ""
+    echo "To stop the instance, run: ./stop.sh"
+else
+    echo "Failed to start PostgreSQL container"
+    docker logs $CONTAINER_NAME
+    exit 1
+fi

--- a/vantage-sql/scripts/postgres/stop.sh
+++ b/vantage-sql/scripts/postgres/stop.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+CONTAINER_NAME="postgres-vantage"
+
+if docker ps -q -f name=$CONTAINER_NAME | grep -q .; then
+    echo "Stopping PostgreSQL container..."
+    docker stop $CONTAINER_NAME > /dev/null 2>&1
+    docker rm $CONTAINER_NAME > /dev/null 2>&1
+    echo "PostgreSQL stopped."
+else
+    echo "PostgreSQL container is not running."
+fi

--- a/vantage-sql/scripts/sqlite/db/v2.sql
+++ b/vantage-sql/scripts/sqlite/db/v2.sql
@@ -34,7 +34,8 @@ CREATE TABLE IF NOT EXISTS product (
     price INTEGER NOT NULL CHECK (price > 0),
     bakery_id TEXT NOT NULL REFERENCES bakery(id),
     is_deleted BOOLEAN NOT NULL DEFAULT 0,
-    inventory_stock INTEGER NOT NULL DEFAULT 0
+    inventory_stock INTEGER NOT NULL DEFAULT 0,
+    sticker TEXT
 );
 
 -- "order" is a reserved word in SQL, so we use "client_order"
@@ -73,20 +74,20 @@ INSERT INTO client (id, name, email, contact_details, is_paying_client, balance,
 VALUES ('biff', 'Biff Tannen', 'biff-3293@hotmail.com', '555-1955', 0, -50.25, 'hill_valley');
 
 -- Products
-INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock)
-VALUES ('flux_cupcake', 'Flux Capacitor Cupcake', 300, 120, 'hill_valley', 0, 50);
+INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock, sticker)
+VALUES ('flux_cupcake', 'Flux Capacitor Cupcake', 300, 120, 'hill_valley', 0, 50, 'cat');
 
-INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock)
-VALUES ('delorean_donut', 'DeLorean Doughnut', 250, 135, 'hill_valley', 0, 30);
+INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock, sticker)
+VALUES ('delorean_donut', 'DeLorean Doughnut', 250, 135, 'hill_valley', 0, 30, 'dog');
 
-INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock)
-VALUES ('time_tart', 'Time Traveler Tart', 200, 220, 'hill_valley', 0, 20);
+INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock, sticker)
+VALUES ('time_tart', 'Time Traveler Tart', 200, 220, 'hill_valley', 0, 20, NULL);
 
-INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock)
-VALUES ('sea_pie', 'Enchantment Under the Sea Pie', 350, 299, 'hill_valley', 0, 15);
+INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock, sticker)
+VALUES ('sea_pie', 'Enchantment Under the Sea Pie', 350, 299, 'hill_valley', 0, 15, 'pig');
 
-INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock)
-VALUES ('hover_cookies', 'Hoverboard Cookies', 150, 199, 'hill_valley', 0, 40);
+INSERT INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock, sticker)
+VALUES ('hover_cookies', 'Hoverboard Cookies', 150, 199, 'hill_valley', 0, 40, 'chicken');
 
 -- Orders (with client_id from the RELATE statements in SurrealDB)
 INSERT INTO client_order (id, bakery_id, client_id, is_deleted, created_at)

--- a/vantage-sql/src/lib.rs
+++ b/vantage-sql/src/lib.rs
@@ -2,3 +2,6 @@ pub mod primitives;
 
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
+
+#[cfg(feature = "postgres")]
+pub mod postgres;

--- a/vantage-sql/src/postgres/impls/expr_data_source.rs
+++ b/vantage-sql/src/postgres/impls/expr_data_source.rs
@@ -23,10 +23,9 @@ impl vantage_expressions::ExprDataSource<AnyPostgresType> for PostgresDB {
             query = bind_postgres_value(query, value);
         }
 
-        let rows = query
-            .fetch_all(self.pool())
-            .await
-            .map_err(|e| vantage_core::error!("PostgreSQL query failed", details = e.to_string()))?;
+        let rows = query.fetch_all(self.pool()).await.map_err(|e| {
+            vantage_core::error!("PostgreSQL query failed", details = e.to_string())
+        })?;
 
         // 4. Convert rows to AnyPostgresType (untyped -- type_variant: None)
         let arr: Vec<JsonValue> = rows

--- a/vantage-sql/src/postgres/impls/expr_data_source.rs
+++ b/vantage-sql/src/postgres/impls/expr_data_source.rs
@@ -103,6 +103,14 @@ fn prepare_typed_query(expr: &Expression<AnyPostgresType>) -> (String, Vec<AnyPo
     let template_parts: Vec<&str> = flattened.template.split("{}").collect();
     let mut param_counter = 0;
 
+    assert_eq!(
+        template_parts.len(),
+        flattened.parameters.len() + 1,
+        "template placeholder count ({}) doesn't match parameter count ({})",
+        template_parts.len() - 1,
+        flattened.parameters.len()
+    );
+
     sql.push_str(template_parts[0]);
 
     for (i, param) in flattened.parameters.iter().enumerate() {

--- a/vantage-sql/src/postgres/impls/expr_data_source.rs
+++ b/vantage-sql/src/postgres/impls/expr_data_source.rs
@@ -1,0 +1,130 @@
+use serde_json::Value as JsonValue;
+use vantage_expressions::traits::expressive::DeferredFn;
+use vantage_expressions::{Expression, ExpressionFlattener, ExpressiveEnum, Flatten};
+
+use crate::postgres::PostgresDB;
+use crate::postgres::row::{bind_postgres_value, row_to_record};
+use crate::postgres::types::AnyPostgresType;
+
+impl vantage_expressions::ExprDataSource<AnyPostgresType> for PostgresDB {
+    async fn execute(
+        &self,
+        expr: &Expression<AnyPostgresType>,
+    ) -> vantage_core::Result<AnyPostgresType> {
+        // 1. Resolve deferred parameters (async -- may call other databases)
+        let resolved = resolve_deferred(expr).await?;
+
+        // 2. Flatten nested expressions + convert {} to $N (PostgreSQL uses $1, $2, ...)
+        let (sql, params) = prepare_typed_query(&resolved);
+
+        // 3. Bind and execute
+        let mut query = sqlx::query(&sql);
+        for value in &params {
+            query = bind_postgres_value(query, value);
+        }
+
+        let rows = query
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| vantage_core::error!("PostgreSQL query failed", details = e.to_string()))?;
+
+        // 4. Convert rows to AnyPostgresType (untyped -- type_variant: None)
+        let arr: Vec<JsonValue> = rows
+            .iter()
+            .map(|row| {
+                let record = row_to_record(row);
+                let json_map: serde_json::Map<String, JsonValue> = record
+                    .into_iter()
+                    .map(|(k, v)| (k, v.into_value()))
+                    .collect();
+                JsonValue::Object(json_map)
+            })
+            .collect();
+
+        let json_arr = JsonValue::Array(arr);
+        Ok(AnyPostgresType::from_json(&json_arr)
+            .expect("JSON array should always convert to AnyPostgresType"))
+    }
+
+    fn defer(&self, expr: Expression<AnyPostgresType>) -> DeferredFn<AnyPostgresType> {
+        let db = self.clone();
+        DeferredFn::from_fn(move || {
+            let db = db.clone();
+            let expr = expr.clone();
+            Box::pin(async move {
+                let result = vantage_expressions::ExprDataSource::execute(&db, &expr).await?;
+                let scalar = match result.value() {
+                    serde_json::Value::Array(arr) => arr
+                        .first()
+                        .and_then(|row| row.as_object())
+                        .and_then(|obj| obj.values().next())
+                        .map(|v| AnyPostgresType::untyped(v.clone()))
+                        .unwrap_or(result),
+                    _ => result,
+                };
+                Ok(scalar)
+            })
+        })
+    }
+}
+
+/// Resolve all Deferred parameters in an expression by calling them.
+async fn resolve_deferred(
+    expr: &Expression<AnyPostgresType>,
+) -> vantage_core::Result<Expression<AnyPostgresType>> {
+    let mut resolved_params = Vec::new();
+
+    for param in &expr.parameters {
+        match param {
+            ExpressiveEnum::Deferred(deferred_fn) => {
+                let result = deferred_fn.call().await?;
+                resolved_params.push(result);
+            }
+            ExpressiveEnum::Nested(inner) => {
+                let resolved_inner = Box::pin(resolve_deferred(inner)).await?;
+                resolved_params.push(ExpressiveEnum::Nested(resolved_inner));
+            }
+            other => {
+                resolved_params.push(other.clone());
+            }
+        }
+    }
+
+    Ok(Expression::new(expr.template.clone(), resolved_params))
+}
+
+/// Flatten an Expression<AnyPostgresType> and convert `{}` placeholders to `$N`.
+/// PostgreSQL uses $1, $2, ... for positional parameters (not ?N like SQLite).
+fn prepare_typed_query(expr: &Expression<AnyPostgresType>) -> (String, Vec<AnyPostgresType>) {
+    let flattener = ExpressionFlattener::new();
+    let flattened = flattener.flatten(expr);
+
+    let mut sql = String::new();
+    let mut params = Vec::new();
+    let template_parts: Vec<&str> = flattened.template.split("{}").collect();
+    let mut param_counter = 0;
+
+    sql.push_str(template_parts[0]);
+
+    for (i, param) in flattened.parameters.iter().enumerate() {
+        match param {
+            ExpressiveEnum::Scalar(value) => {
+                param_counter += 1;
+                sql.push_str(&format!("${}", param_counter));
+                params.push(value.clone());
+            }
+            ExpressiveEnum::Nested(_) => {
+                panic!("nested expression should have been flattened");
+            }
+            ExpressiveEnum::Deferred(_) => {
+                panic!("deferred expression should have been resolved before prepare");
+            }
+        }
+
+        if i + 1 < template_parts.len() {
+            sql.push_str(template_parts[i + 1]);
+        }
+    }
+
+    (sql, params)
+}

--- a/vantage-sql/src/postgres/impls/mod.rs
+++ b/vantage-sql/src/postgres/impls/mod.rs
@@ -1,0 +1,9 @@
+pub mod expr_data_source;
+pub mod selectable_data_source;
+pub mod table_source;
+
+use vantage_expressions::traits::datasource::DataSource;
+
+use super::PostgresDB;
+
+impl DataSource for PostgresDB {}

--- a/vantage-sql/src/postgres/impls/selectable_data_source.rs
+++ b/vantage-sql/src/postgres/impls/selectable_data_source.rs
@@ -1,0 +1,31 @@
+use vantage_expressions::Expressive;
+use vantage_expressions::traits::datasource::SelectableDataSource;
+
+use crate::postgres::PostgresDB;
+use crate::postgres::statements::PostgresSelect;
+use crate::postgres::types::AnyPostgresType;
+
+impl SelectableDataSource<AnyPostgresType> for PostgresDB {
+    type Select = PostgresSelect;
+
+    fn select(&self) -> Self::Select {
+        PostgresSelect::new()
+    }
+
+    async fn execute_select(
+        &self,
+        select: &Self::Select,
+    ) -> vantage_core::Result<Vec<AnyPostgresType>> {
+        use vantage_expressions::ExprDataSource;
+
+        let result = self.execute(&select.expr()).await?;
+
+        match result.value() {
+            serde_json::Value::Array(arr) => Ok(arr
+                .iter()
+                .map(|v| AnyPostgresType::untyped(v.clone()))
+                .collect()),
+            _ => Ok(vec![result]),
+        }
+    }
+}

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -1,0 +1,399 @@
+use async_trait::async_trait;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_expressions::traits::associated_expressions::AssociatedExpression;
+use vantage_expressions::traits::datasource::ExprDataSource;
+use vantage_expressions::traits::expressive::ExpressiveEnum;
+use vantage_expressions::{Expression, Expressive, Selectable};
+use vantage_table::column::core::{Column, ColumnType};
+use vantage_table::table::Table;
+use vantage_table::traits::table_source::TableSource;
+use vantage_types::{Entity, Record};
+
+use crate::postgres::PostgresDB;
+use crate::postgres::types::AnyPostgresType;
+
+/// Create an AnyPostgresType for an id value. If the id parses as an integer,
+/// use Int8 variant so PostgreSQL doesn't complain about `integer = text`.
+fn id_value(id: &str) -> AnyPostgresType {
+    if let Ok(n) = id.parse::<i64>() {
+        AnyPostgresType::new(n)
+    } else {
+        AnyPostgresType::from(id.to_string())
+    }
+}
+
+/// Parse the JSON array result from execute() into an IndexMap of id -> Record.
+fn parse_rows(
+    result: AnyPostgresType,
+    id_field_name: &str,
+) -> Result<IndexMap<String, Record<AnyPostgresType>>> {
+    let arr = match result.into_value() {
+        serde_json::Value::Array(arr) => arr,
+        other => return Err(error!("expected array result", details = other.to_string())),
+    };
+
+    let mut records = IndexMap::new();
+    for item in arr {
+        let obj = match item {
+            serde_json::Value::Object(map) => map,
+            _ => continue,
+        };
+
+        let id = obj
+            .get(id_field_name)
+            .and_then(|v| match v {
+                serde_json::Value::String(s) => Some(s.clone()),
+                serde_json::Value::Number(n) => Some(n.to_string()),
+                _ => None,
+            })
+            .ok_or_else(|| error!("row missing id field", field = id_field_name))?;
+
+        let record: Record<AnyPostgresType> = obj
+            .into_iter()
+            .map(|(k, v)| (k, AnyPostgresType::untyped(v)))
+            .collect();
+
+        records.insert(id, record);
+    }
+
+    Ok(records)
+}
+
+#[async_trait]
+impl TableSource for PostgresDB {
+    type Column<Type>
+        = Column<Type>
+    where
+        Type: ColumnType;
+    type AnyType = AnyPostgresType;
+    type Value = AnyPostgresType;
+    type Id = String;
+
+    fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
+        Column::new(name)
+    }
+
+    fn to_any_column<Type: ColumnType>(
+        &self,
+        column: Self::Column<Type>,
+    ) -> Self::Column<Self::AnyType> {
+        Column::from_column(column)
+    }
+
+    fn convert_any_column<Type: ColumnType>(
+        &self,
+        any_column: Self::Column<Self::AnyType>,
+    ) -> Option<Self::Column<Type>> {
+        Some(Column::from_column(any_column))
+    }
+
+    fn expr(
+        &self,
+        template: impl Into<String>,
+        parameters: Vec<ExpressiveEnum<Self::Value>>,
+    ) -> Expression<Self::Value> {
+        Expression::new(template, parameters)
+    }
+
+    fn search_table_expr<E>(
+        &self,
+        table: &Table<Self, E>,
+        search_value: &str,
+    ) -> Expression<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        let pattern = format!("%{}%", search_value.replace('%', "\\%"));
+        let conditions: Vec<Expression<AnyPostgresType>> = table
+            .columns()
+            .values()
+            .map(|col| {
+                Expression::new(
+                    format!("\"{}\"::text LIKE {{}}", col.name()),
+                    vec![ExpressiveEnum::Scalar(AnyPostgresType::from(pattern.clone()))],
+                )
+            })
+            .collect();
+
+        if conditions.is_empty() {
+            return postgres_expr!("FALSE");
+        }
+        Expression::from_vec(conditions, " OR ")
+    }
+
+    async fn list_table_values<E>(
+        &self,
+        table: &Table<Self, E>,
+    ) -> Result<IndexMap<Self::Id, Record<Self::Value>>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let select = table.select();
+        let result = self.execute(&select.expr()).await?;
+
+        parse_rows(result, &id_field_name)
+    }
+
+    async fn get_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let condition = Expression::new(
+            format!("\"{}\" = {{}}", id_field_name),
+            vec![ExpressiveEnum::Scalar(id_value(id))],
+        );
+        let select = table.select().with_condition(condition);
+        let result = self.execute(&select.expr()).await?;
+
+        let mut rows = parse_rows(result, &id_field_name)?;
+        rows.swap_remove(id)
+            .ok_or_else(|| error!("get_table_value: no row found", id = id.clone()))
+    }
+
+    async fn get_table_some_value<E>(
+        &self,
+        table: &Table<Self, E>,
+    ) -> Result<Option<(Self::Id, Record<Self::Value>)>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let mut select = table.select();
+        select.set_limit(Some(1), None);
+        let result = self.execute(&select.expr()).await?;
+
+        let mut rows = parse_rows(result, &id_field_name)?;
+        Ok(rows.swap_remove_index(0))
+    }
+
+    async fn get_table_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
+    where
+        E: Entity<Self::Value>,
+    {
+        let select = table.select();
+        let result = self.aggregate(&select, "count", postgres_expr!("*")).await?;
+        result.try_get::<i64>().ok_or_else(|| {
+            error!(
+                "get_table_count: expected i64",
+                result = format!("{}", result)
+            )
+        })
+    }
+
+    async fn get_table_sum<E>(
+        &self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        self.aggregate(&table.select(), "sum", column.expr()).await
+    }
+
+    async fn get_table_max<E>(
+        &self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        self.aggregate(&table.select(), "max", column.expr()).await
+    }
+
+    async fn get_table_min<E>(
+        &self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        self.aggregate(&table.select(), "min", column.expr()).await
+    }
+
+    async fn insert_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        record: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let insert = crate::postgres::statements::PostgresInsert::new(table.table_name())
+            .with_field(&id_field_name, id_value(id))
+            .with_record(record);
+        self.execute(&insert.expr()).await?;
+
+        self.get_table_value(table, id).await
+    }
+
+    async fn replace_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        record: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        // PostgreSQL: INSERT ... ON CONFLICT (id) DO UPDATE SET ...
+        let insert = crate::postgres::statements::PostgresInsert::new(table.table_name())
+            .with_field(&id_field_name, id_value(id))
+            .with_record(record);
+        let base = insert.expr();
+
+        let set_parts: Vec<String> = record
+            .keys()
+            .map(|k| format!("\"{}\" = EXCLUDED.\"{}\"", k, k))
+            .collect();
+        let conflict_clause = if set_parts.is_empty() {
+            format!(" ON CONFLICT (\"{}\") DO NOTHING", id_field_name)
+        } else {
+            format!(
+                " ON CONFLICT (\"{}\") DO UPDATE SET {}",
+                id_field_name,
+                set_parts.join(", ")
+            )
+        };
+
+        let upsert = Expression::new(
+            format!("{}{}", base.template, conflict_clause),
+            base.parameters.clone(),
+        );
+        self.execute(&upsert).await?;
+
+        self.get_table_value(table, id).await
+    }
+
+    async fn patch_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        partial: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let id_condition = Expression::new(
+            format!("\"{}\" = {{}}", id_field_name),
+            vec![ExpressiveEnum::Scalar(id_value(id))],
+        );
+        let update = crate::postgres::statements::PostgresUpdate::new(table.table_name())
+            .with_record(partial)
+            .with_condition(id_condition);
+        self.execute(&update.expr()).await?;
+
+        self.get_table_value(table, id).await
+    }
+
+    async fn delete_table_value<E>(&self, table: &Table<Self, E>, id: &Self::Id) -> Result<()>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let id_condition = Expression::new(
+            format!("\"{}\" = {{}}", id_field_name),
+            vec![ExpressiveEnum::Scalar(id_value(id))],
+        );
+        let delete = crate::postgres::statements::PostgresDelete::new(table.table_name())
+            .with_condition(id_condition);
+        self.execute(&delete.expr()).await?;
+        Ok(())
+    }
+
+    async fn delete_table_all_values<E>(&self, table: &Table<Self, E>) -> Result<()>
+    where
+        E: Entity<Self::Value>,
+    {
+        let delete = crate::postgres::statements::PostgresDelete::new(table.table_name());
+        self.execute(&delete.expr()).await?;
+        Ok(())
+    }
+
+    async fn insert_table_return_id_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        record: &Record<Self::Value>,
+    ) -> Result<Self::Id>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let insert =
+            crate::postgres::statements::PostgresInsert::new(table.table_name()).with_record(record);
+
+        let base = insert.expr();
+        let returning = Expression::new(
+            format!("{} RETURNING \"{}\"", base.template, id_field_name),
+            base.parameters.clone(),
+        );
+        let result = self.execute(&returning).await?;
+        let mut rows = parse_rows(result, &id_field_name)?;
+        rows.swap_remove_index(0)
+            .map(|(id, _)| id)
+            .ok_or_else(|| error!("insert_table_return_id_value: no id returned"))
+    }
+
+    fn column_table_values_expr<'a, E, Type: ColumnType>(
+        &'a self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Type>,
+    ) -> AssociatedExpression<'a, Self, Self::Value, Vec<Type>>
+    where
+        E: Entity<Self::Value> + 'static,
+        Self: ExprDataSource<Self::Value> + Sized,
+    {
+        let mut select = table.select();
+        select.clear_fields();
+        select.clear_order_by();
+        select.add_field(column.name());
+
+        let subquery = select.expr();
+        AssociatedExpression::new(subquery, self)
+    }
+}

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -111,7 +111,9 @@ impl TableSource for PostgresDB {
             .map(|col| {
                 Expression::new(
                     format!("\"{}\"::text LIKE {{}}", col.name()),
-                    vec![ExpressiveEnum::Scalar(AnyPostgresType::from(pattern.clone()))],
+                    vec![ExpressiveEnum::Scalar(AnyPostgresType::from(
+                        pattern.clone(),
+                    ))],
                 )
             })
             .collect();
@@ -190,7 +192,9 @@ impl TableSource for PostgresDB {
         E: Entity<Self::Value>,
     {
         let select = table.select();
-        let result = self.aggregate(&select, "count", postgres_expr!("*")).await?;
+        let result = self
+            .aggregate(&select, "count", postgres_expr!("*"))
+            .await?;
         result.try_get::<i64>().ok_or_else(|| {
             error!(
                 "get_table_count: expected i64",
@@ -364,8 +368,8 @@ impl TableSource for PostgresDB {
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let insert =
-            crate::postgres::statements::PostgresInsert::new(table.table_name()).with_record(record);
+        let insert = crate::postgres::statements::PostgresInsert::new(table.table_name())
+            .with_record(record);
 
         let base = insert.expr();
         let returning = Expression::new(

--- a/vantage-sql/src/postgres/macros.rs
+++ b/vantage-sql/src/postgres/macros.rs
@@ -1,0 +1,29 @@
+/// Create a SQL expression with `AnyPostgresType` as the value type.
+///
+/// This is the typed variant -- parameters carry PostgreSQL type markers (Int4,
+/// Text, Float8, etc.) which are used for type-aware binding via `bind_postgres_value`.
+///
+/// Scalar arguments must implement `Into<AnyPostgresType>` -- supported types are:
+/// `i8`-`u32`, `f32`/`f64`, `bool`, `String`, and `&str`.
+///
+/// ```ignore
+/// let expr = postgres_expr!("SELECT * FROM product WHERE price > {}", 100i64);
+/// let result = db.execute(&expr).await?;
+/// ```
+#[macro_export]
+macro_rules! postgres_expr {
+    ($template:expr) => {
+        vantage_expressions::Expression::<$crate::postgres::AnyPostgresType>::new($template, vec![])
+    };
+
+    ($template:expr, $($param:tt),*) => {
+        vantage_expressions::Expression::<$crate::postgres::AnyPostgresType>::new(
+            $template,
+            vec![
+                $(
+                    vantage_expressions::expr_param!($param)
+                ),*
+            ]
+        )
+    };
+}

--- a/vantage-sql/src/postgres/mod.rs
+++ b/vantage-sql/src/postgres/mod.rs
@@ -1,0 +1,49 @@
+#[macro_use]
+mod macros;
+pub mod impls;
+mod operation;
+mod row;
+pub mod statements;
+pub mod types;
+
+use sqlx::postgres::PgPool;
+
+pub use types::{AnyPostgresType, PostgresType};
+
+/// PostgreSQL provider. Wraps a connection pool.
+#[derive(Clone)]
+pub struct PostgresDB {
+    pool: PgPool,
+}
+
+impl PostgresDB {
+    pub async fn connect(url: &str) -> Result<Self, sqlx::Error> {
+        let pool = PgPool::connect(url).await?;
+        Ok(Self { pool })
+    }
+
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    /// Execute an aggregate query (COUNT, SUM, MAX, MIN etc.) and return the scalar result.
+    pub async fn aggregate(
+        &self,
+        select: &statements::PostgresSelect,
+        func: &str,
+        column: impl vantage_expressions::Expressive<AnyPostgresType>,
+    ) -> vantage_core::Result<AnyPostgresType> {
+        use vantage_expressions::ExprDataSource;
+        let expr = select.as_aggregate(func, column);
+        let result = self.execute(&expr).await?;
+        Ok(match result.value() {
+            serde_json::Value::Array(arr) => arr
+                .first()
+                .and_then(|row| row.as_object())
+                .and_then(|obj| obj.values().next())
+                .map(|v| AnyPostgresType::untyped(v.clone()))
+                .unwrap_or(result),
+            _ => result,
+        })
+    }
+}

--- a/vantage-sql/src/postgres/operation.rs
+++ b/vantage-sql/src/postgres/operation.rs
@@ -1,0 +1,2 @@
+// PostgreSQL columns get Operation<AnyPostgresType> via the blanket impl
+// in vantage-table. No explicit impl needed.

--- a/vantage-sql/src/postgres/row.rs
+++ b/vantage-sql/src/postgres/row.rs
@@ -1,0 +1,203 @@
+//! Helpers for converting between sqlx rows/values and vantage types.
+//!
+//! **Writing** (bind): Takes `AnyPostgresType` with variant tags -- the variant
+//! tells us exactly how to bind each value to sqlx.
+//!
+//! **Reading** (row): Returns `Record<AnyPostgresType>` with `type_variant: None`.
+//! The values are marker-less -- `try_get` will attempt conversion without
+//! variant enforcement, and struct deserialization validates the actual types.
+
+use serde_json::Value as JsonValue;
+use sqlx::postgres::PgRow;
+use sqlx::{Column, Row, TypeInfo};
+use vantage_types::Record;
+
+use super::types::{AnyPostgresType, PostgresTypeVariants};
+
+/// Bind an AnyPostgresType to a sqlx query. Uses the variant tag to pick
+/// the right sqlx bind type -- no guessing from the JSON number format.
+pub(crate) fn bind_postgres_value<'q>(
+    query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
+    value: &'q AnyPostgresType,
+) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
+    let json = value.value();
+    match value.type_variant() {
+        Some(PostgresTypeVariants::Null) => query.bind(None::<String>),
+        // Untyped values (from deferred results, database reads) -- infer from JSON
+        None => bind_by_json(query, json),
+        Some(PostgresTypeVariants::Bool) => match json {
+            JsonValue::Null => query.bind(None::<bool>),
+            JsonValue::Bool(b) => query.bind(*b),
+            JsonValue::Number(n) => match n.as_i64() {
+                Some(i) => query.bind(i != 0),
+                None => query.bind(None::<bool>),
+            },
+            _ => query.bind(None::<bool>),
+        },
+        Some(PostgresTypeVariants::Int2) => match json {
+            JsonValue::Null => query.bind(None::<i16>),
+            JsonValue::Number(n) => query.bind(n.as_i64().map(|i| i as i16)),
+            _ => query.bind(None::<i16>),
+        },
+        Some(PostgresTypeVariants::Int4) => match json {
+            JsonValue::Null => query.bind(None::<i32>),
+            JsonValue::Number(n) => query.bind(n.as_i64().map(|i| i as i32)),
+            _ => query.bind(None::<i32>),
+        },
+        Some(PostgresTypeVariants::Int8) => match json {
+            JsonValue::Null => query.bind(None::<i64>),
+            JsonValue::Number(n) => query.bind(n.as_i64()),
+            _ => query.bind(None::<i64>),
+        },
+        Some(PostgresTypeVariants::Float4) => match json {
+            JsonValue::Null => query.bind(None::<f32>),
+            JsonValue::Number(n) => query.bind(n.as_f64().map(|f| f as f32)),
+            _ => query.bind(None::<f32>),
+        },
+        Some(PostgresTypeVariants::Float8) => match json {
+            JsonValue::Null => query.bind(None::<f64>),
+            JsonValue::Number(n) => query.bind(n.as_f64()),
+            _ => query.bind(None::<f64>),
+        },
+        Some(PostgresTypeVariants::Text) => match json {
+            JsonValue::Null => query.bind(None::<String>),
+            JsonValue::String(s) => query.bind(s.as_str()),
+            _ => query.bind(None::<String>),
+        },
+        Some(PostgresTypeVariants::Bytea) => match json {
+            JsonValue::Null => query.bind(None::<Vec<u8>>),
+            JsonValue::Object(o) => {
+                let s = o.get("bytea").and_then(|v| v.as_str()).unwrap_or("");
+                query.bind(s.as_bytes().to_vec())
+            }
+            _ => query.bind(None::<Vec<u8>>),
+        },
+    }
+}
+
+/// Bind a JSON value without type variant -- infers the bind type from the value itself.
+fn bind_by_json<'q>(
+    query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
+    json: &'q JsonValue,
+) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
+    match json {
+        JsonValue::Null => query.bind(None::<String>),
+        JsonValue::Bool(b) => query.bind(*b),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                query.bind(i)
+            } else if let Some(f) = n.as_f64() {
+                query.bind(f)
+            } else {
+                query.bind(n.to_string())
+            }
+        }
+        JsonValue::String(s) => query.bind(s.as_str()),
+        other => query.bind(other.to_string()),
+    }
+}
+
+/// Convert a PgRow to Record<AnyPostgresType>.
+///
+/// Each value has `type_variant: None` -- the database doesn't preserve our
+/// type markers. This means `try_get` on these values bypasses variant
+/// checking and just attempts the conversion.
+pub(crate) fn row_to_record(row: &PgRow) -> Record<AnyPostgresType> {
+    let mut record = Record::new();
+    for col in row.columns() {
+        let name = col.name().to_string();
+        let type_name = col.type_info().name();
+        let json = pg_column_to_json(row, col.ordinal(), type_name);
+        let value = AnyPostgresType::untyped(json);
+        record.insert(name, value);
+    }
+    record
+}
+
+/// Read a single column from a PostgreSQL row as JsonValue.
+/// Uses the declared column type to pick the right extraction method.
+fn pg_column_to_json(row: &PgRow, ordinal: usize, type_name: &str) -> JsonValue {
+    use sqlx::ValueRef;
+
+    if row
+        .try_get_raw(ordinal)
+        .map(|v| v.is_null())
+        .unwrap_or(true)
+    {
+        return JsonValue::Null;
+    }
+
+    match type_name {
+        "BOOL" => {
+            if let Ok(v) = row.try_get::<bool, _>(ordinal) {
+                return JsonValue::Bool(v);
+            }
+        }
+        "INT2" | "SMALLINT" | "SMALLSERIAL" => {
+            if let Ok(v) = row.try_get::<i16, _>(ordinal) {
+                return JsonValue::Number((v as i64).into());
+            }
+        }
+        "INT4" | "INT" | "INTEGER" | "SERIAL" => {
+            if let Ok(v) = row.try_get::<i32, _>(ordinal) {
+                return JsonValue::Number((v as i64).into());
+            }
+        }
+        "INT8" | "BIGINT" | "BIGSERIAL" => {
+            if let Ok(v) = row.try_get::<i64, _>(ordinal) {
+                return JsonValue::Number(v.into());
+            }
+        }
+        "FLOAT4" | "REAL" => {
+            if let Ok(v) = row.try_get::<f32, _>(ordinal) {
+                if let Some(n) = serde_json::Number::from_f64(v as f64) {
+                    return JsonValue::Number(n);
+                }
+            }
+        }
+        "FLOAT8" | "DOUBLE PRECISION" => {
+            if let Ok(v) = row.try_get::<f64, _>(ordinal) {
+                if let Some(n) = serde_json::Number::from_f64(v) {
+                    return JsonValue::Number(n);
+                }
+            }
+        }
+        "NUMERIC" | "DECIMAL" => {
+            // PostgreSQL NUMERIC: SUM(BIGINT) returns NUMERIC.
+            // Try numeric types first, then fall through to fallback chain.
+            if let Ok(v) = row.try_get::<i64, _>(ordinal) {
+                return JsonValue::Number(v.into());
+            }
+            if let Ok(v) = row.try_get::<i32, _>(ordinal) {
+                return JsonValue::Number((v as i64).into());
+            }
+            if let Ok(v) = row.try_get::<f64, _>(ordinal) {
+                if let Some(n) = serde_json::Number::from_f64(v) {
+                    return JsonValue::Number(n);
+                }
+            }
+        }
+        _ => {}
+    }
+
+    // Fallback: try common types in order
+    if let Ok(v) = row.try_get::<bool, _>(ordinal) {
+        return JsonValue::Bool(v);
+    }
+    if let Ok(v) = row.try_get::<i64, _>(ordinal) {
+        return JsonValue::Number(v.into());
+    }
+    if let Ok(v) = row.try_get::<i32, _>(ordinal) {
+        return JsonValue::Number((v as i64).into());
+    }
+    if let Ok(v) = row.try_get::<f64, _>(ordinal) {
+        if let Some(n) = serde_json::Number::from_f64(v) {
+            return JsonValue::Number(n);
+        }
+    }
+    if let Ok(v) = row.try_get::<String, _>(ordinal) {
+        return JsonValue::String(v);
+    }
+
+    JsonValue::Null
+}

--- a/vantage-sql/src/postgres/row.rs
+++ b/vantage-sql/src/postgres/row.rs
@@ -149,17 +149,17 @@ fn pg_column_to_json(row: &PgRow, ordinal: usize, type_name: &str) -> JsonValue 
             }
         }
         "FLOAT4" | "REAL" => {
-            if let Ok(v) = row.try_get::<f32, _>(ordinal) {
-                if let Some(n) = serde_json::Number::from_f64(v as f64) {
-                    return JsonValue::Number(n);
-                }
+            if let Ok(v) = row.try_get::<f32, _>(ordinal)
+                && let Some(n) = serde_json::Number::from_f64(v as f64)
+            {
+                return JsonValue::Number(n);
             }
         }
         "FLOAT8" | "DOUBLE PRECISION" => {
-            if let Ok(v) = row.try_get::<f64, _>(ordinal) {
-                if let Some(n) = serde_json::Number::from_f64(v) {
-                    return JsonValue::Number(n);
-                }
+            if let Ok(v) = row.try_get::<f64, _>(ordinal)
+                && let Some(n) = serde_json::Number::from_f64(v)
+            {
+                return JsonValue::Number(n);
             }
         }
         "NUMERIC" | "DECIMAL" => {
@@ -171,10 +171,10 @@ fn pg_column_to_json(row: &PgRow, ordinal: usize, type_name: &str) -> JsonValue 
             if let Ok(v) = row.try_get::<i32, _>(ordinal) {
                 return JsonValue::Number((v as i64).into());
             }
-            if let Ok(v) = row.try_get::<f64, _>(ordinal) {
-                if let Some(n) = serde_json::Number::from_f64(v) {
-                    return JsonValue::Number(n);
-                }
+            if let Ok(v) = row.try_get::<f64, _>(ordinal)
+                && let Some(n) = serde_json::Number::from_f64(v)
+            {
+                return JsonValue::Number(n);
             }
         }
         _ => {}
@@ -190,10 +190,10 @@ fn pg_column_to_json(row: &PgRow, ordinal: usize, type_name: &str) -> JsonValue 
     if let Ok(v) = row.try_get::<i32, _>(ordinal) {
         return JsonValue::Number((v as i64).into());
     }
-    if let Ok(v) = row.try_get::<f64, _>(ordinal) {
-        if let Some(n) = serde_json::Number::from_f64(v) {
-            return JsonValue::Number(n);
-        }
+    if let Ok(v) = row.try_get::<f64, _>(ordinal)
+        && let Some(n) = serde_json::Number::from_f64(v)
+    {
+        return JsonValue::Number(n);
     }
     if let Ok(v) = row.try_get::<String, _>(ordinal) {
         return JsonValue::String(v);

--- a/vantage-sql/src/postgres/row.rs
+++ b/vantage-sql/src/postgres/row.rs
@@ -64,14 +64,6 @@ pub(crate) fn bind_postgres_value<'q>(
             JsonValue::String(s) => query.bind(s.as_str()),
             _ => query.bind(None::<String>),
         },
-        Some(PostgresTypeVariants::Bytea) => match json {
-            JsonValue::Null => query.bind(None::<Vec<u8>>),
-            JsonValue::Object(o) => {
-                let s = o.get("bytea").and_then(|v| v.as_str()).unwrap_or("");
-                query.bind(s.as_bytes().to_vec())
-            }
-            _ => query.bind(None::<Vec<u8>>),
-        },
     }
 }
 

--- a/vantage-sql/src/postgres/statements/delete/builder.rs
+++ b/vantage-sql/src/postgres/statements/delete/builder.rs
@@ -1,0 +1,19 @@
+use vantage_expressions::Expressive;
+
+use crate::postgres::types::AnyPostgresType;
+
+use super::PostgresDelete;
+
+impl PostgresDelete {
+    pub fn new(table: &str) -> Self {
+        Self {
+            table: table.to_string(),
+            conditions: Vec::new(),
+        }
+    }
+
+    pub fn with_condition(mut self, condition: impl Expressive<AnyPostgresType>) -> Self {
+        self.conditions.push(condition.expr());
+        self
+    }
+}

--- a/vantage-sql/src/postgres/statements/delete/mod.rs
+++ b/vantage-sql/src/postgres/statements/delete/mod.rs
@@ -1,0 +1,14 @@
+mod builder;
+mod render;
+
+use crate::postgres::types::AnyPostgresType;
+use vantage_expressions::Expression;
+
+type Expr = Expression<AnyPostgresType>;
+
+/// PostgreSQL DELETE statement builder.
+#[derive(Debug, Clone)]
+pub struct PostgresDelete {
+    pub table: String,
+    pub conditions: Vec<Expr>,
+}

--- a/vantage-sql/src/postgres/statements/delete/render.rs
+++ b/vantage-sql/src/postgres/statements/delete/render.rs
@@ -1,0 +1,31 @@
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::postgres::types::AnyPostgresType;
+
+use super::{Expr, PostgresDelete};
+
+impl PostgresDelete {
+    pub fn preview(&self) -> String {
+        self.expr().preview()
+    }
+}
+
+impl Expressive<AnyPostgresType> for PostgresDelete {
+    fn expr(&self) -> Expr {
+        if self.conditions.is_empty() {
+            return Expression::new(format!("DELETE FROM \"{}\"", self.table), vec![]);
+        }
+
+        let combined = Expression::from_vec(self.conditions.clone(), " AND ");
+        Expression::new(
+            format!("DELETE FROM \"{}\" WHERE {{}}", self.table),
+            vec![ExpressiveEnum::Nested(combined)],
+        )
+    }
+}
+
+impl From<PostgresDelete> for Expr {
+    fn from(delete: PostgresDelete) -> Self {
+        delete.expr()
+    }
+}

--- a/vantage-sql/src/postgres/statements/insert/builder.rs
+++ b/vantage-sql/src/postgres/statements/insert/builder.rs
@@ -1,0 +1,27 @@
+use indexmap::IndexMap;
+use vantage_types::Record;
+
+use crate::postgres::types::AnyPostgresType;
+
+use super::PostgresInsert;
+
+impl PostgresInsert {
+    pub fn new(table: &str) -> Self {
+        Self {
+            table: table.to_string(),
+            fields: IndexMap::new(),
+        }
+    }
+
+    pub fn with_field(mut self, key: impl Into<String>, value: impl Into<AnyPostgresType>) -> Self {
+        self.fields.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn with_record(mut self, record: &Record<AnyPostgresType>) -> Self {
+        for (key, value) in record.iter() {
+            self.fields.insert(key.clone(), value.clone());
+        }
+        self
+    }
+}

--- a/vantage-sql/src/postgres/statements/insert/mod.rs
+++ b/vantage-sql/src/postgres/statements/insert/mod.rs
@@ -1,0 +1,15 @@
+mod builder;
+mod render;
+
+use crate::postgres::types::AnyPostgresType;
+use indexmap::IndexMap;
+use vantage_expressions::Expression;
+
+type Expr = Expression<AnyPostgresType>;
+
+/// PostgreSQL INSERT statement builder.
+#[derive(Debug, Clone)]
+pub struct PostgresInsert {
+    pub table: String,
+    pub fields: IndexMap<String, AnyPostgresType>,
+}

--- a/vantage-sql/src/postgres/statements/insert/render.rs
+++ b/vantage-sql/src/postgres/statements/insert/render.rs
@@ -1,0 +1,46 @@
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::postgres::types::AnyPostgresType;
+
+use super::{Expr, PostgresInsert};
+
+impl PostgresInsert {
+    pub fn preview(&self) -> String {
+        self.expr().preview()
+    }
+}
+
+impl Expressive<AnyPostgresType> for PostgresInsert {
+    fn expr(&self) -> Expr {
+        if self.fields.is_empty() {
+            return Expression::new(
+                format!("INSERT INTO \"{}\" DEFAULT VALUES", self.table),
+                vec![],
+            );
+        }
+
+        let columns: Vec<String> = self.fields.keys().map(|k| format!("\"{}\"", k)).collect();
+        let placeholders: Vec<&str> = (0..self.fields.len()).map(|_| "{}").collect();
+
+        let template = format!(
+            "INSERT INTO \"{}\" ({}) VALUES ({})",
+            self.table,
+            columns.join(", "),
+            placeholders.join(", ")
+        );
+
+        let params: Vec<ExpressiveEnum<AnyPostgresType>> = self
+            .fields
+            .values()
+            .map(|v| ExpressiveEnum::Scalar(v.clone()))
+            .collect();
+
+        Expression::new(template, params)
+    }
+}
+
+impl From<PostgresInsert> for Expr {
+    fn from(insert: PostgresInsert) -> Self {
+        insert.expr()
+    }
+}

--- a/vantage-sql/src/postgres/statements/mod.rs
+++ b/vantage-sql/src/postgres/statements/mod.rs
@@ -1,0 +1,9 @@
+pub mod delete;
+pub mod insert;
+pub mod select;
+pub mod update;
+
+pub use delete::PostgresDelete;
+pub use insert::PostgresInsert;
+pub use select::PostgresSelect;
+pub use update::PostgresUpdate;

--- a/vantage-sql/src/postgres/statements/select/impls/mod.rs
+++ b/vantage-sql/src/postgres/statements/select/impls/mod.rs
@@ -1,0 +1,1 @@
+pub mod selectable;

--- a/vantage-sql/src/postgres/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/postgres/statements/select/impls/selectable.rs
@@ -1,0 +1,161 @@
+use vantage_expressions::traits::selectable::{Selectable, SourceRef};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::primitives::fx::Fx;
+use crate::postgres::statements::PostgresSelect;
+use crate::postgres::types::AnyPostgresType;
+
+type Expr = Expression<AnyPostgresType>;
+
+impl PostgresSelect {
+    pub fn as_aggregate(&self, func: &str, column: impl Expressive<AnyPostgresType>) -> Expr {
+        let mut s = self.clone();
+        s.clear_fields();
+        // PostgreSQL returns NUMERIC for SUM/AVG on integer types, which sqlx
+        // can't decode without bigdecimal. Cast to a decodable type.
+        let agg = Fx::new(func, [column.expr()]);
+        let cast = Expression::new(
+            "CAST({} AS BIGINT)",
+            vec![ExpressiveEnum::Nested(agg.expr())],
+        );
+        s.add_expression(cast, None);
+        s.clear_order_by();
+        s.render()
+    }
+}
+
+impl Selectable<AnyPostgresType> for PostgresSelect {
+    fn set_source(&mut self, source: impl Into<SourceRef<AnyPostgresType>>, alias: Option<String>) {
+        self.from.clear();
+        let source_ref = source.into().into_expressive_enum();
+        let expr = match (source_ref, alias) {
+            (ExpressiveEnum::Scalar(val), None) => Expression::new(
+                format!("\"{}\"", val.try_get::<String>().unwrap_or_default()),
+                vec![],
+            ),
+            (ExpressiveEnum::Scalar(val), Some(alias)) => Expression::new(
+                format!(
+                    "\"{}\" AS \"{}\"",
+                    val.try_get::<String>().unwrap_or_default(),
+                    alias
+                ),
+                vec![],
+            ),
+            (ExpressiveEnum::Nested(expr), None) => expr,
+            (ExpressiveEnum::Nested(expr), Some(alias)) => Expression::new(
+                format!("{{}} AS \"{}\"", alias),
+                vec![ExpressiveEnum::Nested(expr)],
+            ),
+            _ => return,
+        };
+        self.from.push(expr);
+    }
+
+    fn add_field(&mut self, field: impl Into<String>) {
+        self.fields
+            .push(Expression::new(format!("\"{}\"", field.into()), vec![]));
+    }
+
+    fn add_expression(
+        &mut self,
+        expression: impl Expressive<AnyPostgresType>,
+        alias: Option<String>,
+    ) {
+        let expr = expression.expr();
+        let field = match alias {
+            Some(a) => Expression::new(
+                format!("{{}} AS \"{}\"", a),
+                vec![ExpressiveEnum::Nested(expr)],
+            ),
+            None => expr,
+        };
+        self.fields.push(field);
+    }
+
+    fn add_where_condition(&mut self, condition: impl Expressive<AnyPostgresType>) {
+        self.where_conditions.push(condition.expr());
+    }
+
+    fn set_distinct(&mut self, distinct: bool) {
+        self.distinct = distinct;
+    }
+
+    fn add_order_by(&mut self, expression: impl Expressive<AnyPostgresType>, ascending: bool) {
+        self.order_by.push((expression.expr(), ascending));
+    }
+
+    fn add_group_by(&mut self, expression: impl Expressive<AnyPostgresType>) {
+        self.group_by.push(expression.expr());
+    }
+
+    fn set_limit(&mut self, limit: Option<i64>, skip: Option<i64>) {
+        self.limit = limit;
+        self.skip = skip;
+    }
+
+    fn clear_fields(&mut self) {
+        self.fields.clear();
+    }
+
+    fn clear_where_conditions(&mut self) {
+        self.where_conditions.clear();
+    }
+
+    fn clear_order_by(&mut self) {
+        self.order_by.clear();
+    }
+
+    fn clear_group_by(&mut self) {
+        self.group_by.clear();
+    }
+
+    fn has_fields(&self) -> bool {
+        !self.fields.is_empty()
+    }
+
+    fn has_where_conditions(&self) -> bool {
+        !self.where_conditions.is_empty()
+    }
+
+    fn has_order_by(&self) -> bool {
+        !self.order_by.is_empty()
+    }
+
+    fn has_group_by(&self) -> bool {
+        !self.group_by.is_empty()
+    }
+
+    fn is_distinct(&self) -> bool {
+        self.distinct
+    }
+
+    fn get_limit(&self) -> Option<i64> {
+        self.limit
+    }
+
+    fn get_skip(&self) -> Option<i64> {
+        self.skip
+    }
+
+    fn as_count(&self) -> Expr {
+        let mut count_select = self.clone();
+        count_select.fields.clear();
+        count_select
+            .fields
+            .push(Expression::new("COUNT(*)", vec![]));
+        count_select.order_by.clear();
+        count_select.render()
+    }
+
+    fn as_sum(&self, column: impl Expressive<AnyPostgresType>) -> Expr {
+        self.as_aggregate("sum", column)
+    }
+
+    fn as_max(&self, column: impl Expressive<AnyPostgresType>) -> Expr {
+        self.as_aggregate("max", column)
+    }
+
+    fn as_min(&self, column: impl Expressive<AnyPostgresType>) -> Expr {
+        self.as_aggregate("min", column)
+    }
+}

--- a/vantage-sql/src/postgres/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/postgres/statements/select/impls/selectable.rs
@@ -1,9 +1,9 @@
 use vantage_expressions::traits::selectable::{Selectable, SourceRef};
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
-use crate::primitives::fx::Fx;
 use crate::postgres::statements::PostgresSelect;
 use crate::postgres::types::AnyPostgresType;
+use crate::primitives::fx::Fx;
 
 type Expr = Expression<AnyPostgresType>;
 

--- a/vantage-sql/src/postgres/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/postgres/statements/select/impls/selectable.rs
@@ -11,14 +11,22 @@ impl PostgresSelect {
     pub fn as_aggregate(&self, func: &str, column: impl Expressive<AnyPostgresType>) -> Expr {
         let mut s = self.clone();
         s.clear_fields();
-        // PostgreSQL returns NUMERIC for SUM/AVG on integer types, which sqlx
-        // can't decode without bigdecimal. Cast to a decodable type.
         let agg = Fx::new(func, [column.expr()]);
-        let cast = Expression::new(
-            "CAST({} AS BIGINT)",
-            vec![ExpressiveEnum::Nested(agg.expr())],
-        );
-        s.add_expression(cast, None);
+
+        // PostgreSQL returns NUMERIC for SUM/AVG on integer types, which sqlx
+        // can't decode without bigdecimal. Cast those to BIGINT.
+        // MAX/MIN preserve the column's original type — no cast needed.
+        let needs_cast = matches!(func, "sum" | "avg");
+        if needs_cast {
+            let cast = Expression::new(
+                "CAST({} AS BIGINT)",
+                vec![ExpressiveEnum::Nested(agg.expr())],
+            );
+            s.add_expression(cast, None);
+        } else {
+            s.add_expression(agg, None);
+        }
+
         s.clear_order_by();
         s.render()
     }

--- a/vantage-sql/src/postgres/statements/select/join.rs
+++ b/vantage-sql/src/postgres/statements/select/join.rs
@@ -1,0 +1,104 @@
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::postgres::types::AnyPostgresType;
+
+type Expr = Expression<AnyPostgresType>;
+
+#[derive(Debug, Clone)]
+pub enum PostgresJoinType {
+    Inner,
+    Left,
+    Right,
+}
+
+impl PostgresJoinType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            PostgresJoinType::Inner => "INNER JOIN",
+            PostgresJoinType::Left => "LEFT JOIN",
+            PostgresJoinType::Right => "RIGHT JOIN",
+        }
+    }
+}
+
+/// A JOIN clause for PostgresSelect.
+#[derive(Debug, Clone)]
+pub struct PostgresSelectJoin {
+    join_type: PostgresJoinType,
+    table: Expr,
+    on_condition: Expr,
+}
+
+impl PostgresSelectJoin {
+    fn new(join_type: PostgresJoinType, table: Expr, on_condition: Expr) -> Self {
+        Self {
+            join_type,
+            table,
+            on_condition,
+        }
+    }
+
+    fn table_expr(table: impl Into<String>, alias: impl Into<String>) -> Expr {
+        Expression::new(
+            format!("\"{}\" AS \"{}\"", table.into(), alias.into()),
+            vec![],
+        )
+    }
+
+    fn subquery_expr(subquery: impl Expressive<AnyPostgresType>, alias: impl Into<String>) -> Expr {
+        Expression::new(
+            format!("({{}}) AS \"{}\"", alias.into()),
+            vec![ExpressiveEnum::Nested(subquery.expr())],
+        )
+    }
+
+    pub fn inner(table: impl Into<String>, alias: impl Into<String>, on_condition: Expr) -> Self {
+        Self::new(
+            PostgresJoinType::Inner,
+            Self::table_expr(table, alias),
+            on_condition,
+        )
+    }
+
+    pub fn left(table: impl Into<String>, alias: impl Into<String>, on_condition: Expr) -> Self {
+        Self::new(
+            PostgresJoinType::Left,
+            Self::table_expr(table, alias),
+            on_condition,
+        )
+    }
+
+    pub fn inner_expr(
+        subquery: impl Expressive<AnyPostgresType>,
+        alias: impl Into<String>,
+        on_condition: Expr,
+    ) -> Self {
+        Self::new(
+            PostgresJoinType::Inner,
+            Self::subquery_expr(subquery, alias),
+            on_condition,
+        )
+    }
+
+    pub fn left_expr(
+        subquery: impl Expressive<AnyPostgresType>,
+        alias: impl Into<String>,
+        on_condition: Expr,
+    ) -> Self {
+        Self::new(
+            PostgresJoinType::Left,
+            Self::subquery_expr(subquery, alias),
+            on_condition,
+        )
+    }
+
+    pub fn render(&self) -> Expr {
+        Expression::new(
+            format!(" {} {{}} ON {{}}", self.join_type.as_str()),
+            vec![
+                ExpressiveEnum::Nested(self.table.clone()),
+                ExpressiveEnum::Nested(self.on_condition.clone()),
+            ],
+        )
+    }
+}

--- a/vantage-sql/src/postgres/statements/select/mod.rs
+++ b/vantage-sql/src/postgres/statements/select/mod.rs
@@ -2,8 +2,8 @@ mod impls;
 pub mod join;
 mod render;
 
-use crate::primitives::select::window::Window;
 use crate::postgres::types::AnyPostgresType;
+use crate::primitives::select::window::Window;
 use join::PostgresSelectJoin;
 use vantage_expressions::Expression;
 

--- a/vantage-sql/src/postgres/statements/select/mod.rs
+++ b/vantage-sql/src/postgres/statements/select/mod.rs
@@ -1,0 +1,84 @@
+mod impls;
+pub mod join;
+mod render;
+
+use crate::primitives::select::window::Window;
+use crate::postgres::types::AnyPostgresType;
+use join::PostgresSelectJoin;
+use vantage_expressions::Expression;
+
+type Expr = Expression<AnyPostgresType>;
+
+/// PostgreSQL SELECT statement builder.
+#[derive(Debug, Clone)]
+pub struct PostgresSelect {
+    pub fields: Vec<Expr>,
+    pub from: Vec<Expr>,
+    pub joins: Vec<PostgresSelectJoin>,
+    pub where_conditions: Vec<Expr>,
+    pub order_by: Vec<(Expr, bool)>,
+    pub group_by: Vec<Expr>,
+    pub having: Vec<Expr>,
+    pub windows: Vec<(String, Window<AnyPostgresType>)>,
+    pub ctes: Vec<(String, Expr, bool)>,
+    pub distinct: bool,
+    pub limit: Option<i64>,
+    pub skip: Option<i64>,
+}
+
+impl PostgresSelect {
+    pub fn new() -> Self {
+        Self {
+            fields: Vec::new(),
+            from: Vec::new(),
+            joins: Vec::new(),
+            where_conditions: Vec::new(),
+            order_by: Vec::new(),
+            group_by: Vec::new(),
+            having: Vec::new(),
+            windows: Vec::new(),
+            ctes: Vec::new(),
+            distinct: false,
+            limit: None,
+            skip: None,
+        }
+    }
+
+    pub fn with_join(mut self, join: PostgresSelectJoin) -> Self {
+        self.joins.push(join);
+        self
+    }
+
+    pub fn add_having(&mut self, condition: impl vantage_expressions::Expressive<AnyPostgresType>) {
+        self.having.push(condition.expr());
+    }
+
+    pub fn with_having(
+        mut self,
+        condition: impl vantage_expressions::Expressive<AnyPostgresType>,
+    ) -> Self {
+        self.having.push(condition.expr());
+        self
+    }
+
+    pub fn with_window(mut self, name: impl Into<String>, window: Window<AnyPostgresType>) -> Self {
+        self.windows.push((name.into(), window));
+        self
+    }
+
+    pub fn with_cte(
+        mut self,
+        name: impl Into<String>,
+        query: impl vantage_expressions::Expressive<AnyPostgresType>,
+        recursive: bool,
+    ) -> Self {
+        self.ctes.push((name.into(), query.expr(), recursive));
+        self
+    }
+}
+
+impl Default for PostgresSelect {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/vantage-sql/src/postgres/statements/select/render.rs
+++ b/vantage-sql/src/postgres/statements/select/render.rs
@@ -1,0 +1,194 @@
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::postgres::types::AnyPostgresType;
+
+use super::{Expr, PostgresSelect};
+
+fn render_condition_list(conditions: &[Expr], keyword: &str) -> Expr {
+    if conditions.is_empty() {
+        Expression::new("", vec![])
+    } else {
+        let combined = Expression::from_vec(conditions.to_vec(), " AND ");
+        Expression::new(
+            format!(" {} {{}}", keyword),
+            vec![ExpressiveEnum::Nested(combined)],
+        )
+    }
+}
+
+impl PostgresSelect {
+    fn render_fields(&self) -> Expr {
+        if self.fields.is_empty() {
+            Expression::new("*", vec![])
+        } else {
+            Expression::from_vec(self.fields.clone(), ", ")
+        }
+    }
+
+    fn render_from(&self) -> Expr {
+        if self.from.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            Expression::new(
+                " FROM {}",
+                vec![ExpressiveEnum::Nested(Expression::from_vec(
+                    self.from.clone(),
+                    ", ",
+                ))],
+            )
+        }
+    }
+
+    fn render_joins(&self) -> Expr {
+        if self.joins.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            let parts: Vec<Expr> = self.joins.iter().map(|j| j.render()).collect();
+            Expression::from_vec(parts, "")
+        }
+    }
+
+    fn render_where(&self) -> Expr {
+        render_condition_list(&self.where_conditions, "WHERE")
+    }
+
+    fn render_having(&self) -> Expr {
+        render_condition_list(&self.having, "HAVING")
+    }
+
+    fn render_group_by(&self) -> Expr {
+        if self.group_by.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            Expression::new(
+                " GROUP BY {}",
+                vec![ExpressiveEnum::Nested(Expression::from_vec(
+                    self.group_by.clone(),
+                    ", ",
+                ))],
+            )
+        }
+    }
+
+    fn render_windows(&self) -> Expr {
+        if self.windows.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            let parts: Vec<Expr> = self
+                .windows
+                .iter()
+                .map(|(name, win)| {
+                    Expression::new(
+                        format!("{} AS {{}}", name),
+                        vec![ExpressiveEnum::Nested(win.definition())],
+                    )
+                })
+                .collect();
+            Expression::new(
+                " WINDOW {}",
+                vec![ExpressiveEnum::Nested(Expression::from_vec(parts, ", "))],
+            )
+        }
+    }
+
+    fn render_order_by(&self) -> Expr {
+        if self.order_by.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            let parts: Vec<Expr> = self
+                .order_by
+                .iter()
+                .map(|(expr, asc)| {
+                    if *asc {
+                        expr.clone()
+                    } else {
+                        Expression::new("{} DESC", vec![ExpressiveEnum::Nested(expr.clone())])
+                    }
+                })
+                .collect();
+            Expression::new(
+                " ORDER BY {}",
+                vec![ExpressiveEnum::Nested(Expression::from_vec(parts, ", "))],
+            )
+        }
+    }
+
+    fn render_limit(&self) -> Expr {
+        match (self.limit, self.skip) {
+            (Some(limit), Some(skip)) => Expression::new(
+                " LIMIT {} OFFSET {}",
+                vec![
+                    ExpressiveEnum::Scalar(AnyPostgresType::new(limit)),
+                    ExpressiveEnum::Scalar(AnyPostgresType::new(skip)),
+                ],
+            ),
+            (Some(limit), None) => Expression::new(
+                " LIMIT {}",
+                vec![ExpressiveEnum::Scalar(AnyPostgresType::new(limit))],
+            ),
+            (None, Some(skip)) => Expression::new(
+                " OFFSET {}",
+                vec![ExpressiveEnum::Scalar(AnyPostgresType::new(skip))],
+            ),
+            (None, None) => Expression::new("", vec![]),
+        }
+    }
+
+    fn render_ctes(&self) -> Expr {
+        if self.ctes.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            let is_recursive = self.ctes.iter().any(|(_, _, r)| *r);
+            let parts: Vec<Expr> = self
+                .ctes
+                .iter()
+                .map(|(name, query, _)| {
+                    Expression::new(
+                        format!("{} AS ({{}})", name),
+                        vec![ExpressiveEnum::Nested(query.clone())],
+                    )
+                })
+                .collect();
+            let keyword = if is_recursive {
+                "WITH RECURSIVE"
+            } else {
+                "WITH"
+            };
+            Expression::new(
+                format!("{} {{}} ", keyword),
+                vec![ExpressiveEnum::Nested(Expression::from_vec(parts, ", "))],
+            )
+        }
+    }
+
+    pub fn render(&self) -> Expr {
+        Expression::new(
+            format!(
+                "{{}}SELECT{} {{}}{{}}{{}}{{}}{{}}{{}}{{}}{{}}{{}}",
+                if self.distinct { " DISTINCT" } else { "" }
+            ),
+            vec![
+                ExpressiveEnum::Nested(self.render_ctes()),
+                ExpressiveEnum::Nested(self.render_fields()),
+                ExpressiveEnum::Nested(self.render_from()),
+                ExpressiveEnum::Nested(self.render_joins()),
+                ExpressiveEnum::Nested(self.render_where()),
+                ExpressiveEnum::Nested(self.render_group_by()),
+                ExpressiveEnum::Nested(self.render_having()),
+                ExpressiveEnum::Nested(self.render_windows()),
+                ExpressiveEnum::Nested(self.render_order_by()),
+                ExpressiveEnum::Nested(self.render_limit()),
+            ],
+        )
+    }
+
+    pub fn preview(&self) -> String {
+        self.render().preview()
+    }
+}
+
+impl Expressive<AnyPostgresType> for PostgresSelect {
+    fn expr(&self) -> Expr {
+        self.render()
+    }
+}

--- a/vantage-sql/src/postgres/statements/update/builder.rs
+++ b/vantage-sql/src/postgres/statements/update/builder.rs
@@ -1,0 +1,34 @@
+use indexmap::IndexMap;
+use vantage_expressions::Expressive;
+use vantage_types::Record;
+
+use crate::postgres::types::AnyPostgresType;
+
+use super::PostgresUpdate;
+
+impl PostgresUpdate {
+    pub fn new(table: &str) -> Self {
+        Self {
+            table: table.to_string(),
+            fields: IndexMap::new(),
+            conditions: Vec::new(),
+        }
+    }
+
+    pub fn with_field(mut self, key: impl Into<String>, value: impl Into<AnyPostgresType>) -> Self {
+        self.fields.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn with_record(mut self, record: &Record<AnyPostgresType>) -> Self {
+        for (key, value) in record.iter() {
+            self.fields.insert(key.clone(), value.clone());
+        }
+        self
+    }
+
+    pub fn with_condition(mut self, condition: impl Expressive<AnyPostgresType>) -> Self {
+        self.conditions.push(condition.expr());
+        self
+    }
+}

--- a/vantage-sql/src/postgres/statements/update/mod.rs
+++ b/vantage-sql/src/postgres/statements/update/mod.rs
@@ -1,0 +1,16 @@
+mod builder;
+mod render;
+
+use crate::postgres::types::AnyPostgresType;
+use indexmap::IndexMap;
+use vantage_expressions::Expression;
+
+type Expr = Expression<AnyPostgresType>;
+
+/// PostgreSQL UPDATE statement builder.
+#[derive(Debug, Clone)]
+pub struct PostgresUpdate {
+    pub table: String,
+    pub fields: IndexMap<String, AnyPostgresType>,
+    pub conditions: Vec<Expr>,
+}

--- a/vantage-sql/src/postgres/statements/update/render.rs
+++ b/vantage-sql/src/postgres/statements/update/render.rs
@@ -1,0 +1,55 @@
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::postgres::types::AnyPostgresType;
+
+use super::{Expr, PostgresUpdate};
+
+impl PostgresUpdate {
+    fn render_where(&self) -> Option<Expr> {
+        if self.conditions.is_empty() {
+            return None;
+        }
+        Some(Expression::from_vec(self.conditions.clone(), " AND "))
+    }
+
+    pub fn preview(&self) -> String {
+        self.expr().preview()
+    }
+}
+
+impl Expressive<AnyPostgresType> for PostgresUpdate {
+    fn expr(&self) -> Expr {
+        if self.fields.is_empty() {
+            return Expression::new(format!("UPDATE \"{}\"", self.table), vec![]);
+        }
+
+        let set_parts: Vec<String> = self
+            .fields
+            .keys()
+            .map(|k| format!("\"{}\" = {{}}", k))
+            .collect();
+        let template_base = format!("UPDATE \"{}\" SET {}", self.table, set_parts.join(", "));
+
+        let mut params: Vec<ExpressiveEnum<AnyPostgresType>> = self
+            .fields
+            .values()
+            .map(|v| ExpressiveEnum::Scalar(v.clone()))
+            .collect();
+
+        let template = match self.render_where() {
+            Some(cond) => {
+                params.push(ExpressiveEnum::Nested(cond));
+                format!("{} WHERE {{}}", template_base)
+            }
+            None => template_base,
+        };
+
+        Expression::new(template, params)
+    }
+}
+
+impl From<PostgresUpdate> for Expr {
+    fn from(update: PostgresUpdate) -> Self {
+        update.expr()
+    }
+}

--- a/vantage-sql/src/postgres/statements/update/render.rs
+++ b/vantage-sql/src/postgres/statements/update/render.rs
@@ -20,7 +20,8 @@ impl PostgresUpdate {
 impl Expressive<AnyPostgresType> for PostgresUpdate {
     fn expr(&self) -> Expr {
         if self.fields.is_empty() {
-            return Expression::new(format!("UPDATE \"{}\"", self.table), vec![]);
+            // No fields to update — emit a no-op query rather than invalid SQL
+            return Expression::new("SELECT 1 WHERE FALSE", vec![]);
         }
 
         let set_parts: Vec<String> = self

--- a/vantage-sql/src/postgres/types/bool.rs
+++ b/vantage-sql/src/postgres/types/bool.rs
@@ -1,0 +1,21 @@
+//! Boolean -> PostgreSQL Bool variant.
+//! PostgreSQL has native BOOLEAN type (unlike SQLite's 0/1).
+
+use super::{PostgresType, PostgresTypeBoolMarker};
+use serde_json::Value;
+
+impl PostgresType for bool {
+    type Target = PostgresTypeBoolMarker;
+
+    fn to_json(&self) -> Value {
+        Value::Bool(*self)
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Bool(b) => Some(b),
+            Value::Number(n) => n.as_i64().map(|i| i != 0),
+            _ => None,
+        }
+    }
+}

--- a/vantage-sql/src/postgres/types/mod.rs
+++ b/vantage-sql/src/postgres/types/mod.rs
@@ -1,0 +1,145 @@
+//! PostgreSQL Type System
+//!
+//! Defines type variants aligned with PostgreSQL's type system:
+//!
+//! - Bool       : BOOLEAN
+//! - Int2       : SMALLINT, INT2
+//! - Int4       : INTEGER, INT, INT4
+//! - Int8       : BIGINT, INT8
+//! - Float4     : REAL, FLOAT4
+//! - Float8     : DOUBLE PRECISION, FLOAT8
+//! - Text       : TEXT, VARCHAR(N), CHAR(N), NAME
+//! - Bytea      : BYTEA
+//!
+//! Uses `serde_json::Value` as the underlying value type with type variant
+//! tracking to prevent silent type confusion.
+
+use serde_json::Value;
+use vantage_types::vantage_type_system;
+
+vantage_type_system! {
+    type_trait: PostgresType,
+    method_name: json,
+    value_type: serde_json::Value,
+    type_variants: [
+        Null,
+        Bool,       // bool
+        Int2,       // i16
+        Int4,       // i32
+        Int8,       // i64
+        Float4,     // f32
+        Float8,     // f64
+        Text,       // String, &str
+        Bytea       // Vec<u8> — stored as base64 string
+    ]
+}
+
+impl PostgresTypeVariants {
+    /// Detect the type variant from a JSON value.
+    pub fn from_json(value: &Value) -> Option<Self> {
+        match value {
+            Value::Null => Some(Self::Null),
+            Value::Bool(_) => Some(Self::Bool),
+            Value::Number(n) => {
+                if n.is_i64() || n.is_u64() {
+                    Some(Self::Int8)
+                } else {
+                    Some(Self::Float8)
+                }
+            }
+            Value::String(_) => Some(Self::Text),
+            Value::Object(obj) => {
+                if obj.contains_key("bytea") {
+                    Some(Self::Bytea)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+mod bool;
+mod numbers;
+mod string;
+mod value;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_integer_round_trip() {
+        let val = AnyPostgresType::new(42i64);
+        assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Int8));
+        assert_eq!(val.try_get::<i64>(), Some(42));
+    }
+
+    #[test]
+    fn test_text_round_trip() {
+        let val = AnyPostgresType::new("hello".to_string());
+        assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Text));
+        assert_eq!(val.try_get::<String>(), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn test_real_round_trip() {
+        let val = AnyPostgresType::new(3.15f64);
+        assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Float8));
+        assert_eq!(val.try_get::<f64>(), Some(3.15));
+    }
+
+    #[test]
+    fn test_bool_round_trip() {
+        let val = AnyPostgresType::new(true);
+        assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Bool));
+        assert_eq!(val.try_get::<bool>(), Some(true));
+        // Bool is a distinct variant — i64 extraction blocked by type boundary
+        assert_eq!(val.try_get::<i64>(), None);
+    }
+
+    #[test]
+    fn test_null_round_trip() {
+        let val = AnyPostgresType::new(None::<i64>);
+        assert_eq!(*val.value(), serde_json::Value::Null);
+        assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Int8));
+
+        let direct = <Option<i64> as PostgresType>::from_json(serde_json::Value::Null);
+        assert_eq!(direct, Some(None));
+
+        assert_eq!(val.try_get::<Option<i64>>(), Some(None));
+    }
+
+    #[test]
+    fn test_type_mismatch_text_as_integer() {
+        let val = AnyPostgresType::new("hello".to_string());
+        assert_eq!(val.try_get::<i64>(), None);
+    }
+
+    #[test]
+    fn test_type_mismatch_integer_as_text() {
+        let val = AnyPostgresType::new(42i64);
+        assert_eq!(val.try_get::<String>(), None);
+    }
+
+    #[test]
+    fn test_type_mismatch_real_as_integer() {
+        let val = AnyPostgresType::new(3.15f64);
+        assert_eq!(val.try_get::<i64>(), None);
+    }
+
+    #[test]
+    fn test_i32_round_trip() {
+        let val = AnyPostgresType::new(42i32);
+        assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Int4));
+        assert_eq!(val.try_get::<i32>(), Some(42));
+    }
+
+    #[test]
+    fn test_i16_round_trip() {
+        let val = AnyPostgresType::new(42i16);
+        assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Int2));
+        assert_eq!(val.try_get::<i16>(), Some(42));
+    }
+}

--- a/vantage-sql/src/postgres/types/mod.rs
+++ b/vantage-sql/src/postgres/types/mod.rs
@@ -9,7 +9,6 @@
 //! - Float4     : REAL, FLOAT4
 //! - Float8     : DOUBLE PRECISION, FLOAT8
 //! - Text       : TEXT, VARCHAR(N), CHAR(N), NAME
-//! - Bytea      : BYTEA
 //!
 //! Uses `serde_json::Value` as the underlying value type with type variant
 //! tracking to prevent silent type confusion.
@@ -29,8 +28,7 @@ vantage_type_system! {
         Int8,       // i64
         Float4,     // f32
         Float8,     // f64
-        Text,       // String, &str
-        Bytea       // Vec<u8> — stored as base64 string
+        Text        // String, &str
     ]
 }
 
@@ -48,13 +46,6 @@ impl PostgresTypeVariants {
                 }
             }
             Value::String(_) => Some(Self::Text),
-            Value::Object(obj) => {
-                if obj.contains_key("bytea") {
-                    Some(Self::Bytea)
-                } else {
-                    None
-                }
-            }
             _ => None,
         }
     }

--- a/vantage-sql/src/postgres/types/numbers.rs
+++ b/vantage-sql/src/postgres/types/numbers.rs
@@ -1,0 +1,184 @@
+//! Numeric type implementations for PostgreSQL.
+//!
+//! - i16 -> Int2 (SMALLINT)
+//! - i32 -> Int4 (INTEGER)
+//! - i64 -> Int8 (BIGINT)
+//! - f32 -> Float4 (REAL)
+//! - f64 -> Float8 (DOUBLE PRECISION)
+//! - i8, u8, u16, u32 -> mapped to appropriate integer variants
+//! - Option<T> delegates to T, with Null for None
+
+use super::{
+    PostgresType, PostgresTypeFloat4Marker, PostgresTypeFloat8Marker, PostgresTypeInt2Marker,
+    PostgresTypeInt4Marker, PostgresTypeInt8Marker,
+};
+use serde_json::Value;
+
+// -- i16 -> Int2 (SMALLINT) ---------------------------------------------------
+
+impl PostgresType for i16 {
+    type Target = PostgresTypeInt2Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self as i64).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64().and_then(|i| i16::try_from(i).ok()),
+            _ => None,
+        }
+    }
+}
+
+// -- i32 -> Int4 (INTEGER) ----------------------------------------------------
+
+impl PostgresType for i32 {
+    type Target = PostgresTypeInt4Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self as i64).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64().and_then(|i| i32::try_from(i).ok()),
+            _ => None,
+        }
+    }
+}
+
+// -- i64 -> Int8 (BIGINT) ----------------------------------------------------
+
+impl PostgresType for i64 {
+    type Target = PostgresTypeInt8Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64(),
+            _ => None,
+        }
+    }
+}
+
+// -- Smaller unsigned integers mapped to appropriate Postgres types -----------
+
+impl PostgresType for i8 {
+    type Target = PostgresTypeInt2Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self as i64).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64().and_then(|i| i8::try_from(i).ok()),
+            _ => None,
+        }
+    }
+}
+
+impl PostgresType for u8 {
+    type Target = PostgresTypeInt2Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self as i64).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64().and_then(|i| u8::try_from(i).ok()),
+            _ => None,
+        }
+    }
+}
+
+impl PostgresType for u16 {
+    type Target = PostgresTypeInt4Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self as i64).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64().and_then(|i| u16::try_from(i).ok()),
+            _ => None,
+        }
+    }
+}
+
+impl PostgresType for u32 {
+    type Target = PostgresTypeInt8Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self as i64).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64().and_then(|i| u32::try_from(i).ok()),
+            _ => None,
+        }
+    }
+}
+
+// -- Float types --------------------------------------------------------------
+
+impl PostgresType for f32 {
+    type Target = PostgresTypeFloat4Marker;
+
+    fn to_json(&self) -> Value {
+        serde_json::Number::from_f64(*self as f64)
+            .map(Value::Number)
+            .unwrap_or(Value::Null)
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_f64().map(|f| f as f32),
+            _ => None,
+        }
+    }
+}
+
+impl PostgresType for f64 {
+    type Target = PostgresTypeFloat8Marker;
+
+    fn to_json(&self) -> Value {
+        serde_json::Number::from_f64(*self)
+            .map(Value::Number)
+            .unwrap_or(Value::Null)
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_f64(),
+            _ => None,
+        }
+    }
+}
+
+// -- Option<T> -> Null for None, delegates to T for Some ----------------------
+
+impl<T: PostgresType> PostgresType for Option<T> {
+    type Target = T::Target;
+
+    fn to_json(&self) -> Value {
+        match self {
+            Some(v) => v.to_json(),
+            None => Value::Null,
+        }
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Null => Some(None),
+            other => T::from_json(other).map(Some),
+        }
+    }
+}

--- a/vantage-sql/src/postgres/types/string.rs
+++ b/vantage-sql/src/postgres/types/string.rs
@@ -1,0 +1,31 @@
+//! String types -> PostgreSQL TEXT
+
+use super::{PostgresType, PostgresTypeTextMarker};
+use serde_json::Value;
+
+impl PostgresType for String {
+    type Target = PostgresTypeTextMarker;
+
+    fn to_json(&self) -> Value {
+        Value::String(self.clone())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::String(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+impl PostgresType for &'static str {
+    type Target = PostgresTypeTextMarker;
+
+    fn to_json(&self) -> Value {
+        Value::String(self.to_string())
+    }
+
+    fn from_json(_value: Value) -> Option<Self> {
+        None // cannot produce &'static str from arbitrary data
+    }
+}

--- a/vantage-sql/src/postgres/types/value.rs
+++ b/vantage-sql/src/postgres/types/value.rs
@@ -1,0 +1,175 @@
+//! AnyPostgresType extras: From conversions, Display, Expressive.
+
+use super::{AnyPostgresType, PostgresType, PostgresTypeNullMarker};
+use serde_json::Value;
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+impl AnyPostgresType {
+    /// Create an AnyPostgresType with no type marker. Used for values coming
+    /// back from the database where we don't know the original type.
+    /// `try_get` on these values bypasses variant checking.
+    pub fn untyped(value: serde_json::Value) -> Self {
+        Self {
+            value,
+            type_variant: None,
+        }
+    }
+}
+
+/// AnyPostgresType is itself a PostgresType -- passthrough for type-erased values.
+impl PostgresType for AnyPostgresType {
+    type Target = PostgresTypeNullMarker;
+
+    fn to_json(&self) -> Value {
+        self.value().clone()
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        AnyPostgresType::from_json(&value)
+    }
+}
+
+impl std::fmt::Display for AnyPostgresType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.value() {
+            Value::Null => write!(f, "NULL"),
+            Value::Bool(b) => write!(f, "{}", b),
+            Value::Number(n) => write!(f, "{}", n),
+            Value::String(s) => write!(f, "'{}'", s.replace('\'', "''")),
+            other => write!(f, "{}", other),
+        }
+    }
+}
+
+// From impls for common types
+macro_rules! impl_from_for_any_postgres {
+    ($($ty:ty),*) => {
+        $(
+            impl From<$ty> for AnyPostgresType {
+                fn from(val: $ty) -> Self {
+                    AnyPostgresType::new(val)
+                }
+            }
+        )*
+    };
+}
+
+impl_from_for_any_postgres!(i8, i16, i32, i64, u8, u16, u32, f32, f64, bool, String);
+
+impl From<&str> for AnyPostgresType {
+    fn from(val: &str) -> Self {
+        AnyPostgresType::new(val.to_string())
+    }
+}
+
+// Expressive impls -- allows passing scalars directly into postgres_expr!
+macro_rules! impl_expressive_for_postgres_scalar {
+    ($($ty:ty),*) => {
+        $(
+            impl Expressive<AnyPostgresType> for $ty {
+                fn expr(&self) -> Expression<AnyPostgresType> {
+                    Expression::new(
+                        "{}",
+                        vec![ExpressiveEnum::Scalar(AnyPostgresType::new_ref(self))],
+                    )
+                }
+            }
+        )*
+    };
+}
+
+impl_expressive_for_postgres_scalar!(i8, i16, i32, i64, u8, u16, u32, f32, f64, bool, String);
+
+impl Expressive<AnyPostgresType> for &str {
+    fn expr(&self) -> Expression<AnyPostgresType> {
+        Expression::new(
+            "{}",
+            vec![ExpressiveEnum::Scalar(AnyPostgresType::from(
+                self.to_string(),
+            ))],
+        )
+    }
+}
+
+// TryFrom<AnyPostgresType> impls -- enables AssociatedExpression::get()
+macro_rules! impl_try_from_postgres {
+    ($($ty:ty),*) => {
+        $(
+            impl TryFrom<AnyPostgresType> for $ty {
+                type Error = vantage_core::VantageError;
+                fn try_from(val: AnyPostgresType) -> Result<Self, Self::Error> {
+                    // Try direct extraction first
+                    if let Some(v) = val.try_get::<$ty>() {
+                        return Ok(v);
+                    }
+                    // If result is [{col: value}], extract the scalar
+                    if let serde_json::Value::Array(arr) = val.value() {
+                        if arr.len() == 1 {
+                            if let Some(obj) = arr[0].as_object() {
+                                if obj.len() == 1 {
+                                    let inner = AnyPostgresType::untyped(
+                                        obj.values().next().unwrap().clone()
+                                    );
+                                    if let Some(v) = inner.try_get::<$ty>() {
+                                        return Ok(v);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(vantage_core::error!(
+                        "Cannot convert AnyPostgresType to target type",
+                        target = std::any::type_name::<$ty>(),
+                        value = format!("{}", val)
+                    ))
+                }
+            }
+        )*
+    };
+}
+
+impl_try_from_postgres!(i64, i32, f64, bool, String);
+
+/// Extract first row from a result array as a JSON object.
+fn extract_first_row(val: &AnyPostgresType) -> Option<serde_json::Value> {
+    match val.value() {
+        serde_json::Value::Array(arr) => arr.first().cloned(),
+        obj @ serde_json::Value::Object(_) => Some(obj.clone()),
+        _ => None,
+    }
+}
+
+impl TryFrom<AnyPostgresType> for vantage_types::Record<serde_json::Value> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnyPostgresType) -> Result<Self, Self::Error> {
+        let row = extract_first_row(&val).ok_or_else(|| {
+            vantage_core::error!("Expected row result", value = format!("{}", val))
+        })?;
+        Ok(row.into())
+    }
+}
+
+impl TryFrom<AnyPostgresType> for vantage_types::Record<AnyPostgresType> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnyPostgresType) -> Result<Self, Self::Error> {
+        let row = extract_first_row(&val).ok_or_else(|| {
+            vantage_core::error!("Expected row result", value = format!("{}", val))
+        })?;
+        match row {
+            serde_json::Value::Object(map) => Ok(map
+                .into_iter()
+                .map(|(k, v)| (k, AnyPostgresType::untyped(v)))
+                .collect()),
+            _ => Err(vantage_core::error!(
+                "Expected object row",
+                value = format!("{:?}", row)
+            )),
+        }
+    }
+}
+
+impl Expressive<AnyPostgresType> for AnyPostgresType {
+    fn expr(&self) -> Expression<AnyPostgresType> {
+        Expression::new("{}", vec![ExpressiveEnum::Scalar(self.clone())])
+    }
+}

--- a/vantage-sql/tests/postgres.rs
+++ b/vantage-sql/tests/postgres.rs
@@ -1,31 +1,31 @@
 #[cfg(feature = "postgres")]
 mod postgres {
-    #[path = "1_types_round_trip.rs"]
-    mod types_round_trip;
-    #[path = "1_types_record.rs"]
-    mod types_record;
+    #[path = "4_aggregates.rs"]
+    mod aggregates;
+    #[path = "2_associated.rs"]
+    mod associated;
+    #[path = "4_conditions.rs"]
+    mod conditions;
+    #[path = "2_defer.rs"]
+    mod defer;
+    #[path = "4_editable_data_set.rs"]
+    mod editable_data_set;
     #[path = "2_expressions.rs"]
     mod expressions;
     #[path = "2_insert.rs"]
     mod insert;
+    #[path = "4_readable_data_set.rs"]
+    mod readable_data_set;
     #[path = "2_records.rs"]
     mod records;
-    #[path = "2_defer.rs"]
-    mod defer;
-    #[path = "2_associated.rs"]
-    mod associated;
+    #[path = "5_references.rs"]
+    mod references;
     #[path = "3_select.rs"]
     mod select;
     #[path = "4_table_def.rs"]
     mod table_def;
-    #[path = "4_readable_data_set.rs"]
-    mod readable_data_set;
-    #[path = "4_conditions.rs"]
-    mod conditions;
-    #[path = "4_aggregates.rs"]
-    mod aggregates;
-    #[path = "4_editable_data_set.rs"]
-    mod editable_data_set;
-    #[path = "5_references.rs"]
-    mod references;
+    #[path = "1_types_record.rs"]
+    mod types_record;
+    #[path = "1_types_round_trip.rs"]
+    mod types_round_trip;
 }

--- a/vantage-sql/tests/postgres.rs
+++ b/vantage-sql/tests/postgres.rs
@@ -1,0 +1,31 @@
+#[cfg(feature = "postgres")]
+mod postgres {
+    #[path = "1_types_round_trip.rs"]
+    mod types_round_trip;
+    #[path = "1_types_record.rs"]
+    mod types_record;
+    #[path = "2_expressions.rs"]
+    mod expressions;
+    #[path = "2_insert.rs"]
+    mod insert;
+    #[path = "2_records.rs"]
+    mod records;
+    #[path = "2_defer.rs"]
+    mod defer;
+    #[path = "2_associated.rs"]
+    mod associated;
+    #[path = "3_select.rs"]
+    mod select;
+    #[path = "4_table_def.rs"]
+    mod table_def;
+    #[path = "4_readable_data_set.rs"]
+    mod readable_data_set;
+    #[path = "4_conditions.rs"]
+    mod conditions;
+    #[path = "4_aggregates.rs"]
+    mod aggregates;
+    #[path = "4_editable_data_set.rs"]
+    mod editable_data_set;
+    #[path = "5_references.rs"]
+    mod references;
+}

--- a/vantage-sql/tests/postgres/1_types_record.rs
+++ b/vantage-sql/tests/postgres/1_types_record.rs
@@ -1,0 +1,147 @@
+//! Test 1b: Record<AnyPostgresType> conversions — typed (write path) and
+//! untyped (read path) round-trips, error cases.
+
+use vantage_sql::postgres::AnyPostgresType;
+use vantage_types::Record;
+
+// ── Typed records (write path) ─────────────────────────────────────────────
+// Values created with AnyPostgresType::new() carry variant tags.
+
+#[test]
+fn test_typed_record_creation() {
+    let mut record: Record<AnyPostgresType> = Record::new();
+    record.insert("name".into(), AnyPostgresType::new("Cupcake".to_string()));
+    record.insert("price".into(), AnyPostgresType::new(120i64));
+    record.insert("is_deleted".into(), AnyPostgresType::new(false));
+
+    // Values carry their type markers
+    assert_eq!(
+        record["name"].try_get::<String>(),
+        Some("Cupcake".to_string())
+    );
+    assert_eq!(record["price"].try_get::<i64>(), Some(120));
+    assert_eq!(record["is_deleted"].try_get::<bool>(), Some(false));
+
+    // Type markers enforce boundaries — wrong type → None
+    assert_eq!(record["name"].try_get::<i64>(), None);
+    assert_eq!(record["price"].try_get::<String>(), None);
+}
+
+#[test]
+fn test_typed_record_with_option() {
+    let mut record: Record<AnyPostgresType> = Record::new();
+    record.insert(
+        "nickname".into(),
+        AnyPostgresType::new(Some("Ali".to_string())),
+    );
+    record.insert("note".into(), AnyPostgresType::new(None::<String>));
+
+    assert_eq!(
+        record["nickname"].try_get::<Option<String>>(),
+        Some(Some("Ali".to_string()))
+    );
+    assert_eq!(record["note"].try_get::<Option<String>>(), Some(None));
+}
+
+// ── Untyped records (read path) ────────────────────────────────────────────
+// Values created with AnyPostgresType::untyped() have type_variant: None.
+// try_get is permissive — it attempts conversion without variant check.
+
+#[test]
+fn test_untyped_record_creation() {
+    let mut record: Record<AnyPostgresType> = Record::new();
+    record.insert(
+        "name".into(),
+        AnyPostgresType::untyped(serde_json::json!("Cupcake")),
+    );
+    record.insert(
+        "price".into(),
+        AnyPostgresType::untyped(serde_json::json!(120)),
+    );
+    record.insert(
+        "active".into(),
+        AnyPostgresType::untyped(serde_json::json!(true)),
+    );
+
+    // Untyped values — try_get just attempts the conversion
+    assert_eq!(
+        record["name"].try_get::<String>(),
+        Some("Cupcake".to_string())
+    );
+    assert_eq!(record["price"].try_get::<i64>(), Some(120));
+    assert_eq!(record["active"].try_get::<bool>(), Some(true));
+
+    // Still fails when the underlying value can't convert
+    assert_eq!(record["name"].try_get::<i64>(), None); // "Cupcake" isn't a number
+    assert_eq!(record["price"].try_get::<String>(), None); // 120 isn't a string
+}
+
+#[test]
+fn test_untyped_null() {
+    let mut record: Record<AnyPostgresType> = Record::new();
+    record.insert(
+        "note".into(),
+        AnyPostgresType::untyped(serde_json::json!(null)),
+    );
+
+    // Untyped null → Option<String> works (no variant blocking it)
+    assert_eq!(record["note"].try_get::<Option<String>>(), Some(None));
+    assert_eq!(record["note"].try_get::<Option<i64>>(), Some(None));
+}
+
+// ── Typed vs untyped comparison ────────────────────────────────────────────
+
+#[test]
+fn test_typed_blocks_cross_variant() {
+    // Typed: integer value with Int8 variant
+    let typed = AnyPostgresType::new(42i64);
+    assert_eq!(typed.try_get::<i64>(), Some(42));
+    assert_eq!(typed.try_get::<f64>(), None); // Int8 ≠ Float8 → blocked
+
+    // Untyped: same JSON value but no variant
+    let untyped = AnyPostgresType::untyped(serde_json::json!(42));
+    assert_eq!(untyped.try_get::<i64>(), Some(42));
+}
+
+#[test]
+fn test_untyped_is_permissive_across_numeric() {
+    // Untyped integer: try_get as f64 works because json Number can be read as f64
+    let untyped = AnyPostgresType::untyped(serde_json::json!(42));
+    assert_eq!(untyped.try_get::<i64>(), Some(42));
+    assert_eq!(untyped.try_get::<f64>(), Some(42.0));
+
+    // Typed integer: f64 blocked by variant
+    let typed = AnyPostgresType::new(42i64);
+    assert_eq!(typed.try_get::<f64>(), None); // Int8 ≠ Float8
+}
+
+// ── PostgreSQL-specific: bool stored natively ──────────────────────────────
+
+#[test]
+fn test_typed_bool_in_record() {
+    let mut record: Record<AnyPostgresType> = Record::new();
+    record.insert("active".into(), AnyPostgresType::new(true));
+
+    // PostgreSQL stores bool as native JSON bool, not as 0/1
+    assert_eq!(*record["active"].value(), serde_json::json!(true));
+    assert_eq!(record["active"].try_get::<bool>(), Some(true));
+    // Bool ≠ Int8 → blocked
+    assert_eq!(record["active"].try_get::<i64>(), None);
+}
+
+// ── Error cases ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_missing_field_in_record() {
+    let record: Record<AnyPostgresType> = Record::new();
+    assert!(record.get("name").is_none());
+}
+
+#[test]
+fn test_typed_wrong_extraction() {
+    let mut record: Record<AnyPostgresType> = Record::new();
+    record.insert("name".into(), AnyPostgresType::new(42i64));
+
+    // Trying to get String from an Int8-tagged value fails
+    assert_eq!(record["name"].try_get::<String>(), None);
+}

--- a/vantage-sql/tests/postgres/1_types_round_trip.rs
+++ b/vantage-sql/tests/postgres/1_types_round_trip.rs
@@ -1,0 +1,154 @@
+//! Test 1a: PostgresType system — AnyPostgresType in-memory round-trips.
+//! Pure type system tests, no database, no Records.
+
+use vantage_sql::postgres::AnyPostgresType;
+use vantage_sql::postgres::types::PostgresTypeVariants;
+
+// ── Round-trips per type ───────────────────────────────────────────────────
+
+#[test]
+fn test_integer_round_trip() {
+    let val = AnyPostgresType::new(42i64);
+    assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Int8));
+    assert_eq!(val.try_get::<i64>(), Some(42));
+}
+
+#[test]
+fn test_i32_round_trip() {
+    let val = AnyPostgresType::new(42i32);
+    assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Int4));
+    assert_eq!(val.try_get::<i32>(), Some(42));
+}
+
+#[test]
+fn test_i16_round_trip() {
+    let val = AnyPostgresType::new(42i16);
+    assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Int2));
+    assert_eq!(val.try_get::<i16>(), Some(42));
+}
+
+#[test]
+fn test_text_round_trip() {
+    let val = AnyPostgresType::new("hello".to_string());
+    assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Text));
+    assert_eq!(val.try_get::<String>(), Some("hello".to_string()));
+}
+
+#[test]
+fn test_float8_round_trip() {
+    let val = AnyPostgresType::new(3.15f64);
+    assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Float8));
+    assert_eq!(val.try_get::<f64>(), Some(3.15));
+}
+
+#[test]
+fn test_float4_round_trip() {
+    let val = AnyPostgresType::new(3.15f32);
+    assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Float4));
+    // f32 round-trip goes through f64, so approximate check
+    let result = val.try_get::<f32>().unwrap();
+    assert!((result - 3.15f32).abs() < 0.001);
+}
+
+#[test]
+fn test_bool_round_trip() {
+    let val = AnyPostgresType::new(true);
+    assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Bool));
+    assert_eq!(val.try_get::<bool>(), Some(true));
+    // Bool is distinct from Int8 — type boundary enforced
+    assert_eq!(val.try_get::<i64>(), None);
+}
+
+#[test]
+fn test_null_round_trip() {
+    let val = AnyPostgresType::new(None::<i64>);
+    assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Int8));
+    assert_eq!(val.try_get::<Option<i64>>(), Some(None));
+}
+
+#[test]
+fn test_smaller_integers() {
+    let val = AnyPostgresType::new(127i8);
+    assert_eq!(val.try_get::<i8>(), Some(127));
+    // i8 maps to Int2 in postgres, but underlying JSON is the same number
+    assert_eq!(val.try_get::<i16>(), Some(127));
+
+    let val = AnyPostgresType::new(1000i16);
+    assert_eq!(val.try_get::<i16>(), Some(1000));
+
+    let val = AnyPostgresType::new(200u8);
+    assert_eq!(val.try_get::<u8>(), Some(200));
+}
+
+// ── Type mismatch: wrong variant → None ────────────────────────────────────
+
+#[test]
+fn test_mismatch_text_as_integer() {
+    let val = AnyPostgresType::new("hello".to_string());
+    assert_eq!(val.try_get::<i64>(), None);
+}
+
+#[test]
+fn test_mismatch_integer_as_text() {
+    let val = AnyPostgresType::new(42i64);
+    assert_eq!(val.try_get::<String>(), None);
+}
+
+#[test]
+fn test_mismatch_real_as_integer() {
+    let val = AnyPostgresType::new(3.15f64);
+    assert_eq!(val.try_get::<i64>(), None);
+}
+
+#[test]
+fn test_mismatch_integer_as_real() {
+    let val = AnyPostgresType::new(42i64);
+    assert_eq!(val.try_get::<f64>(), None);
+}
+
+// ── From conversions ───────────────────────────────────────────────────────
+
+#[test]
+fn test_from_str() {
+    let val: AnyPostgresType = "world".into();
+    assert_eq!(val.try_get::<String>(), Some("world".to_string()));
+}
+
+#[test]
+fn test_from_i64() {
+    let val: AnyPostgresType = 99i64.into();
+    assert_eq!(val.try_get::<i64>(), Some(99));
+}
+
+#[test]
+fn test_from_bool() {
+    let val: AnyPostgresType = false.into();
+    assert_eq!(val.try_get::<bool>(), Some(false));
+}
+
+// ── PostgreSQL-specific: distinct integer widths ───────────────────────────
+
+#[test]
+fn test_i32_vs_i64_variant_boundary() {
+    // i32 maps to Int4, i64 maps to Int8 — they are different variants
+    let val32 = AnyPostgresType::new(42i32);
+    let val64 = AnyPostgresType::new(42i64);
+    assert_eq!(val32.type_variant(), Some(PostgresTypeVariants::Int4));
+    assert_eq!(val64.type_variant(), Some(PostgresTypeVariants::Int8));
+
+    // Cross-variant extraction is blocked by type markers
+    assert_eq!(val32.try_get::<i64>(), None); // Int4 ≠ Int8
+    assert_eq!(val64.try_get::<i32>(), None); // Int8 ≠ Int4
+}
+
+#[test]
+fn test_f32_vs_f64_variant_boundary() {
+    let val32 = AnyPostgresType::new(1.5f32);
+    let val64 = AnyPostgresType::new(1.5f64);
+    assert_eq!(val32.type_variant(), Some(PostgresTypeVariants::Float4));
+    assert_eq!(val64.type_variant(), Some(PostgresTypeVariants::Float8));
+
+    // Cross-variant extraction blocked
+    assert_eq!(val32.try_get::<f64>(), None); // Float4 ≠ Float8
+    assert_eq!(val64.try_get::<f32>(), None); // Float8 ≠ Float4
+}

--- a/vantage-sql/tests/postgres/2_associated.rs
+++ b/vantage-sql/tests/postgres/2_associated.rs
@@ -53,8 +53,7 @@ struct Product {
 async fn test_associated_scalar() {
     let db = setup("assoc_scalar").await;
 
-    let associated =
-        db.associate::<i64>(postgres_expr!("SELECT COUNT(*) FROM \"assoc_scalar\""));
+    let associated = db.associate::<i64>(postgres_expr!("SELECT COUNT(*) FROM \"assoc_scalar\""));
     assert_eq!(associated.get().await.unwrap(), 3);
 }
 

--- a/vantage-sql/tests/postgres/2_associated.rs
+++ b/vantage-sql/tests/postgres/2_associated.rs
@@ -1,0 +1,116 @@
+//! Test 2d: AssociatedExpression — expressions with a known return type.
+//!
+//! Call .get() to execute and get a typed result.
+
+use vantage_expressions::ExprDataSource;
+#[allow(unused_imports)]
+use vantage_sql::postgres::PostgresType;
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+use vantage_sql::postgres_expr;
+use vantage_types::{Record, TryFromRecord, entity};
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+async fn setup(table: &str) -> PostgresDB {
+    let db = PostgresDB::connect(PG_URL).await.unwrap();
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE \"{}\" (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL
+        )",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "INSERT INTO \"{}\" VALUES ('a', 'Cheap', 50), ('b', 'Mid', 150), ('c', 'Expensive', 300)",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    db
+}
+
+#[entity(PostgresType)]
+struct Product {
+    id: String,
+    name: String,
+    price: i64,
+}
+
+#[tokio::test]
+async fn test_associated_scalar() {
+    let db = setup("assoc_scalar").await;
+
+    let associated =
+        db.associate::<i64>(postgres_expr!("SELECT COUNT(*) FROM \"assoc_scalar\""));
+    assert_eq!(associated.get().await.unwrap(), 3);
+}
+
+#[tokio::test]
+async fn test_associated_record() {
+    let db = setup("assoc_record").await;
+
+    let associated = db.associate::<Record<AnyPostgresType>>(postgres_expr!(
+        "SELECT name, price FROM \"assoc_record\" WHERE id = {}",
+        "a"
+    ));
+    let record = associated.get().await.unwrap();
+    assert_eq!(
+        record["name"].try_get::<String>(),
+        Some("Cheap".to_string())
+    );
+    assert_eq!(record["price"].try_get::<i64>(), Some(50));
+}
+
+#[tokio::test]
+async fn test_associated_entity() {
+    let db = setup("assoc_entity").await;
+
+    let associated = db.associate::<Record<AnyPostgresType>>(postgres_expr!(
+        "SELECT id, name, price FROM \"assoc_entity\" WHERE id = {}",
+        "c"
+    ));
+    let record = associated.get().await.unwrap();
+    let product = Product::from_record(record).unwrap();
+    assert_eq!(product.id, "c");
+    assert_eq!(product.name, "Expensive");
+    assert_eq!(product.price, 300);
+}
+
+// serde path: Record<JsonValue> + #[derive(Deserialize)]
+#[tokio::test]
+async fn test_associated_entity_serde() {
+    let db = setup("assoc_serde").await;
+
+    #[derive(serde::Deserialize)]
+    struct ProductSerde {
+        id: String,
+        name: String,
+        price: i64,
+    }
+
+    let record: Record<serde_json::Value> = db
+        .associate(postgres_expr!(
+            "SELECT id, name, price FROM \"assoc_serde\" WHERE id = {}",
+            "b"
+        ))
+        .get()
+        .await
+        .unwrap();
+    let product: ProductSerde = ProductSerde::from_record(record).unwrap();
+    assert_eq!(product.id, "b");
+    assert_eq!(product.name, "Mid");
+    assert_eq!(product.price, 150);
+}

--- a/vantage-sql/tests/postgres/2_defer.rs
+++ b/vantage-sql/tests/postgres/2_defer.rs
@@ -1,0 +1,147 @@
+//! Test 2b: Deferred expressions — cross-database value resolution.
+//!
+//! A deferred expression runs a query on one database at execution time,
+//! and the resulting value gets placed as a parameter in another database's query.
+
+use serde_json::Value as JsonValue;
+use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+use vantage_sql::postgres_expr;
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+fn rows(result: AnyPostgresType) -> Vec<JsonValue> {
+    match result.into_value() {
+        JsonValue::Array(arr) => arr,
+        other => panic!("expected array, got: {:?}", other),
+    }
+}
+
+async fn setup(prefix: &str) -> (PostgresDB, PostgresDB) {
+    // Both use the same postgres instance but different tables
+    let db = PostgresDB::connect(PG_URL).await.unwrap();
+
+    let config_table = format!("{}_config", prefix);
+    let product_table = format!("{}_product", prefix);
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", config_table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", product_table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE \"{}\" (key TEXT PRIMARY KEY, value BIGINT NOT NULL)",
+        config_table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+    sqlx::query(&format!(
+        "INSERT INTO \"{}\" VALUES ('min_price', 150)",
+        config_table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE \"{}\" (id TEXT PRIMARY KEY, name TEXT NOT NULL, price BIGINT NOT NULL)",
+        product_table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+    sqlx::query(&format!(
+        "INSERT INTO \"{}\" VALUES ('a', 'Cheap Thing', 50), ('b', 'Mid Thing', 150), ('c', 'Expensive Thing', 300)",
+        product_table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    // Return same pool as two "databases" (using different tables)
+    (db.clone(), db)
+}
+
+// ── defer() resolves a value from one query, binds it into another ────────
+
+#[tokio::test]
+async fn test_cross_database_deferred() {
+    let (config_db, shop_db) = setup("defer1").await;
+
+    let threshold_query = postgres_expr!(
+        "SELECT value FROM \"defer1_config\" WHERE key = {}",
+        "min_price"
+    );
+    let deferred_threshold = config_db.defer(threshold_query);
+
+    let shop_query = Expression::<AnyPostgresType>::new(
+        "SELECT name FROM \"defer1_product\" WHERE price >= {} ORDER BY price",
+        vec![ExpressiveEnum::Deferred(deferred_threshold)],
+    );
+
+    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0]["name"], "Mid Thing");
+    assert_eq!(result[1]["name"], "Expensive Thing");
+}
+
+// ── Deferred mixed with regular scalar parameters ──────────────────────────
+
+#[tokio::test]
+async fn test_deferred_mixed_with_scalars() {
+    let (config_db, shop_db) = setup("defer2").await;
+
+    let threshold_query = postgres_expr!(
+        "SELECT value FROM \"defer2_config\" WHERE key = {}",
+        "min_price"
+    );
+    let deferred_threshold = config_db.defer(threshold_query);
+
+    let shop_query = Expression::<AnyPostgresType>::new(
+        "SELECT name FROM \"defer2_product\" WHERE price >= {} AND name != {} ORDER BY price",
+        vec![
+            ExpressiveEnum::Deferred(deferred_threshold),
+            ExpressiveEnum::Scalar(AnyPostgresType::new("Mid Thing".to_string())),
+        ],
+    );
+
+    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0]["name"], "Expensive Thing");
+}
+
+// ── Deferred inside a nested expression ───────────────────────────────────
+
+#[tokio::test]
+async fn test_nested_deferred() {
+    let (config_db, shop_db) = setup("defer3").await;
+
+    let threshold_query = postgres_expr!(
+        "SELECT value FROM \"defer3_config\" WHERE key = {}",
+        "min_price"
+    );
+    let deferred_threshold = config_db.defer(threshold_query);
+
+    let inner = Expression::<AnyPostgresType>::new(
+        "price >= {}",
+        vec![ExpressiveEnum::Deferred(deferred_threshold)],
+    );
+
+    let shop_query = postgres_expr!(
+        "SELECT name FROM \"defer3_product\" WHERE {} ORDER BY price",
+        (inner)
+    );
+
+    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0]["name"], "Mid Thing");
+    assert_eq!(result[1]["name"], "Expensive Thing");
+}

--- a/vantage-sql/tests/postgres/2_expressions.rs
+++ b/vantage-sql/tests/postgres/2_expressions.rs
@@ -1,0 +1,161 @@
+//! Test 2: ExprDataSource — execute Expression<AnyPostgresType> against live PostgreSQL.
+
+use serde_json::Value as JsonValue;
+use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+async fn setup(table: &str) -> PostgresDB {
+    let db = PostgresDB::connect(PG_URL).await.unwrap();
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE \"{}\" (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL,
+            weight DOUBLE PRECISION NOT NULL,
+            active BOOLEAN NOT NULL
+        )",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "INSERT INTO \"{}\" VALUES (1, 'Apple', 100, 0.2, true), (2, 'Banana', 50, 0.15, true), (3, 'Cherry', 200, 0.01, false)",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    db
+}
+
+/// Helper: unwrap result into JSON array of row objects.
+fn rows(result: AnyPostgresType) -> Vec<JsonValue> {
+    match result.into_value() {
+        JsonValue::Array(arr) => arr,
+        other => panic!("expected array, got: {:?}", other),
+    }
+}
+
+// ── Basic select via ExprDataSource ────────────────────────────────────────
+
+#[tokio::test]
+async fn test_select_all() {
+    let db = setup("expr_select_all").await;
+    let expr = Expression::<AnyPostgresType>::new(
+        "SELECT * FROM \"expr_select_all\" ORDER BY id",
+        vec![],
+    );
+    let result = rows(db.execute(&expr).await.unwrap());
+
+    assert_eq!(result.len(), 3);
+    assert_eq!(result[0]["name"], "Apple");
+    assert_eq!(result[2]["name"], "Cherry");
+}
+
+// ── Parameterized query ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_parameterized_integer() {
+    let db = setup("expr_param_int").await;
+    let expr = Expression::<AnyPostgresType>::new(
+        "SELECT name FROM \"expr_param_int\" WHERE id = {}",
+        vec![ExpressiveEnum::Scalar(AnyPostgresType::new(2i64))],
+    );
+    let result = rows(db.execute(&expr).await.unwrap());
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0]["name"], "Banana");
+}
+
+#[tokio::test]
+async fn test_parameterized_text() {
+    let db = setup("expr_param_text").await;
+    let expr = Expression::<AnyPostgresType>::new(
+        "SELECT price FROM \"expr_param_text\" WHERE name = {}",
+        vec![ExpressiveEnum::Scalar(AnyPostgresType::new(
+            "Cherry".to_string(),
+        ))],
+    );
+    let result = rows(db.execute(&expr).await.unwrap());
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0]["price"], 200);
+}
+
+#[tokio::test]
+async fn test_parameterized_bool() {
+    let db = setup("expr_param_bool").await;
+    let expr = Expression::<AnyPostgresType>::new(
+        "SELECT name FROM \"expr_param_bool\" WHERE active = {} ORDER BY name",
+        vec![ExpressiveEnum::Scalar(AnyPostgresType::new(true))],
+    );
+    let result = rows(db.execute(&expr).await.unwrap());
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0]["name"], "Apple");
+    assert_eq!(result[1]["name"], "Banana");
+}
+
+// ── Multiple parameters ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_multiple_params() {
+    let db = setup("expr_multi_params").await;
+    let expr = Expression::<AnyPostgresType>::new(
+        "SELECT name FROM \"expr_multi_params\" WHERE price >= {} AND active = {}",
+        vec![
+            ExpressiveEnum::Scalar(AnyPostgresType::new(100i64)),
+            ExpressiveEnum::Scalar(AnyPostgresType::new(true)),
+        ],
+    );
+    let result = rows(db.execute(&expr).await.unwrap());
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0]["name"], "Apple");
+}
+
+// ── Nested expressions ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_nested_expression() {
+    let db = setup("expr_nested").await;
+
+    let where_clause = Expression::<AnyPostgresType>::new(
+        "price > {}",
+        vec![ExpressiveEnum::Scalar(AnyPostgresType::new(75i64))],
+    );
+    let full_query = Expression::<AnyPostgresType>::new(
+        "SELECT name FROM \"expr_nested\" WHERE {} ORDER BY name",
+        vec![ExpressiveEnum::Nested(where_clause)],
+    );
+
+    let result = rows(db.execute(&full_query).await.unwrap());
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0]["name"], "Apple");
+    assert_eq!(result[1]["name"], "Cherry");
+}
+
+// ── Empty result ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_empty_result() {
+    let db = setup("expr_empty").await;
+    let expr = Expression::<AnyPostgresType>::new(
+        "SELECT name FROM \"expr_empty\" WHERE id = {}",
+        vec![ExpressiveEnum::Scalar(AnyPostgresType::new(999i64))],
+    );
+    let result = rows(db.execute(&expr).await.unwrap());
+
+    assert!(result.is_empty());
+}

--- a/vantage-sql/tests/postgres/2_expressions.rs
+++ b/vantage-sql/tests/postgres/2_expressions.rs
@@ -52,10 +52,8 @@ fn rows(result: AnyPostgresType) -> Vec<JsonValue> {
 #[tokio::test]
 async fn test_select_all() {
     let db = setup("expr_select_all").await;
-    let expr = Expression::<AnyPostgresType>::new(
-        "SELECT * FROM \"expr_select_all\" ORDER BY id",
-        vec![],
-    );
+    let expr =
+        Expression::<AnyPostgresType>::new("SELECT * FROM \"expr_select_all\" ORDER BY id", vec![]);
     let result = rows(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 3);

--- a/vantage-sql/tests/postgres/2_insert.rs
+++ b/vantage-sql/tests/postgres/2_insert.rs
@@ -175,10 +175,7 @@ async fn test_bool_binds_correctly() {
     db.execute(&insert).await.unwrap();
 
     // Query with bool parameter — PostgreSQL has native BOOLEAN
-    let select = postgres_expr!(
-        "SELECT name FROM \"ins_bool\" WHERE is_deleted = {}",
-        true
-    );
+    let select = postgres_expr!("SELECT name FROM \"ins_bool\" WHERE is_deleted = {}", true);
     let result = rows(db.execute(&select).await.unwrap());
 
     assert_eq!(result.len(), 1);
@@ -200,17 +197,11 @@ async fn test_integer_vs_text_binding() {
     );
     db.execute(&insert).await.unwrap();
 
-    let by_price = postgres_expr!(
-        "SELECT id FROM \"ins_int_text\" WHERE price = {}",
-        100i64
-    );
+    let by_price = postgres_expr!("SELECT id FROM \"ins_int_text\" WHERE price = {}", 100i64);
     let result = rows(db.execute(&by_price).await.unwrap());
     assert_eq!(result.len(), 1);
 
-    let by_name = postgres_expr!(
-        "SELECT id FROM \"ins_int_text\" WHERE name = {}",
-        "Test"
-    );
+    let by_name = postgres_expr!("SELECT id FROM \"ins_int_text\" WHERE name = {}", "Test");
     let result = rows(db.execute(&by_name).await.unwrap());
     assert_eq!(result.len(), 1);
 }

--- a/vantage-sql/tests/postgres/2_insert.rs
+++ b/vantage-sql/tests/postgres/2_insert.rs
@@ -1,0 +1,216 @@
+//! Test 2a: INSERT via Expression<AnyPostgresType> + ExprDataSource.
+//!
+//! No statement builders — raw expressions with typed parameters.
+//! Focuses on the Product table to exercise multiple types (text, integer, bool).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+#[allow(unused_imports)]
+use vantage_expressions::Expressive;
+use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+use vantage_sql::postgres_expr;
+use vantage_types::{Record, TryFromRecord};
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+struct Product {
+    name: String,
+    price: i64,
+    calories: i64,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+async fn setup(table: &str) -> PostgresDB {
+    let db = PostgresDB::connect(PG_URL).await.unwrap();
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE \"{}\" (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL,
+            calories BIGINT NOT NULL,
+            is_deleted BOOLEAN NOT NULL DEFAULT false,
+            inventory_stock BIGINT NOT NULL DEFAULT 0
+        )",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    db
+}
+
+/// Helper: execute expression, unwrap result into JSON rows.
+fn rows(result: AnyPostgresType) -> Vec<JsonValue> {
+    match result.into_value() {
+        JsonValue::Array(arr) => arr,
+        other => panic!("expected array, got: {:?}", other),
+    }
+}
+
+// ── Insert with typed parameters ───────────────────────────────────────────
+
+#[tokio::test]
+async fn test_insert_product() {
+    let db = setup("ins_product").await;
+
+    let insert = postgres_expr!(
+        "INSERT INTO \"ins_product\" (\"id\", \"name\", \"price\", \"calories\", \"is_deleted\", \"inventory_stock\") VALUES ({}, {}, {}, {}, {}, {})",
+        "cupcake",
+        "Flux Cupcake",
+        120i64,
+        300i64,
+        false,
+        50i64
+    );
+
+    db.execute(&insert).await.unwrap();
+
+    let select = postgres_expr!(
+        "SELECT name, price, calories, is_deleted, inventory_stock FROM \"ins_product\" WHERE id = {}",
+        "cupcake"
+    );
+    let result = rows(db.execute(&select).await.unwrap());
+
+    assert_eq!(result.len(), 1);
+
+    let record: Record<JsonValue> = result[0].clone().into();
+    let product: Product = Product::from_record(record).unwrap();
+
+    assert_eq!(product.name, "Flux Cupcake");
+    assert_eq!(product.price, 120);
+    assert_eq!(product.calories, 300);
+    assert!(!product.is_deleted);
+    assert_eq!(product.inventory_stock, 50);
+}
+
+// ── Insert multiple rows via nested expressions ───────────────────────────
+
+#[tokio::test]
+async fn test_insert_multiple_products() {
+    let db = setup("ins_multi").await;
+
+    let row1 = postgres_expr!(
+        "({}, {}, {}, {}, {}, {})",
+        "tart",
+        "Time Tart",
+        220i64,
+        200i64,
+        false,
+        20i64
+    );
+    let row2 = postgres_expr!(
+        "({}, {}, {}, {}, {}, {})",
+        "donut",
+        "DeLorean Doughnut",
+        135i64,
+        250i64,
+        false,
+        30i64
+    );
+    let row3 = postgres_expr!(
+        "({}, {}, {}, {}, {}, {})",
+        "pie",
+        "Sea Pie",
+        299i64,
+        350i64,
+        true,
+        0i64
+    );
+
+    let rows_expr = Expression::from_vec(vec![row1, row2, row3], ", ");
+    let insert = Expression::<AnyPostgresType>::new(
+        "INSERT INTO \"ins_multi\" (\"id\", \"name\", \"price\", \"calories\", \"is_deleted\", \"inventory_stock\") VALUES {}",
+        vec![ExpressiveEnum::Nested(rows_expr)],
+    );
+
+    db.execute(&insert).await.unwrap();
+
+    let select = postgres_expr!(
+        "SELECT name, price, calories, is_deleted, inventory_stock FROM \"ins_multi\" ORDER BY price"
+    );
+    let result = rows(db.execute(&select).await.unwrap());
+
+    assert_eq!(result.len(), 3);
+
+    let parsed: Vec<Product> = result
+        .into_iter()
+        .map(|r| Product::from_record(r.into()).unwrap())
+        .collect();
+
+    assert_eq!(parsed[0].name, "DeLorean Doughnut");
+    assert_eq!(parsed[0].price, 135);
+    assert!(!parsed[0].is_deleted);
+
+    assert_eq!(parsed[2].name, "Sea Pie");
+    assert_eq!(parsed[2].price, 299);
+    assert!(parsed[2].is_deleted);
+    assert_eq!(parsed[2].inventory_stock, 0);
+}
+
+// ── Type marker verification ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_bool_binds_correctly() {
+    let db = setup("ins_bool").await;
+
+    let insert = postgres_expr!(
+        "INSERT INTO \"ins_bool\" (\"id\", \"name\", \"price\", \"calories\", \"is_deleted\", \"inventory_stock\") VALUES ({}, {}, {}, {}, {}, {})",
+        "deleted_item",
+        "Gone",
+        100i64,
+        100i64,
+        true,
+        0i64
+    );
+    db.execute(&insert).await.unwrap();
+
+    // Query with bool parameter — PostgreSQL has native BOOLEAN
+    let select = postgres_expr!(
+        "SELECT name FROM \"ins_bool\" WHERE is_deleted = {}",
+        true
+    );
+    let result = rows(db.execute(&select).await.unwrap());
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0]["name"], "Gone");
+}
+
+#[tokio::test]
+async fn test_integer_vs_text_binding() {
+    let db = setup("ins_int_text").await;
+
+    let insert = postgres_expr!(
+        "INSERT INTO \"ins_int_text\" (\"id\", \"name\", \"price\", \"calories\", \"is_deleted\", \"inventory_stock\") VALUES ({}, {}, {}, {}, {}, {})",
+        "item1",
+        "Test",
+        100i64,
+        100i64,
+        false,
+        10i64
+    );
+    db.execute(&insert).await.unwrap();
+
+    let by_price = postgres_expr!(
+        "SELECT id FROM \"ins_int_text\" WHERE price = {}",
+        100i64
+    );
+    let result = rows(db.execute(&by_price).await.unwrap());
+    assert_eq!(result.len(), 1);
+
+    let by_name = postgres_expr!(
+        "SELECT id FROM \"ins_int_text\" WHERE name = {}",
+        "Test"
+    );
+    let result = rows(db.execute(&by_name).await.unwrap());
+    assert_eq!(result.len(), 1);
+}

--- a/vantage-sql/tests/postgres/2_records.rs
+++ b/vantage-sql/tests/postgres/2_records.rs
@@ -1,0 +1,181 @@
+//! Test 2c: SELECT into Record and deserialize into structs.
+//!
+//! Uses associate::<Record<JsonValue>> and TryFromRecord to verify
+//! the full pipeline. Includes failure cases for field mismatches.
+//!
+//! All tests share pre-populated data via separate tables to avoid race conditions.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use vantage_expressions::ExprDataSource;
+use vantage_sql::postgres::PostgresDB;
+use vantage_sql::postgres_expr;
+use vantage_types::{Record, TryFromRecord};
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+async fn setup(table: &str) -> PostgresDB {
+    let db = PostgresDB::connect(PG_URL).await.unwrap();
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE \"{}\" (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL,
+            calories BIGINT NOT NULL,
+            weight DOUBLE PRECISION,
+            is_deleted BOOLEAN NOT NULL DEFAULT false,
+            description TEXT
+        )",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "INSERT INTO \"{}\" VALUES
+            ('cupcake', 'Flux Cupcake', 120, 300, 0.25, false, 'A tasty cupcake'),
+            ('tart', 'Time Tart', 220, 200, 0.15, true, 'tart'),
+            ('plain', 'Plain Bread', 50, 150, NULL, false, NULL)",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    db
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+struct Product {
+    id: String,
+    name: String,
+    price: i64,
+    calories: i64,
+    weight: Option<f64>,
+    is_deleted: bool,
+    description: Option<String>,
+}
+
+#[tokio::test]
+async fn test_select_single_record_into_entity() {
+    let db = setup("rec_entity").await;
+
+    let record: Record<JsonValue> = db
+        .associate(postgres_expr!(
+            "SELECT * FROM \"rec_entity\" WHERE id = {}",
+            "cupcake"
+        ))
+        .get()
+        .await
+        .unwrap();
+
+    let product: Product = Product::from_record(record).unwrap();
+    assert_eq!(product.name, "Flux Cupcake");
+    assert_eq!(product.price, 120);
+    assert!((product.weight.unwrap() - 0.25).abs() < f64::EPSILON);
+    assert_eq!(product.description, Some("A tasty cupcake".to_string()));
+    assert!(!product.is_deleted);
+}
+
+#[tokio::test]
+async fn test_null_into_optional_field() {
+    let db = setup("rec_optional").await;
+
+    let record: Record<JsonValue> = db
+        .associate(postgres_expr!(
+            "SELECT name, price, weight, description FROM \"rec_optional\" WHERE id = {}",
+            "plain"
+        ))
+        .get()
+        .await
+        .unwrap();
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct ProductOptional {
+        name: String,
+        price: i64,
+        weight: Option<f64>,
+        description: Option<String>,
+    }
+
+    let product: ProductOptional = ProductOptional::from_record(record).unwrap();
+    assert_eq!(product.name, "Plain Bread");
+    assert_eq!(product.weight, None);
+    assert_eq!(product.description, None);
+}
+
+#[tokio::test]
+async fn test_missing_field_fails() {
+    let db = setup("rec_missing").await;
+
+    let record: Record<JsonValue> = db
+        .associate(postgres_expr!(
+            "SELECT * FROM \"rec_missing\" WHERE id = {}",
+            "cupcake"
+        ))
+        .get()
+        .await
+        .unwrap();
+
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    struct ProductWithRating {
+        name: String,
+        rating: f64, // doesn't exist
+    }
+
+    assert!(ProductWithRating::from_record(record).is_err());
+}
+
+#[tokio::test]
+async fn test_null_into_required_field_fails() {
+    let db = setup("rec_null_required").await;
+
+    let record: Record<JsonValue> = db
+        .associate(postgres_expr!(
+            "SELECT name, weight FROM \"rec_null_required\" WHERE id = {}",
+            "plain"
+        ))
+        .get()
+        .await
+        .unwrap();
+
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    struct Strict {
+        name: String,
+        weight: f64, // NOT Option — plain has NULL here
+    }
+
+    assert!(Strict::from_record(record).is_err());
+}
+
+#[tokio::test]
+async fn test_wrong_field_type_fails() {
+    let db = setup("rec_wrong_type").await;
+
+    let record: Record<JsonValue> = db
+        .associate(postgres_expr!(
+            "SELECT name, price FROM \"rec_wrong_type\" WHERE id = {}",
+            "cupcake"
+        ))
+        .get()
+        .await
+        .unwrap();
+
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    struct WrongTypes {
+        name: i64,     // TEXT in DB
+        price: String, // BIGINT in DB
+    }
+
+    assert!(WrongTypes::from_record(record).is_err());
+}

--- a/vantage-sql/tests/postgres/3_select.rs
+++ b/vantage-sql/tests/postgres/3_select.rs
@@ -1,0 +1,215 @@
+//! Test 3a: PostgresSelect via Selectable trait + SelectableDataSource execution.
+
+use vantage_expressions::{ExprDataSource, Expressive, Selectable};
+#[allow(unused_imports)]
+use vantage_sql::postgres::PostgresType;
+use vantage_sql::postgres::statements::PostgresSelect;
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+use vantage_sql::postgres_expr;
+use vantage_types::{Record, TryFromRecord, entity};
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+async fn setup(table: &str) -> PostgresDB {
+    let db = PostgresDB::connect(PG_URL).await.unwrap();
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE \"{}\" (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL,
+            is_deleted BOOLEAN NOT NULL DEFAULT false
+        )",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "INSERT INTO \"{}\" VALUES ('a', 'Cheap', 50, false), ('b', 'Mid', 150, false), ('c', 'Expensive', 300, true)",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    db
+}
+
+#[entity(PostgresType)]
+struct Product {
+    id: String,
+    name: String,
+    price: i64,
+    is_deleted: bool,
+}
+
+// ── Rendering via Selectable trait methods ──────────────────────────────────
+
+#[test]
+fn test_select_all() {
+    let s = PostgresSelect::new().with_source("product");
+    assert_eq!(s.preview(), "SELECT * FROM \"product\"");
+}
+
+#[test]
+fn test_select_fields() {
+    let s = PostgresSelect::new()
+        .with_source("product")
+        .with_field("name")
+        .with_field("price");
+    assert_eq!(s.preview(), "SELECT \"name\", \"price\" FROM \"product\"");
+}
+
+#[test]
+fn test_select_with_condition() {
+    let s = PostgresSelect::new()
+        .with_source("product")
+        .with_condition(postgres_expr!("\"price\" > {}", 100i64));
+    assert_eq!(
+        s.preview(),
+        "SELECT * FROM \"product\" WHERE \"price\" > 100"
+    );
+}
+
+#[test]
+fn test_select_order_and_limit() {
+    let s = PostgresSelect::new()
+        .with_source("product")
+        .with_order(postgres_expr!("\"price\""), false)
+        .with_limit(Some(2), None);
+    assert_eq!(
+        s.preview(),
+        "SELECT * FROM \"product\" ORDER BY \"price\" DESC LIMIT 2"
+    );
+}
+
+#[test]
+fn test_select_distinct() {
+    let mut s = PostgresSelect::new()
+        .with_source("product")
+        .with_field("name");
+    s.set_distinct(true);
+    assert_eq!(s.preview(), "SELECT DISTINCT \"name\" FROM \"product\"");
+}
+
+#[test]
+fn test_select_group_by_with_expression() {
+    let s = PostgresSelect::new()
+        .with_source("product")
+        .with_field("is_deleted")
+        .with_expression(postgres_expr!("COUNT(*)"), Some("cnt".to_string()));
+    let mut s = s;
+    s.add_group_by(postgres_expr!("\"is_deleted\""));
+    assert_eq!(
+        s.preview(),
+        "SELECT \"is_deleted\", COUNT(*) AS \"cnt\" FROM \"product\" GROUP BY \"is_deleted\""
+    );
+}
+
+#[test]
+fn test_as_count() {
+    let s = PostgresSelect::new()
+        .with_source("product")
+        .with_condition(postgres_expr!("\"is_deleted\" = {}", false));
+    let count_expr = s.as_count();
+    assert_eq!(
+        count_expr.preview(),
+        "SELECT COUNT(*) FROM \"product\" WHERE \"is_deleted\" = false"
+    );
+}
+
+#[test]
+fn test_as_sum() {
+    let s = PostgresSelect::new().with_source("product");
+    let sum_expr = s.as_sum(postgres_expr!("\"price\""));
+    assert_eq!(
+        sum_expr.preview(),
+        "SELECT CAST(SUM(\"price\") AS BIGINT) FROM \"product\""
+    );
+}
+
+// ── Live execution via ExprDataSource ──────────────────────────────────────
+
+#[tokio::test]
+async fn test_execute_select_all() {
+    let db = setup("sel_all").await;
+
+    let select = PostgresSelect::new().with_source("sel_all");
+    let result: Record<AnyPostgresType> = db.associate(select.expr()).get().await.unwrap();
+
+    assert!(result.get("id").is_some());
+}
+
+#[tokio::test]
+async fn test_execute_select_with_condition() {
+    let db = setup("sel_cond").await;
+
+    let select = PostgresSelect::new()
+        .with_source("sel_cond")
+        .with_condition(postgres_expr!("\"is_deleted\" = {}", false));
+
+    let result = db.execute(&select.expr()).await.unwrap();
+    let rows = result.into_value();
+    assert_eq!(rows.as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn test_execute_count() {
+    let db = setup("sel_count").await;
+
+    let select = PostgresSelect::new()
+        .with_source("sel_count")
+        .with_condition(postgres_expr!("\"is_deleted\" = {}", false));
+    let count = db.associate::<i64>(select.as_count()).get().await.unwrap();
+    assert_eq!(count, 2);
+}
+
+#[tokio::test]
+async fn test_execute_sum() {
+    let db = setup("sel_sum").await;
+
+    let select = PostgresSelect::new().with_source("sel_sum");
+    let total = db
+        .associate::<i64>(select.as_sum(postgres_expr!("\"price\"")))
+        .get()
+        .await
+        .unwrap();
+    assert_eq!(total, 500); // 50 + 150 + 300
+}
+
+#[tokio::test]
+async fn test_execute_into_entity() {
+    let db = setup("sel_entity").await;
+
+    let select = PostgresSelect::new()
+        .with_source("sel_entity")
+        .with_condition(postgres_expr!("\"id\" = {}", "b"));
+
+    let record: Record<AnyPostgresType> = db.associate(select.expr()).get().await.unwrap();
+    let product = Product::from_record(record).unwrap();
+    assert_eq!(product.name, "Mid");
+    assert_eq!(product.price, 150);
+    assert!(!product.is_deleted);
+}
+
+#[tokio::test]
+async fn test_execute_order_and_limit() {
+    let db = setup("sel_order").await;
+
+    let select = PostgresSelect::new()
+        .with_source("sel_order")
+        .with_order(postgres_expr!("\"price\""), false)
+        .with_limit(Some(1), None);
+
+    let record: Record<AnyPostgresType> = db.associate(select.expr()).get().await.unwrap();
+    let product = Product::from_record(record).unwrap();
+    assert_eq!(product.name, "Expensive");
+    assert_eq!(product.price, 300);
+}

--- a/vantage-sql/tests/postgres/4_aggregates.rs
+++ b/vantage-sql/tests/postgres/4_aggregates.rs
@@ -1,0 +1,69 @@
+//! Test 4: Aggregates — COUNT, SUM, MAX, MIN via Table.
+
+#[allow(unused_imports)]
+use vantage_sql::postgres::PostgresType;
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+async fn get_db() -> PostgresDB {
+    PostgresDB::connect(PG_URL).await.unwrap()
+}
+
+#[entity(PostgresType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+#[tokio::test]
+async fn test_count() {
+    let db = get_db().await;
+    let table = Product::postgres_table(db);
+    assert_eq!(table.get_count().await.unwrap(), 5);
+}
+
+#[tokio::test]
+async fn test_max_price() {
+    let db = get_db().await;
+    let table = Product::postgres_table(db);
+    let max = table.get_max(&table["price"]).await.unwrap();
+    assert_eq!(max.try_get::<i64>().unwrap(), 299);
+}
+
+#[tokio::test]
+async fn test_min_price() {
+    let db = get_db().await;
+    let table = Product::postgres_table(db);
+    let min = table.get_min(&table["price"]).await.unwrap();
+    assert_eq!(min.try_get::<i64>().unwrap(), 120);
+}
+
+#[tokio::test]
+async fn test_sum_price() {
+    let db = get_db().await;
+    let table = Product::postgres_table(db);
+    let sum = table.get_sum(&table["price"]).await.unwrap();
+    // 120 + 135 + 220 + 299 + 199 = 973
+    assert_eq!(sum.try_get::<i64>().unwrap(), 973);
+}

--- a/vantage-sql/tests/postgres/4_aggregates.rs
+++ b/vantage-sql/tests/postgres/4_aggregates.rs
@@ -1,8 +1,10 @@
 //! Test 4: Aggregates — COUNT, SUM, MAX, MIN via Table.
 
 #[allow(unused_imports)]
+use vantage_sql::postgres::AnyPostgresType;
+use vantage_sql::postgres::PostgresDB;
+#[allow(unused_imports)]
 use vantage_sql::postgres::PostgresType;
-use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_table::table::Table;
 use vantage_types::entity;
 

--- a/vantage-sql/tests/postgres/4_conditions.rs
+++ b/vantage-sql/tests/postgres/4_conditions.rs
@@ -55,7 +55,11 @@ async fn test_multiple_conditions() {
     let db = get_db().await;
     let mut table = Product::postgres_table(db);
     table.add_condition(postgres_expr!("{} > {}", (table["price"]), 130i64));
-    table.add_condition(postgres_expr!("{} > {}", (table["price"]), (table["calories"])));
+    table.add_condition(postgres_expr!(
+        "{} > {}",
+        (table["price"]),
+        (table["calories"])
+    ));
 
     let products = table.list().await.unwrap();
     // price > 130 AND price > calories:

--- a/vantage-sql/tests/postgres/4_conditions.rs
+++ b/vantage-sql/tests/postgres/4_conditions.rs
@@ -1,0 +1,77 @@
+//! Test 4: Conditions on Table<PostgresDB, Entity>.
+
+#[allow(unused_imports)]
+use vantage_sql::postgres::PostgresType;
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+use vantage_sql::postgres_expr;
+use vantage_table::operation::Operation;
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::ReadableDataSet;
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+async fn get_db() -> PostgresDB {
+    PostgresDB::connect(PG_URL).await.unwrap()
+}
+
+#[entity(PostgresType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+#[tokio::test]
+async fn test_custom_expression_condition() {
+    let db = get_db().await;
+    let mut table = Product::postgres_table(db);
+    table.add_condition(postgres_expr!("{} > {}", (table["price"]), 130i64));
+
+    let products = table.list().await.unwrap();
+    assert_eq!(products.len(), 4); // 135, 220, 299, 199
+}
+
+#[tokio::test]
+async fn test_multiple_conditions() {
+    let db = get_db().await;
+    let mut table = Product::postgres_table(db);
+    table.add_condition(postgres_expr!("{} > {}", (table["price"]), 130i64));
+    table.add_condition(postgres_expr!("{} > {}", (table["price"]), (table["calories"])));
+
+    let products = table.list().await.unwrap();
+    // price > 130 AND price > calories:
+    // delorean_donut: 135 > 250? no
+    // time_tart: 220 > 200? yes
+    // sea_pie: 299 > 350? no
+    // hover_cookies: 199 > 150? yes
+    assert_eq!(products.len(), 2);
+}
+
+#[tokio::test]
+async fn test_operation_eq() {
+    let db = get_db().await;
+    let mut table = Product::postgres_table(db);
+    table.add_condition(table["is_deleted"].eq(false));
+
+    let products = table.list().await.unwrap();
+    assert_eq!(products.len(), 5); // all products have is_deleted=false
+}

--- a/vantage-sql/tests/postgres/4_conditions.rs
+++ b/vantage-sql/tests/postgres/4_conditions.rs
@@ -1,8 +1,10 @@
 //! Test 4: Conditions on Table<PostgresDB, Entity>.
 
 #[allow(unused_imports)]
+use vantage_sql::postgres::AnyPostgresType;
+use vantage_sql::postgres::PostgresDB;
+#[allow(unused_imports)]
 use vantage_sql::postgres::PostgresType;
-use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_sql::postgres_expr;
 use vantage_table::operation::Operation;
 use vantage_table::table::Table;

--- a/vantage-sql/tests/postgres/4_editable_data_set.rs
+++ b/vantage-sql/tests/postgres/4_editable_data_set.rs
@@ -1,0 +1,155 @@
+//! Test 4: WritableDataSet and InsertableDataSet for Table<PostgresDB, Entity>.
+
+#[allow(unused_imports)]
+use vantage_sql::postgres::PostgresType;
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::{InsertableDataSet, ReadableDataSet, WritableDataSet};
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+#[entity(PostgresType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Item {
+    name: String,
+    price: i64,
+}
+
+async fn setup(suffix: &str) -> (PostgresDB, Table<PostgresDB, Item>) {
+    let db = PostgresDB::connect(PG_URL).await.unwrap();
+    let table_name = format!("edit_item_{}", suffix);
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", table_name))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE \"{}\" (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL
+        )",
+        table_name
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "INSERT INTO \"{}\" VALUES ('a', 'Alpha', 10), ('b', 'Beta', 20)",
+        table_name
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let table = Table::<PostgresDB, Item>::new(&table_name, db.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price");
+    (db, table)
+}
+
+#[tokio::test]
+async fn test_insert() {
+    let (_db, table) = setup("insert").await;
+
+    let item = Item {
+        name: "Gamma".into(),
+        price: 30,
+    };
+    let result = table.insert(&"c".to_string(), &item).await.unwrap();
+    assert_eq!(result.name, "Gamma");
+    assert_eq!(result.price, 30);
+
+    let fetched = table.get("c").await.unwrap();
+    assert_eq!(fetched.name, "Gamma");
+}
+
+#[tokio::test]
+async fn test_replace() {
+    let (_db, table) = setup("replace").await;
+
+    let item = Item {
+        name: "Alpha Replaced".into(),
+        price: 99,
+    };
+    table.replace(&"a".to_string(), &item).await.unwrap();
+
+    let fetched = table.get("a").await.unwrap();
+    assert_eq!(fetched.name, "Alpha Replaced");
+    assert_eq!(fetched.price, 99);
+}
+
+#[tokio::test]
+async fn test_patch() {
+    let (_db, table) = setup("patch").await;
+
+    let partial = Item {
+        name: "".into(),
+        price: 55,
+    };
+    table.patch(&"a".to_string(), &partial).await.unwrap();
+
+    let fetched = table.get("a").await.unwrap();
+    assert_eq!(fetched.price, 55);
+}
+
+#[tokio::test]
+async fn test_delete() {
+    let (_db, table) = setup("delete").await;
+
+    table.delete(&"a".to_string()).await.unwrap();
+
+    let all = table.list().await.unwrap();
+    assert_eq!(all.len(), 1);
+    assert!(!all.contains_key("a"));
+}
+
+#[tokio::test]
+async fn test_delete_all() {
+    let (_db, table) = setup("delete_all").await;
+
+    table.delete_all().await.unwrap();
+    assert!(table.list().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_insert_return_id() {
+    let (db, _) = setup("auto_id").await;
+
+    sqlx::query("DROP TABLE IF EXISTS \"edit_auto_item\"")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(
+        "CREATE TABLE \"edit_auto_item\" (
+            id SERIAL PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let table = Table::<PostgresDB, Item>::new("edit_auto_item", db)
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price");
+
+    let item = Item {
+        name: "Auto".into(),
+        price: 42,
+    };
+    let id = table.insert_return_id(&item).await.unwrap();
+    assert!(!id.is_empty());
+
+    let fetched = table.get(id).await.unwrap();
+    assert_eq!(fetched.name, "Auto");
+    assert_eq!(fetched.price, 42);
+}

--- a/vantage-sql/tests/postgres/4_editable_data_set.rs
+++ b/vantage-sql/tests/postgres/4_editable_data_set.rs
@@ -1,8 +1,10 @@
 //! Test 4: WritableDataSet and InsertableDataSet for Table<PostgresDB, Entity>.
 
 #[allow(unused_imports)]
+use vantage_sql::postgres::AnyPostgresType;
+use vantage_sql::postgres::PostgresDB;
+#[allow(unused_imports)]
 use vantage_sql::postgres::PostgresType;
-use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_table::table::Table;
 use vantage_types::entity;
 

--- a/vantage-sql/tests/postgres/4_readable_data_set.rs
+++ b/vantage-sql/tests/postgres/4_readable_data_set.rs
@@ -1,8 +1,10 @@
 //! Test 4: ReadableDataSet for Table<PostgresDB, Entity>.
 
 #[allow(unused_imports)]
+use vantage_sql::postgres::AnyPostgresType;
+use vantage_sql::postgres::PostgresDB;
+#[allow(unused_imports)]
 use vantage_sql::postgres::PostgresType;
-use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_table::table::Table;
 use vantage_types::entity;
 

--- a/vantage-sql/tests/postgres/4_readable_data_set.rs
+++ b/vantage-sql/tests/postgres/4_readable_data_set.rs
@@ -1,0 +1,81 @@
+//! Test 4: ReadableDataSet for Table<PostgresDB, Entity>.
+
+#[allow(unused_imports)]
+use vantage_sql::postgres::PostgresType;
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::ReadableDataSet;
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+async fn get_db() -> PostgresDB {
+    PostgresDB::connect(PG_URL)
+        .await
+        .expect("Failed to connect — run scripts/postgres/ingress.sh first")
+}
+
+#[entity(PostgresType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+#[tokio::test]
+async fn test_list_products() {
+    let db = get_db().await;
+    let table = Product::postgres_table(db);
+
+    let products = table.list().await.unwrap();
+    assert_eq!(products.len(), 5);
+
+    let cupcake = &products["flux_cupcake"];
+    assert_eq!(cupcake.name, "Flux Capacitor Cupcake");
+    assert_eq!(cupcake.price, 120);
+    assert_eq!(cupcake.calories, 300);
+    assert!(!cupcake.is_deleted);
+}
+
+#[tokio::test]
+async fn test_get_product() {
+    let db = get_db().await;
+    let table = Product::postgres_table(db);
+
+    let product = table.get("delorean_donut").await.unwrap();
+    assert_eq!(product.name, "DeLorean Doughnut");
+    assert_eq!(product.price, 135);
+    assert_eq!(product.calories, 250);
+}
+
+#[tokio::test]
+async fn test_get_some_product() {
+    let db = get_db().await;
+    let table = Product::postgres_table(db);
+
+    let result = table.get_some().await.unwrap();
+    assert!(result.is_some());
+
+    let (id, product) = result.unwrap();
+    assert!(!id.is_empty());
+    assert!(!product.name.is_empty());
+    assert!(product.price > 0);
+}

--- a/vantage-sql/tests/postgres/4_table_def.rs
+++ b/vantage-sql/tests/postgres/4_table_def.rs
@@ -1,0 +1,44 @@
+//! Test 4: Table definition and query generation via TableSource.
+
+#[allow(unused_imports)]
+use vantage_sql::postgres::PostgresType;
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+#[entity(PostgresType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+#[tokio::test]
+async fn test_product_select() {
+    let db = PostgresDB::connect(PG_URL).await.unwrap();
+    let table = Product::postgres_table(db);
+    let select = table.select();
+    assert_eq!(
+        select.preview(),
+        "SELECT \"id\", \"name\", \"calories\", \"price\", \"bakery_id\", \"is_deleted\", \"inventory_stock\" FROM \"product\""
+    );
+}

--- a/vantage-sql/tests/postgres/4_table_def.rs
+++ b/vantage-sql/tests/postgres/4_table_def.rs
@@ -1,8 +1,10 @@
 //! Test 4: Table definition and query generation via TableSource.
 
 #[allow(unused_imports)]
+use vantage_sql::postgres::AnyPostgresType;
+use vantage_sql::postgres::PostgresDB;
+#[allow(unused_imports)]
 use vantage_sql::postgres::PostgresType;
-use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_table::table::Table;
 use vantage_types::entity;
 

--- a/vantage-sql/tests/postgres/5_references.rs
+++ b/vantage-sql/tests/postgres/5_references.rs
@@ -1,8 +1,10 @@
 //! Test 5: Relationship traversal — with_one, with_many, get_ref_as.
 
 #[allow(unused_imports)]
+use vantage_sql::postgres::AnyPostgresType;
+use vantage_sql::postgres::PostgresDB;
+#[allow(unused_imports)]
 use vantage_sql::postgres::PostgresType;
-use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_sql::postgres_expr;
 use vantage_table::table::Table;
 use vantage_types::entity;

--- a/vantage-sql/tests/postgres/5_references.rs
+++ b/vantage-sql/tests/postgres/5_references.rs
@@ -60,7 +60,11 @@ fn order_table(db: PostgresDB) -> Table<PostgresDB, ClientOrder> {
 async fn test_has_many_orders_for_paying_clients() {
     let db = get_db().await;
     let mut clients = client_table(db.clone());
-    clients.add_condition(postgres_expr!("{} = {}", (clients["is_paying_client"]), true));
+    clients.add_condition(postgres_expr!(
+        "{} = {}",
+        (clients["is_paying_client"]),
+        true
+    ));
 
     let orders = clients
         .get_ref_as::<PostgresDB, ClientOrder>("orders")

--- a/vantage-sql/tests/postgres/5_references.rs
+++ b/vantage-sql/tests/postgres/5_references.rs
@@ -1,0 +1,101 @@
+//! Test 5: Relationship traversal — with_one, with_many, get_ref_as.
+
+#[allow(unused_imports)]
+use vantage_sql::postgres::PostgresType;
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+use vantage_sql::postgres_expr;
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::ReadableDataSet;
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+async fn get_db() -> PostgresDB {
+    PostgresDB::connect(PG_URL).await.unwrap()
+}
+
+#[entity(PostgresType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Client {
+    name: String,
+    email: String,
+    contact_details: String,
+    is_paying_client: bool,
+    bakery_id: String,
+}
+
+#[entity(PostgresType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct ClientOrder {
+    bakery_id: String,
+    client_id: String,
+    is_deleted: bool,
+}
+
+fn client_table(db: PostgresDB) -> Table<PostgresDB, Client> {
+    let db2 = db.clone();
+    Table::new("client", db)
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<String>("email")
+        .with_column_of::<String>("contact_details")
+        .with_column_of::<bool>("is_paying_client")
+        .with_column_of::<String>("bakery_id")
+        .with_many("orders", "client_id", move || order_table(db2.clone()))
+}
+
+fn order_table(db: PostgresDB) -> Table<PostgresDB, ClientOrder> {
+    let db2 = db.clone();
+    Table::new("client_order", db)
+        .with_id_column("id")
+        .with_column_of::<String>("bakery_id")
+        .with_column_of::<String>("client_id")
+        .with_column_of::<bool>("is_deleted")
+        .with_one("client", "client_id", move || client_table(db2.clone()))
+}
+
+/// Traverse has_many: paying clients -> their orders
+#[tokio::test]
+async fn test_has_many_orders_for_paying_clients() {
+    let db = get_db().await;
+    let mut clients = client_table(db.clone());
+    clients.add_condition(postgres_expr!("{} = {}", (clients["is_paying_client"]), true));
+
+    let orders = clients
+        .get_ref_as::<PostgresDB, ClientOrder>("orders")
+        .unwrap();
+
+    let order_list = orders.list().await.unwrap();
+    // Marty has 1 order, Doc has 2 orders -> 3 total
+    assert_eq!(order_list.len(), 3);
+}
+
+/// Traverse has_many: single client -> orders
+#[tokio::test]
+async fn test_has_many_orders_for_single_client() {
+    let db = get_db().await;
+    let mut clients = client_table(db.clone());
+    clients.add_condition(postgres_expr!("{} = {}", (clients["name"]), "Doc Brown"));
+
+    let orders = clients
+        .get_ref_as::<PostgresDB, ClientOrder>("orders")
+        .unwrap();
+
+    let order_list = orders.list().await.unwrap();
+    assert_eq!(order_list.len(), 2);
+}
+
+/// Traverse has_one: order -> client
+#[tokio::test]
+async fn test_has_one_client_for_order() {
+    let db = get_db().await;
+    let mut orders = order_table(db.clone());
+    orders.add_condition(postgres_expr!("{} = {}", (orders["id"]), "order1"));
+
+    let client = orders.get_ref_as::<PostgresDB, Client>("client").unwrap();
+
+    let client_list = client.list().await.unwrap();
+    assert_eq!(client_list.len(), 1);
+    assert_eq!(client_list.values().next().unwrap().name, "Marty McFly");
+}


### PR DESCRIPTION
If your production data lives in Postgres, `vantage-sql` finally meets you there. `--features postgres` enables a `PostgresDB` that implements the same `TableSource` your SQLite tables use:

```toml
vantage-sql = { version = "0.4", features = ["postgres"] }
```

```rust
let db = PostgresDB::connect("postgres://...").await?;
let bakery = Bakery::postgres_table(db);   // sits next to bakery.sqlite_table(db)
```

Same query builder, same `with_one`/`with_many`, same `defer()` for cross-database expressions, same `Selectable`. The 84-test suite mirrors SQLite's (round-trips, aggregates, references, editable data sets, `bakery_model3`).

### Where Postgres bites differently from SQLite

The runtime is not just "SQLite with `$1` instead of `?1`". A few places to know:

- **Native `BOOLEAN`.** `AnyPostgresType::new(true)` lands as `Value::Bool(true)`, not `1`. `try_get::<i64>()` on a bool returns `None` — the type variant boundary is real, even round-tripping in memory.
- **Distinct integer widths.** `Int2`/`Int4`/`Int8` are separate variants. An `i32` column will not hand you an `i64`. Untyped reads from the database bypass the check, so this only stings construction-side.
- **`SUM`/`AVG` on integers.** Postgres returns `NUMERIC`, which sqlx will not decode without `bigdecimal`/`rust_decimal`. The aggregate path wraps the result in `CAST(... AS BIGINT)` so you get `i64` back.
- **UPSERT.** SQLite's `INSERT OR REPLACE` becomes `INSERT ... ON CONFLICT (id) DO UPDATE SET col = EXCLUDED.col`. Same `replace_*` API.
- **`LIKE` on non-text columns.** `search_table_expr` casts with `"col"::text LIKE $1` because Postgres won't implicitly coerce.

### Why Postgres before MySQL

The README's "What's Coming Next" promised both via sqlx. Postgres landed first because the type-system shape (real `BOOLEAN`, distinct integer widths, `NUMERIC` aggregates) is what actually stress-tests `vantage_type_system!`; MySQL slots onto the same skeleton next.

### What might affect existing users

The SQLite seed `v2.sql` picked up a `sticker` column on `product` so the `bakery_model3` shape stays consistent across CSV / SQLite / SurrealDB / Postgres. If you rebuild from those scripts, your fixtures get the new column; if you depend on the old shape, regenerate.

Test infra ships with the patch: `vantage-sql/scripts/postgres/{start,stop,ingress}.sh` brings up Postgres 17 on port 5433 (5432 stays free for your local instance), and `.github/workflows/postgres.yaml` runs the suite plus a CLI smoke test against a service container.