### PR TITLE
mysql persistence implementation

### DIFF
--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -15,6 +15,7 @@ autoexamples = false
 default = ["sqlite"]
 sqlite = ["sqlx/sqlite"]
 postgres = ["sqlx/postgres"]
+mysql = ["sqlx/mysql"]
 
 [dependencies]
 vantage-core = { path = "../vantage-core" }

--- a/vantage-sql/scripts/mysql/db/v2.sql
+++ b/vantage-sql/scripts/mysql/db/v2.sql
@@ -1,0 +1,83 @@
+-- Hill Valley Bakery Database - MySQL Version
+
+CREATE TABLE IF NOT EXISTS bakery (
+    id VARCHAR(255) PRIMARY KEY,
+    name TEXT NOT NULL,
+    profit_margin BIGINT NOT NULL CHECK (profit_margin >= 0 AND profit_margin <= 100)
+);
+
+CREATE TABLE IF NOT EXISTS client (
+    id VARCHAR(255) PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    contact_details TEXT NOT NULL,
+    is_paying_client BOOLEAN NOT NULL DEFAULT false,
+    balance DOUBLE NOT NULL DEFAULT 0,
+    bakery_id VARCHAR(255) NOT NULL,
+    FOREIGN KEY (bakery_id) REFERENCES bakery(id)
+);
+
+CREATE TABLE IF NOT EXISTS product (
+    id VARCHAR(255) PRIMARY KEY,
+    name TEXT NOT NULL,
+    calories BIGINT NOT NULL CHECK (calories >= 0),
+    price BIGINT NOT NULL CHECK (price > 0),
+    bakery_id VARCHAR(255) NOT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT false,
+    inventory_stock BIGINT NOT NULL DEFAULT 0,
+    sticker TEXT,
+    FOREIGN KEY (bakery_id) REFERENCES bakery(id)
+);
+
+CREATE TABLE IF NOT EXISTS client_order (
+    id VARCHAR(255) PRIMARY KEY,
+    bakery_id VARCHAR(255) NOT NULL,
+    client_id VARCHAR(255) NOT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT false,
+    created_at VARCHAR(255) NOT NULL DEFAULT (DATE_FORMAT(NOW(), '%Y-%m-%dT%H:%i:%s')),
+    FOREIGN KEY (bakery_id) REFERENCES bakery(id),
+    FOREIGN KEY (client_id) REFERENCES client(id)
+);
+
+CREATE TABLE IF NOT EXISTS order_line (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    order_id VARCHAR(255) NOT NULL,
+    product_id VARCHAR(255) NOT NULL,
+    quantity BIGINT NOT NULL CHECK (quantity > 0),
+    price BIGINT NOT NULL CHECK (price > 0),
+    FOREIGN KEY (order_id) REFERENCES client_order(id),
+    FOREIGN KEY (product_id) REFERENCES product(id)
+);
+
+-- Data
+
+INSERT IGNORE INTO bakery (id, name, profit_margin)
+VALUES ('hill_valley', 'Hill Valley Bakery', 15);
+
+INSERT IGNORE INTO client (id, name, email, contact_details, is_paying_client, balance, bakery_id)
+VALUES
+    ('marty', 'Marty McFly', 'marty@gmail.com', '555-1955', true, 150.00, 'hill_valley'),
+    ('doc', 'Doc Brown', 'doc@brown.com', '555-1885', true, 500.50, 'hill_valley'),
+    ('biff', 'Biff Tannen', 'biff-3293@hotmail.com', '555-1955', false, -50.25, 'hill_valley');
+
+INSERT IGNORE INTO product (id, name, calories, price, bakery_id, is_deleted, inventory_stock, sticker)
+VALUES
+    ('flux_cupcake', 'Flux Capacitor Cupcake', 300, 120, 'hill_valley', false, 50, 'cat'),
+    ('delorean_donut', 'DeLorean Doughnut', 250, 135, 'hill_valley', false, 30, 'dog'),
+    ('time_tart', 'Time Traveler Tart', 200, 220, 'hill_valley', false, 20, NULL),
+    ('sea_pie', 'Enchantment Under the Sea Pie', 350, 299, 'hill_valley', false, 15, 'pig'),
+    ('hover_cookies', 'Hoverboard Cookies', 150, 199, 'hill_valley', false, 40, 'chicken');
+
+INSERT IGNORE INTO client_order (id, bakery_id, client_id, is_deleted, created_at)
+VALUES
+    ('order1', 'hill_valley', 'marty', false, DATE_FORMAT(NOW(), '%Y-%m-%dT%H:%i:%s')),
+    ('order2', 'hill_valley', 'doc', false, DATE_FORMAT(NOW(), '%Y-%m-%dT%H:%i:%s')),
+    ('order3', 'hill_valley', 'doc', false, DATE_FORMAT(NOW(), '%Y-%m-%dT%H:%i:%s'));
+
+INSERT IGNORE INTO order_line (order_id, product_id, quantity, price)
+VALUES
+    ('order1', 'flux_cupcake', 3, 120),
+    ('order1', 'delorean_donut', 1, 135),
+    ('order1', 'hover_cookies', 2, 199),
+    ('order2', 'time_tart', 1, 220),
+    ('order3', 'hover_cookies', 500, 199);

--- a/vantage-sql/src/lib.rs
+++ b/vantage-sql/src/lib.rs
@@ -5,3 +5,6 @@ pub mod sqlite;
 
 #[cfg(feature = "postgres")]
 pub mod postgres;
+
+#[cfg(feature = "mysql")]
+pub mod mysql;

--- a/vantage-sql/src/mysql/expr_data_source.rs
+++ b/vantage-sql/src/mysql/expr_data_source.rs
@@ -1,0 +1,134 @@
+use serde_json::Value as JsonValue;
+use vantage_expressions::traits::expressive::DeferredFn;
+use vantage_expressions::{Expression, ExpressionFlattener, ExpressiveEnum, Flatten};
+
+use crate::mysql::MysqlDB;
+use crate::mysql::row::{bind_mysql_value, row_to_record};
+use crate::mysql::types::AnyMysqlType;
+
+impl vantage_expressions::ExprDataSource<AnyMysqlType> for MysqlDB {
+    async fn execute(
+        &self,
+        expr: &Expression<AnyMysqlType>,
+    ) -> vantage_core::Result<AnyMysqlType> {
+        // 1. Resolve deferred parameters
+        let resolved = resolve_deferred(expr).await?;
+
+        // 2. Flatten nested expressions + convert {} to ? (MySQL uses ? placeholders)
+        let (sql, params) = prepare_typed_query(&resolved);
+
+        // 3. Bind and execute
+        let mut query = sqlx::query(&sql);
+        for value in &params {
+            query = bind_mysql_value(query, value);
+        }
+
+        let rows = query.fetch_all(self.pool()).await.map_err(|e| {
+            vantage_core::error!("MySQL query failed", details = e.to_string())
+        })?;
+
+        // 4. Convert rows to AnyMysqlType (untyped)
+        let arr: Vec<JsonValue> = rows
+            .iter()
+            .map(|row| {
+                let record = row_to_record(row);
+                let json_map: serde_json::Map<String, JsonValue> = record
+                    .into_iter()
+                    .map(|(k, v)| (k, v.into_value()))
+                    .collect();
+                JsonValue::Object(json_map)
+            })
+            .collect();
+
+        let json_arr = JsonValue::Array(arr);
+        Ok(AnyMysqlType::from_json(&json_arr)
+            .expect("JSON array should always convert to AnyMysqlType"))
+    }
+
+    fn defer(&self, expr: Expression<AnyMysqlType>) -> DeferredFn<AnyMysqlType> {
+        let db = self.clone();
+        DeferredFn::from_fn(move || {
+            let db = db.clone();
+            let expr = expr.clone();
+            Box::pin(async move {
+                let result = vantage_expressions::ExprDataSource::execute(&db, &expr).await?;
+                let scalar = match result.value() {
+                    serde_json::Value::Array(arr) => arr
+                        .first()
+                        .and_then(|row| row.as_object())
+                        .and_then(|obj| obj.values().next())
+                        .map(|v| AnyMysqlType::untyped(v.clone()))
+                        .unwrap_or(result),
+                    _ => result,
+                };
+                Ok(scalar)
+            })
+        })
+    }
+}
+
+/// Resolve all Deferred parameters in an expression by calling them.
+async fn resolve_deferred(
+    expr: &Expression<AnyMysqlType>,
+) -> vantage_core::Result<Expression<AnyMysqlType>> {
+    let mut resolved_params = Vec::new();
+
+    for param in &expr.parameters {
+        match param {
+            ExpressiveEnum::Deferred(deferred_fn) => {
+                let result = deferred_fn.call().await?;
+                resolved_params.push(result);
+            }
+            ExpressiveEnum::Nested(inner) => {
+                let resolved_inner = Box::pin(resolve_deferred(inner)).await?;
+                resolved_params.push(ExpressiveEnum::Nested(resolved_inner));
+            }
+            other => {
+                resolved_params.push(other.clone());
+            }
+        }
+    }
+
+    Ok(Expression::new(expr.template.clone(), resolved_params))
+}
+
+/// Flatten an Expression<AnyMysqlType> and convert `{}` placeholders to `?`.
+fn prepare_typed_query(expr: &Expression<AnyMysqlType>) -> (String, Vec<AnyMysqlType>) {
+    let flattener = ExpressionFlattener::new();
+    let flattened = flattener.flatten(expr);
+
+    let mut sql = String::new();
+    let mut params = Vec::new();
+    let template_parts: Vec<&str> = flattened.template.split("{}").collect();
+
+    assert_eq!(
+        template_parts.len(),
+        flattened.parameters.len() + 1,
+        "template placeholder count ({}) doesn't match parameter count ({})",
+        template_parts.len() - 1,
+        flattened.parameters.len()
+    );
+
+    sql.push_str(template_parts[0]);
+
+    for (i, param) in flattened.parameters.iter().enumerate() {
+        match param {
+            ExpressiveEnum::Scalar(value) => {
+                sql.push('?');
+                params.push(value.clone());
+            }
+            ExpressiveEnum::Nested(_) => {
+                panic!("nested expression should have been flattened");
+            }
+            ExpressiveEnum::Deferred(_) => {
+                panic!("deferred expression should have been resolved before prepare");
+            }
+        }
+
+        if i + 1 < template_parts.len() {
+            sql.push_str(template_parts[i + 1]);
+        }
+    }
+
+    (sql, params)
+}

--- a/vantage-sql/src/mysql/macros.rs
+++ b/vantage-sql/src/mysql/macros.rs
@@ -1,0 +1,26 @@
+/// Create a SQL expression with `AnyMysqlType` as the value type.
+///
+/// Scalar arguments must implement `Into<AnyMysqlType>` -- supported types are:
+/// `i8`-`u32`, `f32`/`f64`, `bool`, `String`, and `&str`.
+///
+/// ```ignore
+/// let expr = mysql_expr!("SELECT * FROM product WHERE price > {}", 100i64);
+/// let result = db.execute(&expr).await?;
+/// ```
+#[macro_export]
+macro_rules! mysql_expr {
+    ($template:expr) => {
+        vantage_expressions::Expression::<$crate::mysql::AnyMysqlType>::new($template, vec![])
+    };
+
+    ($template:expr, $($param:tt),*) => {
+        vantage_expressions::Expression::<$crate::mysql::AnyMysqlType>::new(
+            $template,
+            vec![
+                $(
+                    vantage_expressions::expr_param!($param)
+                ),*
+            ]
+        )
+    };
+}

--- a/vantage-sql/src/mysql/mod.rs
+++ b/vantage-sql/src/mysql/mod.rs
@@ -1,0 +1,58 @@
+#[macro_use]
+mod macros;
+mod operation;
+mod row;
+pub mod statements;
+mod table_source;
+pub mod types;
+
+use sqlx::mysql::MySqlPool;
+
+pub use types::{AnyMysqlType, MysqlType};
+
+/// MySQL provider. Wraps a connection pool.
+#[derive(Clone)]
+pub struct MysqlDB {
+    pool: MySqlPool,
+}
+
+impl MysqlDB {
+    pub async fn connect(url: &str) -> Result<Self, sqlx::Error> {
+        let pool = MySqlPool::connect(url).await?;
+        Ok(Self { pool })
+    }
+
+    pub fn pool(&self) -> &MySqlPool {
+        &self.pool
+    }
+
+    /// Execute an aggregate query (COUNT, SUM, MAX, MIN etc.) and return the scalar result.
+    pub async fn aggregate(
+        &self,
+        select: &statements::MysqlSelect,
+        func: &str,
+        column: impl vantage_expressions::Expressive<AnyMysqlType>,
+    ) -> vantage_core::Result<AnyMysqlType> {
+        use vantage_expressions::ExprDataSource;
+        let expr = select.as_aggregate(func, column);
+        let result = self.execute(&expr).await?;
+        Ok(match result.value() {
+            serde_json::Value::Array(arr) => arr
+                .first()
+                .and_then(|row| row.as_object())
+                .and_then(|obj| obj.values().next())
+                .map(|v| AnyMysqlType::untyped(v.clone()))
+                .unwrap_or(result),
+            _ => result,
+        })
+    }
+}
+
+// DataSource marker trait
+impl vantage_expressions::traits::datasource::DataSource for MysqlDB {}
+
+// ExprDataSource impl
+mod expr_data_source;
+
+// SelectableDataSource impl
+mod selectable_data_source;

--- a/vantage-sql/src/mysql/operation.rs
+++ b/vantage-sql/src/mysql/operation.rs
@@ -1,0 +1,2 @@
+// MySQL columns get Operation<AnyMysqlType> via the blanket impl in vantage-table.
+// No explicit impl needed.

