### PR TITLE
fixes, improve identifier

### DIFF
--- a/NEW_PERSISTENCE_GUIDE.md
+++ b/NEW_PERSISTENCE_GUIDE.md
@@ -296,6 +296,58 @@ The macro handles three kinds of parameters:
 - `(sub_expr)` → nested expression (composed into the template)
 - `{deferred}` → lazy evaluation (resolved at execution time)
 
+### Identifier quoting
+
+SQL identifiers (table names, column names) need quoting to handle reserved words, spaces, and
+special characters. Different databases use different quote styles — PostgreSQL and SQLite use
+double quotes (`"name"`), MySQL uses backticks (`` `name` ``), SurrealDB uses something else
+entirely.
+
+Vantage centralises this in the `Identifier` struct (`vantage-sql/src/primitives/identifier.rs`).
+`Identifier` is quote-agnostic — it stores the name parts and optional alias, but the actual quoting
+happens in the `Expressive<T>` implementation for each backend type:
+
+```rust
+impl Expressive<AnyMysqlType> for Identifier {
+    fn expr(&self) -> Expression<AnyMysqlType> {
+        Expression::new(self.render_with('`'), vec![])  // `name`
+    }
+}
+```
+
+When you add a new SQL backend, add an `Expressive<YourAnyType>` impl with your quote character. The
+compiler picks the right impl based on the expression type context.
+
+In practice you use the `ident()` shorthand and pass it into the vendor macro with parentheses —
+the `(...)` syntax calls `.expr()` automatically, so quoting is handled by the type context:
+
+```rust
+use vantage_sql::primitives::identifier::{Identifier, ident};
+
+// The (ident(...)) syntax invokes Expressive — quoting is automatic
+let expr = mysql_expr!("SELECT {} FROM {} WHERE {} = {}",
+    (ident("name")), (ident("product")), (ident("price")), 100i64);
+// → SELECT `name` FROM `product` WHERE `price` = 100
+
+let expr = postgres_expr!("SELECT {} FROM {} WHERE {} = {}",
+    (ident("name")), (ident("product")), (ident("price")), 100i64);
+// → SELECT "name" FROM "product" WHERE "price" = 100
+```
+
+For qualified identifiers (table.column) and aliases:
+
+```rust
+let expr = sqlite_expr!("SELECT {}", (Identifier::with_dot("u", "name")));
+// → SELECT "u"."name"
+
+let expr = mysql_expr!("SELECT {}", (ident("name").with_alias("n")));
+// → SELECT `name` AS `n`
+```
+
+Test identifier quoting in `tests/<backend>/2_identifier.rs` — cover basic names, reserved words,
+spaces, hyphens, unicode, and names that start with numbers. These are all legal inside quoted
+identifiers in both PostgreSQL and MySQL.
+
 ### ExprDataSource
 
 Implement `DataSource` (marker) and `ExprDataSource<AnySqliteType>` on your DB struct. The `execute`
@@ -459,6 +511,7 @@ At this point you should have:
    - Type marker verification (bool binds as bool, not as string "true")
    - Cross-database deferred value resolution
    - AssociatedExpression with scalar, Record, and entity results
+   - Identifier quoting: basic names, reserved words, spaces, hyphens, unicode
 
 ## Step 3: Statement builders and SelectableDataSource
 
@@ -801,9 +854,8 @@ conditions get their own test file next.
 
 ### Error handling
 
-All `TableSource` methods return `vantage_core::Result<T>` (an alias for
-`Result<T, VantageError>`). Use the `error!` macro from `vantage_core` to create errors with
-structured context:
+All `TableSource` methods return `vantage_core::Result<T>` (an alias for `Result<T, VantageError>`).
+Use the `error!` macro from `vantage_core` to create errors with structured context:
 
 ```rust
 use vantage_core::error;
@@ -832,15 +884,14 @@ let data = std::fs::read("config.json")
     .context(error!("failed to load config"))?;
 ```
 
-This chains errors — the original `io::Error` is preserved as the source, so `Display` renders
-both messages and the source chain is available via `std::error::Error::source()`.
+This chains errors — the original `io::Error` is preserved as the source, so `Display` renders both
+messages and the source chain is available via `std::error::Error::source()`.
 
 ### Operation trait — condition building
 
-The `Operation` trait (from `vantage-table`) provides `.eq()`, `.ne()`, `.gt()`, `.gte()`,
-`.lt()`, `.lte()`, and `.in_()` methods for building conditions. It has a **blanket implementation**
-for all `Expressive<T>` types, so your columns get these methods automatically — no explicit impl
-needed.
+The `Operation` trait (from `vantage-table`) provides `.eq()`, `.ne()`, `.gt()`, `.gte()`, `.lt()`,
+`.lte()`, and `.in_()` methods for building conditions. It has a **blanket implementation** for all
+`Expressive<T>` types, so your columns get these methods automatically — no explicit impl needed.
 
 All methods accept `impl Expressive<YourAnyType>`, so you can pass native Rust values (`false`,
 `42`, `"hello"`), other columns (`table["other_field"]`), or full expressions. This requires your
@@ -924,14 +975,14 @@ let fetched = table.get(id).await.unwrap();
 ## Step 5: Relationships
 
 Tables can declare relationships using `with_one` and `with_many`, then traverse them at runtime
-with `get_ref_as`. The relationship system is provided by `vantage-table` — your backend just
-needs `column_table_values_expr` implemented to make it work.
+with `get_ref_as`. The relationship system is provided by `vantage-table` — your backend just needs
+`column_table_values_expr` implemented to make it work.
 
 Implement `column_table_values_expr` — it builds a subquery for a single column respecting current
 conditions. For SQL backends this is a `SELECT "col" FROM "table" WHERE ...` expression.
 
-Define relationships when constructing tables — `with_one` for foreign-key-to-parent,
-`with_many` for parent-to-children. Then traverse:
+Define relationships when constructing tables — `with_one` for foreign-key-to-parent, `with_many`
+for parent-to-children. Then traverse:
 
 ```rust
 let mut clients = client_table(db);
@@ -948,15 +999,15 @@ assert_eq!(orders.list().await.unwrap().len(), 3);
 ## Step 6: Using tables in a multi-backend application
 
 At this point your backend works — you can define tables, query data, and traverse relationships.
-But a real application typically has a *model crate* that defines entities once and offers table
+But a real application typically has a _model crate_ that defines entities once and offers table
 constructors for each backend. That's `bakery_model3` in the Vantage repo. The final piece is
 `AnyTable`, which lets you treat tables from different backends uniformly.
 
 ### AnyTable: the type-erased wrapper
 
 `AnyTable` erases the backend and entity types behind a uniform `serde_json::Value`-based interface.
-This is what makes it possible to write generic UI, CLI, or API code that doesn't care which database
-is behind it.
+This is what makes it possible to write generic UI, CLI, or API code that doesn't care which
+database is behind it.
 
 There are two ways to create one:
 
@@ -981,9 +1032,9 @@ matches on the user's chosen source, calls the right entity constructor, and wra
 identically regardless of which database is behind it.
 
 Because the values flow through as `serde_json::Value`, the CLI renderer can inspect types at
-runtime — booleans like `is_deleted` display as `true`/`false` with color highlighting, numbers
-stay numeric, and nulls render cleanly. Your type system work in Step 1 ensures these values
-arrive with the right JSON type rather than everything being a string.
+runtime — booleans like `is_deleted` display as `true`/`false` with color highlighting, numbers stay
+numeric, and nulls render cleanly. Your type system work in Step 1 ensures these values arrive with
+the right JSON type rather than everything being a string.
 
 Try it out:
 

--- a/vantage-expressions/src/expression/macros.rs
+++ b/vantage-expressions/src/expression/macros.rs
@@ -3,6 +3,7 @@
 /// - expr_as!(T, "template", arg) -> arg becomes Scalar
 /// - expr_as!(T, "template", (expr)) -> expr becomes Nested
 /// - expr_as!(T, "template", {deferred}) -> deferred becomes Deferred
