### PR TITLE
Improve search_table escaping and add tests

### DIFF
--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -104,16 +104,16 @@ impl TableSource for MysqlDB {
         E: Entity<Self::Value>,
     {
         let escaped = search_value
-            .replace('\\', "\\\\")
-            .replace('%', "\\%")
-            .replace('_', "\\_");
+            .replace('$', "$$")
+            .replace('%', "$%")
+            .replace('_', "$_");
         let pattern = format!("%{}%", escaped);
         let conditions: Vec<Expression<AnyMysqlType>> = table
             .columns()
             .values()
             .map(|col| {
                 let p = pattern.clone();
-                mysql_expr!("{} LIKE {} ESCAPE '\\\\'", (ident(col.name())), p)
+                mysql_expr!("{} LIKE {} ESCAPE '$'", (ident(col.name())), p)
             })
             .collect();
 

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -107,16 +107,16 @@ impl TableSource for PostgresDB {
         E: Entity<Self::Value>,
     {
         let escaped = search_value
-            .replace('\\', "\\\\")
-            .replace('%', "\\%")
-            .replace('_', "\\_");
+            .replace('$', "$$")
+            .replace('%', "$%")
+            .replace('_', "$_");
         let pattern = format!("%{}%", escaped);
         let conditions: Vec<Expression<AnyPostgresType>> = table
             .columns()
             .values()
             .map(|col| {
                 let p = pattern.clone();
-                postgres_expr!("{}::text LIKE {} ESCAPE '\\\\'", (ident(col.name())), p)
+                postgres_expr!("{}::text LIKE {} ESCAPE '$'", (ident(col.name())), p)
             })
             .collect();
 

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -97,16 +97,16 @@ impl TableSource for SqliteDB {
         E: Entity<Self::Value>,
     {
         let escaped = search_value
-            .replace('\\', "\\\\")
-            .replace('%', "\\%")
-            .replace('_', "\\_");
+            .replace('$', "$$")
+            .replace('%', "$%")
+            .replace('_', "$_");
         let pattern = format!("%{}%", escaped);
         let conditions: Vec<Expression<AnySqliteType>> = table
             .columns()
             .values()
             .map(|col| {
                 let p = pattern.clone();
-                sqlite_expr!("{} LIKE {} ESCAPE '\\\\'", (ident(col.name())), p)
+                sqlite_expr!("{} LIKE {} ESCAPE '$'", (ident(col.name())), p)
             })
             .collect();
 

--- a/vantage-sql/tests/mysql.rs
+++ b/vantage-sql/tests/mysql.rs
@@ -20,10 +20,10 @@ mod mysql {
     mod readable_data_set;
     #[path = "2_records.rs"]
     mod records;
-    #[path = "2_search.rs"]
-    mod search;
     #[path = "5_references.rs"]
     mod references;
+    #[path = "2_search.rs"]
+    mod search;
     #[path = "3_select.rs"]
     mod select;
     #[path = "4_table_def.rs"]

--- a/vantage-sql/tests/postgres.rs
+++ b/vantage-sql/tests/postgres.rs
@@ -20,6 +20,8 @@ mod postgres {
     mod readable_data_set;
     #[path = "2_records.rs"]
     mod records;
+    #[path = "2_search.rs"]
+    mod search;
     #[path = "5_references.rs"]
     mod references;
     #[path = "3_select.rs"]

--- a/vantage-sql/tests/postgres.rs
+++ b/vantage-sql/tests/postgres.rs
@@ -20,10 +20,10 @@ mod postgres {
     mod readable_data_set;
     #[path = "2_records.rs"]
     mod records;
-    #[path = "2_search.rs"]
-    mod search;
     #[path = "5_references.rs"]
     mod references;
+    #[path = "2_search.rs"]
+    mod search;
     #[path = "3_select.rs"]
     mod select;
     #[path = "4_table_def.rs"]

--- a/vantage-sql/tests/postgres/2_search.rs
+++ b/vantage-sql/tests/postgres/2_search.rs
@@ -1,0 +1,85 @@
+//! Test 2f: search_table_expr LIKE escaping — verifies that %, _, and \ in
+//! search values don't act as wildcards.
+
+use vantage_dataset::ReadableDataSet;
+#[allow(unused_imports)]
+use vantage_sql::postgres::{AnyPostgresType, PostgresDB, PostgresType};
+use vantage_table::table::Table;
+use vantage_table::traits::table_source::TableSource;
+use vantage_types::entity;
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+#[entity(PostgresType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Item {
+    name: String,
+}
+
+async fn setup(suffix: &str, rows: &[&str]) -> (PostgresDB, Table<PostgresDB, Item>) {
+    let db = PostgresDB::connect(PG_URL).await.unwrap();
+    let table_name = format!("search_{}", suffix);
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", table_name))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE \"{}\" (id TEXT PRIMARY KEY, name TEXT NOT NULL)",
+        table_name
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    for (i, name) in rows.iter().enumerate() {
+        sqlx::query(&format!(
+            "INSERT INTO \"{}\" (id, name) VALUES ($1, $2)",
+            table_name
+        ))
+        .bind(i.to_string())
+        .bind(*name)
+        .execute(db.pool())
+        .await
+        .unwrap();
+    }
+
+    let table = Table::<PostgresDB, Item>::new(&table_name, db.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name");
+    (db, table)
+}
+
+#[tokio::test]
+async fn test_search_percent_literal() {
+    let (db, table) = setup("pct", &["100% organic", "regular item", "50% off"]).await;
+    let condition = db.search_table_expr(&table, "100%");
+    let mut table = table;
+    table.add_condition(condition);
+    let results = table.list().await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.values().next().unwrap().name, "100% organic");
+}
+
+#[tokio::test]
+async fn test_search_underscore_literal() {
+    let (db, table) = setup("usc", &["a_b", "axb", "a__b", "axxb"]).await;
+    let condition = db.search_table_expr(&table, "a_b");
+    let mut table = table;
+    table.add_condition(condition);
+    let results = table.list().await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.values().next().unwrap().name, "a_b");
+}
+
+#[tokio::test]
+async fn test_search_backslash_literal() {
+    let (db, table) = setup("bs", &["path\\to\\file", "pathXtoXfile", "other"]).await;
+    let condition = db.search_table_expr(&table, "\\to\\");
+    let mut table = table;
+    table.add_condition(condition);
+    let results = table.list().await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.values().next().unwrap().name, "path\\to\\file");
+}

--- a/vantage-sql/tests/sqlite.rs
+++ b/vantage-sql/tests/sqlite.rs
@@ -26,10 +26,10 @@ mod sqlite {
     mod readable_value_set;
     #[path = "2_records.rs"]
     mod records;
-    #[path = "2_search.rs"]
-    mod search;
     #[path = "5_references.rs"]
     mod references;
+    #[path = "2_search.rs"]
+    mod search;
     #[path = "3_select.rs"]
     mod select;
     #[path = "4_table_def.rs"]

--- a/vantage-sql/tests/sqlite.rs
+++ b/vantage-sql/tests/sqlite.rs
@@ -26,6 +26,8 @@ mod sqlite {
     mod readable_value_set;
     #[path = "2_records.rs"]
     mod records;
+    #[path = "2_search.rs"]
+    mod search;
     #[path = "5_references.rs"]
     mod references;
     #[path = "3_select.rs"]

--- a/vantage-sql/tests/sqlite/2_search.rs
+++ b/vantage-sql/tests/sqlite/2_search.rs
@@ -1,0 +1,71 @@
+//! Test 2f: search_table_expr LIKE escaping — verifies that %, _, and \ in
+//! search values don't act as wildcards.
+
+use vantage_dataset::ReadableDataSet;
+#[allow(unused_imports)]
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB, SqliteType};
+use vantage_table::table::Table;
+use vantage_table::traits::table_source::TableSource;
+use vantage_types::entity;
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Item {
+    name: String,
+}
+
+async fn setup(rows: &[&str]) -> (SqliteDB, Table<SqliteDB, Item>) {
+    let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+
+    sqlx::query("CREATE TABLE item (id TEXT PRIMARY KEY, name TEXT NOT NULL)")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    for (i, name) in rows.iter().enumerate() {
+        sqlx::query("INSERT INTO item (id, name) VALUES (?, ?)")
+            .bind(i.to_string())
+            .bind(*name)
+            .execute(db.pool())
+            .await
+            .unwrap();
+    }
+
+    let table = Table::<SqliteDB, Item>::new("item", db.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name");
+    (db, table)
+}
+
+#[tokio::test]
+async fn test_search_percent_literal() {
+    let (db, table) = setup(&["100% organic", "regular item", "50% off"]).await;
+    let condition = db.search_table_expr(&table, "100%");
+    let mut table = table;
+    table.add_condition(condition);
+    let results = table.list().await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.values().next().unwrap().name, "100% organic");
+}
+
+#[tokio::test]
+async fn test_search_underscore_literal() {
+    let (db, table) = setup(&["a_b", "axb", "a__b", "axxb"]).await;
+    let condition = db.search_table_expr(&table, "a_b");
+    let mut table = table;
+    table.add_condition(condition);
+    let results = table.list().await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.values().next().unwrap().name, "a_b");
+}
+
+#[tokio::test]
+async fn test_search_backslash_literal() {
+    let (db, table) = setup(&["path\\to\\file", "pathXtoXfile", "other"]).await;
+    let condition = db.search_table_expr(&table, "\\to\\");
+    let mut table = table;
+    table.add_condition(condition);
+    let results = table.list().await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.values().next().unwrap().name, "path\\to\\file");
+}


### PR DESCRIPTION
`search_table_expr` now correctly matches `%`, `_`, and `\` as literals. Search values containing those characters previously either over-matched (treating them as wildcards) or, on Postgres/SQLite, produced patterns whose `ESCAPE '\\'` clause didn't behave consistently with how the driver re-interpreted backslashes in the bound string.

Same trait, same call site, same results for non-special inputs — but if you'd been searching for `100%` or `a_b` and getting noisy results, that's fixed.

### Why `$` as the escape char

The previous escape character was backslash, which collides with C-style string-literal escaping in Postgres (depending on `standard_conforming_strings`) and is generally annoying to round-trip. `$` has no special meaning in `LIKE` patterns, doesn't need re-escaping when bound, and behaves identically across MySQL, Postgres, and SQLite. All three backends now use `ESCAPE '$'` and escape `$`/`%`/`_` in the search value.

### Tests

Added `tests/{postgres,sqlite}/2_search.rs` covering literal `%`, `_`, and `\` in search values. MySQL already had the equivalent file; the per-backend test module lists pick it up alongside the new ones. Run with `cargo test -p vantage-sql --test postgres` (requires the local `ingress.sh` Postgres) and `--test sqlite` (in-memory).