--- a/vantage-sql/src/mysql/row.rs
+++ b/vantage-sql/src/mysql/row.rs
@@ -1,0 +1,190 @@
+//! Helpers for converting between sqlx rows/values and vantage types.
+//!
+//! **Writing** (bind): Takes `AnyMysqlType` with variant tags -- the variant
+//! tells us exactly how to bind each value to sqlx.
+//!
+//! **Reading** (row): Returns `Record<AnyMysqlType>` with `type_variant: None`.
+
+use serde_json::Value as JsonValue;
+use sqlx::mysql::MySqlRow;
+use sqlx::{Column, Row, TypeInfo};
+use vantage_types::Record;
+
+use super::types::{AnyMysqlType, MysqlTypeVariants};
+
+/// Bind an AnyMysqlType to a sqlx query.
+pub(crate) fn bind_mysql_value<'q>(
+    query: sqlx::query::Query<'q, sqlx::MySql, sqlx::mysql::MySqlArguments>,
+    value: &'q AnyMysqlType,
+) -> sqlx::query::Query<'q, sqlx::MySql, sqlx::mysql::MySqlArguments> {
+    let json = value.value();
+    match value.type_variant() {
+        Some(MysqlTypeVariants::Null) => query.bind(None::<String>),
+        None => bind_by_json(query, json),
+        Some(MysqlTypeVariants::Bool) => match json {
+            JsonValue::Null => query.bind(None::<bool>),
+            JsonValue::Bool(b) => query.bind(*b),
+            JsonValue::Number(n) => match n.as_i64() {
+                Some(i) => query.bind(i != 0),
+                None => query.bind(None::<bool>),
+            },
+            _ => query.bind(None::<bool>),
+        },
+        Some(MysqlTypeVariants::Int2) => match json {
+            JsonValue::Null => query.bind(None::<i16>),
+            JsonValue::Number(n) => query.bind(n.as_i64().map(|i| i as i16)),
+            _ => query.bind(None::<i16>),
+        },
+        Some(MysqlTypeVariants::Int4) => match json {
+            JsonValue::Null => query.bind(None::<i32>),
+            JsonValue::Number(n) => query.bind(n.as_i64().map(|i| i as i32)),
+            _ => query.bind(None::<i32>),
+        },
+        Some(MysqlTypeVariants::Int8) => match json {
+            JsonValue::Null => query.bind(None::<i64>),
+            JsonValue::Number(n) => query.bind(n.as_i64()),
+            _ => query.bind(None::<i64>),
+        },
+        Some(MysqlTypeVariants::Float4) => match json {
+            JsonValue::Null => query.bind(None::<f32>),
+            JsonValue::Number(n) => query.bind(n.as_f64().map(|f| f as f32)),
+            _ => query.bind(None::<f32>),
+        },
+        Some(MysqlTypeVariants::Float8) => match json {
+            JsonValue::Null => query.bind(None::<f64>),
+            JsonValue::Number(n) => query.bind(n.as_f64()),
+            _ => query.bind(None::<f64>),
+        },
+        Some(MysqlTypeVariants::Text) => match json {
+            JsonValue::Null => query.bind(None::<String>),
+            JsonValue::String(s) => query.bind(s.as_str()),
+            _ => query.bind(None::<String>),
+        },
+    }
+}
+
+/// Bind a JSON value without type variant -- infers from the value itself.
+fn bind_by_json<'q>(
+    query: sqlx::query::Query<'q, sqlx::MySql, sqlx::mysql::MySqlArguments>,
+    json: &'q JsonValue,
+) -> sqlx::query::Query<'q, sqlx::MySql, sqlx::mysql::MySqlArguments> {
+    match json {
+        JsonValue::Null => query.bind(None::<String>),
+        JsonValue::Bool(b) => query.bind(*b),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                query.bind(i)
+            } else if let Some(f) = n.as_f64() {
+                query.bind(f)
+            } else {
+                query.bind(n.to_string())
+            }
+        }
+        JsonValue::String(s) => query.bind(s.as_str()),
+        other => query.bind(other.to_string()),
+    }
+}
+
+/// Convert a MySqlRow to Record<AnyMysqlType>.
+pub(crate) fn row_to_record(row: &MySqlRow) -> Record<AnyMysqlType> {
+    let mut record = Record::new();
+    for col in row.columns() {
+        let name = col.name().to_string();
+        let type_name = col.type_info().name();
+        let json = mysql_column_to_json(row, col.ordinal(), type_name);
+        let value = AnyMysqlType::untyped(json);
+        record.insert(name, value);
+    }
+    record
+}
+
+/// Read a single column from a MySQL row as JsonValue.
+fn mysql_column_to_json(row: &MySqlRow, ordinal: usize, type_name: &str) -> JsonValue {
+    use sqlx::ValueRef;
+
+    if row
+        .try_get_raw(ordinal)
+        .map(|v| v.is_null())
+        .unwrap_or(true)
+    {
+        return JsonValue::Null;
+    }
+
+    match type_name {
+        "BOOLEAN" | "BOOL" => {
+            // MySQL BOOLEAN is TINYINT(1). sqlx decodes as i8.
+            if let Ok(v) = row.try_get::<i8, _>(ordinal) {
+                return JsonValue::Bool(v != 0);
+            }
+            if let Ok(v) = row.try_get::<bool, _>(ordinal) {
+                return JsonValue::Bool(v);
+            }
+        }
+        "TINYINT" => {
+            if let Ok(v) = row.try_get::<i8, _>(ordinal) {
+                return JsonValue::Number((v as i64).into());
+            }
+        }
+        "SMALLINT" => {
+            if let Ok(v) = row.try_get::<i16, _>(ordinal) {
+                return JsonValue::Number((v as i64).into());
+            }
+        }
+        "INT" | "INTEGER" | "MEDIUMINT" => {
+            if let Ok(v) = row.try_get::<i32, _>(ordinal) {
+                return JsonValue::Number((v as i64).into());
+            }
+        }
+        "BIGINT" => {
+            if let Ok(v) = row.try_get::<i64, _>(ordinal) {
+                return JsonValue::Number(v.into());
+            }
+        }
+        "FLOAT" => {
+            if let Ok(v) = row.try_get::<f32, _>(ordinal)
+                && let Some(n) = serde_json::Number::from_f64(v as f64)
+            {
+                return JsonValue::Number(n);
+            }
+        }
+        "DOUBLE" => {
+            if let Ok(v) = row.try_get::<f64, _>(ordinal)
+                && let Some(n) = serde_json::Number::from_f64(v)
+            {
+                return JsonValue::Number(n);
+            }
+        }
+        "DECIMAL" | "NUMERIC" => {
+            if let Ok(v) = row.try_get::<String, _>(ordinal) {
+                if let Ok(i) = v.parse::<i64>() {
+                    return JsonValue::Number(i.into());
+                }
+                if let Ok(f) = v.parse::<f64>() {
+                    if let Some(n) = serde_json::Number::from_f64(f) {
+                        return JsonValue::Number(n);
+                    }
+                }
+                return JsonValue::String(v);
+            }
+        }
+        _ => {}
+    }
+
+    // Fallback: try common types in order
+    if let Ok(v) = row.try_get::<i64, _>(ordinal) {
+        return JsonValue::Number(v.into());
+    }
+    if let Ok(v) = row.try_get::<i32, _>(ordinal) {
+        return JsonValue::Number((v as i64).into());
+    }
+    if let Ok(v) = row.try_get::<f64, _>(ordinal)
+        && let Some(n) = serde_json::Number::from_f64(v)
+    {
+        return JsonValue::Number(n);
+    }
+    if let Ok(v) = row.try_get::<String, _>(ordinal) {
+        return JsonValue::String(v);
+    }
+
+    JsonValue::Null
+}

--- a/vantage-sql/src/mysql/selectable_data_source.rs
+++ b/vantage-sql/src/mysql/selectable_data_source.rs
@@ -1,0 +1,31 @@
+use vantage_expressions::Expressive;
+use vantage_expressions::traits::datasource::SelectableDataSource;
+
+use crate::mysql::MysqlDB;
+use crate::mysql::statements::MysqlSelect;
+use crate::mysql::types::AnyMysqlType;
+
+impl SelectableDataSource<AnyMysqlType> for MysqlDB {
+    type Select = MysqlSelect;
+
+    fn select(&self) -> Self::Select {
+        MysqlSelect::new()
+    }
+
+    async fn execute_select(
+        &self,
+        select: &Self::Select,
+    ) -> vantage_core::Result<Vec<AnyMysqlType>> {
+        use vantage_expressions::ExprDataSource;
+
+        let result = self.execute(&select.expr()).await?;
+
+        match result.value() {
+            serde_json::Value::Array(arr) => Ok(arr
+                .iter()
+                .map(|v| AnyMysqlType::untyped(v.clone()))
+                .collect()),
+            _ => Ok(vec![result]),
+        }
+    }
+}

--- a/vantage-sql/src/mysql/statements/delete/builder.rs
+++ b/vantage-sql/src/mysql/statements/delete/builder.rs
@@ -1,0 +1,19 @@
+use vantage_expressions::Expressive;
+
+use crate::mysql::types::AnyMysqlType;
+
+use super::MysqlDelete;
+
+impl MysqlDelete {
+    pub fn new(table: &str) -> Self {
+        Self {
+            table: table.to_string(),
+            conditions: Vec::new(),
+        }
+    }
+
+    pub fn with_condition(mut self, condition: impl Expressive<AnyMysqlType>) -> Self {
+        self.conditions.push(condition.expr());
+        self
+    }
+}

--- a/vantage-sql/src/mysql/statements/delete/mod.rs
+++ b/vantage-sql/src/mysql/statements/delete/mod.rs
@@ -1,0 +1,14 @@
+mod builder;
+mod render;
+
+use crate::mysql::types::AnyMysqlType;
+use vantage_expressions::Expression;
+
+type Expr = Expression<AnyMysqlType>;
+
+/// MySQL DELETE statement builder.
+#[derive(Debug, Clone)]
+pub struct MysqlDelete {
+    pub table: String,
+    pub conditions: Vec<Expr>,
+}

--- a/vantage-sql/src/mysql/statements/delete/render.rs
+++ b/vantage-sql/src/mysql/statements/delete/render.rs
@@ -1,0 +1,31 @@
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::mysql::types::AnyMysqlType;
+
+use super::{Expr, MysqlDelete};
+
+impl MysqlDelete {
+    pub fn preview(&self) -> String {
+        self.expr().preview()
+    }
+}
+
+impl Expressive<AnyMysqlType> for MysqlDelete {
+    fn expr(&self) -> Expr {
+        if self.conditions.is_empty() {
+            return Expression::new(format!("DELETE FROM `{}`", self.table), vec![]);
+        }
+
+        let combined = Expression::from_vec(self.conditions.clone(), " AND ");
+        Expression::new(
+            format!("DELETE FROM `{}` WHERE {{}}", self.table),
+            vec![ExpressiveEnum::Nested(combined)],
+        )
+    }
+}
+
+impl From<MysqlDelete> for Expr {
+    fn from(delete: MysqlDelete) -> Self {
+        delete.expr()
+    }
+}

--- a/vantage-sql/src/mysql/statements/insert/builder.rs
+++ b/vantage-sql/src/mysql/statements/insert/builder.rs
@@ -1,0 +1,27 @@
+use indexmap::IndexMap;
+use vantage_types::Record;
+
+use crate::mysql::types::AnyMysqlType;
+
+use super::MysqlInsert;
+
+impl MysqlInsert {
+    pub fn new(table: &str) -> Self {
+        Self {
+            table: table.to_string(),
+            fields: IndexMap::new(),
+        }
+    }
+
+    pub fn with_field(mut self, key: impl Into<String>, value: impl Into<AnyMysqlType>) -> Self {
+        self.fields.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn with_record(mut self, record: &Record<AnyMysqlType>) -> Self {
+        for (key, value) in record.iter() {
+            self.fields.insert(key.clone(), value.clone());
+        }
+        self
+    }
+}

--- a/vantage-sql/src/mysql/statements/insert/mod.rs
+++ b/vantage-sql/src/mysql/statements/insert/mod.rs
@@ -1,0 +1,15 @@
+mod builder;
+mod render;
+
+use crate::mysql::types::AnyMysqlType;
+use indexmap::IndexMap;
+use vantage_expressions::Expression;
+
+type Expr = Expression<AnyMysqlType>;
+
+/// MySQL INSERT statement builder.
+#[derive(Debug, Clone)]
+pub struct MysqlInsert {
+    pub table: String,
+    pub fields: IndexMap<String, AnyMysqlType>,
+}

--- a/vantage-sql/src/mysql/statements/insert/render.rs
+++ b/vantage-sql/src/mysql/statements/insert/render.rs
@@ -1,0 +1,46 @@
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::mysql::types::AnyMysqlType;
+
+use super::{Expr, MysqlInsert};
+
+impl MysqlInsert {
+    pub fn preview(&self) -> String {
+        self.expr().preview()
+    }
+}
+
+impl Expressive<AnyMysqlType> for MysqlInsert {
+    fn expr(&self) -> Expr {
+        if self.fields.is_empty() {
+            return Expression::new(
+                format!("INSERT INTO `{}` () VALUES ()", self.table),
+                vec![],
+            );
+        }
+
+        let columns: Vec<String> = self.fields.keys().map(|k| format!("`{}`", k)).collect();
+        let placeholders: Vec<&str> = (0..self.fields.len()).map(|_| "{}").collect();
+
+        let template = format!(
+            "INSERT INTO `{}` ({}) VALUES ({})",
+            self.table,
+            columns.join(", "),
+            placeholders.join(", ")
+        );
+
+        let params: Vec<ExpressiveEnum<AnyMysqlType>> = self
+            .fields
+            .values()
+            .map(|v| ExpressiveEnum::Scalar(v.clone()))
+            .collect();
+
+        Expression::new(template, params)
+    }
+}
+
+impl From<MysqlInsert> for Expr {
+    fn from(insert: MysqlInsert) -> Self {
+        insert.expr()
+    }
+}

--- a/vantage-sql/src/mysql/statements/mod.rs
+++ b/vantage-sql/src/mysql/statements/mod.rs
@@ -1,0 +1,9 @@
+pub mod delete;
+pub mod insert;
+pub mod select;
+pub mod update;
+
+pub use delete::MysqlDelete;
+pub use insert::MysqlInsert;
+pub use select::MysqlSelect;
+pub use update::MysqlUpdate;

--- a/vantage-sql/src/mysql/statements/select/impls/mod.rs
+++ b/vantage-sql/src/mysql/statements/select/impls/mod.rs
@@ -1,0 +1,1 @@
+pub mod selectable;

--- a/vantage-sql/src/mysql/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/mysql/statements/select/impls/selectable.rs
@@ -1,0 +1,168 @@
+use vantage_expressions::traits::selectable::{Selectable, SourceRef};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::mysql::statements::MysqlSelect;
+use crate::mysql::types::AnyMysqlType;
+use crate::primitives::fx::Fx;
+
+type Expr = Expression<AnyMysqlType>;
+
+impl MysqlSelect {
+    pub fn as_aggregate(&self, func: &str, column: impl Expressive<AnyMysqlType>) -> Expr {
+        let mut s = self.clone();
+        s.clear_fields();
+        let agg = Fx::new(func, [column.expr()]);
+
+        // MySQL returns DECIMAL for SUM/AVG on integer types.
+        // Cast to SIGNED (MySQL's equivalent of BIGINT for CAST).
+        let needs_cast = matches!(func, "sum" | "avg");
+        if needs_cast {
+            let cast = Expression::new(
+                "CAST({} AS SIGNED)",
+                vec![ExpressiveEnum::Nested(agg.expr())],
+            );
+            s.add_expression(cast, None);
+        } else {
+            s.add_expression(agg, None);
+        }
+
+        s.clear_order_by();
+        s.render()
+    }
+}
+
+impl Selectable<AnyMysqlType> for MysqlSelect {
+    fn set_source(&mut self, source: impl Into<SourceRef<AnyMysqlType>>, alias: Option<String>) {
+        self.from.clear();
+        let source_ref = source.into().into_expressive_enum();
+        let expr = match (source_ref, alias) {
+            (ExpressiveEnum::Scalar(val), None) => Expression::new(
+                format!("`{}`", val.try_get::<String>().unwrap_or_default()),
+                vec![],
+            ),
+            (ExpressiveEnum::Scalar(val), Some(alias)) => Expression::new(
+                format!(
+                    "`{}` AS `{}`",
+                    val.try_get::<String>().unwrap_or_default(),
+                    alias
+                ),
+                vec![],
+            ),
+            (ExpressiveEnum::Nested(expr), None) => expr,
+            (ExpressiveEnum::Nested(expr), Some(alias)) => Expression::new(
+                format!("{{}} AS `{}`", alias),
+                vec![ExpressiveEnum::Nested(expr)],
+            ),
+            _ => return,
+        };
+        self.from.push(expr);
+    }
+
+    fn add_field(&mut self, field: impl Into<String>) {
+        self.fields
+            .push(Expression::new(format!("`{}`", field.into()), vec![]));
+    }
+
+    fn add_expression(
+        &mut self,
+        expression: impl Expressive<AnyMysqlType>,
+        alias: Option<String>,
+    ) {
+        let expr = expression.expr();
+        let field = match alias {
+            Some(a) => Expression::new(
+                format!("{{}} AS `{}`", a),
+                vec![ExpressiveEnum::Nested(expr)],
+            ),
+            None => expr,
+        };
+        self.fields.push(field);
+    }
+
+    fn add_where_condition(&mut self, condition: impl Expressive<AnyMysqlType>) {
+        self.where_conditions.push(condition.expr());
+    }
+
+    fn set_distinct(&mut self, distinct: bool) {
+        self.distinct = distinct;
+    }
+
+    fn add_order_by(&mut self, expression: impl Expressive<AnyMysqlType>, ascending: bool) {
+        self.order_by.push((expression.expr(), ascending));
+    }
+
+    fn add_group_by(&mut self, expression: impl Expressive<AnyMysqlType>) {
+        self.group_by.push(expression.expr());
+    }
+
+    fn set_limit(&mut self, limit: Option<i64>, skip: Option<i64>) {
+        self.limit = limit;
+        self.skip = skip;
+    }
+
+    fn clear_fields(&mut self) {
+        self.fields.clear();
+    }
+
+    fn clear_where_conditions(&mut self) {
+        self.where_conditions.clear();
+    }
+
+    fn clear_order_by(&mut self) {
+        self.order_by.clear();
+    }
+
+    fn clear_group_by(&mut self) {
+        self.group_by.clear();
+    }
+
+    fn has_fields(&self) -> bool {
+        !self.fields.is_empty()
+    }
+
+    fn has_where_conditions(&self) -> bool {
+        !self.where_conditions.is_empty()
+    }
+
+    fn has_order_by(&self) -> bool {
+        !self.order_by.is_empty()
+    }
+
+    fn has_group_by(&self) -> bool {
+        !self.group_by.is_empty()
+    }
+
+    fn is_distinct(&self) -> bool {
+        self.distinct
+    }
+
+    fn get_limit(&self) -> Option<i64> {
+        self.limit
+    }
+
+    fn get_skip(&self) -> Option<i64> {
+        self.skip
+    }
+
+    fn as_count(&self) -> Expr {
+        let mut count_select = self.clone();
+        count_select.fields.clear();
+        count_select
+            .fields
+            .push(Expression::new("COUNT(*)", vec![]));
+        count_select.order_by.clear();
+        count_select.render()
+    }
+
+    fn as_sum(&self, column: impl Expressive<AnyMysqlType>) -> Expr {
+        self.as_aggregate("sum", column)
+    }
+
+    fn as_max(&self, column: impl Expressive<AnyMysqlType>) -> Expr {
+        self.as_aggregate("max", column)
+    }
+
+    fn as_min(&self, column: impl Expressive<AnyMysqlType>) -> Expr {
+        self.as_aggregate("min", column)
+    }
+}

--- a/vantage-sql/src/mysql/statements/select/join.rs
+++ b/vantage-sql/src/mysql/statements/select/join.rs
@@ -1,0 +1,104 @@
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::mysql::types::AnyMysqlType;
+
+type Expr = Expression<AnyMysqlType>;
+
+#[derive(Debug, Clone)]
+pub enum MysqlJoinType {
+    Inner,
+    Left,
+    Right,
+}
+
+impl MysqlJoinType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            MysqlJoinType::Inner => "INNER JOIN",
+            MysqlJoinType::Left => "LEFT JOIN",
+            MysqlJoinType::Right => "RIGHT JOIN",
+        }
+    }
+}
+
+/// A JOIN clause for MysqlSelect.
+#[derive(Debug, Clone)]
+pub struct MysqlSelectJoin {
+    join_type: MysqlJoinType,
+    table: Expr,
+    on_condition: Expr,
+}
+
+impl MysqlSelectJoin {
+    fn new(join_type: MysqlJoinType, table: Expr, on_condition: Expr) -> Self {
+        Self {
+            join_type,
+            table,
+            on_condition,
+        }
+    }
+
+    fn table_expr(table: impl Into<String>, alias: impl Into<String>) -> Expr {
+        Expression::new(
+            format!("`{}` AS `{}`", table.into(), alias.into()),
+            vec![],
+        )
+    }
+
+    fn subquery_expr(subquery: impl Expressive<AnyMysqlType>, alias: impl Into<String>) -> Expr {
+        Expression::new(
+            format!("({{}}) AS `{}`", alias.into()),
+            vec![ExpressiveEnum::Nested(subquery.expr())],
+        )
+    }
+
+    pub fn inner(table: impl Into<String>, alias: impl Into<String>, on_condition: Expr) -> Self {
+        Self::new(
+            MysqlJoinType::Inner,
+            Self::table_expr(table, alias),
+            on_condition,
+        )
+    }
+
+    pub fn left(table: impl Into<String>, alias: impl Into<String>, on_condition: Expr) -> Self {
+        Self::new(
+            MysqlJoinType::Left,
+            Self::table_expr(table, alias),
+            on_condition,
+        )
+    }
+
+    pub fn inner_expr(
+        subquery: impl Expressive<AnyMysqlType>,
+        alias: impl Into<String>,
+        on_condition: Expr,
+    ) -> Self {
+        Self::new(
+            MysqlJoinType::Inner,
+            Self::subquery_expr(subquery, alias),
+            on_condition,
+        )
+    }
+
+    pub fn left_expr(
+        subquery: impl Expressive<AnyMysqlType>,
+        alias: impl Into<String>,
+        on_condition: Expr,
+    ) -> Self {
+        Self::new(
+            MysqlJoinType::Left,
+            Self::subquery_expr(subquery, alias),
+            on_condition,
+        )
+    }
+
+    pub fn render(&self) -> Expr {
+        Expression::new(
+            format!(" {} {{}} ON {{}}", self.join_type.as_str()),
+            vec![
+                ExpressiveEnum::Nested(self.table.clone()),
+                ExpressiveEnum::Nested(self.on_condition.clone()),
+            ],
+        )
+    }
+}