+///
 #[macro_export]
 macro_rules! expr_as {
     // Simple template without parameters: expr_as!(T, "age")
@@ -28,6 +29,8 @@ macro_rules! expr_as {
 /// - expr_any!("template", arg) -> arg becomes Scalar
 /// - expr_any!("template", (expr)) -> expr becomes Nested
 /// - expr_any!("template", {deferred}) -> deferred becomes Deferred
+///
+/// Function calls like `f(x)` work as scalar parameters without extra wrapping.
 #[macro_export]
 macro_rules! expr_any {
     // Simple template without parameters: expr_any!("age")
@@ -66,11 +69,17 @@ macro_rules! expr {
     };
 }
 
-/// Helper macro to handle different parameter syntaxes
+/// Helper macro to handle different parameter syntaxes.
+///
+/// - `(expr)` — nested expression (calls `.expr()` via `Expressive`)
+/// - `{expr}` — deferred function
+/// - `expr`   — scalar (calls `.into()`)
+///
+/// Function calls like `id_value(id)` work as scalars because `$($rest:tt)*`
+/// captures the entire token sequence before forwarding to the scalar arm.
 #[macro_export]
 macro_rules! expr_param {
     // Nested expression: (expr) -> ExpressiveEnum::Nested(expr)
-    // If expr implements Expressive, convert it to Expression first
     (($expr:expr)) => {
         $crate::traits::expressive::ExpressiveEnum::Nested({
             #[allow(unused_imports)]

--- a/vantage-sql/src/mysql/expr_data_source.rs
+++ b/vantage-sql/src/mysql/expr_data_source.rs
@@ -7,10 +7,7 @@ use crate::mysql::row::{bind_mysql_value, row_to_record};
 use crate::mysql::types::AnyMysqlType;
 
 impl vantage_expressions::ExprDataSource<AnyMysqlType> for MysqlDB {
-    async fn execute(
-        &self,
-        expr: &Expression<AnyMysqlType>,
-    ) -> vantage_core::Result<AnyMysqlType> {
+    async fn execute(&self, expr: &Expression<AnyMysqlType>) -> vantage_core::Result<AnyMysqlType> {
         // 1. Resolve deferred parameters
         let resolved = resolve_deferred(expr).await?;
 
@@ -23,9 +20,10 @@ impl vantage_expressions::ExprDataSource<AnyMysqlType> for MysqlDB {
             query = bind_mysql_value(query, value);
         }
 
-        let rows = query.fetch_all(self.pool()).await.map_err(|e| {
-            vantage_core::error!("MySQL query failed", details = e.to_string())
-        })?;
+        let rows = query
+            .fetch_all(self.pool())
+            .await
+            .map_err(|e| vantage_core::error!("MySQL query failed", details = e.to_string()))?;
 
         // 4. Convert rows to AnyMysqlType (untyped)
         let arr: Vec<JsonValue> = rows

--- a/vantage-sql/src/mysql/row.rs
+++ b/vantage-sql/src/mysql/row.rs
@@ -159,10 +159,10 @@ fn mysql_column_to_json(row: &MySqlRow, ordinal: usize, type_name: &str) -> Json
                 if let Ok(i) = v.parse::<i64>() {
                     return JsonValue::Number(i.into());
                 }
-                if let Ok(f) = v.parse::<f64>() {
-                    if let Some(n) = serde_json::Number::from_f64(f) {
-                        return JsonValue::Number(n);
-                    }
+                if let Ok(f) = v.parse::<f64>()
+                    && let Some(n) = serde_json::Number::from_f64(f)
+                {
+                    return JsonValue::Number(n);
                 }
                 return JsonValue::String(v);
             }

--- a/vantage-sql/src/mysql/statements/delete/render.rs
+++ b/vantage-sql/src/mysql/statements/delete/render.rs
@@ -1,6 +1,7 @@
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, expr_any};
 
 use crate::mysql::types::AnyMysqlType;
+use crate::primitives::identifier::ident;
 
 use super::{Expr, MysqlDelete};
 
@@ -13,14 +14,11 @@ impl MysqlDelete {
 impl Expressive<AnyMysqlType> for MysqlDelete {
     fn expr(&self) -> Expr {
         if self.conditions.is_empty() {
-            return Expression::new(format!("DELETE FROM `{}`", self.table), vec![]);
+            return expr_any!("DELETE FROM {}", (ident(&self.table)));
         }
 
         let combined = Expression::from_vec(self.conditions.clone(), " AND ");
-        Expression::new(
-            format!("DELETE FROM `{}` WHERE {{}}", self.table),
-            vec![ExpressiveEnum::Nested(combined)],
-        )
+        expr_any!("DELETE FROM {} WHERE {}", (ident(&self.table)), (combined))
     }
 }
 

--- a/vantage-sql/src/mysql/statements/insert/render.rs
+++ b/vantage-sql/src/mysql/statements/insert/render.rs
@@ -1,6 +1,7 @@
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
 use crate::mysql::types::AnyMysqlType;
+use crate::primitives::identifier::ident;
 
 use super::{Expr, MysqlInsert};
 
@@ -13,29 +14,25 @@ impl MysqlInsert {
 impl Expressive<AnyMysqlType> for MysqlInsert {
     fn expr(&self) -> Expr {
         if self.fields.is_empty() {
-            return Expression::new(
-                format!("INSERT INTO `{}` () VALUES ()", self.table),
-                vec![],
-            );
+            return expr_any!("INSERT INTO {} () VALUES ()", (ident(&self.table)));
         }
 
-        let columns: Vec<String> = self.fields.keys().map(|k| format!("`{}`", k)).collect();
-        let placeholders: Vec<&str> = (0..self.fields.len()).map(|_| "{}").collect();
+        let columns: Vec<Expr> = self.fields.keys().map(|k| ident(k).expr()).collect();
+        let cols = Expression::from_vec(columns, ", ");
 
-        let template = format!(
-            "INSERT INTO `{}` ({}) VALUES ({})",
-            self.table,
-            columns.join(", "),
-            placeholders.join(", ")
-        );
-
-        let params: Vec<ExpressiveEnum<AnyMysqlType>> = self
+        let values: Vec<Expr> = self
             .fields
             .values()
-            .map(|v| ExpressiveEnum::Scalar(v.clone()))
+            .map(|v| Expression::new("{}", vec![ExpressiveEnum::Scalar(v.clone())]))
             .collect();
+        let vals = Expression::from_vec(values, ", ");
 
-        Expression::new(template, params)
+        expr_any!(
+            "INSERT INTO {} ({}) VALUES ({})",
+            (ident(&self.table)),
+            (cols),
+            (vals)
+        )
     }
 }
 

--- a/vantage-sql/src/mysql/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/mysql/statements/select/impls/selectable.rs
@@ -1,9 +1,10 @@
 use vantage_expressions::traits::selectable::{Selectable, SourceRef};
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
 use crate::mysql::statements::MysqlSelect;
 use crate::mysql::types::AnyMysqlType;
 use crate::primitives::fx::Fx;
+use crate::primitives::identifier::ident;
 
 type Expr = Expression<AnyMysqlType>;
 
@@ -13,14 +14,9 @@ impl MysqlSelect {
         s.clear_fields();
         let agg = Fx::new(func, [column.expr()]);
 
-        // MySQL returns DECIMAL for SUM/AVG on integer types.
-        // Cast to SIGNED (MySQL's equivalent of BIGINT for CAST).
         let needs_cast = matches!(func, "sum" | "avg");
         if needs_cast {
-            let cast = Expression::new(
-                "CAST({} AS SIGNED)",
-                vec![ExpressiveEnum::Nested(agg.expr())],
-            );
+            let cast = expr_any!("CAST({} AS SIGNED)", (agg));
             s.add_expression(cast, None);
         } else {
             s.add_expression(agg, None);
@@ -36,44 +32,35 @@ impl Selectable<AnyMysqlType> for MysqlSelect {
         self.from.clear();
         let source_ref = source.into().into_expressive_enum();
         let expr = match (source_ref, alias) {
-            (ExpressiveEnum::Scalar(val), None) => Expression::new(
-                format!("`{}`", val.try_get::<String>().unwrap_or_default()),
-                vec![],
-            ),
-            (ExpressiveEnum::Scalar(val), Some(alias)) => Expression::new(
-                format!(
-                    "`{}` AS `{}`",
-                    val.try_get::<String>().unwrap_or_default(),
-                    alias
-                ),
-                vec![],
-            ),
+            (ExpressiveEnum::Scalar(val), None) => {
+                let Some(name) = val.try_get::<String>().filter(|s| !s.is_empty()) else {
+                    return;
+                };
+                ident(name).expr()
+            }
+            (ExpressiveEnum::Scalar(val), Some(alias)) => {
+                let Some(name) = val.try_get::<String>().filter(|s| !s.is_empty()) else {
+                    return;
+                };
+                ident(name).with_alias(alias).expr()
+            }
             (ExpressiveEnum::Nested(expr), None) => expr,
-            (ExpressiveEnum::Nested(expr), Some(alias)) => Expression::new(
-                format!("{{}} AS `{}`", alias),
-                vec![ExpressiveEnum::Nested(expr)],
-            ),
+            (ExpressiveEnum::Nested(expr), Some(alias)) => {
+                expr_any!("{} AS {}", (expr), (ident(alias)))
+            }
             _ => return,
         };
         self.from.push(expr);
     }
 
     fn add_field(&mut self, field: impl Into<String>) {
-        self.fields
-            .push(Expression::new(format!("`{}`", field.into()), vec![]));
+        self.fields.push(ident(field).expr());
     }
 
-    fn add_expression(
-        &mut self,
-        expression: impl Expressive<AnyMysqlType>,
-        alias: Option<String>,
-    ) {
+    fn add_expression(&mut self, expression: impl Expressive<AnyMysqlType>, alias: Option<String>) {
         let expr = expression.expr();
         let field = match alias {
-            Some(a) => Expression::new(
-                format!("{{}} AS `{}`", a),
-                vec![ExpressiveEnum::Nested(expr)],
-            ),
+            Some(a) => expr_any!("{} AS {}", (expr), (ident(a))),
             None => expr,
         };
         self.fields.push(field);

--- a/vantage-sql/src/mysql/statements/select/join.rs
+++ b/vantage-sql/src/mysql/statements/select/join.rs
@@ -1,6 +1,7 @@
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
 use crate::mysql::types::AnyMysqlType;
+use crate::primitives::identifier::ident;
 
 type Expr = Expression<AnyMysqlType>;
 
@@ -39,17 +40,11 @@ impl MysqlSelectJoin {
     }
 
     fn table_expr(table: impl Into<String>, alias: impl Into<String>) -> Expr {
-        Expression::new(
-            format!("`{}` AS `{}`", table.into(), alias.into()),
-            vec![],
-        )
+        ident(table).with_alias(alias).expr()
     }
 
     fn subquery_expr(subquery: impl Expressive<AnyMysqlType>, alias: impl Into<String>) -> Expr {
-        Expression::new(
-            format!("({{}}) AS `{}`", alias.into()),
-            vec![ExpressiveEnum::Nested(subquery.expr())],
-        )
+        expr_any!("({}) AS {}", (subquery), (ident(alias)))
     }
 
     pub fn inner(table: impl Into<String>, alias: impl Into<String>, on_condition: Expr) -> Self {

--- a/vantage-sql/src/mysql/statements/update/render.rs
+++ b/vantage-sql/src/mysql/statements/update/render.rs
@@ -1,6 +1,7 @@
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
 use crate::mysql::types::AnyMysqlType;
+use crate::primitives::identifier::ident;
 
 use super::{Expr, MysqlUpdate};
 
@@ -23,28 +24,30 @@ impl Expressive<AnyMysqlType> for MysqlUpdate {
             return Expression::new("SELECT 1 WHERE FALSE", vec![]);
         }
 
-        let set_parts: Vec<String> = self
+        let set_parts: Vec<Expr> = self
             .fields
-            .keys()
-            .map(|k| format!("`{}` = {{}}", k))
+            .iter()
+            .map(|(k, v)| {
+                Expression::new(
+                    "{} = {}",
+                    vec![
+                        ExpressiveEnum::Nested(ident(k).expr()),
+                        ExpressiveEnum::Scalar(v.clone()),
+                    ],
+                )
+            })
             .collect();
-        let template_base = format!("UPDATE `{}` SET {}", self.table, set_parts.join(", "));
+        let set_list = Expression::from_vec(set_parts, ", ");
 
-        let mut params: Vec<ExpressiveEnum<AnyMysqlType>> = self
-            .fields
-            .values()
-            .map(|v| ExpressiveEnum::Scalar(v.clone()))
-            .collect();
-
-        let template = match self.render_where() {
-            Some(cond) => {
-                params.push(ExpressiveEnum::Nested(cond));
-                format!("{} WHERE {{}}", template_base)
-            }
-            None => template_base,
-        };
-
-        Expression::new(template, params)
+        match self.render_where() {
+            Some(cond) => expr_any!(
+                "UPDATE {} SET {} WHERE {}",
+                (ident(&self.table)),
+                (set_list),
+                (cond)
+            ),
+            None => expr_any!("UPDATE {} SET {}", (ident(&self.table)), (set_list)),
+        }
     }
 }
 

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -12,15 +12,14 @@ use vantage_types::{Entity, Record};
 
 use crate::mysql::MysqlDB;
 use crate::mysql::types::AnyMysqlType;
+use crate::primitives::identifier::ident;
+use vantage_expressions::expr_any;
 
-/// Create an AnyMysqlType for an id value. If the id parses as an integer,
-/// use Int8 variant so MySQL doesn't complain about type mismatches.
+/// Create an AnyMysqlType for an id value. Always binds as string to
+/// preserve semantics of textual ids (e.g., leading zeros in "00123").
+/// MySQL will coerce to integer when the column type requires it.
 fn id_value(id: &str) -> AnyMysqlType {
-    if let Ok(n) = id.parse::<i64>() {
-        AnyMysqlType::new(n)
-    } else {
-        AnyMysqlType::from(id.to_string())
-    }
+    AnyMysqlType::from(id.to_string())
 }
 
 /// Parse the JSON array result from execute() into an IndexMap of id -> Record.
@@ -104,17 +103,17 @@ impl TableSource for MysqlDB {
     where
         E: Entity<Self::Value>,
     {
-        let pattern = format!("%{}%", search_value.replace('%', "\\%"));
+        let escaped = search_value
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+        let pattern = format!("%{}%", escaped);
         let conditions: Vec<Expression<AnyMysqlType>> = table
             .columns()
             .values()
             .map(|col| {
-                Expression::new(
-                    format!("`{}` LIKE {{}}", col.name()),
-                    vec![ExpressiveEnum::Scalar(AnyMysqlType::from(
-                        pattern.clone(),
-                    ))],
-                )
+                let p = pattern.clone();
+                mysql_expr!("{} LIKE {} ESCAPE '\\\\'", (ident(col.name())), p)
             })
             .collect();
 
@@ -155,10 +154,10 @@ impl TableSource for MysqlDB {
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let condition = Expression::new(
-            format!("`{}` = {{}}", id_field_name),
-            vec![ExpressiveEnum::Scalar(id_value(id))],
-        );
+        let condition = {
+            let id_val = id_value(id);
+            mysql_expr!("{} = {}", (ident(&id_field_name)), id_val)
+        };
         let select = table.select().with_condition(condition);
         let result = self.execute(&select.expr()).await?;
 
@@ -192,9 +191,7 @@ impl TableSource for MysqlDB {
         E: Entity<Self::Value>,
     {
         let select = table.select();
-        let result = self
-            .aggregate(&select, "count", mysql_expr!("*"))
-            .await?;
+        let result = self.aggregate(&select, "count", mysql_expr!("*")).await?;
         result.try_get::<i64>().ok_or_else(|| {
             error!(
                 "get_table_count: expected i64",
@@ -278,23 +275,20 @@ impl TableSource for MysqlDB {
             .with_record(record);
         let base = insert.expr();
 
-        let set_parts: Vec<String> = record
-            .keys()
-            .map(|k| format!("`{}` = VALUES(`{}`)", k, k))
-            .collect();
-        let conflict_clause = if set_parts.is_empty() {
-            format!(" ON DUPLICATE KEY UPDATE `{}` = `{}`", id_field_name, id_field_name)
+        let set_parts: Vec<Expression<AnyMysqlType>> = if record.is_empty() {
+            vec![expr_any!(
+                "{} = {}",
+                (ident(&id_field_name)),
+                (ident(&id_field_name))
+            )]
         } else {
-            format!(
-                " ON DUPLICATE KEY UPDATE {}",
-                set_parts.join(", ")
-            )
+            record
+                .keys()
+                .map(|k| expr_any!("{} = VALUES({})", (ident(k)), (ident(k))))
+                .collect()
         };
-
-        let upsert = Expression::new(
-            format!("{}{}", base.template, conflict_clause),
-            base.parameters.clone(),
-        );
+        let conflict = Expression::from_vec(set_parts, ", ");
+        let upsert = expr_any!("{} ON DUPLICATE KEY UPDATE {}", (base), (conflict));
         self.execute(&upsert).await?;
 
         self.get_table_value(table, id).await
@@ -314,10 +308,10 @@ impl TableSource for MysqlDB {
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let id_condition = Expression::new(
-            format!("`{}` = {{}}", id_field_name),
-            vec![ExpressiveEnum::Scalar(id_value(id))],
-        );
+        let id_condition = {
+            let id_val = id_value(id);
+            mysql_expr!("{} = {}", (ident(&id_field_name)), id_val)
+        };
         let update = crate::mysql::statements::MysqlUpdate::new(table.table_name())
             .with_record(partial)
             .with_condition(id_condition);
@@ -335,10 +329,10 @@ impl TableSource for MysqlDB {
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let id_condition = Expression::new(
-            format!("`{}` = {{}}", id_field_name),
-            vec![ExpressiveEnum::Scalar(id_value(id))],
-        );
+        let id_condition = {
+            let id_val = id_value(id);
+            mysql_expr!("{} = {}", (ident(&id_field_name)), id_val)
+        };
         let delete = crate::mysql::statements::MysqlDelete::new(table.table_name())
             .with_condition(id_condition);
         self.execute(&delete.expr()).await?;
@@ -362,8 +356,8 @@ impl TableSource for MysqlDB {
     where
         E: Entity<Self::Value>,
     {
-        let insert = crate::mysql::statements::MysqlInsert::new(table.table_name())
-            .with_record(record);
+        let insert =
+            crate::mysql::statements::MysqlInsert::new(table.table_name()).with_record(record);
 
         // MySQL doesn't support RETURNING. Execute INSERT and SELECT LAST_INSERT_ID()
         // on the same connection to get the auto-generated id.
@@ -375,38 +369,59 @@ impl TableSource for MysqlDB {
         let flattened = flattener.flatten(&expr);
 
         // Build the INSERT query with ? placeholders
+        let template_parts: Vec<&str> = flattened.template.split("{}").collect();
+        if template_parts.len() != flattened.parameters.len() + 1 {
+            return Err(error!(
+                "MySQL insert expression placeholder mismatch",
+                placeholders = (template_parts.len() - 1).to_string(),
+                parameters = flattened.parameters.len().to_string()
+            ));
+        }
+
         let mut sql = String::new();
         let mut params = Vec::new();
-        let template_parts: Vec<&str> = flattened.template.split("{}").collect();
         sql.push_str(template_parts[0]);
         for (i, param) in flattened.parameters.iter().enumerate() {
-            if let ExpressiveEnum::Scalar(value) = param {
-                sql.push('?');
-                params.push(value.clone());
+            match param {
+                ExpressiveEnum::Scalar(value) => {
+                    sql.push('?');
+                    params.push(value.clone());
+                }
+                _ => {
+                    return Err(error!(
+                        "MySQL insert expression contains non-scalar parameter",
+                        index = i.to_string()
+                    ));
+                }
             }
-            if i + 1 < template_parts.len() {
-                sql.push_str(template_parts[i + 1]);
-            }
+            sql.push_str(template_parts[i + 1]);
         }
 
         // Acquire a single connection to ensure LAST_INSERT_ID() works
-        let mut conn = self.pool().acquire().await
+        let mut conn = self
+            .pool()
+            .acquire()
+            .await
             .map_err(|e| error!("MySQL acquire connection failed", details = e.to_string()))?;
 
         let mut query = sqlx::query(&sql);
         for value in &params {
             query = bind_mysql_value(query, value);
         }
-        query.execute(&mut *conn).await
+        query
+            .execute(&mut *conn)
+            .await
             .map_err(|e| error!("MySQL insert failed", details = e.to_string()))?;
 
-        let row = sqlx::query("SELECT LAST_INSERT_ID() AS `id`")
+        let last_id_sql = "SELECT LAST_INSERT_ID() AS id";
+        let row = sqlx::query(last_id_sql)
             .fetch_one(&mut *conn)
             .await
             .map_err(|e| error!("MySQL LAST_INSERT_ID failed", details = e.to_string()))?;
 
         use sqlx::Row;
-        let id: u64 = row.try_get("id")
+        let id: u64 = row
+            .try_get("id")
             .map_err(|e| error!("MySQL get id failed", details = e.to_string()))?;
 
         Ok(id.to_string())

--- a/vantage-sql/src/mysql/types/value.rs
+++ b/vantage-sql/src/mysql/types/value.rs
@@ -84,9 +84,7 @@ impl Expressive<AnyMysqlType> for &str {
     fn expr(&self) -> Expression<AnyMysqlType> {
         Expression::new(
             "{}",
-            vec![ExpressiveEnum::Scalar(AnyMysqlType::from(
-                self.to_string(),
-            ))],
+            vec![ExpressiveEnum::Scalar(AnyMysqlType::from(self.to_string()))],
         )
     }
 }

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -12,6 +12,8 @@ use vantage_types::{Entity, Record};
 
 use crate::postgres::PostgresDB;
 use crate::postgres::types::AnyPostgresType;
+use crate::primitives::identifier::ident;
+use vantage_expressions::expr_any;
 
 /// Create an AnyPostgresType for an id value. If the id parses as an integer,
 /// use Int8 variant so PostgreSQL doesn't complain about `integer = text`.
@@ -104,17 +106,17 @@ impl TableSource for PostgresDB {
     where
         E: Entity<Self::Value>,
     {
-        let pattern = format!("%{}%", search_value.replace('%', "\\%"));
+        let escaped = search_value
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+        let pattern = format!("%{}%", escaped);
         let conditions: Vec<Expression<AnyPostgresType>> = table
             .columns()
             .values()
             .map(|col| {
-                Expression::new(
-                    format!("\"{}\"::text LIKE {{}}", col.name()),
-                    vec![ExpressiveEnum::Scalar(AnyPostgresType::from(
-                        pattern.clone(),
-                    ))],
-                )
+                let p = pattern.clone();
+                postgres_expr!("{}::text LIKE {} ESCAPE '\\\\'", (ident(col.name())), p)
             })
             .collect();
 
@@ -155,10 +157,10 @@ impl TableSource for PostgresDB {
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let condition = Expression::new(
-            format!("\"{}\" = {{}}", id_field_name),
-            vec![ExpressiveEnum::Scalar(id_value(id))],
-        );
+        let condition = {
+            let id_val = id_value(id);
+            postgres_expr!("{} = {}", (ident(&id_field_name)), id_val)
+        };
         let select = table.select().with_condition(condition);
         let result = self.execute(&select.expr()).await?;
 
@@ -278,23 +280,26 @@ impl TableSource for PostgresDB {
             .with_record(record);
         let base = insert.expr();
 
-        let set_parts: Vec<String> = record
-            .keys()
-            .map(|k| format!("\"{}\" = EXCLUDED.\"{}\"", k, k))
-            .collect();
-        let conflict_clause = if set_parts.is_empty() {
-            format!(" ON CONFLICT (\"{}\") DO NOTHING", id_field_name)
+        let set_parts: Vec<Expression<AnyPostgresType>> = if record.is_empty() {
+            let upsert = expr_any!(
+                "{} ON CONFLICT ({}) DO NOTHING",
+                (base),
+                (ident(&id_field_name))
+            );
+            self.execute(&upsert).await?;
+            return self.get_table_value(table, id).await;
         } else {
-            format!(
-                " ON CONFLICT (\"{}\") DO UPDATE SET {}",
-                id_field_name,
-                set_parts.join(", ")
-            )
+            record
+                .keys()
+                .map(|k| expr_any!("{} = EXCLUDED.{}", (ident(k)), (ident(k))))
+                .collect()
         };
-
-        let upsert = Expression::new(
-            format!("{}{}", base.template, conflict_clause),
-            base.parameters.clone(),
+        let conflict_set = Expression::from_vec(set_parts, ", ");
+        let upsert = expr_any!(
+            "{} ON CONFLICT ({}) DO UPDATE SET {}",
+            (base),
+            (ident(&id_field_name)),
+            (conflict_set)
         );
         self.execute(&upsert).await?;
 
@@ -315,10 +320,10 @@ impl TableSource for PostgresDB {
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let id_condition = Expression::new(
-            format!("\"{}\" = {{}}", id_field_name),
-            vec![ExpressiveEnum::Scalar(id_value(id))],
-        );
+        let id_condition = {
+            let id_val = id_value(id);
+            postgres_expr!("{} = {}", (ident(&id_field_name)), id_val)
+        };
         let update = crate::postgres::statements::PostgresUpdate::new(table.table_name())
             .with_record(partial)
             .with_condition(id_condition);
@@ -336,10 +341,10 @@ impl TableSource for PostgresDB {
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let id_condition = Expression::new(
-            format!("\"{}\" = {{}}", id_field_name),
-            vec![ExpressiveEnum::Scalar(id_value(id))],
-        );
+        let id_condition = {
+            let id_val = id_value(id);
+            postgres_expr!("{} = {}", (ident(&id_field_name)), id_val)
+        };
         let delete = crate::postgres::statements::PostgresDelete::new(table.table_name())
             .with_condition(id_condition);
         self.execute(&delete.expr()).await?;
@@ -372,10 +377,7 @@ impl TableSource for PostgresDB {
             .with_record(record);
 
         let base = insert.expr();
-        let returning = Expression::new(
-            format!("{} RETURNING \"{}\"", base.template, id_field_name),
-            base.parameters.clone(),
-        );
+        let returning = expr_any!("{} RETURNING {}", (base), (ident(&id_field_name)));
         let result = self.execute(&returning).await?;
         let mut rows = parse_rows(result, &id_field_name)?;
         rows.swap_remove_index(0)

--- a/vantage-sql/src/postgres/statements/delete/render.rs
+++ b/vantage-sql/src/postgres/statements/delete/render.rs
@@ -1,6 +1,7 @@
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, expr_any};
 
 use crate::postgres::types::AnyPostgresType;
+use crate::primitives::identifier::ident;
 
 use super::{Expr, PostgresDelete};
 
@@ -13,14 +14,11 @@ impl PostgresDelete {
 impl Expressive<AnyPostgresType> for PostgresDelete {
     fn expr(&self) -> Expr {
         if self.conditions.is_empty() {
-            return Expression::new(format!("DELETE FROM \"{}\"", self.table), vec![]);
+            return expr_any!("DELETE FROM {}", (ident(&self.table)));
         }
 
         let combined = Expression::from_vec(self.conditions.clone(), " AND ");
-        Expression::new(
-            format!("DELETE FROM \"{}\" WHERE {{}}", self.table),
-            vec![ExpressiveEnum::Nested(combined)],
-        )
+        expr_any!("DELETE FROM {} WHERE {}", (ident(&self.table)), (combined))
     }
 }
 

--- a/vantage-sql/src/postgres/statements/insert/render.rs
+++ b/vantage-sql/src/postgres/statements/insert/render.rs
@@ -1,6 +1,7 @@
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
 use crate::postgres::types::AnyPostgresType;
+use crate::primitives::identifier::ident;
 
 use super::{Expr, PostgresInsert};
 
@@ -13,29 +14,25 @@ impl PostgresInsert {
 impl Expressive<AnyPostgresType> for PostgresInsert {
     fn expr(&self) -> Expr {
         if self.fields.is_empty() {
-            return Expression::new(
-                format!("INSERT INTO \"{}\" DEFAULT VALUES", self.table),
-                vec![],
-            );
+            return expr_any!("INSERT INTO {} DEFAULT VALUES", (ident(&self.table)));
         }
 
-        let columns: Vec<String> = self.fields.keys().map(|k| format!("\"{}\"", k)).collect();
-        let placeholders: Vec<&str> = (0..self.fields.len()).map(|_| "{}").collect();
+        let columns: Vec<Expr> = self.fields.keys().map(|k| ident(k).expr()).collect();
+        let cols = Expression::from_vec(columns, ", ");
 
-        let template = format!(
-            "INSERT INTO \"{}\" ({}) VALUES ({})",
-            self.table,
-            columns.join(", "),
-            placeholders.join(", ")
-        );
-
-        let params: Vec<ExpressiveEnum<AnyPostgresType>> = self
+        let values: Vec<Expr> = self
             .fields
             .values()
-            .map(|v| ExpressiveEnum::Scalar(v.clone()))
+            .map(|v| Expression::new("{}", vec![ExpressiveEnum::Scalar(v.clone())]))
             .collect();
+        let vals = Expression::from_vec(values, ", ");
 
-        Expression::new(template, params)
+        expr_any!(
+            "INSERT INTO {} ({}) VALUES ({})",
+            (ident(&self.table)),
+            (cols),
+            (vals)
+        )
     }
 }
 

--- a/vantage-sql/src/postgres/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/postgres/statements/select/impls/selectable.rs
@@ -1,9 +1,10 @@
 use vantage_expressions::traits::selectable::{Selectable, SourceRef};
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
 use crate::postgres::statements::PostgresSelect;
 use crate::postgres::types::AnyPostgresType;
 use crate::primitives::fx::Fx;
+use crate::primitives::identifier::ident;
 
 type Expr = Expression<AnyPostgresType>;
 
@@ -13,15 +14,9 @@ impl PostgresSelect {
         s.clear_fields();
         let agg = Fx::new(func, [column.expr()]);
 
-        // PostgreSQL returns NUMERIC for SUM/AVG on integer types, which sqlx
-        // can't decode without bigdecimal. Cast those to BIGINT.
-        // MAX/MIN preserve the column's original type — no cast needed.
         let needs_cast = matches!(func, "sum" | "avg");
         if needs_cast {
-            let cast = Expression::new(
-                "CAST({} AS BIGINT)",
-                vec![ExpressiveEnum::Nested(agg.expr())],
-            );
+            let cast = expr_any!("CAST({} AS BIGINT)", (agg));
             s.add_expression(cast, None);
         } else {
             s.add_expression(agg, None);
@@ -37,31 +32,29 @@ impl Selectable<AnyPostgresType> for PostgresSelect {
         self.from.clear();
         let source_ref = source.into().into_expressive_enum();
         let expr = match (source_ref, alias) {
-            (ExpressiveEnum::Scalar(val), None) => Expression::new(
-                format!("\"{}\"", val.try_get::<String>().unwrap_or_default()),
-                vec![],
-            ),
-            (ExpressiveEnum::Scalar(val), Some(alias)) => Expression::new(
-                format!(
-                    "\"{}\" AS \"{}\"",
-                    val.try_get::<String>().unwrap_or_default(),
-                    alias
-                ),
-                vec![],
-            ),
+            (ExpressiveEnum::Scalar(val), None) => {
+                let Some(name) = val.try_get::<String>().filter(|s| !s.is_empty()) else {
+                    return;
+                };
+                ident(name).expr()
+            }
+            (ExpressiveEnum::Scalar(val), Some(alias)) => {
+                let Some(name) = val.try_get::<String>().filter(|s| !s.is_empty()) else {
+                    return;
+                };
+                ident(name).with_alias(alias).expr()
+            }
             (ExpressiveEnum::Nested(expr), None) => expr,
-            (ExpressiveEnum::Nested(expr), Some(alias)) => Expression::new(
-                format!("{{}} AS \"{}\"", alias),
-                vec![ExpressiveEnum::Nested(expr)],
-            ),
+            (ExpressiveEnum::Nested(expr), Some(alias)) => {
+                expr_any!("{} AS {}", (expr), (ident(alias)))
+            }
             _ => return,
         };
         self.from.push(expr);
     }
 
     fn add_field(&mut self, field: impl Into<String>) {
-        self.fields
-            .push(Expression::new(format!("\"{}\"", field.into()), vec![]));
+        self.fields.push(ident(field).expr());
     }
 
     fn add_expression(
@@ -71,10 +64,7 @@ impl Selectable<AnyPostgresType> for PostgresSelect {
     ) {
         let expr = expression.expr();
         let field = match alias {
-            Some(a) => Expression::new(
-                format!("{{}} AS \"{}\"", a),
-                vec![ExpressiveEnum::Nested(expr)],
-            ),
+            Some(a) => expr_any!("{} AS {}", (expr), (ident(a))),
             None => expr,
         };
         self.fields.push(field);

--- a/vantage-sql/src/postgres/statements/select/join.rs
+++ b/vantage-sql/src/postgres/statements/select/join.rs
@@ -1,6 +1,7 @@
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
 use crate::postgres::types::AnyPostgresType;
+use crate::primitives::identifier::ident;
 
 type Expr = Expression<AnyPostgresType>;
 
@@ -39,17 +40,11 @@ impl PostgresSelectJoin {
     }
 
     fn table_expr(table: impl Into<String>, alias: impl Into<String>) -> Expr {
-        Expression::new(
-            format!("\"{}\" AS \"{}\"", table.into(), alias.into()),
-            vec![],
-        )
+        ident(table).with_alias(alias).expr()
     }
 
     fn subquery_expr(subquery: impl Expressive<AnyPostgresType>, alias: impl Into<String>) -> Expr {
-        Expression::new(
-            format!("({{}}) AS \"{}\"", alias.into()),
-            vec![ExpressiveEnum::Nested(subquery.expr())],
-        )
+        expr_any!("({}) AS {}", (subquery), (ident(alias)))
     }
 
     pub fn inner(table: impl Into<String>, alias: impl Into<String>, on_condition: Expr) -> Self {

--- a/vantage-sql/src/postgres/statements/update/render.rs
+++ b/vantage-sql/src/postgres/statements/update/render.rs
@@ -1,6 +1,7 @@
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
 use crate::postgres::types::AnyPostgresType;
+use crate::primitives::identifier::ident;
 
 use super::{Expr, PostgresUpdate};
 
@@ -20,32 +21,33 @@ impl PostgresUpdate {
 impl Expressive<AnyPostgresType> for PostgresUpdate {
     fn expr(&self) -> Expr {
         if self.fields.is_empty() {
-            // No fields to update — emit a no-op query rather than invalid SQL
             return Expression::new("SELECT 1 WHERE FALSE", vec![]);
         }
 
-        let set_parts: Vec<String> = self
+        let set_parts: Vec<Expr> = self
             .fields
-            .keys()
-            .map(|k| format!("\"{}\" = {{}}", k))
+            .iter()
+            .map(|(k, v)| {
+                Expression::new(
+                    "{} = {}",
+                    vec![
+                        ExpressiveEnum::Nested(ident(k).expr()),
+                        ExpressiveEnum::Scalar(v.clone()),
+                    ],
+                )
+            })
             .collect();
-        let template_base = format!("UPDATE \"{}\" SET {}", self.table, set_parts.join(", "));
+        let set_list = Expression::from_vec(set_parts, ", ");
 
-        let mut params: Vec<ExpressiveEnum<AnyPostgresType>> = self
-            .fields
-            .values()
-            .map(|v| ExpressiveEnum::Scalar(v.clone()))
-            .collect();
-
-        let template = match self.render_where() {
-            Some(cond) => {
-                params.push(ExpressiveEnum::Nested(cond));
-                format!("{} WHERE {{}}", template_base)
-            }
-            None => template_base,
-        };
-
-        Expression::new(template, params)
+        match self.render_where() {
+            Some(cond) => expr_any!(
+                "UPDATE {} SET {} WHERE {}",
+                (ident(&self.table)),
+                (set_list),
+                (cond)
+            ),
+            None => expr_any!("UPDATE {} SET {}", (ident(&self.table)), (set_list)),
+        }
     }
 }
 

--- a/vantage-sql/src/primitives/identifier.rs
+++ b/vantage-sql/src/primitives/identifier.rs
@@ -1,28 +1,29 @@
 use vantage_expressions::{Expression, Expressive};
 
-/// SQL identifier with proper double-quote escaping and optional alias.
+/// SQL identifier with optional qualification and alias.
 ///
-/// Handles single identifiers (`"name"`), qualified names (`"u"."name"`),
-/// and aliased expressions (`"name" AS "alias"`).
+/// Quoting is determined by the `Expressive<T>` impl — each backend
+/// renders with its own quote style (`"` for PostgreSQL/SQLite,
+/// `` ` `` for MySQL). This means `Identifier` is quote-agnostic;
+/// the quoting happens only when `.expr()` is called for a specific type.
 ///
-/// **Warning:** Identifier names are not escaped for embedded double quotes.
+/// **Warning:** Identifier names are not escaped for embedded quote characters.
 /// Do not pass untrusted user input as identifier names — this is intended
 /// for code-defined table/column names only.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// use vantage_sql::primitives::identifier::Identifier;
+/// use vantage_sql::primitives::identifier::ident;
 ///
-/// // Simple column
-/// let id = Identifier::new("name");            // "name"
+/// // Simple column — quoting depends on which Expressive<T> is used
+/// let expr = mysql_expr!("SELECT {} FROM {}", (ident("name")), (ident("product")));
 ///
 /// // Qualified (table.column)
-/// let id = Identifier::with_dot("u", "name");  // "u"."name"
+/// let expr = mysql_expr!("SELECT {}", (Identifier::with_dot("u", "name")));
 ///
 /// // With alias
-/// let id = Identifier::with_dot("d", "name")
-///     .with_alias("department_name");           // "d"."name" AS "department_name"
+/// let expr = mysql_expr!("SELECT {}", (ident("name").with_alias("n")));
 /// ```
 #[derive(Debug, Clone)]
 pub struct Identifier {
@@ -31,7 +32,7 @@ pub struct Identifier {
 }
 
 impl Identifier {
-    /// Single identifier: renders as `"name"`.
+    /// Single identifier: `name`.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             parts: vec![name.into()],
@@ -39,7 +40,7 @@ impl Identifier {
         }
     }
 
-    /// Qualified identifier: renders as `"prefix"."name"`.
+    /// Qualified identifier: `prefix.name`.
     pub fn with_dot(prefix: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             parts: vec![prefix.into(), name.into()],
@@ -47,27 +48,51 @@ impl Identifier {
         }
     }
 
-    /// Adds an AS alias: `... AS "alias"`.
+    /// Adds an AS alias.
     pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
         self.alias = Some(alias.into());
         self
     }
 
-    fn render_parts(&self) -> String {
-        self.parts
+    /// Render with a given quote character. Used by backend `Expressive` impls.
+    fn render_with(&self, q: char) -> String {
+        let base = self
+            .parts
             .iter()
-            .map(|p| format!("\"{}\"", p))
+            .map(|p| format!("{q}{p}{q}"))
             .collect::<Vec<_>>()
-            .join(".")
+            .join(".");
+        match &self.alias {
+            Some(alias) => format!("{base} AS {q}{alias}{q}"),
+            None => base,
+        }
     }
 }
 
-impl<T> Expressive<T> for Identifier {
-    fn expr(&self) -> Expression<T> {
-        let sql = match &self.alias {
-            Some(alias) => format!("{} AS \"{}\"", self.render_parts(), alias),
-            None => self.render_parts(),
-        };
-        Expression::new(sql, vec![])
+/// Shorthand for `Identifier::new(name)`.
+pub fn ident(name: impl Into<String>) -> Identifier {
+    Identifier::new(name)
+}
+
+// Each backend impl owns its quoting style.
+
+#[cfg(feature = "sqlite")]
+impl Expressive<crate::sqlite::types::AnySqliteType> for Identifier {
+    fn expr(&self) -> Expression<crate::sqlite::types::AnySqliteType> {
+        Expression::new(self.render_with('"'), vec![])
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl Expressive<crate::postgres::types::AnyPostgresType> for Identifier {
+    fn expr(&self) -> Expression<crate::postgres::types::AnyPostgresType> {
+        Expression::new(self.render_with('"'), vec![])
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl Expressive<crate::mysql::types::AnyMysqlType> for Identifier {
+    fn expr(&self) -> Expression<crate::mysql::types::AnyMysqlType> {
+        Expression::new(self.render_with('`'), vec![])
     }
 }

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -10,8 +10,10 @@ use vantage_table::table::Table;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
 
+use crate::primitives::identifier::ident;
 use crate::sqlite::SqliteDB;
 use crate::sqlite::types::AnySqliteType;
+use vantage_expressions::expr_any;
 
 /// Parse the JSON array result from execute() into an IndexMap of id → Record.
 fn parse_rows(
@@ -94,15 +96,17 @@ impl TableSource for SqliteDB {
     where
         E: Entity<Self::Value>,
     {
-        let pattern = format!("%{}%", search_value.replace('%', "\\%"));
+        let escaped = search_value
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+        let pattern = format!("%{}%", escaped);
         let conditions: Vec<Expression<AnySqliteType>> = table
             .columns()
             .values()
             .map(|col| {
-                Expression::new(
-                    format!("\"{}\" LIKE {{}}", col.name()),
-                    vec![ExpressiveEnum::Scalar(AnySqliteType::from(pattern.clone()))],
-                )
+                let p = pattern.clone();
+                sqlite_expr!("{} LIKE {} ESCAPE '\\\\'", (ident(col.name())), p)
             })
             .collect();
 
@@ -143,10 +147,8 @@ impl TableSource for SqliteDB {
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let condition = Expression::new(
-            format!("\"{}\" = {{}}", id_field_name),
-            vec![ExpressiveEnum::Scalar(AnySqliteType::from(id.clone()))],
-        );
+        let id_val = id.clone();
+        let condition = sqlite_expr!("{} = {}", (ident(&id_field_name)), id_val);
         let select = table.select().with_condition(condition);
         let result = self.execute(&select.expr()).await?;
 
@@ -288,10 +290,8 @@ impl TableSource for SqliteDB {
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let id_condition = Expression::new(
-            format!("\"{}\" = {{}}", id_field_name),
-            vec![ExpressiveEnum::Scalar(AnySqliteType::from(id.clone()))],
-        );
+        let id_val = id.clone();
+        let id_condition = sqlite_expr!("{} = {}", (ident(&id_field_name)), id_val);
         let update = crate::sqlite::statements::SqliteUpdate::new(table.table_name())
             .with_record(partial)
             .with_condition(id_condition);
@@ -309,10 +309,8 @@ impl TableSource for SqliteDB {
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let id_condition = Expression::new(
-            format!("\"{}\" = {{}}", id_field_name),
-            vec![ExpressiveEnum::Scalar(AnySqliteType::from(id.clone()))],
-        );
+        let id_val = id.clone();
+        let id_condition = sqlite_expr!("{} = {}", (ident(&id_field_name)), id_val);
         let delete = crate::sqlite::statements::SqliteDelete::new(table.table_name())
             .with_condition(id_condition);
         self.execute(&delete.expr()).await?;
@@ -346,10 +344,7 @@ impl TableSource for SqliteDB {
 
         // Append RETURNING id_field to get the generated ID back
         let base = insert.expr();
-        let returning = Expression::new(
-            format!("{} RETURNING \"{}\"", base.template, id_field_name),
-            base.parameters.clone(),
-        );
+        let returning = expr_any!("{} RETURNING {}", (base), (ident(&id_field_name)));
         let result = self.execute(&returning).await?;
         let mut rows = parse_rows(result, &id_field_name)?;
         rows.swap_remove_index(0)

--- a/vantage-sql/src/sqlite/statements/delete/render.rs
+++ b/vantage-sql/src/sqlite/statements/delete/render.rs
@@ -1,5 +1,6 @@
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, expr_any};
 
+use crate::primitives::identifier::ident;
 use crate::sqlite::types::AnySqliteType;
 
 use super::{Expr, SqliteDelete};
@@ -13,14 +14,11 @@ impl SqliteDelete {
 impl Expressive<AnySqliteType> for SqliteDelete {
     fn expr(&self) -> Expr {
         if self.conditions.is_empty() {
-            return Expression::new(format!("DELETE FROM \"{}\"", self.table), vec![]);
+            return expr_any!("DELETE FROM {}", (ident(&self.table)));
         }
 
         let combined = Expression::from_vec(self.conditions.clone(), " AND ");
-        Expression::new(
-            format!("DELETE FROM \"{}\" WHERE {{}}", self.table),
-            vec![ExpressiveEnum::Nested(combined)],
-        )
+        expr_any!("DELETE FROM {} WHERE {}", (ident(&self.table)), (combined))
     }
 }
 

--- a/vantage-sql/src/sqlite/statements/insert/render.rs
+++ b/vantage-sql/src/sqlite/statements/insert/render.rs
@@ -1,5 +1,6 @@
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
+use crate::primitives::identifier::ident;
 use crate::sqlite::types::AnySqliteType;
 
 use super::{Expr, SqliteInsert};
@@ -13,29 +14,25 @@ impl SqliteInsert {
 impl Expressive<AnySqliteType> for SqliteInsert {
     fn expr(&self) -> Expr {
         if self.fields.is_empty() {
-            return Expression::new(
-                format!("INSERT INTO \"{}\" DEFAULT VALUES", self.table),
-                vec![],
-            );
+            return expr_any!("INSERT INTO {} DEFAULT VALUES", (ident(&self.table)));
         }
 
-        let columns: Vec<String> = self.fields.keys().map(|k| format!("\"{}\"", k)).collect();
-        let placeholders: Vec<&str> = (0..self.fields.len()).map(|_| "{}").collect();
+        let columns: Vec<Expr> = self.fields.keys().map(|k| ident(k).expr()).collect();
+        let cols = Expression::from_vec(columns, ", ");
 
-        let template = format!(
-            "INSERT INTO \"{}\" ({}) VALUES ({})",
-            self.table,
-            columns.join(", "),
-            placeholders.join(", ")
-        );
-
-        let params: Vec<ExpressiveEnum<AnySqliteType>> = self
+        let values: Vec<Expr> = self
             .fields
             .values()
-            .map(|v| ExpressiveEnum::Scalar(v.clone()))
+            .map(|v| Expression::new("{}", vec![ExpressiveEnum::Scalar(v.clone())]))
             .collect();
+        let vals = Expression::from_vec(values, ", ");
 
-        Expression::new(template, params)
+        expr_any!(
+            "INSERT INTO {} ({}) VALUES ({})",
+            (ident(&self.table)),
+            (cols),
+            (vals)
+        )
     }
 }
 

--- a/vantage-sql/src/sqlite/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/sqlite/statements/select/impls/selectable.rs
@@ -1,7 +1,8 @@
 use vantage_expressions::traits::selectable::{Selectable, SourceRef};
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
 use crate::primitives::fx::Fx;
+use crate::primitives::identifier::ident;
 use crate::sqlite::statements::SqliteSelect;
 use crate::sqlite::types::AnySqliteType;
 
@@ -22,31 +23,29 @@ impl Selectable<AnySqliteType> for SqliteSelect {
         self.from.clear();
         let source_ref = source.into().into_expressive_enum();
         let expr = match (source_ref, alias) {
-            (ExpressiveEnum::Scalar(val), None) => Expression::new(
-                format!("\"{}\"", val.try_get::<String>().unwrap_or_default()),
-                vec![],
-            ),
-            (ExpressiveEnum::Scalar(val), Some(alias)) => Expression::new(
-                format!(
-                    "\"{}\" AS \"{}\"",
-                    val.try_get::<String>().unwrap_or_default(),
-                    alias
-                ),
-                vec![],
-            ),
+            (ExpressiveEnum::Scalar(val), None) => {
+                let Some(name) = val.try_get::<String>().filter(|s| !s.is_empty()) else {
+                    return;
+                };
+                ident(name).expr()
+            }
+            (ExpressiveEnum::Scalar(val), Some(alias)) => {
+                let Some(name) = val.try_get::<String>().filter(|s| !s.is_empty()) else {
+                    return;
+                };
+                ident(name).with_alias(alias).expr()
+            }
             (ExpressiveEnum::Nested(expr), None) => expr,
-            (ExpressiveEnum::Nested(expr), Some(alias)) => Expression::new(
-                format!("{{}} AS \"{}\"", alias),
-                vec![ExpressiveEnum::Nested(expr)],
-            ),
+            (ExpressiveEnum::Nested(expr), Some(alias)) => {
+                expr_any!("{} AS {}", (expr), (ident(alias)))
+            }
             _ => return,
         };
         self.from.push(expr);
     }
 
     fn add_field(&mut self, field: impl Into<String>) {
-        self.fields
-            .push(Expression::new(format!("\"{}\"", field.into()), vec![]));
+        self.fields.push(ident(field).expr());
     }
 
     fn add_expression(
@@ -56,10 +55,7 @@ impl Selectable<AnySqliteType> for SqliteSelect {
     ) {
         let expr = expression.expr();
         let field = match alias {
-            Some(a) => Expression::new(
-                format!("{{}} AS \"{}\"", a),
-                vec![ExpressiveEnum::Nested(expr)],
-            ),
+            Some(a) => expr_any!("{} AS {}", (expr), (ident(a))),
             None => expr,
         };
         self.fields.push(field);

--- a/vantage-sql/src/sqlite/statements/select/join.rs
+++ b/vantage-sql/src/sqlite/statements/select/join.rs
@@ -1,5 +1,6 @@
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
+use crate::primitives::identifier::ident;
 use crate::sqlite::types::AnySqliteType;
 
 type Expr = Expression<AnySqliteType>;
@@ -39,17 +40,11 @@ impl SqliteSelectJoin {
     }
 
     fn table_expr(table: impl Into<String>, alias: impl Into<String>) -> Expr {
-        Expression::new(
-            format!("\"{}\" AS \"{}\"", table.into(), alias.into()),
-            vec![],
-        )
+        ident(table).with_alias(alias).expr()
     }
 
     fn subquery_expr(subquery: impl Expressive<AnySqliteType>, alias: impl Into<String>) -> Expr {
-        Expression::new(
-            format!("({{}}) AS \"{}\"", alias.into()),
-            vec![ExpressiveEnum::Nested(subquery.expr())],
-        )
+        expr_any!("({}) AS {}", (subquery), (ident(alias)))
     }
 
     /// INNER JOIN on a named table.

--- a/vantage-sql/src/sqlite/statements/update/render.rs
+++ b/vantage-sql/src/sqlite/statements/update/render.rs
@@ -1,5 +1,6 @@
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
+use crate::primitives::identifier::ident;
 use crate::sqlite::types::AnySqliteType;
 
 use super::{Expr, SqliteUpdate};
@@ -20,31 +21,33 @@ impl SqliteUpdate {
 impl Expressive<AnySqliteType> for SqliteUpdate {
     fn expr(&self) -> Expr {
         if self.fields.is_empty() {
-            return Expression::new(format!("UPDATE \"{}\"", self.table), vec![]);
+            return expr_any!("UPDATE {}", (ident(&self.table)));
         }
 
-        let set_parts: Vec<String> = self
+        let set_parts: Vec<Expr> = self
             .fields
-            .keys()
-            .map(|k| format!("\"{}\" = {{}}", k))
+            .iter()
+            .map(|(k, v)| {
+                Expression::new(
+                    "{} = {}",
+                    vec![
+                        ExpressiveEnum::Nested(ident(k).expr()),
+                        ExpressiveEnum::Scalar(v.clone()),
+                    ],
+                )
+            })
             .collect();
-        let template_base = format!("UPDATE \"{}\" SET {}", self.table, set_parts.join(", "));
+        let set_list = Expression::from_vec(set_parts, ", ");
 
-        let mut params: Vec<ExpressiveEnum<AnySqliteType>> = self
-            .fields
-            .values()
-            .map(|v| ExpressiveEnum::Scalar(v.clone()))
-            .collect();
-
-        let template = match self.render_where() {
-            Some(cond) => {
-                params.push(ExpressiveEnum::Nested(cond));
-                format!("{} WHERE {{}}", template_base)
-            }
-            None => template_base,
-        };
-
-        Expression::new(template, params)
+        match self.render_where() {
+            Some(cond) => expr_any!(
+                "UPDATE {} SET {} WHERE {}",
+                (ident(&self.table)),
+                (set_list),
+                (cond)
+            ),
+            None => expr_any!("UPDATE {} SET {}", (ident(&self.table)), (set_list)),
+        }
     }
 }
 

--- a/vantage-sql/tests/mysql.rs
+++ b/vantage-sql/tests/mysql.rs
@@ -12,12 +12,16 @@ mod mysql {
     mod editable_data_set;
     #[path = "2_expressions.rs"]
     mod expressions;
+    #[path = "2_identifier.rs"]
+    mod identifier;
     #[path = "2_insert.rs"]
     mod insert;
     #[path = "4_readable_data_set.rs"]
     mod readable_data_set;
     #[path = "2_records.rs"]
     mod records;
+    #[path = "2_search.rs"]
+    mod search;
     #[path = "5_references.rs"]
     mod references;
     #[path = "3_select.rs"]

--- a/vantage-sql/tests/mysql/2_identifier.rs
+++ b/vantage-sql/tests/mysql/2_identifier.rs
@@ -1,0 +1,73 @@
+//! Test 2e: Identifier quoting with mysql_expr! macro.
+//! Verifies that Identifier works as an Expressive in expression macros
+//! and handles unusual but valid MySQL identifier characters.
+
+use vantage_sql::mysql_expr;
+use vantage_sql::primitives::identifier::{Identifier, ident};
+
+// ── ident() in expr macro via (parentheses) ───────────────────────────────────
+
+#[test]
+fn test_id_in_select() {
+    let expr = mysql_expr!("SELECT {} FROM {}", (ident("name")), (ident("product")));
+    assert_eq!(expr.preview(), "SELECT `name` FROM `product`");
+}
+
+#[test]
+fn test_id_in_condition() {
+    let expr = mysql_expr!("{} = {}", (ident("price")), 100i64);
+    assert_eq!(expr.preview(), "`price` = 100");
+}
+
+#[test]
+fn test_id_with_alias() {
+    let expr = mysql_expr!("SELECT {}", (ident("name").with_alias("n")));
+    assert_eq!(expr.preview(), "SELECT `name` AS `n`");
+}
+
+#[test]
+fn test_id_qualified() {
+    let expr = mysql_expr!("SELECT {}", (Identifier::with_dot("t", "name")));
+    assert_eq!(expr.preview(), "SELECT `t`.`name`");
+}
+
+// ── Unusual but valid identifier characters ────────────────────────────────
+// MySQL and PostgreSQL both allow spaces, hyphens, special chars inside
+// quoted identifiers.
+
+#[test]
+fn test_id_with_space() {
+    let expr = mysql_expr!("SELECT {}", (ident("first name")));
+    assert_eq!(expr.preview(), "SELECT `first name`");
+}
+
+#[test]
+fn test_id_with_hyphen() {
+    let expr = mysql_expr!("SELECT {}", (ident("my-column")));
+    assert_eq!(expr.preview(), "SELECT `my-column`");
+}
+
+#[test]
+fn test_id_reserved_word() {
+    let expr = mysql_expr!("SELECT {} FROM {}", (ident("select")), (ident("order")));
+    assert_eq!(expr.preview(), "SELECT `select` FROM `order`");
+}
+
+#[test]
+fn test_id_with_dot_in_name() {
+    // A single identifier containing a literal dot (not qualified)
+    let expr = mysql_expr!("SELECT {}", (ident("weird.name")));
+    assert_eq!(expr.preview(), "SELECT `weird.name`");
+}
+
+#[test]
+fn test_id_unicode() {
+    let expr = mysql_expr!("SELECT {}", (ident("名前")));
+    assert_eq!(expr.preview(), "SELECT `名前`");
+}
+
+#[test]
+fn test_id_number_start() {
+    let expr = mysql_expr!("SELECT {}", (ident("1bad_name")));
+    assert_eq!(expr.preview(), "SELECT `1bad_name`");
+}

--- a/vantage-sql/tests/mysql/2_search.rs
+++ b/vantage-sql/tests/mysql/2_search.rs
@@ -1,0 +1,86 @@
+//! Test 2f: search_table_expr LIKE escaping — verifies that %, _, and \ in
+//! search values don't act as wildcards.
+
+use vantage_dataset::ReadableDataSet;
+#[allow(unused_imports)]
+use vantage_sql::mysql::{AnyMysqlType, MysqlDB, MysqlType};
+use vantage_table::table::Table;
+use vantage_table::traits::table_source::TableSource;
+use vantage_types::entity;
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+#[entity(MysqlType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Item {
+    name: String,
+}
+
+async fn setup(suffix: &str, rows: &[&str]) -> (MysqlDB, Table<MysqlDB, Item>) {
+    let db = MysqlDB::connect(MYSQL_URL).await.unwrap();
+    let table_name = format!("search_{}", suffix);
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", table_name))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE `{}` (id VARCHAR(255) PRIMARY KEY, name TEXT NOT NULL)",
+        table_name
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    for (i, name) in rows.iter().enumerate() {
+        sqlx::query(&format!(
+            "INSERT INTO `{}` (id, name) VALUES (?, ?)",
+            table_name
+        ))
+        .bind(i.to_string())
+        .bind(*name)
+        .execute(db.pool())
+        .await
+        .unwrap();
+    }
+
+    let table = Table::<MysqlDB, Item>::new(&table_name, db.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name");
+    (db, table)
+}
+
+#[tokio::test]
+async fn test_search_percent_literal() {
+    let (db, table) = setup("pct", &["100% organic", "regular item", "50% off"]).await;
+    let condition = db.search_table_expr(&table, "100%");
+    let mut table = table;
+    table.add_condition(condition);
+    let results = table.list().await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.values().next().unwrap().name, "100% organic");
+}
+
+#[tokio::test]
+async fn test_search_underscore_literal() {
+    let (db, table) = setup("usc", &["a_b", "axb", "a__b", "axxb"]).await;
+    let condition = db.search_table_expr(&table, "a_b");
+    let mut table = table;
+    table.add_condition(condition);
+    let results = table.list().await.unwrap();
+    // Only "a_b" should match, not "axb"
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.values().next().unwrap().name, "a_b");
+}
+
+#[tokio::test]
+async fn test_search_backslash_literal() {
+    let (db, table) = setup("bs", &["path\\to\\file", "pathXtoXfile", "other"]).await;
+    let condition = db.search_table_expr(&table, "\\to\\");
+    let mut table = table;
+    table.add_condition(condition);
+    let results = table.list().await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.values().next().unwrap().name, "path\\to\\file");
+}

--- a/vantage-sql/tests/mysql/3_select.rs
+++ b/vantage-sql/tests/mysql/3_select.rs
@@ -72,10 +72,7 @@ fn test_select_with_condition() {
     let s = MysqlSelect::new()
         .with_source("product")
         .with_condition(mysql_expr!("`price` > {}", 100i64));
-    assert_eq!(
-        s.preview(),
-        "SELECT * FROM `product` WHERE `price` > 100"
-    );
+    assert_eq!(s.preview(), "SELECT * FROM `product` WHERE `price` > 100");
 }
 
 #[test]
@@ -92,9 +89,7 @@ fn test_select_order_and_limit() {
 
 #[test]
 fn test_select_distinct() {
-    let mut s = MysqlSelect::new()
-        .with_source("product")
-        .with_field("name");
+    let mut s = MysqlSelect::new().with_source("product").with_field("name");
     s.set_distinct(true);
     assert_eq!(s.preview(), "SELECT DISTINCT `name` FROM `product`");
 }

--- a/vantage-sql/tests/mysql/5_references.rs
+++ b/vantage-sql/tests/mysql/5_references.rs
@@ -62,11 +62,7 @@ fn order_table(db: MysqlDB) -> Table<MysqlDB, ClientOrder> {
 async fn test_has_many_orders_for_paying_clients() {
     let db = get_db().await;
     let mut clients = client_table(db.clone());
-    clients.add_condition(mysql_expr!(
-        "{} = {}",
-        (clients["is_paying_client"]),
-        true
-    ));
+    clients.add_condition(mysql_expr!("{} = {}", (clients["is_paying_client"]), true));
 
     let orders = clients
         .get_ref_as::<MysqlDB, ClientOrder>("orders")

--- a/vantage-sql/tests/postgres.rs
+++ b/vantage-sql/tests/postgres.rs
@@ -12,6 +12,8 @@ mod postgres {
     mod editable_data_set;
     #[path = "2_expressions.rs"]
     mod expressions;
+    #[path = "2_identifier.rs"]
+    mod identifier;
     #[path = "2_insert.rs"]
     mod insert;
     #[path = "4_readable_data_set.rs"]

--- a/vantage-sql/tests/postgres/2_identifier.rs
+++ b/vantage-sql/tests/postgres/2_identifier.rs
@@ -1,0 +1,64 @@
+//! Test 2e: Identifier quoting with postgres_expr! macro.
+
+use vantage_sql::postgres_expr;
+use vantage_sql::primitives::identifier::{Identifier, ident};
+
+#[test]
+fn test_id_in_select() {
+    let expr = postgres_expr!("SELECT {} FROM {}", (ident("name")), (ident("product")));
+    assert_eq!(expr.preview(), "SELECT \"name\" FROM \"product\"");
+}
+
+#[test]
+fn test_id_in_condition() {
+    let expr = postgres_expr!("{} = {}", (ident("price")), 100i64);
+    assert_eq!(expr.preview(), "\"price\" = 100");
+}
+
+#[test]
+fn test_id_with_alias() {
+    let expr = postgres_expr!("SELECT {}", (ident("name").with_alias("n")));
+    assert_eq!(expr.preview(), "SELECT \"name\" AS \"n\"");
+}
+
+#[test]
+fn test_id_qualified() {
+    let expr = postgres_expr!("SELECT {}", (Identifier::with_dot("t", "name")));
+    assert_eq!(expr.preview(), "SELECT \"t\".\"name\"");
+}
+
+#[test]
+fn test_id_with_space() {
+    let expr = postgres_expr!("SELECT {}", (ident("first name")));
+    assert_eq!(expr.preview(), "SELECT \"first name\"");
+}
+
+#[test]
+fn test_id_with_hyphen() {
+    let expr = postgres_expr!("SELECT {}", (ident("my-column")));
+    assert_eq!(expr.preview(), "SELECT \"my-column\"");
+}
+
+#[test]
+fn test_id_reserved_word() {
+    let expr = postgres_expr!("SELECT {} FROM {}", (ident("select")), (ident("order")));
+    assert_eq!(expr.preview(), "SELECT \"select\" FROM \"order\"");
+}
+
+#[test]
+fn test_id_with_dot_in_name() {
+    let expr = postgres_expr!("SELECT {}", (ident("weird.name")));
+    assert_eq!(expr.preview(), "SELECT \"weird.name\"");
+}
+
+#[test]
+fn test_id_unicode() {
+    let expr = postgres_expr!("SELECT {}", (ident("名前")));
+    assert_eq!(expr.preview(), "SELECT \"名前\"");
+}
+
+#[test]
+fn test_id_number_start() {
+    let expr = postgres_expr!("SELECT {}", (ident("1bad_name")));
+    assert_eq!(expr.preview(), "SELECT \"1bad_name\"");
+}

--- a/vantage-sql/tests/sqlite.rs
+++ b/vantage-sql/tests/sqlite.rs
@@ -16,6 +16,8 @@ mod sqlite {
     mod editable_value_set;
     #[path = "2_expressions.rs"]
     mod expressions;
+    #[path = "2_identifier.rs"]
+    mod identifier;
     #[path = "2_insert.rs"]
     mod insert;
     #[path = "4_readable_data_set.rs"]

--- a/vantage-sql/tests/sqlite/2_identifier.rs
+++ b/vantage-sql/tests/sqlite/2_identifier.rs
@@ -1,0 +1,64 @@
+//! Test 2e: Identifier quoting with sqlite_expr! macro.
+
+use vantage_sql::primitives::identifier::{Identifier, ident};
+use vantage_sql::sqlite_expr;
+
+#[test]
+fn test_id_in_select() {
+    let expr = sqlite_expr!("SELECT {} FROM {}", (ident("name")), (ident("product")));
+    assert_eq!(expr.preview(), "SELECT \"name\" FROM \"product\"");
+}
+
+#[test]
+fn test_id_in_condition() {
+    let expr = sqlite_expr!("{} = {}", (ident("price")), 100i64);
+    assert_eq!(expr.preview(), "\"price\" = 100");
+}
+
+#[test]
+fn test_id_with_alias() {
+    let expr = sqlite_expr!("SELECT {}", (ident("name").with_alias("n")));
+    assert_eq!(expr.preview(), "SELECT \"name\" AS \"n\"");
+}
+
+#[test]
+fn test_id_qualified() {
+    let expr = sqlite_expr!("SELECT {}", (Identifier::with_dot("t", "name")));
+    assert_eq!(expr.preview(), "SELECT \"t\".\"name\"");
+}
+
+#[test]
+fn test_id_with_space() {
+    let expr = sqlite_expr!("SELECT {}", (ident("first name")));
+    assert_eq!(expr.preview(), "SELECT \"first name\"");
+}
+
+#[test]
+fn test_id_with_hyphen() {
+    let expr = sqlite_expr!("SELECT {}", (ident("my-column")));
+    assert_eq!(expr.preview(), "SELECT \"my-column\"");
+}
+
+#[test]
+fn test_id_reserved_word() {
+    let expr = sqlite_expr!("SELECT {} FROM {}", (ident("select")), (ident("order")));
+    assert_eq!(expr.preview(), "SELECT \"select\" FROM \"order\"");
+}
+
+#[test]
+fn test_id_with_dot_in_name() {
+    let expr = sqlite_expr!("SELECT {}", (ident("weird.name")));
+    assert_eq!(expr.preview(), "SELECT \"weird.name\"");
+}
+
+#[test]
+fn test_id_unicode() {
+    let expr = sqlite_expr!("SELECT {}", (ident("名前")));
+    assert_eq!(expr.preview(), "SELECT \"名前\"");
+}
+
+#[test]
+fn test_id_number_start() {
+    let expr = sqlite_expr!("SELECT {}", (ident("1bad_name")));
+    assert_eq!(expr.preview(), "SELECT \"1bad_name\"");
+}


### PR DESCRIPTION
In `vantage-sql`, `ident()` is the new shorthand for SQL identifiers, and it picks the right quote style from the expression type around it.

```rust
use vantage_sql::primitives::identifier::ident;

mysql_expr!("SELECT {} FROM {}", (ident("name")), (ident("order")))
// SELECT `name` FROM `order`

postgres_expr!("SELECT {} FROM {}", (ident("name")), (ident("order")))
// SELECT "name" FROM "order"
```

Same `Identifier`, different quote — chosen by which backend's `AnyType` the surrounding expression carries. The blanket `impl<T> Expressive<T> for Identifier` is gone; each backend (`sqlite`, `postgres`, `mysql`) now has its own impl with its own quote character. A quote character on `Identifier` itself would have meant threading it through every call site — the type-context route gives the same answer for free. If you wrote code against the blanket impl, enable the matching backend feature flag for the impl to exist.

### What you might notice

- Reserved words, spaces, hyphens, unicode, leading digits — all legal as identifier names now and tested per backend (`tests/<backend>/2_identifier.rs`).
- `search_table_expr` now escapes `%`, `_`, and `\` properly with `ESCAPE '\\'`. Searching for `"100%"` no longer silently wildcards.
- MySQL ids always bind as string; MySQL coerces. Previous integer detection on `id_value` is gone — it was eating leading zeros on ids like `"00123"`.

### Render-path consolidation

`MysqlInsert`, `MysqlUpdate`, `MysqlDelete` and their Postgres / SQLite counterparts all stopped hand-rolling `format!("\`{}\`", ...)` and now compose through `expr_any!` + `ident()`. Smaller behavioural change than it looks — same SQL output, single quoting path. SurrealDB unaffected.