--- a/vantage-sql/src/mysql/statements/select/mod.rs
+++ b/vantage-sql/src/mysql/statements/select/mod.rs
@@ -1,0 +1,84 @@
+mod impls;
+pub mod join;
+mod render;
+
+use crate::mysql::types::AnyMysqlType;
+use crate::primitives::select::window::Window;
+use join::MysqlSelectJoin;
+use vantage_expressions::Expression;
+
+type Expr = Expression<AnyMysqlType>;
+
+/// MySQL SELECT statement builder.
+#[derive(Debug, Clone)]
+pub struct MysqlSelect {
+    pub fields: Vec<Expr>,
+    pub from: Vec<Expr>,
+    pub joins: Vec<MysqlSelectJoin>,
+    pub where_conditions: Vec<Expr>,
+    pub order_by: Vec<(Expr, bool)>,
+    pub group_by: Vec<Expr>,
+    pub having: Vec<Expr>,
+    pub windows: Vec<(String, Window<AnyMysqlType>)>,
+    pub ctes: Vec<(String, Expr, bool)>,
+    pub distinct: bool,
+    pub limit: Option<i64>,
+    pub skip: Option<i64>,
+}
+
+impl MysqlSelect {
+    pub fn new() -> Self {
+        Self {
+            fields: Vec::new(),
+            from: Vec::new(),
+            joins: Vec::new(),
+            where_conditions: Vec::new(),
+            order_by: Vec::new(),
+            group_by: Vec::new(),
+            having: Vec::new(),
+            windows: Vec::new(),
+            ctes: Vec::new(),
+            distinct: false,
+            limit: None,
+            skip: None,
+        }
+    }
+
+    pub fn with_join(mut self, join: MysqlSelectJoin) -> Self {
+        self.joins.push(join);
+        self
+    }
+
+    pub fn add_having(&mut self, condition: impl vantage_expressions::Expressive<AnyMysqlType>) {
+        self.having.push(condition.expr());
+    }
+
+    pub fn with_having(
+        mut self,
+        condition: impl vantage_expressions::Expressive<AnyMysqlType>,
+    ) -> Self {
+        self.having.push(condition.expr());
+        self
+    }
+
+    pub fn with_window(mut self, name: impl Into<String>, window: Window<AnyMysqlType>) -> Self {
+        self.windows.push((name.into(), window));
+        self
+    }
+
+    pub fn with_cte(
+        mut self,
+        name: impl Into<String>,
+        query: impl vantage_expressions::Expressive<AnyMysqlType>,
+        recursive: bool,
+    ) -> Self {
+        self.ctes.push((name.into(), query.expr(), recursive));
+        self
+    }
+}
+
+impl Default for MysqlSelect {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/vantage-sql/src/mysql/statements/select/render.rs
+++ b/vantage-sql/src/mysql/statements/select/render.rs
@@ -1,0 +1,194 @@
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::mysql::types::AnyMysqlType;
+
+use super::{Expr, MysqlSelect};
+
+fn render_condition_list(conditions: &[Expr], keyword: &str) -> Expr {
+    if conditions.is_empty() {
+        Expression::new("", vec![])
+    } else {
+        let combined = Expression::from_vec(conditions.to_vec(), " AND ");
+        Expression::new(
+            format!(" {} {{}}", keyword),
+            vec![ExpressiveEnum::Nested(combined)],
+        )
+    }
+}
+
+impl MysqlSelect {
+    fn render_fields(&self) -> Expr {
+        if self.fields.is_empty() {
+            Expression::new("*", vec![])
+        } else {
+            Expression::from_vec(self.fields.clone(), ", ")
+        }
+    }
+
+    fn render_from(&self) -> Expr {
+        if self.from.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            Expression::new(
+                " FROM {}",
+                vec![ExpressiveEnum::Nested(Expression::from_vec(
+                    self.from.clone(),
+                    ", ",
+                ))],
+            )
+        }
+    }
+
+    fn render_joins(&self) -> Expr {
+        if self.joins.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            let parts: Vec<Expr> = self.joins.iter().map(|j| j.render()).collect();
+            Expression::from_vec(parts, "")
+        }
+    }
+
+    fn render_where(&self) -> Expr {
+        render_condition_list(&self.where_conditions, "WHERE")
+    }
+
+    fn render_having(&self) -> Expr {
+        render_condition_list(&self.having, "HAVING")
+    }
+
+    fn render_group_by(&self) -> Expr {
+        if self.group_by.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            Expression::new(
+                " GROUP BY {}",
+                vec![ExpressiveEnum::Nested(Expression::from_vec(
+                    self.group_by.clone(),
+                    ", ",
+                ))],
+            )
+        }
+    }
+
+    fn render_windows(&self) -> Expr {
+        if self.windows.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            let parts: Vec<Expr> = self
+                .windows
+                .iter()
+                .map(|(name, win)| {
+                    Expression::new(
+                        format!("{} AS {{}}", name),
+                        vec![ExpressiveEnum::Nested(win.definition())],
+                    )
+                })
+                .collect();
+            Expression::new(
+                " WINDOW {}",
+                vec![ExpressiveEnum::Nested(Expression::from_vec(parts, ", "))],
+            )
+        }
+    }
+
+    fn render_order_by(&self) -> Expr {
+        if self.order_by.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            let parts: Vec<Expr> = self
+                .order_by
+                .iter()
+                .map(|(expr, asc)| {
+                    if *asc {
+                        expr.clone()
+                    } else {
+                        Expression::new("{} DESC", vec![ExpressiveEnum::Nested(expr.clone())])
+                    }
+                })
+                .collect();
+            Expression::new(
+                " ORDER BY {}",
+                vec![ExpressiveEnum::Nested(Expression::from_vec(parts, ", "))],
+            )
+        }
+    }
+
+    fn render_limit(&self) -> Expr {
+        match (self.limit, self.skip) {
+            (Some(limit), Some(skip)) => Expression::new(
+                " LIMIT {} OFFSET {}",
+                vec![
+                    ExpressiveEnum::Scalar(AnyMysqlType::new(limit)),
+                    ExpressiveEnum::Scalar(AnyMysqlType::new(skip)),
+                ],
+            ),
+            (Some(limit), None) => Expression::new(
+                " LIMIT {}",
+                vec![ExpressiveEnum::Scalar(AnyMysqlType::new(limit))],
+            ),
+            (None, Some(skip)) => Expression::new(
+                " OFFSET {}",
+                vec![ExpressiveEnum::Scalar(AnyMysqlType::new(skip))],
+            ),
+            (None, None) => Expression::new("", vec![]),
+        }
+    }
+
+    fn render_ctes(&self) -> Expr {
+        if self.ctes.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            let is_recursive = self.ctes.iter().any(|(_, _, r)| *r);
+            let parts: Vec<Expr> = self
+                .ctes
+                .iter()
+                .map(|(name, query, _)| {
+                    Expression::new(
+                        format!("{} AS ({{}})", name),
+                        vec![ExpressiveEnum::Nested(query.clone())],
+                    )
+                })
+                .collect();
+            let keyword = if is_recursive {
+                "WITH RECURSIVE"
+            } else {
+                "WITH"
+            };
+            Expression::new(
+                format!("{} {{}} ", keyword),
+                vec![ExpressiveEnum::Nested(Expression::from_vec(parts, ", "))],
+            )
+        }
+    }
+
+    pub fn render(&self) -> Expr {
+        Expression::new(
+            format!(
+                "{{}}SELECT{} {{}}{{}}{{}}{{}}{{}}{{}}{{}}{{}}{{}}",
+                if self.distinct { " DISTINCT" } else { "" }
+            ),
+            vec![
+                ExpressiveEnum::Nested(self.render_ctes()),
+                ExpressiveEnum::Nested(self.render_fields()),
+                ExpressiveEnum::Nested(self.render_from()),
+                ExpressiveEnum::Nested(self.render_joins()),
+                ExpressiveEnum::Nested(self.render_where()),
+                ExpressiveEnum::Nested(self.render_group_by()),
+                ExpressiveEnum::Nested(self.render_having()),
+                ExpressiveEnum::Nested(self.render_windows()),
+                ExpressiveEnum::Nested(self.render_order_by()),
+                ExpressiveEnum::Nested(self.render_limit()),
+            ],
+        )
+    }
+
+    pub fn preview(&self) -> String {
+        self.render().preview()
+    }
+}
+
+impl Expressive<AnyMysqlType> for MysqlSelect {
+    fn expr(&self) -> Expr {
+        self.render()
+    }
+}

--- a/vantage-sql/src/mysql/statements/update/builder.rs
+++ b/vantage-sql/src/mysql/statements/update/builder.rs
@@ -1,0 +1,34 @@
+use indexmap::IndexMap;
+use vantage_expressions::Expressive;
+use vantage_types::Record;
+
+use crate::mysql::types::AnyMysqlType;
+
+use super::MysqlUpdate;
+
+impl MysqlUpdate {
+    pub fn new(table: &str) -> Self {
+        Self {
+            table: table.to_string(),
+            fields: IndexMap::new(),
+            conditions: Vec::new(),
+        }
+    }
+
+    pub fn with_field(mut self, key: impl Into<String>, value: impl Into<AnyMysqlType>) -> Self {
+        self.fields.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn with_record(mut self, record: &Record<AnyMysqlType>) -> Self {
+        for (key, value) in record.iter() {
+            self.fields.insert(key.clone(), value.clone());
+        }
+        self
+    }
+
+    pub fn with_condition(mut self, condition: impl Expressive<AnyMysqlType>) -> Self {
+        self.conditions.push(condition.expr());
+        self
+    }
+}

--- a/vantage-sql/src/mysql/statements/update/mod.rs
+++ b/vantage-sql/src/mysql/statements/update/mod.rs
@@ -1,0 +1,16 @@
+mod builder;
+mod render;
+
+use crate::mysql::types::AnyMysqlType;
+use indexmap::IndexMap;
+use vantage_expressions::Expression;
+
+type Expr = Expression<AnyMysqlType>;
+
+/// MySQL UPDATE statement builder.
+#[derive(Debug, Clone)]
+pub struct MysqlUpdate {
+    pub table: String,
+    pub fields: IndexMap<String, AnyMysqlType>,
+    pub conditions: Vec<Expr>,
+}

--- a/vantage-sql/src/mysql/statements/update/render.rs
+++ b/vantage-sql/src/mysql/statements/update/render.rs
@@ -1,0 +1,55 @@
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+use crate::mysql::types::AnyMysqlType;
+
+use super::{Expr, MysqlUpdate};
+
+impl MysqlUpdate {
+    fn render_where(&self) -> Option<Expr> {
+        if self.conditions.is_empty() {
+            return None;
+        }
+        Some(Expression::from_vec(self.conditions.clone(), " AND "))
+    }
+
+    pub fn preview(&self) -> String {
+        self.expr().preview()
+    }
+}
+
+impl Expressive<AnyMysqlType> for MysqlUpdate {
+    fn expr(&self) -> Expr {
+        if self.fields.is_empty() {
+            return Expression::new("SELECT 1 WHERE FALSE", vec![]);
+        }
+
+        let set_parts: Vec<String> = self
+            .fields
+            .keys()
+            .map(|k| format!("`{}` = {{}}", k))
+            .collect();
+        let template_base = format!("UPDATE `{}` SET {}", self.table, set_parts.join(", "));
+
+        let mut params: Vec<ExpressiveEnum<AnyMysqlType>> = self
+            .fields
+            .values()
+            .map(|v| ExpressiveEnum::Scalar(v.clone()))
+            .collect();
+
+        let template = match self.render_where() {
+            Some(cond) => {
+                params.push(ExpressiveEnum::Nested(cond));
+                format!("{} WHERE {{}}", template_base)
+            }
+            None => template_base,
+        };
+
+        Expression::new(template, params)
+    }
+}
+
+impl From<MysqlUpdate> for Expr {
+    fn from(update: MysqlUpdate) -> Self {
+        update.expr()
+    }
+}

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -1,0 +1,432 @@
+use async_trait::async_trait;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_expressions::traits::associated_expressions::AssociatedExpression;
+use vantage_expressions::traits::datasource::ExprDataSource;
+use vantage_expressions::traits::expressive::ExpressiveEnum;
+use vantage_expressions::{Expression, Expressive, Selectable};
+use vantage_table::column::core::{Column, ColumnType};
+use vantage_table::table::Table;
+use vantage_table::traits::table_source::TableSource;
+use vantage_types::{Entity, Record};
+
+use crate::mysql::MysqlDB;
+use crate::mysql::types::AnyMysqlType;
+
+/// Create an AnyMysqlType for an id value. If the id parses as an integer,
+/// use Int8 variant so MySQL doesn't complain about type mismatches.
+fn id_value(id: &str) -> AnyMysqlType {
+    if let Ok(n) = id.parse::<i64>() {
+        AnyMysqlType::new(n)
+    } else {
+        AnyMysqlType::from(id.to_string())
+    }
+}
+
+/// Parse the JSON array result from execute() into an IndexMap of id -> Record.
+fn parse_rows(
+    result: AnyMysqlType,
+    id_field_name: &str,
+) -> Result<IndexMap<String, Record<AnyMysqlType>>> {
+    let arr = match result.into_value() {
+        serde_json::Value::Array(arr) => arr,
+        other => return Err(error!("expected array result", details = other.to_string())),
+    };
+
+    let mut records = IndexMap::new();
+    for item in arr {
+        let obj = match item {
+            serde_json::Value::Object(map) => map,
+            _ => continue,
+        };
+
+        let id = obj
+            .get(id_field_name)
+            .and_then(|v| match v {
+                serde_json::Value::String(s) => Some(s.clone()),
+                serde_json::Value::Number(n) => Some(n.to_string()),
+                _ => None,
+            })
+            .ok_or_else(|| error!("row missing id field", field = id_field_name))?;
+
+        let record: Record<AnyMysqlType> = obj
+            .into_iter()
+            .map(|(k, v)| (k, AnyMysqlType::untyped(v)))
+            .collect();
+
+        records.insert(id, record);
+    }
+
+    Ok(records)
+}
+
+#[async_trait]
+impl TableSource for MysqlDB {
+    type Column<Type>
+        = Column<Type>
+    where
+        Type: ColumnType;
+    type AnyType = AnyMysqlType;
+    type Value = AnyMysqlType;
+    type Id = String;
+
+    fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
+        Column::new(name)
+    }
+
+    fn to_any_column<Type: ColumnType>(
+        &self,
+        column: Self::Column<Type>,
+    ) -> Self::Column<Self::AnyType> {
+        Column::from_column(column)
+    }
+
+    fn convert_any_column<Type: ColumnType>(
+        &self,
+        any_column: Self::Column<Self::AnyType>,
+    ) -> Option<Self::Column<Type>> {
+        Some(Column::from_column(any_column))
+    }
+
+    fn expr(
+        &self,
+        template: impl Into<String>,
+        parameters: Vec<ExpressiveEnum<Self::Value>>,
+    ) -> Expression<Self::Value> {
+        Expression::new(template, parameters)
+    }
+
+    fn search_table_expr<E>(
+        &self,
+        table: &Table<Self, E>,
+        search_value: &str,
+    ) -> Expression<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        let pattern = format!("%{}%", search_value.replace('%', "\\%"));
+        let conditions: Vec<Expression<AnyMysqlType>> = table
+            .columns()
+            .values()
+            .map(|col| {
+                Expression::new(
+                    format!("`{}` LIKE {{}}", col.name()),
+                    vec![ExpressiveEnum::Scalar(AnyMysqlType::from(
+                        pattern.clone(),
+                    ))],
+                )
+            })
+            .collect();
+
+        if conditions.is_empty() {
+            return mysql_expr!("FALSE");
+        }
+        Expression::from_vec(conditions, " OR ")
+    }
+
+    async fn list_table_values<E>(
+        &self,
+        table: &Table<Self, E>,
+    ) -> Result<IndexMap<Self::Id, Record<Self::Value>>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let select = table.select();
+        let result = self.execute(&select.expr()).await?;
+
+        parse_rows(result, &id_field_name)
+    }
+
+    async fn get_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let condition = Expression::new(
+            format!("`{}` = {{}}", id_field_name),
+            vec![ExpressiveEnum::Scalar(id_value(id))],
+        );
+        let select = table.select().with_condition(condition);
+        let result = self.execute(&select.expr()).await?;
+
+        let mut rows = parse_rows(result, &id_field_name)?;
+        rows.swap_remove(id)
+            .ok_or_else(|| error!("get_table_value: no row found", id = id.clone()))
+    }
+
+    async fn get_table_some_value<E>(
+        &self,
+        table: &Table<Self, E>,
+    ) -> Result<Option<(Self::Id, Record<Self::Value>)>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let mut select = table.select();
+        select.set_limit(Some(1), None);
+        let result = self.execute(&select.expr()).await?;
+
+        let mut rows = parse_rows(result, &id_field_name)?;
+        Ok(rows.swap_remove_index(0))
+    }
+
+    async fn get_table_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
+    where
+        E: Entity<Self::Value>,
+    {
+        let select = table.select();
+        let result = self
+            .aggregate(&select, "count", mysql_expr!("*"))
+            .await?;
+        result.try_get::<i64>().ok_or_else(|| {
+            error!(
+                "get_table_count: expected i64",
+                result = format!("{}", result)
+            )
+        })
+    }
+
+    async fn get_table_sum<E>(
+        &self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        self.aggregate(&table.select(), "sum", column.expr()).await
+    }
+
+    async fn get_table_max<E>(
+        &self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        self.aggregate(&table.select(), "max", column.expr()).await
+    }
+
+    async fn get_table_min<E>(
+        &self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        self.aggregate(&table.select(), "min", column.expr()).await
+    }
+
+    async fn insert_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        record: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let insert = crate::mysql::statements::MysqlInsert::new(table.table_name())
+            .with_field(&id_field_name, id_value(id))
+            .with_record(record);
+        self.execute(&insert.expr()).await?;
+
+        self.get_table_value(table, id).await
+    }
+
+    async fn replace_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        record: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        // MySQL: INSERT ... ON DUPLICATE KEY UPDATE ...
+        let insert = crate::mysql::statements::MysqlInsert::new(table.table_name())
+            .with_field(&id_field_name, id_value(id))
+            .with_record(record);
+        let base = insert.expr();
+
+        let set_parts: Vec<String> = record
+            .keys()
+            .map(|k| format!("`{}` = VALUES(`{}`)", k, k))
+            .collect();
+        let conflict_clause = if set_parts.is_empty() {
+            format!(" ON DUPLICATE KEY UPDATE `{}` = `{}`", id_field_name, id_field_name)
+        } else {
+            format!(
+                " ON DUPLICATE KEY UPDATE {}",
+                set_parts.join(", ")
+            )
+        };
+
+        let upsert = Expression::new(
+            format!("{}{}", base.template, conflict_clause),
+            base.parameters.clone(),
+        );
+        self.execute(&upsert).await?;
+
+        self.get_table_value(table, id).await
+    }
+
+    async fn patch_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        partial: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let id_condition = Expression::new(
+            format!("`{}` = {{}}", id_field_name),
+            vec![ExpressiveEnum::Scalar(id_value(id))],
+        );
+        let update = crate::mysql::statements::MysqlUpdate::new(table.table_name())
+            .with_record(partial)
+            .with_condition(id_condition);
+        self.execute(&update.expr()).await?;
+
+        self.get_table_value(table, id).await
+    }
+
+    async fn delete_table_value<E>(&self, table: &Table<Self, E>, id: &Self::Id) -> Result<()>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let id_condition = Expression::new(
+            format!("`{}` = {{}}", id_field_name),
+            vec![ExpressiveEnum::Scalar(id_value(id))],
+        );
+        let delete = crate::mysql::statements::MysqlDelete::new(table.table_name())
+            .with_condition(id_condition);
+        self.execute(&delete.expr()).await?;
+        Ok(())
+    }
+
+    async fn delete_table_all_values<E>(&self, table: &Table<Self, E>) -> Result<()>
+    where
+        E: Entity<Self::Value>,
+    {
+        let delete = crate::mysql::statements::MysqlDelete::new(table.table_name());
+        self.execute(&delete.expr()).await?;
+        Ok(())
+    }
+
+    async fn insert_table_return_id_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        record: &Record<Self::Value>,
+    ) -> Result<Self::Id>
+    where
+        E: Entity<Self::Value>,
+    {
+        let insert = crate::mysql::statements::MysqlInsert::new(table.table_name())
+            .with_record(record);
+
+        // MySQL doesn't support RETURNING. Execute INSERT and SELECT LAST_INSERT_ID()
+        // on the same connection to get the auto-generated id.
+        use crate::mysql::row::bind_mysql_value;
+        use vantage_expressions::{ExpressionFlattener, Flatten};
+
+        let expr = insert.expr();
+        let flattener = ExpressionFlattener::new();
+        let flattened = flattener.flatten(&expr);
+
+        // Build the INSERT query with ? placeholders
+        let mut sql = String::new();
+        let mut params = Vec::new();
+        let template_parts: Vec<&str> = flattened.template.split("{}").collect();
+        sql.push_str(template_parts[0]);
+        for (i, param) in flattened.parameters.iter().enumerate() {
+            if let ExpressiveEnum::Scalar(value) = param {
+                sql.push('?');
+                params.push(value.clone());
+            }
+            if i + 1 < template_parts.len() {
+                sql.push_str(template_parts[i + 1]);
+            }
+        }
+
+        // Acquire a single connection to ensure LAST_INSERT_ID() works
+        let mut conn = self.pool().acquire().await
+            .map_err(|e| error!("MySQL acquire connection failed", details = e.to_string()))?;
+
+        let mut query = sqlx::query(&sql);
+        for value in &params {
+            query = bind_mysql_value(query, value);
+        }
+        query.execute(&mut *conn).await
+            .map_err(|e| error!("MySQL insert failed", details = e.to_string()))?;
+
+        let row = sqlx::query("SELECT LAST_INSERT_ID() AS `id`")
+            .fetch_one(&mut *conn)
+            .await
+            .map_err(|e| error!("MySQL LAST_INSERT_ID failed", details = e.to_string()))?;
+
+        use sqlx::Row;
+        let id: u64 = row.try_get("id")
+            .map_err(|e| error!("MySQL get id failed", details = e.to_string()))?;
+
+        Ok(id.to_string())
+    }
+
+    fn column_table_values_expr<'a, E, Type: ColumnType>(
+        &'a self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Type>,
+    ) -> AssociatedExpression<'a, Self, Self::Value, Vec<Type>>
+    where
+        E: Entity<Self::Value> + 'static,
+        Self: ExprDataSource<Self::Value> + Sized,
+    {
+        let mut select = table.select();
+        select.clear_fields();
+        select.clear_order_by();
+        select.add_field(column.name());
+
+        let subquery = select.expr();
+        AssociatedExpression::new(subquery, self)
+    }
+}

--- a/vantage-sql/src/mysql/types/bool.rs
+++ b/vantage-sql/src/mysql/types/bool.rs
@@ -1,0 +1,21 @@
+//! Boolean -> MySQL Bool variant.
+//! MySQL has BOOLEAN type (alias for TINYINT(1)).
+
+use super::{MysqlType, MysqlTypeBoolMarker};
+use serde_json::Value;
+
+impl MysqlType for bool {
+    type Target = MysqlTypeBoolMarker;
+
+    fn to_json(&self) -> Value {
+        Value::Bool(*self)
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Bool(b) => Some(b),
+            Value::Number(n) => n.as_i64().map(|i| i != 0),
+            _ => None,
+        }
+    }
+}

--- a/vantage-sql/src/mysql/types/mod.rs
+++ b/vantage-sql/src/mysql/types/mod.rs
@@ -1,0 +1,136 @@
+//! MySQL Type System
+//!
+//! Defines type variants aligned with MySQL's type system:
+//!
+//! - Bool       : BOOLEAN / TINYINT(1)
+//! - Int2       : SMALLINT
+//! - Int4       : INT, INTEGER
+//! - Int8       : BIGINT
+//! - Float4     : FLOAT
+//! - Float8     : DOUBLE
+//! - Text       : TEXT, VARCHAR(N), CHAR(N)
+//!
+//! Uses `serde_json::Value` as the underlying value type with type variant
+//! tracking to prevent silent type confusion.
+
+use serde_json::Value;
+use vantage_types::vantage_type_system;
+
+vantage_type_system! {
+    type_trait: MysqlType,
+    method_name: json,
+    value_type: serde_json::Value,
+    type_variants: [
+        Null,
+        Bool,       // bool
+        Int2,       // i16
+        Int4,       // i32
+        Int8,       // i64
+        Float4,     // f32
+        Float8,     // f64
+        Text        // String, &str
+    ]
+}
+
+impl MysqlTypeVariants {
+    /// Detect the type variant from a JSON value.
+    pub fn from_json(value: &Value) -> Option<Self> {
+        match value {
+            Value::Null => Some(Self::Null),
+            Value::Bool(_) => Some(Self::Bool),
+            Value::Number(n) => {
+                if n.is_i64() || n.is_u64() {
+                    Some(Self::Int8)
+                } else {
+                    Some(Self::Float8)
+                }
+            }
+            Value::String(_) => Some(Self::Text),
+            _ => None,
+        }
+    }
+}
+
+mod bool;
+mod numbers;
+mod string;
+mod value;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_integer_round_trip() {
+        let val = AnyMysqlType::new(42i64);
+        assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Int8));
+        assert_eq!(val.try_get::<i64>(), Some(42));
+    }
+
+    #[test]
+    fn test_text_round_trip() {
+        let val = AnyMysqlType::new("hello".to_string());
+        assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Text));
+        assert_eq!(val.try_get::<String>(), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn test_real_round_trip() {
+        let val = AnyMysqlType::new(3.15f64);
+        assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Float8));
+        assert_eq!(val.try_get::<f64>(), Some(3.15));
+    }
+
+    #[test]
+    fn test_bool_round_trip() {
+        let val = AnyMysqlType::new(true);
+        assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Bool));
+        assert_eq!(val.try_get::<bool>(), Some(true));
+        // Bool is a distinct variant -- i64 extraction blocked by type boundary
+        assert_eq!(val.try_get::<i64>(), None);
+    }
+
+    #[test]
+    fn test_null_round_trip() {
+        let val = AnyMysqlType::new(None::<i64>);
+        assert_eq!(*val.value(), serde_json::Value::Null);
+        assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Int8));
+
+        let direct = <Option<i64> as MysqlType>::from_json(serde_json::Value::Null);
+        assert_eq!(direct, Some(None));
+
+        assert_eq!(val.try_get::<Option<i64>>(), Some(None));
+    }
+
+    #[test]
+    fn test_type_mismatch_text_as_integer() {
+        let val = AnyMysqlType::new("hello".to_string());
+        assert_eq!(val.try_get::<i64>(), None);
+    }
+
+    #[test]
+    fn test_type_mismatch_integer_as_text() {
+        let val = AnyMysqlType::new(42i64);
+        assert_eq!(val.try_get::<String>(), None);
+    }
+
+    #[test]
+    fn test_type_mismatch_real_as_integer() {
+        let val = AnyMysqlType::new(3.15f64);
+        assert_eq!(val.try_get::<i64>(), None);
+    }
+
+    #[test]
+    fn test_i32_round_trip() {
+        let val = AnyMysqlType::new(42i32);
+        assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Int4));
+        assert_eq!(val.try_get::<i32>(), Some(42));
+    }
+
+    #[test]
+    fn test_i16_round_trip() {
+        let val = AnyMysqlType::new(42i16);
+        assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Int2));
+        assert_eq!(val.try_get::<i16>(), Some(42));
+    }
+}

--- a/vantage-sql/src/mysql/types/numbers.rs
+++ b/vantage-sql/src/mysql/types/numbers.rs
@@ -1,0 +1,184 @@
+//! Numeric type implementations for MySQL.
+//!
+//! - i16 -> Int2 (SMALLINT)
+//! - i32 -> Int4 (INT)
+//! - i64 -> Int8 (BIGINT)
+//! - f32 -> Float4 (FLOAT)
+//! - f64 -> Float8 (DOUBLE)
+//! - i8, u8, u16, u32 -> mapped to appropriate integer variants
+//! - Option<T> delegates to T, with Null for None
+
+use super::{
+    MysqlType, MysqlTypeFloat4Marker, MysqlTypeFloat8Marker, MysqlTypeInt2Marker,
+    MysqlTypeInt4Marker, MysqlTypeInt8Marker,
+};
+use serde_json::Value;
+
+// -- i16 -> Int2 (SMALLINT) ---------------------------------------------------
+
+impl MysqlType for i16 {
+    type Target = MysqlTypeInt2Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self as i64).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64().and_then(|i| i16::try_from(i).ok()),
+            _ => None,
+        }
+    }
+}
+
+// -- i32 -> Int4 (INT) --------------------------------------------------------
+
+impl MysqlType for i32 {
+    type Target = MysqlTypeInt4Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self as i64).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64().and_then(|i| i32::try_from(i).ok()),
+            _ => None,
+        }
+    }
+}
+
+// -- i64 -> Int8 (BIGINT) ----------------------------------------------------
+
+impl MysqlType for i64 {
+    type Target = MysqlTypeInt8Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64(),
+            _ => None,
+        }
+    }
+}
+
+// -- Smaller unsigned integers mapped to appropriate MySQL types ---------------
+
+impl MysqlType for i8 {
+    type Target = MysqlTypeInt2Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self as i64).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64().and_then(|i| i8::try_from(i).ok()),
+            _ => None,
+        }
+    }
+}
+
+impl MysqlType for u8 {
+    type Target = MysqlTypeInt2Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self as i64).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64().and_then(|i| u8::try_from(i).ok()),
+            _ => None,
+        }
+    }
+}
+
+impl MysqlType for u16 {
+    type Target = MysqlTypeInt4Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self as i64).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64().and_then(|i| u16::try_from(i).ok()),
+            _ => None,
+        }
+    }
+}
+
+impl MysqlType for u32 {
+    type Target = MysqlTypeInt8Marker;
+
+    fn to_json(&self) -> Value {
+        Value::Number((*self as i64).into())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64().and_then(|i| u32::try_from(i).ok()),
+            _ => None,
+        }
+    }
+}
+
+// -- Float types --------------------------------------------------------------
+
+impl MysqlType for f32 {
+    type Target = MysqlTypeFloat4Marker;
+
+    fn to_json(&self) -> Value {
+        serde_json::Number::from_f64(*self as f64)
+            .map(Value::Number)
+            .unwrap_or(Value::Null)
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_f64().map(|f| f as f32),
+            _ => None,
+        }
+    }
+}
+
+impl MysqlType for f64 {
+    type Target = MysqlTypeFloat8Marker;
+
+    fn to_json(&self) -> Value {
+        serde_json::Number::from_f64(*self)
+            .map(Value::Number)
+            .unwrap_or(Value::Null)
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_f64(),
+            _ => None,
+        }
+    }
+}
+
+// -- Option<T> -> Null for None, delegates to T for Some ----------------------
+
+impl<T: MysqlType> MysqlType for Option<T> {
+    type Target = T::Target;
+
+    fn to_json(&self) -> Value {
+        match self {
+            Some(v) => v.to_json(),
+            None => Value::Null,
+        }
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Null => Some(None),
+            other => T::from_json(other).map(Some),
+        }
+    }
+}

--- a/vantage-sql/src/mysql/types/string.rs
+++ b/vantage-sql/src/mysql/types/string.rs
@@ -1,0 +1,31 @@
+//! String types -> MySQL TEXT
+
+use super::{MysqlType, MysqlTypeTextMarker};
+use serde_json::Value;
+
+impl MysqlType for String {
+    type Target = MysqlTypeTextMarker;
+
+    fn to_json(&self) -> Value {
+        Value::String(self.clone())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::String(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+impl MysqlType for &'static str {
+    type Target = MysqlTypeTextMarker;
+
+    fn to_json(&self) -> Value {
+        Value::String(self.to_string())
+    }
+
+    fn from_json(_value: Value) -> Option<Self> {
+        None // cannot produce &'static str from arbitrary data
+    }
+}

--- a/vantage-sql/src/mysql/types/value.rs
+++ b/vantage-sql/src/mysql/types/value.rs
@@ -1,0 +1,175 @@
+//! AnyMysqlType extras: From conversions, Display, Expressive.
+
+use super::{AnyMysqlType, MysqlType, MysqlTypeNullMarker};
+use serde_json::Value;
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+impl AnyMysqlType {
+    /// Create an AnyMysqlType with no type marker. Used for values coming
+    /// back from the database where we don't know the original type.
+    /// `try_get` on these values bypasses variant checking.
+    pub fn untyped(value: serde_json::Value) -> Self {
+        Self {
+            value,
+            type_variant: None,
+        }
+    }
+}
+
+/// AnyMysqlType is itself a MysqlType -- passthrough for type-erased values.
+impl MysqlType for AnyMysqlType {
+    type Target = MysqlTypeNullMarker;
+
+    fn to_json(&self) -> Value {
+        self.value().clone()
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        AnyMysqlType::from_json(&value)
+    }
+}
+
+impl std::fmt::Display for AnyMysqlType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.value() {
+            Value::Null => write!(f, "NULL"),
+            Value::Bool(b) => write!(f, "{}", b),
+            Value::Number(n) => write!(f, "{}", n),
+            Value::String(s) => write!(f, "'{}'", s.replace('\'', "''")),
+            other => write!(f, "{}", other),
+        }
+    }
+}
+
+// From impls for common types
+macro_rules! impl_from_for_any_mysql {
+    ($($ty:ty),*) => {
+        $(
+            impl From<$ty> for AnyMysqlType {
+                fn from(val: $ty) -> Self {
+                    AnyMysqlType::new(val)
+                }
+            }
+        )*
+    };
+}
+
+impl_from_for_any_mysql!(i8, i16, i32, i64, u8, u16, u32, f32, f64, bool, String);
+
+impl From<&str> for AnyMysqlType {
+    fn from(val: &str) -> Self {
+        AnyMysqlType::new(val.to_string())
+    }
+}
+
+// Expressive impls -- allows passing scalars directly into mysql_expr!
+macro_rules! impl_expressive_for_mysql_scalar {
+    ($($ty:ty),*) => {
+        $(
+            impl Expressive<AnyMysqlType> for $ty {
+                fn expr(&self) -> Expression<AnyMysqlType> {
+                    Expression::new(
+                        "{}",
+                        vec![ExpressiveEnum::Scalar(AnyMysqlType::new_ref(self))],
+                    )
+                }
+            }
+        )*
+    };
+}
+
+impl_expressive_for_mysql_scalar!(i8, i16, i32, i64, u8, u16, u32, f32, f64, bool, String);
+
+impl Expressive<AnyMysqlType> for &str {
+    fn expr(&self) -> Expression<AnyMysqlType> {
+        Expression::new(
+            "{}",
+            vec![ExpressiveEnum::Scalar(AnyMysqlType::from(
+                self.to_string(),
+            ))],
+        )
+    }
+}
+
+// TryFrom<AnyMysqlType> impls -- enables AssociatedExpression::get()
+macro_rules! impl_try_from_mysql {
+    ($($ty:ty),*) => {
+        $(
+            impl TryFrom<AnyMysqlType> for $ty {
+                type Error = vantage_core::VantageError;
+                fn try_from(val: AnyMysqlType) -> Result<Self, Self::Error> {
+                    // Try direct extraction first
+                    if let Some(v) = val.try_get::<$ty>() {
+                        return Ok(v);
+                    }
+                    // If result is [{col: value}], extract the scalar
+                    if let serde_json::Value::Array(arr) = val.value() {
+                        if arr.len() == 1 {
+                            if let Some(obj) = arr[0].as_object() {
+                                if obj.len() == 1 {
+                                    let inner = AnyMysqlType::untyped(
+                                        obj.values().next().unwrap().clone()
+                                    );
+                                    if let Some(v) = inner.try_get::<$ty>() {
+                                        return Ok(v);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(vantage_core::error!(
+                        "Cannot convert AnyMysqlType to target type",
+                        target = std::any::type_name::<$ty>(),
+                        value = format!("{}", val)
+                    ))
+                }
+            }
+        )*
+    };
+}
+
+impl_try_from_mysql!(i64, i32, f64, bool, String);
+
+/// Extract first row from a result array as a JSON object.
+fn extract_first_row(val: &AnyMysqlType) -> Option<serde_json::Value> {
+    match val.value() {
+        serde_json::Value::Array(arr) => arr.first().cloned(),
+        obj @ serde_json::Value::Object(_) => Some(obj.clone()),
+        _ => None,
+    }
+}
+
+impl TryFrom<AnyMysqlType> for vantage_types::Record<serde_json::Value> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnyMysqlType) -> Result<Self, Self::Error> {
+        let row = extract_first_row(&val).ok_or_else(|| {
+            vantage_core::error!("Expected row result", value = format!("{}", val))
+        })?;
+        Ok(row.into())
+    }
+}
+
+impl TryFrom<AnyMysqlType> for vantage_types::Record<AnyMysqlType> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnyMysqlType) -> Result<Self, Self::Error> {
+        let row = extract_first_row(&val).ok_or_else(|| {
+            vantage_core::error!("Expected row result", value = format!("{}", val))
+        })?;
+        match row {
+            serde_json::Value::Object(map) => Ok(map
+                .into_iter()
+                .map(|(k, v)| (k, AnyMysqlType::untyped(v)))
+                .collect()),
+            _ => Err(vantage_core::error!(
+                "Expected object row",
+                value = format!("{:?}", row)
+            )),
+        }
+    }
+}
+
+impl Expressive<AnyMysqlType> for AnyMysqlType {
+    fn expr(&self) -> Expression<AnyMysqlType> {
+        Expression::new("{}", vec![ExpressiveEnum::Scalar(self.clone())])
+    }
+}

--- a/vantage-sql/tests/mysql.rs
+++ b/vantage-sql/tests/mysql.rs
@@ -1,0 +1,31 @@
+#[cfg(feature = "mysql")]
+mod mysql {
+    #[path = "4_aggregates.rs"]
+    mod aggregates;
+    #[path = "2_associated.rs"]
+    mod associated;
+    #[path = "4_conditions.rs"]
+    mod conditions;
+    #[path = "2_defer.rs"]
+    mod defer;
+    #[path = "4_editable_data_set.rs"]
+    mod editable_data_set;
+    #[path = "2_expressions.rs"]
+    mod expressions;
+    #[path = "2_insert.rs"]
+    mod insert;
+    #[path = "4_readable_data_set.rs"]
+    mod readable_data_set;
+    #[path = "2_records.rs"]
+    mod records;
+    #[path = "5_references.rs"]
+    mod references;
+    #[path = "3_select.rs"]
+    mod select;
+    #[path = "4_table_def.rs"]
+    mod table_def;
+    #[path = "1_types_record.rs"]
+    mod types_record;
+    #[path = "1_types_round_trip.rs"]
+    mod types_round_trip;
+}

--- a/vantage-sql/tests/mysql/1_types_record.rs
+++ b/vantage-sql/tests/mysql/1_types_record.rs
@@ -1,0 +1,147 @@
+//! Test 1b: Record<AnyMysqlType> conversions — typed (write path) and
+//! untyped (read path) round-trips, error cases.
+
+use vantage_sql::mysql::AnyMysqlType;
+use vantage_types::Record;
+
+// ── Typed records (write path) ─────────────────────────────────────────────
+// Values created with AnyMysqlType::new() carry variant tags.
+
+#[test]
+fn test_typed_record_creation() {
+    let mut record: Record<AnyMysqlType> = Record::new();
+    record.insert("name".into(), AnyMysqlType::new("Cupcake".to_string()));
+    record.insert("price".into(), AnyMysqlType::new(120i64));
+    record.insert("is_deleted".into(), AnyMysqlType::new(false));
+
+    // Values carry their type markers
+    assert_eq!(
+        record["name"].try_get::<String>(),
+        Some("Cupcake".to_string())
+    );
+    assert_eq!(record["price"].try_get::<i64>(), Some(120));
+    assert_eq!(record["is_deleted"].try_get::<bool>(), Some(false));
+
+    // Type markers enforce boundaries — wrong type → None
+    assert_eq!(record["name"].try_get::<i64>(), None);
+    assert_eq!(record["price"].try_get::<String>(), None);
+}
+
+#[test]
+fn test_typed_record_with_option() {
+    let mut record: Record<AnyMysqlType> = Record::new();
+    record.insert(
+        "nickname".into(),
+        AnyMysqlType::new(Some("Ali".to_string())),
+    );
+    record.insert("note".into(), AnyMysqlType::new(None::<String>));
+
+    assert_eq!(
+        record["nickname"].try_get::<Option<String>>(),
+        Some(Some("Ali".to_string()))
+    );
+    assert_eq!(record["note"].try_get::<Option<String>>(), Some(None));
+}
+
+// ── Untyped records (read path) ────────────────────────────────────────────
+// Values created with AnyMysqlType::untyped() have type_variant: None.
+// try_get is permissive — it attempts conversion without variant check.
+
+#[test]
+fn test_untyped_record_creation() {
+    let mut record: Record<AnyMysqlType> = Record::new();
+    record.insert(
+        "name".into(),
+        AnyMysqlType::untyped(serde_json::json!("Cupcake")),
+    );
+    record.insert(
+        "price".into(),
+        AnyMysqlType::untyped(serde_json::json!(120)),
+    );
+    record.insert(
+        "active".into(),
+        AnyMysqlType::untyped(serde_json::json!(true)),
+    );
+
+    // Untyped values — try_get just attempts the conversion
+    assert_eq!(
+        record["name"].try_get::<String>(),
+        Some("Cupcake".to_string())
+    );
+    assert_eq!(record["price"].try_get::<i64>(), Some(120));
+    assert_eq!(record["active"].try_get::<bool>(), Some(true));
+
+    // Still fails when the underlying value can't convert
+    assert_eq!(record["name"].try_get::<i64>(), None); // "Cupcake" isn't a number
+    assert_eq!(record["price"].try_get::<String>(), None); // 120 isn't a string
+}
+
+#[test]
+fn test_untyped_null() {
+    let mut record: Record<AnyMysqlType> = Record::new();
+    record.insert(
+        "note".into(),
+        AnyMysqlType::untyped(serde_json::json!(null)),
+    );
+
+    // Untyped null → Option<String> works (no variant blocking it)
+    assert_eq!(record["note"].try_get::<Option<String>>(), Some(None));
+    assert_eq!(record["note"].try_get::<Option<i64>>(), Some(None));
+}
+
+// ── Typed vs untyped comparison ────────────────────────────────────────────
+
+#[test]
+fn test_typed_blocks_cross_variant() {
+    // Typed: integer value with Int8 variant
+    let typed = AnyMysqlType::new(42i64);
+    assert_eq!(typed.try_get::<i64>(), Some(42));
+    assert_eq!(typed.try_get::<f64>(), None); // Int8 ≠ Float8 → blocked
+
+    // Untyped: same JSON value but no variant
+    let untyped = AnyMysqlType::untyped(serde_json::json!(42));
+    assert_eq!(untyped.try_get::<i64>(), Some(42));
+}
+
+#[test]
+fn test_untyped_is_permissive_across_numeric() {
+    // Untyped integer: try_get as f64 works because json Number can be read as f64
+    let untyped = AnyMysqlType::untyped(serde_json::json!(42));
+    assert_eq!(untyped.try_get::<i64>(), Some(42));
+    assert_eq!(untyped.try_get::<f64>(), Some(42.0));
+
+    // Typed integer: f64 blocked by variant
+    let typed = AnyMysqlType::new(42i64);
+    assert_eq!(typed.try_get::<f64>(), None); // Int8 ≠ Float8
+}
+
+// ── MySQL-specific: bool stored natively ──────────────────────────────────
+
+#[test]
+fn test_typed_bool_in_record() {
+    let mut record: Record<AnyMysqlType> = Record::new();
+    record.insert("active".into(), AnyMysqlType::new(true));
+
+    // MySQL stores bool as native JSON bool
+    assert_eq!(*record["active"].value(), serde_json::json!(true));
+    assert_eq!(record["active"].try_get::<bool>(), Some(true));
+    // Bool ≠ Int8 → blocked
+    assert_eq!(record["active"].try_get::<i64>(), None);
+}
+
+// ── Error cases ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_missing_field_in_record() {
+    let record: Record<AnyMysqlType> = Record::new();
+    assert!(record.get("name").is_none());
+}
+
+#[test]
+fn test_typed_wrong_extraction() {
+    let mut record: Record<AnyMysqlType> = Record::new();
+    record.insert("name".into(), AnyMysqlType::new(42i64));
+
+    // Trying to get String from an Int8-tagged value fails
+    assert_eq!(record["name"].try_get::<String>(), None);
+}

--- a/vantage-sql/tests/mysql/1_types_round_trip.rs
+++ b/vantage-sql/tests/mysql/1_types_round_trip.rs
@@ -1,0 +1,154 @@
+//! Test 1a: MysqlType system — AnyMysqlType in-memory round-trips.
+//! Pure type system tests, no database, no Records.
+
+use vantage_sql::mysql::AnyMysqlType;
+use vantage_sql::mysql::types::MysqlTypeVariants;
+
+// ── Round-trips per type ───────────────────────────────────────────────────
+
+#[test]
+fn test_integer_round_trip() {
+    let val = AnyMysqlType::new(42i64);
+    assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Int8));
+    assert_eq!(val.try_get::<i64>(), Some(42));
+}
+
+#[test]
+fn test_i32_round_trip() {
+    let val = AnyMysqlType::new(42i32);
+    assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Int4));
+    assert_eq!(val.try_get::<i32>(), Some(42));
+}
+
+#[test]
+fn test_i16_round_trip() {
+    let val = AnyMysqlType::new(42i16);
+    assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Int2));
+    assert_eq!(val.try_get::<i16>(), Some(42));
+}
+
+#[test]
+fn test_text_round_trip() {
+    let val = AnyMysqlType::new("hello".to_string());
+    assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Text));
+    assert_eq!(val.try_get::<String>(), Some("hello".to_string()));
+}
+
+#[test]
+fn test_float8_round_trip() {
+    let val = AnyMysqlType::new(3.15f64);
+    assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Float8));
+    assert_eq!(val.try_get::<f64>(), Some(3.15));
+}
+
+#[test]
+fn test_float4_round_trip() {
+    let val = AnyMysqlType::new(3.15f32);
+    assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Float4));
+    // f32 round-trip goes through f64, so approximate check
+    let result = val.try_get::<f32>().unwrap();
+    assert!((result - 3.15f32).abs() < 0.001);
+}
+
+#[test]
+fn test_bool_round_trip() {
+    let val = AnyMysqlType::new(true);
+    assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Bool));
+    assert_eq!(val.try_get::<bool>(), Some(true));
+    // Bool is distinct from Int8 — type boundary enforced
+    assert_eq!(val.try_get::<i64>(), None);
+}
+
+#[test]
+fn test_null_round_trip() {
+    let val = AnyMysqlType::new(None::<i64>);
+    assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Int8));
+    assert_eq!(val.try_get::<Option<i64>>(), Some(None));
+}
+
+#[test]
+fn test_smaller_integers() {
+    let val = AnyMysqlType::new(127i8);
+    assert_eq!(val.try_get::<i8>(), Some(127));
+    // i8 maps to Int2 in mysql, but underlying JSON is the same number
+    assert_eq!(val.try_get::<i16>(), Some(127));
+
+    let val = AnyMysqlType::new(1000i16);
+    assert_eq!(val.try_get::<i16>(), Some(1000));
+
+    let val = AnyMysqlType::new(200u8);
+    assert_eq!(val.try_get::<u8>(), Some(200));
+}
+
+// ── Type mismatch: wrong variant → None ────────────────────────────────────
+
+#[test]
+fn test_mismatch_text_as_integer() {
+    let val = AnyMysqlType::new("hello".to_string());
+    assert_eq!(val.try_get::<i64>(), None);
+}
+
+#[test]
+fn test_mismatch_integer_as_text() {
+    let val = AnyMysqlType::new(42i64);
+    assert_eq!(val.try_get::<String>(), None);
+}
+
+#[test]
+fn test_mismatch_real_as_integer() {
+    let val = AnyMysqlType::new(3.15f64);
+    assert_eq!(val.try_get::<i64>(), None);
+}
+
+#[test]
+fn test_mismatch_integer_as_real() {
+    let val = AnyMysqlType::new(42i64);
+    assert_eq!(val.try_get::<f64>(), None);
+}
+
+// ── From conversions ───────────────────────────────────────────────────────
+
+#[test]
+fn test_from_str() {
+    let val: AnyMysqlType = "world".into();
+    assert_eq!(val.try_get::<String>(), Some("world".to_string()));
+}
+
+#[test]
+fn test_from_i64() {
+    let val: AnyMysqlType = 99i64.into();
+    assert_eq!(val.try_get::<i64>(), Some(99));
+}
+
+#[test]
+fn test_from_bool() {
+    let val: AnyMysqlType = false.into();
+    assert_eq!(val.try_get::<bool>(), Some(false));
+}
+
+// ── MySQL-specific: distinct integer widths ────────────────────────────────
+
+#[test]
+fn test_i32_vs_i64_variant_boundary() {
+    // i32 maps to Int4, i64 maps to Int8 — they are different variants
+    let val32 = AnyMysqlType::new(42i32);
+    let val64 = AnyMysqlType::new(42i64);
+    assert_eq!(val32.type_variant(), Some(MysqlTypeVariants::Int4));
+    assert_eq!(val64.type_variant(), Some(MysqlTypeVariants::Int8));
+
+    // Cross-variant extraction is blocked by type markers
+    assert_eq!(val32.try_get::<i64>(), None); // Int4 ≠ Int8
+    assert_eq!(val64.try_get::<i32>(), None); // Int8 ≠ Int4
+}
+
+#[test]
+fn test_f32_vs_f64_variant_boundary() {
+    let val32 = AnyMysqlType::new(1.5f32);
+    let val64 = AnyMysqlType::new(1.5f64);
+    assert_eq!(val32.type_variant(), Some(MysqlTypeVariants::Float4));
+    assert_eq!(val64.type_variant(), Some(MysqlTypeVariants::Float8));
+
+    // Cross-variant extraction blocked
+    assert_eq!(val32.try_get::<f64>(), None); // Float4 ≠ Float8
+    assert_eq!(val64.try_get::<f32>(), None); // Float8 ≠ Float4
+}

--- a/vantage-sql/tests/mysql/2_associated.rs
+++ b/vantage-sql/tests/mysql/2_associated.rs
@@ -1,0 +1,115 @@
+//! Test 2d: AssociatedExpression — expressions with a known return type.
+//!
+//! Call .get() to execute and get a typed result.
+
+use vantage_expressions::ExprDataSource;
+#[allow(unused_imports)]
+use vantage_sql::mysql::MysqlType;
+use vantage_sql::mysql::{AnyMysqlType, MysqlDB};
+use vantage_sql::mysql_expr;
+use vantage_types::{Record, TryFromRecord, entity};
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+async fn setup(table: &str) -> MysqlDB {
+    let db = MysqlDB::connect(MYSQL_URL).await.unwrap();
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE `{}` (
+            id VARCHAR(255) PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL
+        )",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "INSERT INTO `{}` VALUES ('a', 'Cheap', 50), ('b', 'Mid', 150), ('c', 'Expensive', 300)",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    db
+}
+
+#[entity(MysqlType)]
+struct Product {
+    id: String,
+    name: String,
+    price: i64,
+}
+
+#[tokio::test]
+async fn test_associated_scalar() {
+    let db = setup("assoc_scalar").await;
+
+    let associated = db.associate::<i64>(mysql_expr!("SELECT COUNT(*) FROM `assoc_scalar`"));
+    assert_eq!(associated.get().await.unwrap(), 3);
+}
+
+#[tokio::test]
+async fn test_associated_record() {
+    let db = setup("assoc_record").await;
+
+    let associated = db.associate::<Record<AnyMysqlType>>(mysql_expr!(
+        "SELECT name, price FROM `assoc_record` WHERE id = {}",
+        "a"
+    ));
+    let record = associated.get().await.unwrap();
+    assert_eq!(
+        record["name"].try_get::<String>(),
+        Some("Cheap".to_string())
+    );
+    assert_eq!(record["price"].try_get::<i64>(), Some(50));
+}
+
+#[tokio::test]
+async fn test_associated_entity() {
+    let db = setup("assoc_entity").await;
+
+    let associated = db.associate::<Record<AnyMysqlType>>(mysql_expr!(
+        "SELECT id, name, price FROM `assoc_entity` WHERE id = {}",
+        "c"
+    ));
+    let record = associated.get().await.unwrap();
+    let product = Product::from_record(record).unwrap();
+    assert_eq!(product.id, "c");
+    assert_eq!(product.name, "Expensive");
+    assert_eq!(product.price, 300);
+}
+
+// serde path: Record<JsonValue> + #[derive(Deserialize)]
+#[tokio::test]
+async fn test_associated_entity_serde() {
+    let db = setup("assoc_serde").await;
+
+    #[derive(serde::Deserialize)]
+    struct ProductSerde {
+        id: String,
+        name: String,
+        price: i64,
+    }
+
+    let record: Record<serde_json::Value> = db
+        .associate(mysql_expr!(
+            "SELECT id, name, price FROM `assoc_serde` WHERE id = {}",
+            "b"
+        ))
+        .get()
+        .await
+        .unwrap();
+    let product: ProductSerde = ProductSerde::from_record(record).unwrap();
+    assert_eq!(product.id, "b");
+    assert_eq!(product.name, "Mid");
+    assert_eq!(product.price, 150);
+}

--- a/vantage-sql/tests/mysql/2_defer.rs
+++ b/vantage-sql/tests/mysql/2_defer.rs
@@ -1,0 +1,147 @@
+//! Test 2b: Deferred expressions — cross-database value resolution.
+//!
+//! A deferred expression runs a query on one database at execution time,
+//! and the resulting value gets placed as a parameter in another database's query.
+
+use serde_json::Value as JsonValue;
+use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
+use vantage_sql::mysql::{AnyMysqlType, MysqlDB};
+use vantage_sql::mysql_expr;
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+fn rows(result: AnyMysqlType) -> Vec<JsonValue> {
+    match result.into_value() {
+        JsonValue::Array(arr) => arr,
+        other => panic!("expected array, got: {:?}", other),
+    }
+}
+
+async fn setup(prefix: &str) -> (MysqlDB, MysqlDB) {
+    // Both use the same mysql instance but different tables
+    let db = MysqlDB::connect(MYSQL_URL).await.unwrap();
+
+    let config_table = format!("{}_config", prefix);
+    let product_table = format!("{}_product", prefix);
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", config_table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", product_table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE `{}` (`key` VARCHAR(255) PRIMARY KEY, value BIGINT NOT NULL)",
+        config_table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+    sqlx::query(&format!(
+        "INSERT INTO `{}` VALUES ('min_price', 150)",
+        config_table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE `{}` (id VARCHAR(255) PRIMARY KEY, name TEXT NOT NULL, price BIGINT NOT NULL)",
+        product_table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+    sqlx::query(&format!(
+        "INSERT INTO `{}` VALUES ('a', 'Cheap Thing', 50), ('b', 'Mid Thing', 150), ('c', 'Expensive Thing', 300)",
+        product_table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    // Return same pool as two "databases" (using different tables)
+    (db.clone(), db)
+}
+
+// ── defer() resolves a value from one query, binds it into another ────────
+
+#[tokio::test]
+async fn test_cross_database_deferred() {
+    let (config_db, shop_db) = setup("defer1").await;
+
+    let threshold_query = mysql_expr!(
+        "SELECT value FROM `defer1_config` WHERE `key` = {}",
+        "min_price"
+    );
+    let deferred_threshold = config_db.defer(threshold_query);
+
+    let shop_query = Expression::<AnyMysqlType>::new(
+        "SELECT name FROM `defer1_product` WHERE price >= {} ORDER BY price",
+        vec![ExpressiveEnum::Deferred(deferred_threshold)],
+    );
+
+    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0]["name"], "Mid Thing");
+    assert_eq!(result[1]["name"], "Expensive Thing");
+}
+
+// ── Deferred mixed with regular scalar parameters ──────────────────────────
+
+#[tokio::test]
+async fn test_deferred_mixed_with_scalars() {
+    let (config_db, shop_db) = setup("defer2").await;
+
+    let threshold_query = mysql_expr!(
+        "SELECT value FROM `defer2_config` WHERE `key` = {}",
+        "min_price"
+    );
+    let deferred_threshold = config_db.defer(threshold_query);
+
+    let shop_query = Expression::<AnyMysqlType>::new(
+        "SELECT name FROM `defer2_product` WHERE price >= {} AND name != {} ORDER BY price",
+        vec![
+            ExpressiveEnum::Deferred(deferred_threshold),
+            ExpressiveEnum::Scalar(AnyMysqlType::new("Mid Thing".to_string())),
+        ],
+    );
+
+    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0]["name"], "Expensive Thing");
+}
+
+// ── Deferred inside a nested expression ───────────────────────────────────
+
+#[tokio::test]
+async fn test_nested_deferred() {
+    let (config_db, shop_db) = setup("defer3").await;
+
+    let threshold_query = mysql_expr!(
+        "SELECT value FROM `defer3_config` WHERE `key` = {}",
+        "min_price"
+    );
+    let deferred_threshold = config_db.defer(threshold_query);
+
+    let inner = Expression::<AnyMysqlType>::new(
+        "price >= {}",
+        vec![ExpressiveEnum::Deferred(deferred_threshold)],
+    );
+
+    let shop_query = mysql_expr!(
+        "SELECT name FROM `defer3_product` WHERE {} ORDER BY price",
+        (inner)
+    );
+
+    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0]["name"], "Mid Thing");
+    assert_eq!(result[1]["name"], "Expensive Thing");
+}

--- a/vantage-sql/tests/mysql/2_expressions.rs
+++ b/vantage-sql/tests/mysql/2_expressions.rs
@@ -1,0 +1,159 @@
+//! Test 2: ExprDataSource — execute Expression<AnyMysqlType> against live MySQL.
+
+use serde_json::Value as JsonValue;
+use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
+use vantage_sql::mysql::{AnyMysqlType, MysqlDB};
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+async fn setup(table: &str) -> MysqlDB {
+    let db = MysqlDB::connect(MYSQL_URL).await.unwrap();
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE `{}` (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL,
+            weight DOUBLE NOT NULL,
+            active BOOLEAN NOT NULL
+        )",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "INSERT INTO `{}` VALUES (1, 'Apple', 100, 0.2, true), (2, 'Banana', 50, 0.15, true), (3, 'Cherry', 200, 0.01, false)",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    db
+}
+
+/// Helper: unwrap result into JSON array of row objects.
+fn rows(result: AnyMysqlType) -> Vec<JsonValue> {
+    match result.into_value() {
+        JsonValue::Array(arr) => arr,
+        other => panic!("expected array, got: {:?}", other),
+    }
+}
+
+// ── Basic select via ExprDataSource ────────────────────────────────────────
+
+#[tokio::test]
+async fn test_select_all() {
+    let db = setup("expr_select_all").await;
+    let expr =
+        Expression::<AnyMysqlType>::new("SELECT * FROM `expr_select_all` ORDER BY id", vec![]);
+    let result = rows(db.execute(&expr).await.unwrap());
+
+    assert_eq!(result.len(), 3);
+    assert_eq!(result[0]["name"], "Apple");
+    assert_eq!(result[2]["name"], "Cherry");
+}
+
+// ── Parameterized query ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_parameterized_integer() {
+    let db = setup("expr_param_int").await;
+    let expr = Expression::<AnyMysqlType>::new(
+        "SELECT name FROM `expr_param_int` WHERE id = {}",
+        vec![ExpressiveEnum::Scalar(AnyMysqlType::new(2i64))],
+    );
+    let result = rows(db.execute(&expr).await.unwrap());
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0]["name"], "Banana");
+}
+
+#[tokio::test]
+async fn test_parameterized_text() {
+    let db = setup("expr_param_text").await;
+    let expr = Expression::<AnyMysqlType>::new(
+        "SELECT price FROM `expr_param_text` WHERE name = {}",
+        vec![ExpressiveEnum::Scalar(AnyMysqlType::new(
+            "Cherry".to_string(),
+        ))],
+    );
+    let result = rows(db.execute(&expr).await.unwrap());
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0]["price"], 200);
+}
+
+#[tokio::test]
+async fn test_parameterized_bool() {
+    let db = setup("expr_param_bool").await;
+    let expr = Expression::<AnyMysqlType>::new(
+        "SELECT name FROM `expr_param_bool` WHERE active = {} ORDER BY name",
+        vec![ExpressiveEnum::Scalar(AnyMysqlType::new(true))],
+    );
+    let result = rows(db.execute(&expr).await.unwrap());
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0]["name"], "Apple");
+    assert_eq!(result[1]["name"], "Banana");
+}
+
+// ── Multiple parameters ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_multiple_params() {
+    let db = setup("expr_multi_params").await;
+    let expr = Expression::<AnyMysqlType>::new(
+        "SELECT name FROM `expr_multi_params` WHERE price >= {} AND active = {}",
+        vec![
+            ExpressiveEnum::Scalar(AnyMysqlType::new(100i64)),
+            ExpressiveEnum::Scalar(AnyMysqlType::new(true)),
+        ],
+    );
+    let result = rows(db.execute(&expr).await.unwrap());
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0]["name"], "Apple");
+}
+
+// ── Nested expressions ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_nested_expression() {
+    let db = setup("expr_nested").await;
+
+    let where_clause = Expression::<AnyMysqlType>::new(
+        "price > {}",
+        vec![ExpressiveEnum::Scalar(AnyMysqlType::new(75i64))],
+    );
+    let full_query = Expression::<AnyMysqlType>::new(
+        "SELECT name FROM `expr_nested` WHERE {} ORDER BY name",
+        vec![ExpressiveEnum::Nested(where_clause)],
+    );
+
+    let result = rows(db.execute(&full_query).await.unwrap());
+    assert_eq!(result.len(), 2);
+    assert_eq!(result[0]["name"], "Apple");
+    assert_eq!(result[1]["name"], "Cherry");
+}
+
+// ── Empty result ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_empty_result() {
+    let db = setup("expr_empty").await;
+    let expr = Expression::<AnyMysqlType>::new(
+        "SELECT name FROM `expr_empty` WHERE id = {}",
+        vec![ExpressiveEnum::Scalar(AnyMysqlType::new(999i64))],
+    );
+    let result = rows(db.execute(&expr).await.unwrap());
+
+    assert!(result.is_empty());
+}

--- a/vantage-sql/tests/mysql/2_insert.rs
+++ b/vantage-sql/tests/mysql/2_insert.rs
@@ -1,0 +1,207 @@
+//! Test 2a: INSERT via Expression<AnyMysqlType> + ExprDataSource.
+//!
+//! No statement builders — raw expressions with typed parameters.
+//! Focuses on the Product table to exercise multiple types (text, integer, bool).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+#[allow(unused_imports)]
+use vantage_expressions::Expressive;
+use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
+use vantage_sql::mysql::{AnyMysqlType, MysqlDB};
+use vantage_sql::mysql_expr;
+use vantage_types::{Record, TryFromRecord};
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+struct Product {
+    name: String,
+    price: i64,
+    calories: i64,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+async fn setup(table: &str) -> MysqlDB {
+    let db = MysqlDB::connect(MYSQL_URL).await.unwrap();
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE `{}` (
+            id VARCHAR(255) PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL,
+            calories BIGINT NOT NULL,
+            is_deleted BOOLEAN NOT NULL DEFAULT false,
+            inventory_stock BIGINT NOT NULL DEFAULT 0
+        )",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    db
+}
+
+/// Helper: execute expression, unwrap result into JSON rows.
+fn rows(result: AnyMysqlType) -> Vec<JsonValue> {
+    match result.into_value() {
+        JsonValue::Array(arr) => arr,
+        other => panic!("expected array, got: {:?}", other),
+    }
+}
+
+// ── Insert with typed parameters ───────────────────────────────────────────
+
+#[tokio::test]
+async fn test_insert_product() {
+    let db = setup("ins_product").await;
+
+    let insert = mysql_expr!(
+        "INSERT INTO `ins_product` (`id`, `name`, `price`, `calories`, `is_deleted`, `inventory_stock`) VALUES ({}, {}, {}, {}, {}, {})",
+        "cupcake",
+        "Flux Cupcake",
+        120i64,
+        300i64,
+        false,
+        50i64
+    );
+
+    db.execute(&insert).await.unwrap();
+
+    let select = mysql_expr!(
+        "SELECT name, price, calories, is_deleted, inventory_stock FROM `ins_product` WHERE id = {}",
+        "cupcake"
+    );
+    let result = rows(db.execute(&select).await.unwrap());
+
+    assert_eq!(result.len(), 1);
+
+    let record: Record<JsonValue> = result[0].clone().into();
+    let product: Product = Product::from_record(record).unwrap();
+
+    assert_eq!(product.name, "Flux Cupcake");
+    assert_eq!(product.price, 120);
+    assert_eq!(product.calories, 300);
+    assert!(!product.is_deleted);
+    assert_eq!(product.inventory_stock, 50);
+}
+
+// ── Insert multiple rows via nested expressions ───────────────────────────
+
+#[tokio::test]
+async fn test_insert_multiple_products() {
+    let db = setup("ins_multi").await;
+
+    let row1 = mysql_expr!(
+        "({}, {}, {}, {}, {}, {})",
+        "tart",
+        "Time Tart",
+        220i64,
+        200i64,
+        false,
+        20i64
+    );
+    let row2 = mysql_expr!(
+        "({}, {}, {}, {}, {}, {})",
+        "donut",
+        "DeLorean Doughnut",
+        135i64,
+        250i64,
+        false,
+        30i64
+    );
+    let row3 = mysql_expr!(
+        "({}, {}, {}, {}, {}, {})",
+        "pie",
+        "Sea Pie",
+        299i64,
+        350i64,
+        true,
+        0i64
+    );
+
+    let rows_expr = Expression::from_vec(vec![row1, row2, row3], ", ");
+    let insert = Expression::<AnyMysqlType>::new(
+        "INSERT INTO `ins_multi` (`id`, `name`, `price`, `calories`, `is_deleted`, `inventory_stock`) VALUES {}",
+        vec![ExpressiveEnum::Nested(rows_expr)],
+    );
+
+    db.execute(&insert).await.unwrap();
+
+    let select = mysql_expr!(
+        "SELECT name, price, calories, is_deleted, inventory_stock FROM `ins_multi` ORDER BY price"
+    );
+    let result = rows(db.execute(&select).await.unwrap());
+
+    assert_eq!(result.len(), 3);
+
+    let parsed: Vec<Product> = result
+        .into_iter()
+        .map(|r| Product::from_record(r.into()).unwrap())
+        .collect();
+
+    assert_eq!(parsed[0].name, "DeLorean Doughnut");
+    assert_eq!(parsed[0].price, 135);
+    assert!(!parsed[0].is_deleted);
+
+    assert_eq!(parsed[2].name, "Sea Pie");
+    assert_eq!(parsed[2].price, 299);
+    assert!(parsed[2].is_deleted);
+    assert_eq!(parsed[2].inventory_stock, 0);
+}
+
+// ── Type marker verification ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_bool_binds_correctly() {
+    let db = setup("ins_bool").await;
+
+    let insert = mysql_expr!(
+        "INSERT INTO `ins_bool` (`id`, `name`, `price`, `calories`, `is_deleted`, `inventory_stock`) VALUES ({}, {}, {}, {}, {}, {})",
+        "deleted_item",
+        "Gone",
+        100i64,
+        100i64,
+        true,
+        0i64
+    );
+    db.execute(&insert).await.unwrap();
+
+    // Query with bool parameter — MySQL BOOLEAN is TINYINT(1)
+    let select = mysql_expr!("SELECT name FROM `ins_bool` WHERE is_deleted = {}", true);
+    let result = rows(db.execute(&select).await.unwrap());
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0]["name"], "Gone");
+}
+
+#[tokio::test]
+async fn test_integer_vs_text_binding() {
+    let db = setup("ins_int_text").await;
+
+    let insert = mysql_expr!(
+        "INSERT INTO `ins_int_text` (`id`, `name`, `price`, `calories`, `is_deleted`, `inventory_stock`) VALUES ({}, {}, {}, {}, {}, {})",
+        "item1",
+        "Test",
+        100i64,
+        100i64,
+        false,
+        10i64
+    );
+    db.execute(&insert).await.unwrap();
+
+    let by_price = mysql_expr!("SELECT id FROM `ins_int_text` WHERE price = {}", 100i64);
+    let result = rows(db.execute(&by_price).await.unwrap());
+    assert_eq!(result.len(), 1);
+
+    let by_name = mysql_expr!("SELECT id FROM `ins_int_text` WHERE name = {}", "Test");
+    let result = rows(db.execute(&by_name).await.unwrap());
+    assert_eq!(result.len(), 1);
+}

--- a/vantage-sql/tests/mysql/2_records.rs
+++ b/vantage-sql/tests/mysql/2_records.rs
@@ -1,0 +1,181 @@
+//! Test 2c: SELECT into Record and deserialize into structs.
+//!
+//! Uses associate::<Record<JsonValue>> and TryFromRecord to verify
+//! the full pipeline. Includes failure cases for field mismatches.
+//!
+//! All tests share pre-populated data via separate tables to avoid race conditions.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use vantage_expressions::ExprDataSource;
+use vantage_sql::mysql::MysqlDB;
+use vantage_sql::mysql_expr;
+use vantage_types::{Record, TryFromRecord};
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+async fn setup(table: &str) -> MysqlDB {
+    let db = MysqlDB::connect(MYSQL_URL).await.unwrap();
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE `{}` (
+            id VARCHAR(255) PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL,
+            calories BIGINT NOT NULL,
+            weight DOUBLE,
+            is_deleted BOOLEAN NOT NULL DEFAULT false,
+            description TEXT
+        )",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "INSERT INTO `{}` VALUES
+            ('cupcake', 'Flux Cupcake', 120, 300, 0.25, false, 'A tasty cupcake'),
+            ('tart', 'Time Tart', 220, 200, 0.15, true, 'tart'),
+            ('plain', 'Plain Bread', 50, 150, NULL, false, NULL)",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    db
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+struct Product {
+    id: String,
+    name: String,
+    price: i64,
+    calories: i64,
+    weight: Option<f64>,
+    is_deleted: bool,
+    description: Option<String>,
+}
+
+#[tokio::test]
+async fn test_select_single_record_into_entity() {
+    let db = setup("rec_entity").await;
+
+    let record: Record<JsonValue> = db
+        .associate(mysql_expr!(
+            "SELECT * FROM `rec_entity` WHERE id = {}",
+            "cupcake"
+        ))
+        .get()
+        .await
+        .unwrap();
+
+    let product: Product = Product::from_record(record).unwrap();
+    assert_eq!(product.name, "Flux Cupcake");
+    assert_eq!(product.price, 120);
+    assert!((product.weight.unwrap() - 0.25).abs() < f64::EPSILON);
+    assert_eq!(product.description, Some("A tasty cupcake".to_string()));
+    assert!(!product.is_deleted);
+}
+
+#[tokio::test]
+async fn test_null_into_optional_field() {
+    let db = setup("rec_optional").await;
+
+    let record: Record<JsonValue> = db
+        .associate(mysql_expr!(
+            "SELECT name, price, weight, description FROM `rec_optional` WHERE id = {}",
+            "plain"
+        ))
+        .get()
+        .await
+        .unwrap();
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct ProductOptional {
+        name: String,
+        price: i64,
+        weight: Option<f64>,
+        description: Option<String>,
+    }
+
+    let product: ProductOptional = ProductOptional::from_record(record).unwrap();
+    assert_eq!(product.name, "Plain Bread");
+    assert_eq!(product.weight, None);
+    assert_eq!(product.description, None);
+}
+
+#[tokio::test]
+async fn test_missing_field_fails() {
+    let db = setup("rec_missing").await;
+
+    let record: Record<JsonValue> = db
+        .associate(mysql_expr!(
+            "SELECT * FROM `rec_missing` WHERE id = {}",
+            "cupcake"
+        ))
+        .get()
+        .await
+        .unwrap();
+
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    struct ProductWithRating {
+        name: String,
+        rating: f64, // doesn't exist
+    }
+
+    assert!(ProductWithRating::from_record(record).is_err());
+}
+
+#[tokio::test]
+async fn test_null_into_required_field_fails() {
+    let db = setup("rec_null_required").await;
+
+    let record: Record<JsonValue> = db
+        .associate(mysql_expr!(
+            "SELECT name, weight FROM `rec_null_required` WHERE id = {}",
+            "plain"
+        ))
+        .get()
+        .await
+        .unwrap();
+
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    struct Strict {
+        name: String,
+        weight: f64, // NOT Option — plain has NULL here
+    }
+
+    assert!(Strict::from_record(record).is_err());
+}
+
+#[tokio::test]
+async fn test_wrong_field_type_fails() {
+    let db = setup("rec_wrong_type").await;
+
+    let record: Record<JsonValue> = db
+        .associate(mysql_expr!(
+            "SELECT name, price FROM `rec_wrong_type` WHERE id = {}",
+            "cupcake"
+        ))
+        .get()
+        .await
+        .unwrap();
+
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    struct WrongTypes {
+        name: i64,     // TEXT in DB
+        price: String, // BIGINT in DB
+    }
+
+    assert!(WrongTypes::from_record(record).is_err());
+}

--- a/vantage-sql/tests/mysql/3_select.rs
+++ b/vantage-sql/tests/mysql/3_select.rs
@@ -1,0 +1,215 @@
+//! Test 3a: MysqlSelect via Selectable trait + SelectableDataSource execution.
+
+use vantage_expressions::{ExprDataSource, Expressive, Selectable};
+#[allow(unused_imports)]
+use vantage_sql::mysql::MysqlType;
+use vantage_sql::mysql::statements::MysqlSelect;
+use vantage_sql::mysql::{AnyMysqlType, MysqlDB};
+use vantage_sql::mysql_expr;
+use vantage_types::{Record, TryFromRecord, entity};
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+async fn setup(table: &str) -> MysqlDB {
+    let db = MysqlDB::connect(MYSQL_URL).await.unwrap();
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", table))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE `{}` (
+            id VARCHAR(255) PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL,
+            is_deleted BOOLEAN NOT NULL DEFAULT false
+        )",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "INSERT INTO `{}` VALUES ('a', 'Cheap', 50, false), ('b', 'Mid', 150, false), ('c', 'Expensive', 300, true)",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    db
+}
+
+#[entity(MysqlType)]
+struct Product {
+    id: String,
+    name: String,
+    price: i64,
+    is_deleted: bool,
+}
+
+// ── Rendering via Selectable trait methods ──────────────────────────────────
+
+#[test]
+fn test_select_all() {
+    let s = MysqlSelect::new().with_source("product");
+    assert_eq!(s.preview(), "SELECT * FROM `product`");
+}
+
+#[test]
+fn test_select_fields() {
+    let s = MysqlSelect::new()
+        .with_source("product")
+        .with_field("name")
+        .with_field("price");
+    assert_eq!(s.preview(), "SELECT `name`, `price` FROM `product`");
+}
+
+#[test]
+fn test_select_with_condition() {
+    let s = MysqlSelect::new()
+        .with_source("product")
+        .with_condition(mysql_expr!("`price` > {}", 100i64));
+    assert_eq!(
+        s.preview(),
+        "SELECT * FROM `product` WHERE `price` > 100"
+    );
+}
+
+#[test]
+fn test_select_order_and_limit() {
+    let s = MysqlSelect::new()
+        .with_source("product")
+        .with_order(mysql_expr!("`price`"), false)
+        .with_limit(Some(2), None);
+    assert_eq!(
+        s.preview(),
+        "SELECT * FROM `product` ORDER BY `price` DESC LIMIT 2"
+    );
+}
+
+#[test]
+fn test_select_distinct() {
+    let mut s = MysqlSelect::new()
+        .with_source("product")
+        .with_field("name");
+    s.set_distinct(true);
+    assert_eq!(s.preview(), "SELECT DISTINCT `name` FROM `product`");
+}
+
+#[test]
+fn test_select_group_by_with_expression() {
+    let s = MysqlSelect::new()
+        .with_source("product")
+        .with_field("is_deleted")
+        .with_expression(mysql_expr!("COUNT(*)"), Some("cnt".to_string()));
+    let mut s = s;
+    s.add_group_by(mysql_expr!("`is_deleted`"));
+    assert_eq!(
+        s.preview(),
+        "SELECT `is_deleted`, COUNT(*) AS `cnt` FROM `product` GROUP BY `is_deleted`"
+    );
+}
+
+#[test]
+fn test_as_count() {
+    let s = MysqlSelect::new()
+        .with_source("product")
+        .with_condition(mysql_expr!("`is_deleted` = {}", false));
+    let count_expr = s.as_count();
+    assert_eq!(
+        count_expr.preview(),
+        "SELECT COUNT(*) FROM `product` WHERE `is_deleted` = false"
+    );
+}
+
+#[test]
+fn test_as_sum() {
+    let s = MysqlSelect::new().with_source("product");
+    let sum_expr = s.as_sum(mysql_expr!("`price`"));
+    assert_eq!(
+        sum_expr.preview(),
+        "SELECT CAST(SUM(`price`) AS SIGNED) FROM `product`"
+    );
+}
+
+// ── Live execution via ExprDataSource ──────────────────────────────────────
+
+#[tokio::test]
+async fn test_execute_select_all() {
+    let db = setup("sel_all").await;
+
+    let select = MysqlSelect::new().with_source("sel_all");
+    let result: Record<AnyMysqlType> = db.associate(select.expr()).get().await.unwrap();
+
+    assert!(result.get("id").is_some());
+}
+
+#[tokio::test]
+async fn test_execute_select_with_condition() {
+    let db = setup("sel_cond").await;
+
+    let select = MysqlSelect::new()
+        .with_source("sel_cond")
+        .with_condition(mysql_expr!("`is_deleted` = {}", false));
+
+    let result = db.execute(&select.expr()).await.unwrap();
+    let rows = result.into_value();
+    assert_eq!(rows.as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn test_execute_count() {
+    let db = setup("sel_count").await;
+
+    let select = MysqlSelect::new()
+        .with_source("sel_count")
+        .with_condition(mysql_expr!("`is_deleted` = {}", false));
+    let count = db.associate::<i64>(select.as_count()).get().await.unwrap();
+    assert_eq!(count, 2);
+}
+
+#[tokio::test]
+async fn test_execute_sum() {
+    let db = setup("sel_sum").await;
+
+    let select = MysqlSelect::new().with_source("sel_sum");
+    let total = db
+        .associate::<i64>(select.as_sum(mysql_expr!("`price`")))
+        .get()
+        .await
+        .unwrap();
+    assert_eq!(total, 500); // 50 + 150 + 300
+}
+
+#[tokio::test]
+async fn test_execute_into_entity() {
+    let db = setup("sel_entity").await;
+
+    let select = MysqlSelect::new()
+        .with_source("sel_entity")
+        .with_condition(mysql_expr!("`id` = {}", "b"));
+
+    let record: Record<AnyMysqlType> = db.associate(select.expr()).get().await.unwrap();
+    let product = Product::from_record(record).unwrap();
+    assert_eq!(product.name, "Mid");
+    assert_eq!(product.price, 150);
+    assert!(!product.is_deleted);
+}
+
+#[tokio::test]
+async fn test_execute_order_and_limit() {
+    let db = setup("sel_order").await;
+
+    let select = MysqlSelect::new()
+        .with_source("sel_order")
+        .with_order(mysql_expr!("`price`"), false)
+        .with_limit(Some(1), None);
+
+    let record: Record<AnyMysqlType> = db.associate(select.expr()).get().await.unwrap();
+    let product = Product::from_record(record).unwrap();
+    assert_eq!(product.name, "Expensive");
+    assert_eq!(product.price, 300);
+}

--- a/vantage-sql/tests/mysql/4_aggregates.rs
+++ b/vantage-sql/tests/mysql/4_aggregates.rs
@@ -1,0 +1,71 @@
+//! Test 4: Aggregates — COUNT, SUM, MAX, MIN via Table.
+
+#[allow(unused_imports)]
+use vantage_sql::mysql::AnyMysqlType;
+use vantage_sql::mysql::MysqlDB;
+#[allow(unused_imports)]
+use vantage_sql::mysql::MysqlType;
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+async fn get_db() -> MysqlDB {
+    MysqlDB::connect(MYSQL_URL).await.unwrap()
+}
+
+#[entity(MysqlType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn mysql_table(db: MysqlDB) -> Table<MysqlDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+#[tokio::test]
+async fn test_count() {
+    let db = get_db().await;
+    let table = Product::mysql_table(db);
+    assert_eq!(table.get_count().await.unwrap(), 5);
+}
+
+#[tokio::test]
+async fn test_max_price() {
+    let db = get_db().await;
+    let table = Product::mysql_table(db);
+    let max = table.get_max(&table["price"]).await.unwrap();
+    assert_eq!(max.try_get::<i64>().unwrap(), 299);
+}
+
+#[tokio::test]
+async fn test_min_price() {
+    let db = get_db().await;
+    let table = Product::mysql_table(db);
+    let min = table.get_min(&table["price"]).await.unwrap();
+    assert_eq!(min.try_get::<i64>().unwrap(), 120);
+}
+
+#[tokio::test]
+async fn test_sum_price() {
+    let db = get_db().await;
+    let table = Product::mysql_table(db);
+    let sum = table.get_sum(&table["price"]).await.unwrap();
+    // 120 + 135 + 220 + 299 + 199 = 973
+    assert_eq!(sum.try_get::<i64>().unwrap(), 973);
+}

--- a/vantage-sql/tests/mysql/4_conditions.rs
+++ b/vantage-sql/tests/mysql/4_conditions.rs
@@ -1,0 +1,83 @@
+//! Test 4: Conditions on Table<MysqlDB, Entity>.
+
+#[allow(unused_imports)]
+use vantage_sql::mysql::AnyMysqlType;
+use vantage_sql::mysql::MysqlDB;
+#[allow(unused_imports)]
+use vantage_sql::mysql::MysqlType;
+use vantage_sql::mysql_expr;
+use vantage_table::operation::Operation;
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::ReadableDataSet;
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+async fn get_db() -> MysqlDB {
+    MysqlDB::connect(MYSQL_URL).await.unwrap()
+}
+
+#[entity(MysqlType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn mysql_table(db: MysqlDB) -> Table<MysqlDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+#[tokio::test]
+async fn test_custom_expression_condition() {
+    let db = get_db().await;
+    let mut table = Product::mysql_table(db);
+    table.add_condition(mysql_expr!("{} > {}", (table["price"]), 130i64));
+
+    let products = table.list().await.unwrap();
+    assert_eq!(products.len(), 4); // 135, 220, 299, 199
+}
+
+#[tokio::test]
+async fn test_multiple_conditions() {
+    let db = get_db().await;
+    let mut table = Product::mysql_table(db);
+    table.add_condition(mysql_expr!("{} > {}", (table["price"]), 130i64));
+    table.add_condition(mysql_expr!(
+        "{} > {}",
+        (table["price"]),
+        (table["calories"])
+    ));
+
+    let products = table.list().await.unwrap();
+    // price > 130 AND price > calories:
+    // delorean_donut: 135 > 250? no
+    // time_tart: 220 > 200? yes
+    // sea_pie: 299 > 350? no
+    // hover_cookies: 199 > 150? yes
+    assert_eq!(products.len(), 2);
+}
+
+#[tokio::test]
+async fn test_operation_eq() {
+    let db = get_db().await;
+    let mut table = Product::mysql_table(db);
+    table.add_condition(table["is_deleted"].eq(false));
+
+    let products = table.list().await.unwrap();
+    assert_eq!(products.len(), 5); // all products have is_deleted=false
+}

--- a/vantage-sql/tests/mysql/4_editable_data_set.rs
+++ b/vantage-sql/tests/mysql/4_editable_data_set.rs
@@ -1,0 +1,157 @@
+//! Test 4: WritableDataSet and InsertableDataSet for Table<MysqlDB, Entity>.
+
+#[allow(unused_imports)]
+use vantage_sql::mysql::AnyMysqlType;
+use vantage_sql::mysql::MysqlDB;
+#[allow(unused_imports)]
+use vantage_sql::mysql::MysqlType;
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::{InsertableDataSet, ReadableDataSet, WritableDataSet};
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+#[entity(MysqlType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Item {
+    name: String,
+    price: i64,
+}
+
+async fn setup(suffix: &str) -> (MysqlDB, Table<MysqlDB, Item>) {
+    let db = MysqlDB::connect(MYSQL_URL).await.unwrap();
+    let table_name = format!("edit_item_{}", suffix);
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", table_name))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE `{}` (
+            id VARCHAR(255) PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL
+        )",
+        table_name
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "INSERT INTO `{}` VALUES ('a', 'Alpha', 10), ('b', 'Beta', 20)",
+        table_name
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let table = Table::<MysqlDB, Item>::new(&table_name, db.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price");
+    (db, table)
+}
+
+#[tokio::test]
+async fn test_insert() {
+    let (_db, table) = setup("insert").await;
+
+    let item = Item {
+        name: "Gamma".into(),
+        price: 30,
+    };
+    let result = table.insert(&"c".to_string(), &item).await.unwrap();
+    assert_eq!(result.name, "Gamma");
+    assert_eq!(result.price, 30);
+
+    let fetched = table.get("c").await.unwrap();
+    assert_eq!(fetched.name, "Gamma");
+}
+
+#[tokio::test]
+async fn test_replace() {
+    let (_db, table) = setup("replace").await;
+
+    let item = Item {
+        name: "Alpha Replaced".into(),
+        price: 99,
+    };
+    table.replace(&"a".to_string(), &item).await.unwrap();
+
+    let fetched = table.get("a").await.unwrap();
+    assert_eq!(fetched.name, "Alpha Replaced");
+    assert_eq!(fetched.price, 99);
+}
+
+#[tokio::test]
+async fn test_patch() {
+    let (_db, table) = setup("patch").await;
+
+    let partial = Item {
+        name: "".into(),
+        price: 55,
+    };
+    table.patch(&"a".to_string(), &partial).await.unwrap();
+
+    let fetched = table.get("a").await.unwrap();
+    assert_eq!(fetched.price, 55);
+}
+
+#[tokio::test]
+async fn test_delete() {
+    let (_db, table) = setup("delete").await;
+
+    table.delete(&"a".to_string()).await.unwrap();
+
+    let all = table.list().await.unwrap();
+    assert_eq!(all.len(), 1);
+    assert!(!all.contains_key("a"));
+}
+
+#[tokio::test]
+async fn test_delete_all() {
+    let (_db, table) = setup("delete_all").await;
+
+    table.delete_all().await.unwrap();
+    assert!(table.list().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_insert_return_id() {
+    let (db, _) = setup("auto_id").await;
+
+    sqlx::query("DROP TABLE IF EXISTS `edit_auto_item`")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(
+        "CREATE TABLE `edit_auto_item` (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let table = Table::<MysqlDB, Item>::new("edit_auto_item", db)
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price");
+
+    let item = Item {
+        name: "Auto".into(),
+        price: 42,
+    };
+    let id = table.insert_return_id(&item).await.unwrap();
+    assert!(!id.is_empty());
+
+    let fetched = table.get(id).await.unwrap();
+    assert_eq!(fetched.name, "Auto");
+    assert_eq!(fetched.price, 42);
+}

--- a/vantage-sql/tests/mysql/4_readable_data_set.rs
+++ b/vantage-sql/tests/mysql/4_readable_data_set.rs
@@ -1,0 +1,83 @@
+//! Test 4: ReadableDataSet for Table<MysqlDB, Entity>.
+
+#[allow(unused_imports)]
+use vantage_sql::mysql::AnyMysqlType;
+use vantage_sql::mysql::MysqlDB;
+#[allow(unused_imports)]
+use vantage_sql::mysql::MysqlType;
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::ReadableDataSet;
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+async fn get_db() -> MysqlDB {
+    MysqlDB::connect(MYSQL_URL)
+        .await
+        .expect("Failed to connect — run scripts/mysql/db/v2.sql first")
+}
+
+#[entity(MysqlType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn mysql_table(db: MysqlDB) -> Table<MysqlDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+#[tokio::test]
+async fn test_list_products() {
+    let db = get_db().await;
+    let table = Product::mysql_table(db);
+
+    let products = table.list().await.unwrap();
+    assert_eq!(products.len(), 5);
+
+    let cupcake = &products["flux_cupcake"];
+    assert_eq!(cupcake.name, "Flux Capacitor Cupcake");
+    assert_eq!(cupcake.price, 120);
+    assert_eq!(cupcake.calories, 300);
+    assert!(!cupcake.is_deleted);
+}
+
+#[tokio::test]
+async fn test_get_product() {
+    let db = get_db().await;
+    let table = Product::mysql_table(db);
+
+    let product = table.get("delorean_donut").await.unwrap();
+    assert_eq!(product.name, "DeLorean Doughnut");
+    assert_eq!(product.price, 135);
+    assert_eq!(product.calories, 250);
+}
+
+#[tokio::test]
+async fn test_get_some_product() {
+    let db = get_db().await;
+    let table = Product::mysql_table(db);
+
+    let result = table.get_some().await.unwrap();
+    assert!(result.is_some());
+
+    let (id, product) = result.unwrap();
+    assert!(!id.is_empty());
+    assert!(!product.name.is_empty());
+    assert!(product.price > 0);
+}

--- a/vantage-sql/tests/mysql/4_table_def.rs
+++ b/vantage-sql/tests/mysql/4_table_def.rs
@@ -1,0 +1,46 @@
+//! Test 4: Table definition and query generation via TableSource.
+
+#[allow(unused_imports)]
+use vantage_sql::mysql::AnyMysqlType;
+use vantage_sql::mysql::MysqlDB;
+#[allow(unused_imports)]
+use vantage_sql::mysql::MysqlType;
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+#[entity(MysqlType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Product {
+    name: String,
+    calories: i64,
+    price: i64,
+    bakery_id: String,
+    is_deleted: bool,
+    inventory_stock: i64,
+}
+
+impl Product {
+    fn mysql_table(db: MysqlDB) -> Table<MysqlDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<String>("bakery_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<i64>("inventory_stock")
+    }
+}
+
+#[tokio::test]
+async fn test_product_select() {
+    let db = MysqlDB::connect(MYSQL_URL).await.unwrap();
+    let table = Product::mysql_table(db);
+    let select = table.select();
+    assert_eq!(
+        select.preview(),
+        "SELECT `id`, `name`, `calories`, `price`, `bakery_id`, `is_deleted`, `inventory_stock` FROM `product`"
+    );
+}

--- a/vantage-sql/tests/mysql/5_references.rs
+++ b/vantage-sql/tests/mysql/5_references.rs
@@ -1,0 +1,107 @@
+//! Test 5: Relationship traversal — with_one, with_many, get_ref_as.
+
+#[allow(unused_imports)]
+use vantage_sql::mysql::AnyMysqlType;
+use vantage_sql::mysql::MysqlDB;
+#[allow(unused_imports)]
+use vantage_sql::mysql::MysqlType;
+use vantage_sql::mysql_expr;
+use vantage_table::table::Table;
+use vantage_types::entity;
+
+use vantage_dataset::ReadableDataSet;
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+async fn get_db() -> MysqlDB {
+    MysqlDB::connect(MYSQL_URL).await.unwrap()
+}
+
+#[entity(MysqlType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Client {
+    name: String,
+    email: String,
+    contact_details: String,
+    is_paying_client: bool,
+    bakery_id: String,
+}
+
+#[entity(MysqlType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct ClientOrder {
+    bakery_id: String,
+    client_id: String,
+    is_deleted: bool,
+}
+
+fn client_table(db: MysqlDB) -> Table<MysqlDB, Client> {
+    let db2 = db.clone();
+    Table::new("client", db)
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<String>("email")
+        .with_column_of::<String>("contact_details")
+        .with_column_of::<bool>("is_paying_client")
+        .with_column_of::<String>("bakery_id")
+        .with_many("orders", "client_id", move || order_table(db2.clone()))
+}
+
+fn order_table(db: MysqlDB) -> Table<MysqlDB, ClientOrder> {
+    let db2 = db.clone();
+    Table::new("client_order", db)
+        .with_id_column("id")
+        .with_column_of::<String>("bakery_id")
+        .with_column_of::<String>("client_id")
+        .with_column_of::<bool>("is_deleted")
+        .with_one("client", "client_id", move || client_table(db2.clone()))
+}
+
+/// Traverse has_many: paying clients -> their orders
+#[tokio::test]
+async fn test_has_many_orders_for_paying_clients() {
+    let db = get_db().await;
+    let mut clients = client_table(db.clone());
+    clients.add_condition(mysql_expr!(
+        "{} = {}",
+        (clients["is_paying_client"]),
+        true
+    ));
+
+    let orders = clients
+        .get_ref_as::<MysqlDB, ClientOrder>("orders")
+        .unwrap();
+
+    let order_list = orders.list().await.unwrap();
+    // Marty has 1 order, Doc has 2 orders -> 3 total
+    assert_eq!(order_list.len(), 3);
+}
+
+/// Traverse has_many: single client -> orders
+#[tokio::test]
+async fn test_has_many_orders_for_single_client() {
+    let db = get_db().await;
+    let mut clients = client_table(db.clone());
+    clients.add_condition(mysql_expr!("{} = {}", (clients["name"]), "Doc Brown"));
+
+    let orders = clients
+        .get_ref_as::<MysqlDB, ClientOrder>("orders")
+        .unwrap();
+
+    let order_list = orders.list().await.unwrap();
+    assert_eq!(order_list.len(), 2);
+}
+
+/// Traverse has_one: order -> client
+#[tokio::test]
+async fn test_has_one_client_for_order() {
+    let db = get_db().await;
+    let mut orders = order_table(db.clone());
+    orders.add_condition(mysql_expr!("{} = {}", (orders["id"]), "order1"));
+
+    let client = orders.get_ref_as::<MysqlDB, Client>("client").unwrap();
+
+    let client_list = client.list().await.unwrap();
+    assert_eq!(client_list.len(), 1);
+    assert_eq!(client_list.values().next().unwrap().name, "Marty McFly");
+}

--- a/vantage-surrealdb/tests/table_source_read.rs
+++ b/vantage-surrealdb/tests/table_source_read.rs
@@ -27,7 +27,7 @@ async fn test_build_select_basic() {
     let select = table.select();
     assert_eq!(
         select.preview(),
-        "SELECT id, name, calories, price, is_deleted, bakery FROM product"
+        "SELECT id, name, calories, price, is_deleted, sticker, bakery FROM product"
     );
 }
 
@@ -39,7 +39,7 @@ async fn test_build_select_with_condition() {
     let select = table.select();
     assert_eq!(
         select.preview(),
-        "SELECT id, name, calories, price, is_deleted, bakery FROM product WHERE active = true"
+        "SELECT id, name, calories, price, is_deleted, sticker, bakery FROM product WHERE active = true"
     );
 }
 


### PR DESCRIPTION
MySQL is now a supported backend in `vantage-sql`. Pull in the crate with `features = ["mysql"]`, connect via `MysqlDB::connect("mysql://...")`, and the same `Table`, `ExprDataSource`, `Selectable`, and `AssociatedExpression` plumbing you use against SQLite or Postgres works against MySQL — three backends in one crate, gated by feature flag so existing builds aren't affected.

```rust
let db = MysqlDB::connect("mysql://vantage:vantage@localhost:3306/vantage").await?;
let products: Vec<Record<JsonValue>> = db
    .associate(mysql_expr!("SELECT * FROM product WHERE price > {}", 100i64))
    .get()
    .await?;
```

Lands right after the postgres backend (#171), closing out the SQLite → Postgres → MySQL arc. `MysqlDB` (sqlx pool wrapper) implements `DataSource`, `ExprDataSource`, `SelectableDataSource`, and `TableSource`. The `MysqlSelect` / `MysqlInsert` / `MysqlUpdate` / `MysqlDelete` builders cover JOINs, GROUP BY / HAVING, window functions, and CTEs (including `WITH RECURSIVE`). `mysql_expr!` mirrors the sibling backends' macros. `AnyMysqlType` gets `Bool` / `Int2` / `Int4` / `Int8` / `Float4` / `Float8` / `Text` variants via `vantage_type_system!`; the variant tag drives `sqlx::bind` so an `i32` doesn't silently widen to `i64` on the wire.

### Not in this drop

No DECIMAL/NUMERIC variant — values come back as `i64` or `f64` if they parse, otherwise as a string. DATE/DATETIME/TIME/JSON aren't modelled either; they round-trip as text via the fallback path. `MySqlPool` is created with sqlx defaults — pool tuning isn't exposed yet.