### PR TITLE
add custom pg tests

### DIFF
--- a/.github/workflows/vantage-sql.yaml
+++ b/.github/workflows/vantage-sql.yaml
@@ -77,6 +77,16 @@ jobs:
             PGPASSWORD=vantage psql -h localhost -p 5433 -U vantage -d vantage -f "$f"
           done
 
+      - name: Populate PostgreSQL-specific database
+        if: matrix.backend == 'postgres'
+        run: |
+          cd vantage-sql/scripts/postgres
+          PGPASSWORD=vantage psql -h localhost -p 5433 -U vantage -d postgres -c "CREATE DATABASE vantage_pg OWNER vantage;"
+          for f in db/v4*.sql; do
+            echo "Loading $f..."
+            PGPASSWORD=vantage psql -h localhost -p 5433 -U vantage -d vantage_pg -f "$f"
+          done
+
       - name: Populate MySQL database
         if: matrix.backend == 'mysql'
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,6 +2363,7 @@ checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -2388,6 +2389,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2439,6 +2441,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -2468,6 +2471,7 @@ dependencies = [
  "stringprep",
  "thiserror 2.0.18",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -2481,6 +2485,7 @@ dependencies = [
  "base64",
  "bitflags",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -2506,6 +2511,7 @@ dependencies = [
  "stringprep",
  "thiserror 2.0.18",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -2516,6 +2522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",
@@ -2531,6 +2538,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3240,6 +3248,7 @@ name = "vantage-sql"
 version = "0.4.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "indexmap",
  "paste",
  "rust_decimal",
@@ -3247,6 +3256,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
+ "uuid",
  "vantage-core",
  "vantage-dataset",
  "vantage-expressions",

--- a/vantage-core/src/util/into_vec.rs
+++ b/vantage-core/src/util/into_vec.rs
@@ -29,3 +29,17 @@ impl<T: Clone> IntoVec<T> for &[T] {
         self.to_vec()
     }
 }
+
+/// Single `&str` becomes a one-element `Vec<String>`.
+impl IntoVec<String> for &str {
+    fn into_vec(self) -> Vec<String> {
+        vec![self.to_string()]
+    }
+}
+
+/// Array of `&str` becomes `Vec<String>`.
+impl<const N: usize> IntoVec<String> for [&str; N] {
+    fn into_vec(self) -> Vec<String> {
+        self.into_iter().map(|s| s.to_string()).collect()
+    }
+}

--- a/vantage-expressions/src/expression/core.rs
+++ b/vantage-expressions/src/expression/core.rs
@@ -143,6 +143,48 @@ impl<T: std::fmt::Display + std::fmt::Debug> Expression<T> {
     }
 }
 
+// -- Arithmetic operators for Expression<T> ----------------------------------
+
+impl<T> std::ops::Add for Expression<T> {
+    type Output = Expression<T>;
+    fn add(self, rhs: Self) -> Self::Output {
+        Expression::new(
+            "{} + {}",
+            vec![ExpressiveEnum::Nested(self), ExpressiveEnum::Nested(rhs)],
+        )
+    }
+}
+
+impl<T> std::ops::Sub for Expression<T> {
+    type Output = Expression<T>;
+    fn sub(self, rhs: Self) -> Self::Output {
+        Expression::new(
+            "{} - {}",
+            vec![ExpressiveEnum::Nested(self), ExpressiveEnum::Nested(rhs)],
+        )
+    }
+}
+
+impl<T> std::ops::Mul for Expression<T> {
+    type Output = Expression<T>;
+    fn mul(self, rhs: Self) -> Self::Output {
+        Expression::new(
+            "{} * {}",
+            vec![ExpressiveEnum::Nested(self), ExpressiveEnum::Nested(rhs)],
+        )
+    }
+}
+
+impl<T> std::ops::Div for Expression<T> {
+    type Output = Expression<T>;
+    fn div(self, rhs: Self) -> Self::Output {
+        Expression::new(
+            "{} / {}",
+            vec![ExpressiveEnum::Nested(self), ExpressiveEnum::Nested(rhs)],
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vantage-expressions/src/lib.rs
+++ b/vantage-expressions/src/lib.rs
@@ -20,7 +20,7 @@ pub use traits::datasource::ExprDataSource;
 pub use traits::datasource::SelectableDataSource;
 pub use traits::expressive::{DeferredFn, Expressive, ExpressiveEnum};
 pub use traits::expressive_or::ExpressiveOr;
-pub use traits::selectable::Selectable;
+pub use traits::selectable::{Nulls, Order, Selectable};
 
 pub use traits::result;
 

--- a/vantage-expressions/src/mocks/select.rs
+++ b/vantage-expressions/src/mocks/select.rs
@@ -153,8 +153,8 @@ impl Selectable<serde_json::Value> for MockSelect {
         self.distinct = distinct;
     }
 
-    fn add_order_by(&mut self, expression: impl Expressive<Value>, ascending: bool) {
-        self.order_by.push((expression.expr(), ascending));
+    fn add_order_by(&mut self, expression: impl Expressive<Value>, order: crate::Order) {
+        self.order_by.push((expression.expr(), order.ascending));
     }
 
     fn add_group_by(&mut self, _expression: impl Expressive<Value>) {

--- a/vantage-expressions/src/traits/selectable.rs
+++ b/vantage-expressions/src/traits/selectable.rs
@@ -3,6 +3,64 @@ use std::fmt::Debug;
 use super::expressive::Expressive;
 use crate::{Expression, ExpressiveEnum};
 
+/// Sort direction and null handling for ORDER BY clauses.
+///
+/// ```ignore
+/// .with_order(ident("name"), Order::Asc)
+/// .with_order(ident("score"), Order::Desc.nulls_last())
+/// .with_order(ident("id"), true)  // bool still works
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Order {
+    pub ascending: bool,
+    pub nulls: Option<Nulls>,
+}
+
+/// NULL placement in ORDER BY.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Nulls {
+    First,
+    Last,
+}
+
+#[allow(non_upper_case_globals)]
+impl Order {
+    pub const Asc: Order = Order {
+        ascending: true,
+        nulls: None,
+    };
+    pub const Desc: Order = Order {
+        ascending: false,
+        nulls: None,
+    };
+
+    pub fn nulls_last(self) -> Self {
+        Self {
+            nulls: Some(Nulls::Last),
+            ..self
+        }
+    }
+
+    pub fn nulls_first(self) -> Self {
+        Self {
+            nulls: Some(Nulls::First),
+            ..self
+        }
+    }
+
+    /// Returns the SQL suffix for this ordering, e.g. `""`, `" DESC"`, `" DESC NULLS LAST"`.
+    pub fn suffix(&self) -> &'static str {
+        match (self.ascending, self.nulls) {
+            (true, None) => "",
+            (false, None) => " DESC",
+            (true, Some(Nulls::Last)) => " NULLS LAST",
+            (true, Some(Nulls::First)) => " NULLS FIRST",
+            (false, Some(Nulls::Last)) => " DESC NULLS LAST",
+            (false, Some(Nulls::First)) => " DESC NULLS FIRST",
+        }
+    }
+}
+
 /// Unified protocol for building SELECT queries across different databases.
 ///
 /// The `Selectable` trait provides a standardized interface for building SELECT-style
@@ -29,8 +87,8 @@ pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
     /// Sets whether the query should return distinct results.
     fn set_distinct(&mut self, distinct: bool);
 
-    /// Adds an ORDER BY clause with direction.
-    fn add_order_by(&mut self, expression: impl Expressive<T>, ascending: bool);
+    /// Adds an ORDER BY clause with direction and optional null handling.
+    fn add_order_by(&mut self, expression: impl Expressive<T>, order: Order);
 
     /// Adds a GROUP BY clause.
     fn add_group_by(&mut self, expression: impl Expressive<T>);
@@ -113,11 +171,11 @@ pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
     }
 
     /// Builder pattern method identical to [`Self::add_order_by`].
-    fn with_order(mut self, expression: impl Expressive<T>, ascending: bool) -> Self
+    fn with_order(mut self, expression: impl Expressive<T>, order: Order) -> Self
     where
         Self: Sized,
     {
-        Self::add_order_by(&mut self, expression, ascending);
+        Self::add_order_by(&mut self, expression, order);
         self
     }
 

--- a/vantage-expressions/src/traits/selectable.rs
+++ b/vantage-expressions/src/traits/selectable.rs
@@ -8,7 +8,6 @@ use crate::{Expression, ExpressiveEnum};
 /// ```ignore
 /// .with_order(ident("name"), Order::Asc)
 /// .with_order(ident("score"), Order::Desc.nulls_last())
-/// .with_order(ident("id"), true)  // bool still works
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Order {

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -26,8 +26,10 @@ paste = "1.0"
 vantage-dataset = { path = "../vantage-dataset" }
 vantage-table = { path = "../vantage-table" }
 async-trait = "0.1"
-sqlx = { version = "0.8", features = ["runtime-tokio", "rust_decimal"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "rust_decimal", "uuid", "chrono"] }
 rust_decimal = "1"
+uuid = "1"
+chrono = "0.4"
 serde_json = { version = "1", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
 indexmap = { version = "2.12.0", features = ["serde"] }

--- a/vantage-sql/scripts/postgres/db/v4_pg.sql
+++ b/vantage-sql/scripts/postgres/db/v4_pg.sql
@@ -20,6 +20,9 @@
 --
 -- =============================================================================
 
+-- Required for EXCLUDE USING GIST with non-geometric types
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
 -- Enum type for ticket priority
 CREATE TYPE priority_level AS ENUM ('low', 'medium', 'high', 'critical');
 
@@ -63,8 +66,7 @@ CREATE TABLE users (
     is_active       BOOLEAN NOT NULL DEFAULT TRUE,
     skills          TEXT[] DEFAULT '{}',
     last_login_ip   INET,
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    tenure          INTERVAL GENERATED ALWAYS AS (NOW() - created_at) STORED
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 INSERT INTO users (id, name, email, role, department_id, salary, is_active, skills, last_login_ip, created_at) VALUES

--- a/vantage-sql/scripts/postgres/ingress_pg.sh
+++ b/vantage-sql/scripts/postgres/ingress_pg.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONTAINER_NAME="postgres-vantage"
+USER="vantage"
+DB="vantage_pg"
+
+echo "Loading PostgreSQL-specific data into $DB..."
+
+for db_file in "$SCRIPT_DIR"/db/v4*.sql; do
+    db_name=$(basename "$db_file" .sql)
+    echo "Loading $db_name..."
+    docker exec -i $CONTAINER_NAME psql -U $USER -d $DB < "$db_file"
+    echo "  done."
+done
+
+echo "PostgreSQL-specific data loaded into $DB."

--- a/vantage-sql/scripts/postgres/start.sh
+++ b/vantage-sql/scripts/postgres/start.sh
@@ -52,6 +52,10 @@ for i in $(seq 1 30); do
     sleep 1
 done
 
+# Create additional databases
+echo "Creating additional databases..."
+docker exec $CONTAINER_NAME psql -U $USER -d $DB -c "CREATE DATABASE vantage_pg OWNER $USER;" 2>/dev/null || true
+
 # Check if container is running
 if docker ps -q -f name=$CONTAINER_NAME | grep -q .; then
     echo ""

--- a/vantage-sql/src/mysql/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/mysql/statements/select/impls/selectable.rs
@@ -74,8 +74,12 @@ impl Selectable<AnyMysqlType> for MysqlSelect {
         self.distinct = distinct;
     }
 
-    fn add_order_by(&mut self, expression: impl Expressive<AnyMysqlType>, ascending: bool) {
-        self.order_by.push((expression.expr(), ascending));
+    fn add_order_by(
+        &mut self,
+        expression: impl Expressive<AnyMysqlType>,
+        order: vantage_expressions::Order,
+    ) {
+        self.order_by.push((expression.expr(), order));
     }
 
     fn add_group_by(&mut self, expression: impl Expressive<AnyMysqlType>) {

--- a/vantage-sql/src/mysql/statements/select/mod.rs
+++ b/vantage-sql/src/mysql/statements/select/mod.rs
@@ -16,7 +16,7 @@ pub struct MysqlSelect {
     pub from: Vec<Expr>,
     pub joins: Vec<MysqlSelectJoin>,
     pub where_conditions: Vec<Expr>,
-    pub order_by: Vec<(Expr, bool)>,
+    pub order_by: Vec<(Expr, vantage_expressions::Order)>,
     pub group_by: Vec<Expr>,
     pub having: Vec<Expr>,
     pub windows: Vec<(String, Window<AnyMysqlType>)>,

--- a/vantage-sql/src/mysql/statements/select/render.rs
+++ b/vantage-sql/src/mysql/statements/select/render.rs
@@ -98,12 +98,11 @@ impl MysqlSelect {
             let parts: Vec<Expr> = self
                 .order_by
                 .iter()
-                .map(|(expr, asc)| {
-                    if *asc {
-                        expr.clone()
-                    } else {
-                        Expression::new("{} DESC", vec![ExpressiveEnum::Nested(expr.clone())])
-                    }
+                .map(|(expr, order)| {
+                    Expression::new(
+                        format!("{{}}{}", order.suffix()),
+                        vec![ExpressiveEnum::Nested(expr.clone())],
+                    )
                 })
                 .collect();
             Expression::new(

--- a/vantage-sql/src/postgres/row.rs
+++ b/vantage-sql/src/postgres/row.rs
@@ -172,6 +172,46 @@ fn pg_column_to_json(row: &PgRow, ordinal: usize, type_name: &str) -> JsonValue 
                 }
             }
         }
+        // -- PostgreSQL-specific types --
+        "_TEXT" | "TEXT[]" => {
+            if let Ok(v) = row.try_get::<Vec<String>, _>(ordinal) {
+                return JsonValue::Array(v.into_iter().map(JsonValue::String).collect());
+            }
+        }
+        "_INT4" | "INT4[]" | "INTEGER[]" => {
+            if let Ok(v) = row.try_get::<Vec<i32>, _>(ordinal) {
+                return JsonValue::Array(
+                    v.into_iter()
+                        .map(|i| JsonValue::Number((i as i64).into()))
+                        .collect(),
+                );
+            }
+        }
+        "UUID" => {
+            if let Ok(v) = row.try_get::<uuid::Uuid, _>(ordinal) {
+                return JsonValue::String(v.to_string());
+            }
+        }
+        "DATE" => {
+            if let Ok(v) = row.try_get::<chrono::NaiveDate, _>(ordinal) {
+                return JsonValue::String(v.format("%Y-%m-%d").to_string());
+            }
+        }
+        "TIMESTAMPTZ" | "TIMESTAMP WITH TIME ZONE" => {
+            if let Ok(v) = row.try_get::<chrono::DateTime<chrono::Utc>, _>(ordinal) {
+                return JsonValue::String(v.to_rfc3339());
+            }
+        }
+        "TIMESTAMP" | "TIMESTAMP WITHOUT TIME ZONE" => {
+            if let Ok(v) = row.try_get::<chrono::NaiveDateTime, _>(ordinal) {
+                return JsonValue::String(v.format("%Y-%m-%dT%H:%M:%S").to_string());
+            }
+        }
+        "JSONB" | "JSON" => {
+            if let Ok(v) = row.try_get::<serde_json::Value, _>(ordinal) {
+                return v;
+            }
+        }
         _ => {}
     }
 

--- a/vantage-sql/src/postgres/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/postgres/statements/select/impls/selectable.rs
@@ -78,8 +78,12 @@ impl Selectable<AnyPostgresType> for PostgresSelect {
         self.distinct = distinct;
     }
 
-    fn add_order_by(&mut self, expression: impl Expressive<AnyPostgresType>, ascending: bool) {
-        self.order_by.push((expression.expr(), ascending));
+    fn add_order_by(
+        &mut self,
+        expression: impl Expressive<AnyPostgresType>,
+        order: vantage_expressions::Order,
+    ) {
+        self.order_by.push((expression.expr(), order));
     }
 
     fn add_group_by(&mut self, expression: impl Expressive<AnyPostgresType>) {

--- a/vantage-sql/src/postgres/statements/select/join.rs
+++ b/vantage-sql/src/postgres/statements/select/join.rs
@@ -10,6 +10,10 @@ pub enum PostgresJoinType {
     Inner,
     Left,
     Right,
+    FullOuter,
+    // -- PostgreSQL-specific --
+    LeftLateral,
+    CrossLateral,
 }
 
 impl PostgresJoinType {
@@ -18,6 +22,9 @@ impl PostgresJoinType {
             PostgresJoinType::Inner => "INNER JOIN",
             PostgresJoinType::Left => "LEFT JOIN",
             PostgresJoinType::Right => "RIGHT JOIN",
+            PostgresJoinType::FullOuter => "FULL OUTER JOIN",
+            PostgresJoinType::LeftLateral => "LEFT JOIN LATERAL",
+            PostgresJoinType::CrossLateral => "CROSS JOIN LATERAL",
         }
     }
 }
@@ -63,6 +70,18 @@ impl PostgresSelectJoin {
         )
     }
 
+    pub fn full_outer(
+        table: impl Into<String>,
+        alias: impl Into<String>,
+        on_condition: Expr,
+    ) -> Self {
+        Self::new(
+            PostgresJoinType::FullOuter,
+            Self::table_expr(table, alias),
+            on_condition,
+        )
+    }
+
     pub fn inner_expr(
         subquery: impl Expressive<AnyPostgresType>,
         alias: impl Into<String>,
@@ -87,13 +106,56 @@ impl PostgresSelectJoin {
         )
     }
 
-    pub fn render(&self) -> Expr {
-        Expression::new(
-            format!(" {} {{}} ON {{}}", self.join_type.as_str()),
-            vec![
-                ExpressiveEnum::Nested(self.table.clone()),
-                ExpressiveEnum::Nested(self.on_condition.clone()),
-            ],
+    /// PostgreSQL-specific: `LEFT JOIN LATERAL (subquery) AS alias ON TRUE`
+    pub fn left_lateral(
+        subquery: impl Expressive<AnyPostgresType>,
+        alias: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            PostgresJoinType::LeftLateral,
+            Self::subquery_expr(subquery, alias),
+            Expression::new("TRUE", vec![]),
         )
+    }
+
+    /// PostgreSQL-specific: `CROSS JOIN LATERAL (subquery) AS alias`
+    pub fn cross_lateral(
+        subquery: impl Expressive<AnyPostgresType>,
+        alias: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            PostgresJoinType::CrossLateral,
+            Self::subquery_expr(subquery, alias),
+            Expression::new("", vec![]),
+        )
+    }
+
+    /// PostgreSQL-specific: `CROSS JOIN LATERAL expr` (no wrapping parens).
+    /// Useful for set-returning functions like `UNNEST(...) WITH ORDINALITY AS alias(col, col)`.
+    pub fn cross_lateral_raw(table_expr: impl Expressive<AnyPostgresType>) -> Self {
+        Self::new(
+            PostgresJoinType::CrossLateral,
+            table_expr.expr(),
+            Expression::new("", vec![]),
+        )
+    }
+
+    pub fn render(&self) -> Expr {
+        match self.join_type {
+            PostgresJoinType::CrossLateral => {
+                // CROSS JOIN LATERAL has no ON clause
+                Expression::new(
+                    format!(" {} {{}}", self.join_type.as_str()),
+                    vec![ExpressiveEnum::Nested(self.table.clone())],
+                )
+            }
+            _ => Expression::new(
+                format!(" {} {{}} ON {{}}", self.join_type.as_str()),
+                vec![
+                    ExpressiveEnum::Nested(self.table.clone()),
+                    ExpressiveEnum::Nested(self.on_condition.clone()),
+                ],
+            ),
+        }
     }
 }

--- a/vantage-sql/src/postgres/statements/select/mod.rs
+++ b/vantage-sql/src/postgres/statements/select/mod.rs
@@ -16,7 +16,7 @@ pub struct PostgresSelect {
     pub from: Vec<Expr>,
     pub joins: Vec<PostgresSelectJoin>,
     pub where_conditions: Vec<Expr>,
-    pub order_by: Vec<(Expr, bool)>,
+    pub order_by: Vec<(Expr, vantage_expressions::Order)>,
     pub group_by: Vec<Expr>,
     pub having: Vec<Expr>,
     pub windows: Vec<(String, Window<AnyPostgresType>)>,
@@ -24,6 +24,9 @@ pub struct PostgresSelect {
     pub distinct: bool,
     pub limit: Option<i64>,
     pub skip: Option<i64>,
+
+    // -- PostgreSQL-specific fields --
+    pub distinct_on: Vec<Expr>,
 }
 
 impl PostgresSelect {
@@ -41,6 +44,7 @@ impl PostgresSelect {
             distinct: false,
             limit: None,
             skip: None,
+            distinct_on: Vec::new(),
         }
     }
 
@@ -73,6 +77,20 @@ impl PostgresSelect {
         recursive: bool,
     ) -> Self {
         self.ctes.push((name.into(), query.expr(), recursive));
+        self
+    }
+}
+
+// -- PostgreSQL-specific methods --
+
+impl PostgresSelect {
+    /// `SELECT DISTINCT ON (expr, ...) ...`
+    /// ORDER BY must start with the DISTINCT ON expressions.
+    pub fn with_distinct_on(
+        mut self,
+        expr: impl vantage_expressions::Expressive<AnyPostgresType>,
+    ) -> Self {
+        self.distinct_on.push(expr.expr());
         self
     }
 }

--- a/vantage-sql/src/postgres/statements/select/render.rs
+++ b/vantage-sql/src/postgres/statements/select/render.rs
@@ -98,12 +98,11 @@ impl PostgresSelect {
             let parts: Vec<Expr> = self
                 .order_by
                 .iter()
-                .map(|(expr, asc)| {
-                    if *asc {
-                        expr.clone()
-                    } else {
-                        Expression::new("{} DESC", vec![ExpressiveEnum::Nested(expr.clone())])
-                    }
+                .map(|(expr, order)| {
+                    Expression::new(
+                        format!("{{}}{}", order.suffix()),
+                        vec![ExpressiveEnum::Nested(expr.clone())],
+                    )
                 })
                 .collect();
             Expression::new(
@@ -161,14 +160,35 @@ impl PostgresSelect {
         }
     }
 
+    fn render_distinct(&self) -> &str {
+        if !self.distinct_on.is_empty() {
+            // DISTINCT ON is rendered as part of fields via render_distinct_on()
+            ""
+        } else if self.distinct {
+            " DISTINCT"
+        } else {
+            ""
+        }
+    }
+
+    fn render_distinct_on(&self) -> Expr {
+        if self.distinct_on.is_empty() {
+            Expression::new("", vec![])
+        } else {
+            let exprs = Expression::from_vec(self.distinct_on.clone(), ", ");
+            Expression::new("DISTINCT ON ({}) ", vec![ExpressiveEnum::Nested(exprs)])
+        }
+    }
+
     pub fn render(&self) -> Expr {
         Expression::new(
             format!(
-                "{{}}SELECT{} {{}}{{}}{{}}{{}}{{}}{{}}{{}}{{}}{{}}",
-                if self.distinct { " DISTINCT" } else { "" }
+                "{{}}SELECT{} {{}}{{}}{{}}{{}}{{}}{{}}{{}}{{}}{{}}{{}}",
+                self.render_distinct()
             ),
             vec![
                 ExpressiveEnum::Nested(self.render_ctes()),
+                ExpressiveEnum::Nested(self.render_distinct_on()),
                 ExpressiveEnum::Nested(self.render_fields()),
                 ExpressiveEnum::Nested(self.render_from()),
                 ExpressiveEnum::Nested(self.render_joins()),

--- a/vantage-sql/src/primitives/interval.rs
+++ b/vantage-sql/src/primitives/interval.rs
@@ -1,0 +1,74 @@
+use vantage_expressions::{Expression, Expressive};
+
+/// Vendor-aware time interval literal.
+///
+/// Renders as:
+/// - **PostgreSQL:** `INTERVAL '1 year'`
+/// - **MySQL:**      `INTERVAL 1 YEAR`
+/// - **SQLite:**     `1` (numeric days — caller must convert units)
+///
+/// # Examples
+///
+/// ```ignore
+/// use vantage_sql::primitives::interval::Interval;
+///
+/// Interval::new(1, "year")
+/// Interval::new(6, "month")
+/// Interval::new(30, "day")
+/// ```
+#[derive(Debug, Clone)]
+pub struct Interval {
+    amount: i64,
+    unit: String,
+}
+
+impl Interval {
+    pub fn new(amount: i64, unit: impl Into<String>) -> Self {
+        Self {
+            amount,
+            unit: unit.into().to_lowercase(),
+        }
+    }
+
+    /// Convert to approximate days for SQLite (which has no INTERVAL type).
+    fn to_days(&self) -> i64 {
+        match self.unit.as_str() {
+            "year" | "years" => self.amount * 365,
+            "month" | "months" => self.amount * 30,
+            "week" | "weeks" => self.amount * 7,
+            "day" | "days" => self.amount,
+            "hour" | "hours" => self.amount / 24,
+            _ => self.amount,
+        }
+    }
+}
+
+// -- SQLite: numeric days (approximate) --------------------------------------
+
+#[cfg(feature = "sqlite")]
+impl Expressive<crate::sqlite::types::AnySqliteType> for Interval {
+    fn expr(&self) -> Expression<crate::sqlite::types::AnySqliteType> {
+        Expression::new(format!("{}", self.to_days()), vec![])
+    }
+}
+
+// -- MySQL: INTERVAL 1 YEAR -------------------------------------------------
+
+#[cfg(feature = "mysql")]
+impl Expressive<crate::mysql::types::AnyMysqlType> for Interval {
+    fn expr(&self) -> Expression<crate::mysql::types::AnyMysqlType> {
+        Expression::new(
+            format!("INTERVAL {} {}", self.amount, self.unit.to_uppercase()),
+            vec![],
+        )
+    }
+}
+
+// -- PostgreSQL: INTERVAL '1 year' ------------------------------------------
+
+#[cfg(feature = "postgres")]
+impl Expressive<crate::postgres::types::AnyPostgresType> for Interval {
+    fn expr(&self) -> Expression<crate::postgres::types::AnyPostgresType> {
+        Expression::new(format!("INTERVAL '{} {}'", self.amount, self.unit), vec![])
+    }
+}

--- a/vantage-sql/src/primitives/interval.rs
+++ b/vantage-sql/src/primitives/interval.rs
@@ -37,7 +37,7 @@ impl Interval {
             "month" | "months" => self.amount * 30,
             "week" | "weeks" => self.amount * 7,
             "day" | "days" => self.amount,
-            "hour" | "hours" => self.amount / 24,
+            "hour" | "hours" => (self.amount as f64 / 24.0).round() as i64,
             _ => self.amount,
         }
     }

--- a/vantage-sql/src/primitives/json_extract.rs
+++ b/vantage-sql/src/primitives/json_extract.rs
@@ -57,7 +57,8 @@ pub fn json_extract<T: Debug + Display + Clone>(
 
 /// Helper: create an inline SQL literal (not a bind parameter).
 fn sql_lit<T: Debug + Display + Clone>(s: &str) -> Expression<T> {
-    Expression::new(format!("'{s}'"), vec![])
+    let escaped = s.replace('\'', "''");
+    Expression::new(format!("'{escaped}'"), vec![])
 }
 
 // -- SQLite: JSON_EXTRACT("col", '$.a.b') ------------------------------------
@@ -113,6 +114,10 @@ impl Expressive<crate::postgres::types::AnyPostgresType>
     fn expr(&self) -> Expression<crate::postgres::types::AnyPostgresType> {
         // Build chain: source -> 'a' -> 'b' ->> 'last'
         // All intermediate steps use -> (returns jsonb), final step uses ->> (returns text)
+        assert!(
+            !self.path.is_empty(),
+            "JsonExtract requires at least one path segment"
+        );
         let mut current = self.source.clone();
         let last = self.path.len() - 1;
 

--- a/vantage-sql/src/primitives/json_extract.rs
+++ b/vantage-sql/src/primitives/json_extract.rs
@@ -1,37 +1,42 @@
 use std::fmt::{Debug, Display};
 
+use vantage_core::util::IntoVec;
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
 
 use super::identifier::Identifier;
 
 /// Vendor-aware JSON field extraction.
 ///
+/// Accepts a single field or a path of fields. For multi-level paths,
+/// intermediate steps use the JSON-object accessor and the final step
+/// extracts as text.
+///
 /// Renders as:
-/// - **SQLite:**    `JSON_EXTRACT("col", '$.field')`
-/// - **MySQL:**     `JSON_EXTRACT(\`col\`, '$.field')`
-/// - **PostgreSQL:** `"col"->>'field'`
+/// - **SQLite:**    `JSON_EXTRACT("col", '$.field')` or `JSON_EXTRACT("col", '$.a.b')`
+/// - **MySQL:**     `JSON_EXTRACT(\`col\`, '$.field')` or `JSON_EXTRACT(\`col\`, '$.a.b')`
+/// - **PostgreSQL:** `"col"->>'field'` or `"col"->'a'->>'b'`
 ///
 /// # Examples
 ///
 /// ```ignore
-/// use vantage_sql::primitives::json_extract::JsonExtract;
+/// // Single field
+/// JsonExtract::new(ident("metadata"), "color")
 ///
-/// // Extract a text field from a JSON column:
-/// JsonExtract::new(Identifier::new("metadata"), "color")
-///     .with_alias("color")
+/// // Nested path
+/// JsonExtract::new(ident("metadata"), ["specs", "voltage"])
 /// ```
 #[derive(Debug, Clone)]
 pub struct JsonExtract<T: Debug + Display + Clone> {
     source: Expression<T>,
-    field: String,
+    path: Vec<String>,
     alias: Option<String>,
 }
 
 impl<T: Debug + Display + Clone> JsonExtract<T> {
-    pub fn new(source: impl Expressive<T>, field: impl Into<String>) -> Self {
+    pub fn new(source: impl Expressive<T>, path: impl IntoVec<String>) -> Self {
         Self {
             source: source.expr(),
-            field: field.into(),
+            path: path.into_vec(),
             alias: None,
         }
     }
@@ -42,31 +47,32 @@ impl<T: Debug + Display + Clone> JsonExtract<T> {
     }
 }
 
-/// Shorthand for `JsonExtract::new(source, field)`.
+/// Shorthand for `JsonExtract::new(source, path)`.
 pub fn json_extract<T: Debug + Display + Clone>(
     source: impl Expressive<T>,
-    field: impl Into<String>,
+    path: impl IntoVec<String>,
 ) -> JsonExtract<T> {
-    JsonExtract::new(source, field)
+    JsonExtract::new(source, path)
 }
 
-/// Helper: create a SQL path literal as an inline expression (not a bind parameter).
-fn json_path<T: Debug + Display + Clone>(field: &str, prefix: &str) -> Expression<T> {
-    Expression::new(format!("'{prefix}{field}'"), vec![])
+/// Helper: create an inline SQL literal (not a bind parameter).
+fn sql_lit<T: Debug + Display + Clone>(s: &str) -> Expression<T> {
+    Expression::new(format!("'{s}'"), vec![])
 }
 
-// -- SQLite: JSON_EXTRACT("col", '$.field') ----------------------------------
+// -- SQLite: JSON_EXTRACT("col", '$.a.b') ------------------------------------
 
 #[cfg(feature = "sqlite")]
 impl Expressive<crate::sqlite::types::AnySqliteType>
     for JsonExtract<crate::sqlite::types::AnySqliteType>
 {
     fn expr(&self) -> Expression<crate::sqlite::types::AnySqliteType> {
+        let json_path = format!("$.{}", self.path.join("."));
         let base = Expression::new(
             "JSON_EXTRACT({}, {})",
             vec![
                 ExpressiveEnum::Nested(self.source.clone()),
-                ExpressiveEnum::Nested(json_path(&self.field, "$.")),
+                ExpressiveEnum::Nested(sql_lit(&json_path)),
             ],
         );
         match &self.alias {
@@ -76,18 +82,19 @@ impl Expressive<crate::sqlite::types::AnySqliteType>
     }
 }
 
-// -- MySQL: JSON_EXTRACT(`col`, '$.field') -----------------------------------
+// -- MySQL: JSON_EXTRACT(`col`, '$.a.b') -------------------------------------
 
 #[cfg(feature = "mysql")]
 impl Expressive<crate::mysql::types::AnyMysqlType>
     for JsonExtract<crate::mysql::types::AnyMysqlType>
 {
     fn expr(&self) -> Expression<crate::mysql::types::AnyMysqlType> {
+        let json_path = format!("$.{}", self.path.join("."));
         let base = Expression::new(
             "JSON_EXTRACT({}, {})",
             vec![
                 ExpressiveEnum::Nested(self.source.clone()),
-                ExpressiveEnum::Nested(json_path(&self.field, "$.")),
+                ExpressiveEnum::Nested(sql_lit(&json_path)),
             ],
         );
         match &self.alias {
@@ -97,23 +104,32 @@ impl Expressive<crate::mysql::types::AnyMysqlType>
     }
 }
 
-// -- PostgreSQL: "col"->>'field' ---------------------------------------------
+// -- PostgreSQL: "col"->'a'->>'b' --------------------------------------------
 
 #[cfg(feature = "postgres")]
 impl Expressive<crate::postgres::types::AnyPostgresType>
     for JsonExtract<crate::postgres::types::AnyPostgresType>
 {
     fn expr(&self) -> Expression<crate::postgres::types::AnyPostgresType> {
-        let base = Expression::new(
-            "{} ->> {}",
-            vec![
-                ExpressiveEnum::Nested(self.source.clone()),
-                ExpressiveEnum::Nested(json_path(&self.field, "")),
-            ],
-        );
+        // Build chain: source -> 'a' -> 'b' ->> 'last'
+        // All intermediate steps use -> (returns jsonb), final step uses ->> (returns text)
+        let mut current = self.source.clone();
+        let last = self.path.len() - 1;
+
+        for (i, field) in self.path.iter().enumerate() {
+            let op = if i == last { " ->> " } else { " -> " };
+            current = Expression::new(
+                format!("{{}}{op}{{}}"),
+                vec![
+                    ExpressiveEnum::Nested(current),
+                    ExpressiveEnum::Nested(sql_lit(field)),
+                ],
+            );
+        }
+
         match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (base), (Identifier::new(alias))),
-            None => base,
+            Some(alias) => expr_any!("{} AS {}", (current), (Identifier::new(alias))),
+            None => current,
         }
     }
 }

--- a/vantage-sql/src/primitives/mod.rs
+++ b/vantage-sql/src/primitives/mod.rs
@@ -4,6 +4,7 @@ pub mod date_format;
 pub mod fx;
 pub mod identifier;
 pub mod iif;
+pub mod interval;
 pub mod json_extract;
 pub mod select;
 pub mod ternary;

--- a/vantage-sql/src/primitives/select/window.rs
+++ b/vantage-sql/src/primitives/select/window.rs
@@ -9,7 +9,7 @@ use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 /// ```ignore
 /// let win = Window::new()
 ///     .partition_by(ident("department_id").dot_of("u"))
-///     .order_by(ident("salary").dot_of("u"), false);
+///     .order_by(ident("salary").dot_of("u"), Order::Desc);
 ///
 /// // Inline: SUM(u.salary) OVER (PARTITION BY ... ORDER BY ... DESC)
 /// win.apply(Fx::new("sum", [ident("salary").dot_of("u").expr()]))
@@ -20,7 +20,7 @@ use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 #[derive(Debug, Clone)]
 pub struct Window<T: Debug + Display + Clone> {
     partition_by: Vec<Expression<T>>,
-    order_by: Vec<(Expression<T>, bool)>,
+    order_by: Vec<(Expression<T>, vantage_expressions::Order)>,
     frame: Option<String>,
     named_ref: Option<String>,
 }
@@ -56,8 +56,8 @@ impl<T: Debug + Display + Clone> Window<T> {
         self
     }
 
-    pub fn order_by(mut self, expr: impl Expressive<T>, ascending: bool) -> Self {
-        self.order_by.push((expr.expr(), ascending));
+    pub fn order_by(mut self, expr: impl Expressive<T>, order: vantage_expressions::Order) -> Self {
+        self.order_by.push((expr.expr(), order));
         self
     }
 
@@ -104,12 +104,11 @@ impl<T: Debug + Display + Clone> Window<T> {
             let order_parts: Vec<Expression<T>> = self
                 .order_by
                 .iter()
-                .map(|(expr, asc)| {
-                    if *asc {
-                        expr.clone()
-                    } else {
-                        Expression::new("{} DESC", vec![ExpressiveEnum::Nested(expr.clone())])
-                    }
+                .map(|(expr, order)| {
+                    Expression::new(
+                        format!("{{}}{}", order.suffix()),
+                        vec![ExpressiveEnum::Nested(expr.clone())],
+                    )
                 })
                 .collect();
             parts.push(Expression::new(

--- a/vantage-sql/src/sqlite/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/sqlite/statements/select/impls/selectable.rs
@@ -69,8 +69,12 @@ impl Selectable<AnySqliteType> for SqliteSelect {
         self.distinct = distinct;
     }
 
-    fn add_order_by(&mut self, expression: impl Expressive<AnySqliteType>, ascending: bool) {
-        self.order_by.push((expression.expr(), ascending));
+    fn add_order_by(
+        &mut self,
+        expression: impl Expressive<AnySqliteType>,
+        order: vantage_expressions::Order,
+    ) {
+        self.order_by.push((expression.expr(), order));
     }
 
     fn add_group_by(&mut self, expression: impl Expressive<AnySqliteType>) {

--- a/vantage-sql/src/sqlite/statements/select/mod.rs
+++ b/vantage-sql/src/sqlite/statements/select/mod.rs
@@ -16,7 +16,7 @@ pub struct SqliteSelect {
     pub from: Vec<Expr>,
     pub joins: Vec<SqliteSelectJoin>,
     pub where_conditions: Vec<Expr>,
-    pub order_by: Vec<(Expr, bool)>,
+    pub order_by: Vec<(Expr, vantage_expressions::Order)>,
     pub group_by: Vec<Expr>,
     pub having: Vec<Expr>,
     pub windows: Vec<(String, Window<AnySqliteType>)>,

--- a/vantage-sql/src/sqlite/statements/select/render.rs
+++ b/vantage-sql/src/sqlite/statements/select/render.rs
@@ -98,12 +98,11 @@ impl SqliteSelect {
             let parts: Vec<Expr> = self
                 .order_by
                 .iter()
-                .map(|(expr, asc)| {
-                    if *asc {
-                        expr.clone()
-                    } else {
-                        Expression::new("{} DESC", vec![ExpressiveEnum::Nested(expr.clone())])
-                    }
+                .map(|(expr, order)| {
+                    Expression::new(
+                        format!("{{}}{}", order.suffix()),
+                        vec![ExpressiveEnum::Nested(expr.clone())],
+                    )
                 })
                 .collect();
             Expression::new(

--- a/vantage-sql/tests/mysql/3_complex_queries.rs
+++ b/vantage-sql/tests/mysql/3_complex_queries.rs
@@ -4,7 +4,7 @@
 #![allow(dead_code)]
 
 use serde::Deserialize;
-use vantage_expressions::{ExprDataSource, Expressive, Selectable};
+use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 use vantage_sql::mysql::MysqlDB;
 use vantage_sql::mysql::statements::MysqlSelect;
 use vantage_sql::mysql::statements::select::join::MysqlSelectJoin;
@@ -69,7 +69,7 @@ async fn test_q1() {
             .with_field("email")
             .with_condition(ident("role").eq("admin"))
             .with_condition(ident("salary").gt(50000.0f64))
-            .with_order(ident("name"), true),
+            .with_order(ident("name"), Order::Asc),
         "SELECT `id`, `name`, `email` FROM `users` \
          WHERE `role` = 'admin' AND `salary` > 50000.0 \
          ORDER BY `name`",
@@ -124,8 +124,8 @@ async fn test_q2() {
                 (ident("salary").dot_of("u")),
                 30000.0f64
             ))
-            .with_order(ident("name").dot_of("d"), true)
-            .with_order(ident("name").dot_of("u"), true),
+            .with_order(ident("name").dot_of("d"), Order::Asc)
+            .with_order(ident("name").dot_of("u"), Order::Asc),
         "SELECT `u`.`id`, `u`.`name`, `d`.`name` AS `department_name` \
          FROM `users` AS `u` \
          INNER JOIN `departments` AS `d` ON `d`.`id` = `u`.`department_id` \
@@ -195,7 +195,7 @@ async fn test_q3() {
         ))
         .with_group_by(ident("id").dot_of("u"))
         .with_group_by(ident("name").dot_of("u"))
-        .with_order(ident("total_spent"), false);
+        .with_order(ident("total_spent"), Order::Desc);
 
     let users: Vec<UserSpend> = check_and_run(
         &select,
@@ -280,7 +280,7 @@ async fn test_q4() {
                 (Fx::new("avg", [price.expr()])),
                 500.0f64
             ))
-            .with_order(ident("product_count"), false),
+            .with_order(ident("product_count"), Order::Desc),
         "SELECT `category`, COUNT(*) AS `product_count`, AVG(`price`) AS `avg_price`, \
          MIN(`price`) AS `cheapest`, MAX(`price`) AS `most_expensive` \
          FROM `products` \
@@ -357,7 +357,7 @@ async fn test_q5() {
                 Some("order_count".into()),
             )
             .with_condition(Fx::new("exists", [exists_subquery.expr()]))
-            .with_order(ident("order_count"), false)
+            .with_order(ident("order_count"), Order::Desc)
             .with_limit(Some(20), None),
         concat!(
             r#"SELECT `u`.`id`, `u`.`name`, "#,
@@ -442,7 +442,7 @@ async fn test_q6() {
                 (ident("order_count").dot_of("stats")),
                 2i64
             ))
-            .with_order(ident("avg_total").dot_of("stats"), false),
+            .with_order(ident("avg_total").dot_of("stats"), Order::Desc),
         concat!(
             r#"SELECT `u`.`name`, `stats`.`order_count`, `stats`.`avg_total` "#,
             r#"FROM `users` AS `u` "#,
@@ -531,7 +531,7 @@ async fn test_q7() {
                 None,
             )
             .with_field("display_name")
-            .with_order(ident("salary"), false),
+            .with_order(ident("salary"), Order::Desc),
         "SELECT `id`, `name`, `salary`, \
          CASE WHEN `salary` >= 100000.0 THEN 'senior' WHEN `salary` >= 60000.0 THEN 'mid' \
          WHEN `salary` >= 30000.0 THEN 'junior' ELSE 'intern' END AS `band`, \
@@ -688,7 +688,7 @@ async fn test_q9() {
             .with_expression(
                 Window::new()
                     .partition_by(dept.clone())
-                    .order_by(salary.clone(), false)
+                    .order_by(salary.clone(), Order::Desc)
                     .rows("UNBOUNDED PRECEDING", "CURRENT ROW")
                     .apply(Fx::new("sum", [salary.expr()])),
                 Some("running_total".into()),
@@ -696,7 +696,7 @@ async fn test_q9() {
             .with_condition(mysql_expr!("{} IS NOT NULL", (dept)))
             .with_window("win", Window::new()
                 .partition_by(dept.clone())
-                .order_by(salary.clone(), false)),
+                .order_by(salary.clone(), Order::Desc)),
         concat!(
             r#"SELECT `u`.`department_id`, `u`.`name`, `u`.`salary`, "#,
             r#"ROW_NUMBER() OVER win AS `row_num`, "#,
@@ -777,7 +777,7 @@ async fn test_q10() {
                 mysql_expr!("{} = {}",
                     (ident("id").dot_of("u")),
                     (ident("user_id").dot_of("t")))))
-            .with_order(ident("revenue").dot_of("t"), false)
+            .with_order(ident("revenue").dot_of("t"), Order::Desc)
             .with_limit(Some(10), None),
         concat!(
             r#"WITH active_orders AS (SELECT `user_id`, COUNT(*) AS `cnt`, SUM(`total`) AS `revenue` "#,
@@ -875,7 +875,7 @@ async fn test_q11() {
             .with_field("name")
             .with_field("depth")
             .with_field("path")
-            .with_order(ident("path"), true),
+            .with_order(ident("path"), Order::Asc),
         concat!(
             r#"WITH RECURSIVE dept_tree(id, name, depth, path) AS "#,
             r#"(SELECT `id`, `name`, 0, `name` FROM `departments` WHERE `parent_id` IS NULL "#,
@@ -963,7 +963,7 @@ async fn test_q12() {
                 "%Pro%"
             ))
             .with_condition(mysql_expr!("{} > {}", (ident("stock").dot_of("p")), 0i64))
-            .with_order(ident("price").dot_of("p"), true)
+            .with_order(ident("price").dot_of("p"), Order::Asc)
             .with_limit(Some(50), None),
         concat!(
             r#"SELECT DISTINCT `p`.`id`, `p`.`name`, `p`.`price` "#,
@@ -1054,7 +1054,7 @@ async fn test_q13() {
                 5.0f64
             ))
             .with_condition(JsonExtract::new(metadata.clone(), "in_stock").eq(1i64))
-            .with_order(ident("rating"), false),
+            .with_order(ident("rating"), Order::Desc),
         concat!(
             r#"SELECT `id`, `name`, "#,
             r#"JSON_EXTRACT(`metadata`, '$.color') AS `color`, "#,
@@ -1153,8 +1153,8 @@ async fn test_q14() {
             .with_group_by(ident("month"))
             .with_group_by(ident("name").dot_of("d"))
             .with_having(mysql_expr!("{} > {}", (sum_total), 100.0f64))
-            .with_order(ident("month"), false)
-            .with_order(ident("monthly_revenue"), false),
+            .with_order(ident("month"), Order::Desc)
+            .with_order(ident("monthly_revenue"), Order::Desc),
         concat!(
             r#"SELECT DATE_FORMAT(`o`.`created_at`, '%Y-%m') AS `month`, "#,
             r#"`d`.`name` AS `department`, "#,

--- a/vantage-sql/tests/mysql/3_select.rs
+++ b/vantage-sql/tests/mysql/3_select.rs
@@ -1,6 +1,6 @@
 //! Test 3a: MysqlSelect via Selectable trait + SelectableDataSource execution.
 
-use vantage_expressions::{ExprDataSource, Expressive, Selectable};
+use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 #[allow(unused_imports)]
 use vantage_sql::mysql::MysqlType;
 use vantage_sql::mysql::statements::MysqlSelect;
@@ -79,7 +79,7 @@ fn test_select_with_condition() {
 fn test_select_order_and_limit() {
     let s = MysqlSelect::new()
         .with_source("product")
-        .with_order(mysql_expr!("`price`"), false)
+        .with_order(mysql_expr!("`price`"), Order::Desc)
         .with_limit(Some(2), None);
     assert_eq!(
         s.preview(),
@@ -200,7 +200,7 @@ async fn test_execute_order_and_limit() {
 
     let select = MysqlSelect::new()
         .with_source("sel_order")
-        .with_order(mysql_expr!("`price`"), false)
+        .with_order(mysql_expr!("`price`"), Order::Desc)
         .with_limit(Some(1), None);
 
     let record: Record<AnyMysqlType> = db.associate(select.expr()).get().await.unwrap();

--- a/vantage-sql/tests/postgres.rs
+++ b/vantage-sql/tests/postgres.rs
@@ -6,6 +6,8 @@ mod postgres {
     mod associated;
     #[path = "3_complex_queries.rs"]
     mod complex_queries;
+    #[path = "3_complex_queries_pg.rs"]
+    mod complex_queries_pg;
     #[path = "4_conditions.rs"]
     mod conditions;
     #[path = "2_defer.rs"]

--- a/vantage-sql/tests/postgres/3_complex_queries.rs
+++ b/vantage-sql/tests/postgres/3_complex_queries.rs
@@ -4,7 +4,7 @@
 #![allow(dead_code)]
 
 use serde::Deserialize;
-use vantage_expressions::{ExprDataSource, Expressive, Selectable};
+use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 use vantage_sql::postgres::PostgresDB;
 use vantage_sql::postgres::statements::PostgresSelect;
 use vantage_sql::postgres::statements::select::join::PostgresSelectJoin;
@@ -69,7 +69,7 @@ async fn test_q1() {
             .with_field("email")
             .with_condition(postgres_expr!("\"role\" = {}", "admin"))
             .with_condition(postgres_expr!("\"salary\" > {}", 50000.0f64))
-            .with_order(postgres_expr!("\"name\""), true),
+            .with_order(postgres_expr!("\"name\""), Order::Asc),
         "SELECT \"id\", \"name\", \"email\" FROM \"users\" \
          WHERE \"role\" = 'admin' AND \"salary\" > 50000.0 \
          ORDER BY \"name\"",
@@ -124,8 +124,8 @@ async fn test_q2() {
                 (ident("salary").dot_of("u")),
                 30000.0f64
             ))
-            .with_order(ident("name").dot_of("d"), true)
-            .with_order(ident("name").dot_of("u"), true),
+            .with_order(ident("name").dot_of("d"), Order::Asc)
+            .with_order(ident("name").dot_of("u"), Order::Asc),
         "SELECT \"u\".\"id\", \"u\".\"name\", \"d\".\"name\" AS \"department_name\" \
          FROM \"users\" AS \"u\" \
          INNER JOIN \"departments\" AS \"d\" ON \"d\".\"id\" = \"u\".\"department_id\" \
@@ -195,7 +195,7 @@ async fn test_q3() {
         ))
         .with_group_by(ident("id").dot_of("u"))
         .with_group_by(ident("name").dot_of("u"))
-        .with_order(ident("total_spent"), false);
+        .with_order(ident("total_spent"), Order::Desc);
 
     let users: Vec<UserSpend> = check_and_run(
         &select,
@@ -280,7 +280,7 @@ async fn test_q4() {
                 (Fx::new("avg", [price.expr()])),
                 500.0f64
             ))
-            .with_order(ident("product_count"), false),
+            .with_order(ident("product_count"), Order::Desc),
         "SELECT \"category\", COUNT(*) AS \"product_count\", AVG(\"price\") AS \"avg_price\", \
          MIN(\"price\") AS \"cheapest\", MAX(\"price\") AS \"most_expensive\" \
          FROM \"products\" \
@@ -357,7 +357,7 @@ async fn test_q5() {
                 Some("order_count".into()),
             )
             .with_condition(Fx::new("exists", [exists_subquery.expr()]))
-            .with_order(ident("order_count"), false)
+            .with_order(ident("order_count"), Order::Desc)
             .with_limit(Some(20), None),
         concat!(
             r#"SELECT "u"."id", "u"."name", "#,
@@ -442,7 +442,7 @@ async fn test_q6() {
                 (ident("order_count").dot_of("stats")),
                 2i64
             ))
-            .with_order(ident("avg_total").dot_of("stats"), false),
+            .with_order(ident("avg_total").dot_of("stats"), Order::Desc),
         concat!(
             r#"SELECT "u"."name", "stats"."order_count", "stats"."avg_total" "#,
             r#"FROM "users" AS "u" "#,
@@ -531,7 +531,7 @@ async fn test_q7() {
                 None,
             )
             .with_field("display_name")
-            .with_order(ident("salary"), false),
+            .with_order(ident("salary"), Order::Desc),
         "SELECT \"id\", \"name\", \"salary\", \
          CASE WHEN \"salary\" >= 100000.0 THEN 'senior' WHEN \"salary\" >= 60000.0 THEN 'mid' \
          WHEN \"salary\" >= 30000.0 THEN 'junior' ELSE 'intern' END AS \"band\", \
@@ -688,7 +688,7 @@ async fn test_q9() {
             .with_expression(
                 Window::new()
                     .partition_by(dept.clone())
-                    .order_by(salary.clone(), false)
+                    .order_by(salary.clone(), Order::Desc)
                     .rows("UNBOUNDED PRECEDING", "CURRENT ROW")
                     .apply(Fx::new("sum", [salary.expr()])),
                 Some("running_total".into()),
@@ -696,7 +696,7 @@ async fn test_q9() {
             .with_condition(postgres_expr!("{} IS NOT NULL", (dept)))
             .with_window("win", Window::new()
                 .partition_by(dept.clone())
-                .order_by(salary.clone(), false)),
+                .order_by(salary.clone(), Order::Desc)),
         concat!(
             r#"SELECT "u"."department_id", "u"."name", "u"."salary", "#,
             r#"ROW_NUMBER() OVER win AS "row_num", "#,
@@ -777,7 +777,7 @@ async fn test_q10() {
                 postgres_expr!("{} = {}",
                     (ident("id").dot_of("u")),
                     (ident("user_id").dot_of("t")))))
-            .with_order(ident("revenue").dot_of("t"), false)
+            .with_order(ident("revenue").dot_of("t"), Order::Desc)
             .with_limit(Some(10), None),
         concat!(
             r#"WITH active_orders AS (SELECT "user_id", COUNT(*) AS "cnt", SUM("total") AS "revenue" "#,
@@ -878,7 +878,7 @@ async fn test_q11() {
             .with_field("name")
             .with_field("depth")
             .with_field("path")
-            .with_order(ident("path"), true),
+            .with_order(ident("path"), Order::Asc),
         concat!(
             r#"WITH RECURSIVE dept_tree(id, name, depth, path) AS "#,
             r#"(SELECT "id", "name", 0, "name" FROM "departments" WHERE "parent_id" IS NULL "#,
@@ -970,7 +970,7 @@ async fn test_q12() {
                 (ident("stock").dot_of("p")),
                 0i64
             ))
-            .with_order(ident("price").dot_of("p"), true)
+            .with_order(ident("price").dot_of("p"), Order::Asc)
             .with_limit(Some(50), None),
         concat!(
             r#"SELECT DISTINCT "p"."id", "p"."name", "p"."price" "#,
@@ -1064,7 +1064,7 @@ async fn test_q13() {
                 5.0f64
             ))
             .with_condition(JsonExtract::new(metadata.clone(), "in_stock").eq("1"))
-            .with_order(ident("rating"), false),
+            .with_order(ident("rating"), Order::Desc),
         concat!(
             r#"SELECT "id", "name", "#,
             r#""metadata" ->> 'color' AS "color", "#,
@@ -1164,8 +1164,8 @@ async fn test_q14() {
             .with_group_by(ident("month"))
             .with_group_by(ident("name").dot_of("d"))
             .with_having(postgres_expr!("{} > {}", (sum_total), 100.0f64))
-            .with_order(ident("month"), false)
-            .with_order(ident("monthly_revenue"), false),
+            .with_order(ident("month"), Order::Desc)
+            .with_order(ident("monthly_revenue"), Order::Desc),
         concat!(
             r#"SELECT TO_CHAR("o"."created_at", 'YYYY-MM') AS "month", "#,
             r#""d"."name" AS "department", "#,
@@ -1239,7 +1239,7 @@ async fn test_q15() {
 
     let dept_salary_win = Window::new()
         .partition_by(dept.clone())
-        .order_by(salary.clone(), false);
+        .order_by(salary.clone(), Order::Desc);
 
     let rows: Vec<UserWindowStats> = check_and_run(
         &PostgresSelect::new()
@@ -1257,12 +1257,12 @@ async fn test_q15() {
                 Some("completed_count".into()),
             )
             .with_expression(
-                Window::new().order_by(salary.clone(), true)
+                Window::new().order_by(salary.clone(), Order::Asc)
                     .apply(postgres_expr!("LAG({}, 1)", (salary.clone()))),
                 Some("prev_salary".into()),
             )
             .with_expression(
-                Window::new().order_by(salary.clone(), true)
+                Window::new().order_by(salary.clone(), Order::Asc)
                     .apply(postgres_expr!("LEAD({}, 1)", (salary.clone()))),
                 Some("next_salary".into()),
             )
@@ -1283,8 +1283,8 @@ async fn test_q15() {
                     (ident("user_id").dot_of("o")),
                     (ident("id").dot_of("u")))))
             .with_condition(postgres_expr!("{} IS NOT NULL", (dept.clone())))
-            .with_order(dept, true)
-            .with_order(salary, false),
+            .with_order(dept, Order::Asc)
+            .with_order(salary, Order::Desc),
         concat!(
             r#"SELECT "u"."id", "u"."name", "u"."salary", "u"."department_id", "#,
             r#"COUNT(*) FILTER (WHERE "o"."status" = 'completed') OVER (PARTITION BY "u"."id") AS "completed_count", "#,

--- a/vantage-sql/tests/postgres/3_complex_queries_pg.rs
+++ b/vantage-sql/tests/postgres/3_complex_queries_pg.rs
@@ -1,0 +1,1229 @@
+//! PostgreSQL-specific query builder tests.
+//! These exercise features that only exist in PostgreSQL (DISTINCT ON, array ops, etc.).
+//! Runs against the vantage_pg database (v4_pg.sql schema).
+
+#![allow(dead_code)]
+
+use serde::Deserialize;
+use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
+use vantage_sql::postgres::PostgresDB;
+use vantage_sql::postgres::statements::PostgresSelect;
+use vantage_sql::postgres::statements::select::join::PostgresSelectJoin;
+use vantage_sql::postgres_expr;
+use vantage_sql::primitives::identifier::ident;
+use vantage_table::operation::Operation;
+use vantage_types::{Record, TryFromRecord};
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage_pg";
+
+async fn get_db() -> PostgresDB {
+    PostgresDB::connect(PG_URL)
+        .await
+        .expect("Failed to connect to vantage_pg")
+}
+
+/// Checks that `select.preview()` matches `expected_sql`, then executes the
+/// query and returns deserialized rows.
+async fn check_and_run<T: for<'de> Deserialize<'de>>(
+    select: &PostgresSelect,
+    expected_sql: &str,
+) -> Vec<T> {
+    assert_eq!(select.preview(), expected_sql);
+
+    let db = get_db().await;
+    let result = db.execute(&select.expr()).await.unwrap();
+    let rows = result.into_value();
+    let arr = rows.as_array().unwrap();
+
+    let records: Vec<Record<serde_json::Value>> = arr.iter().map(|v| v.clone().into()).collect();
+    records
+        .into_iter()
+        .map(|r| T::from_record(r).unwrap())
+        .collect()
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 1. DISTINCT ON — return one row per group (PG-only)
+// -- Features: DISTINCT ON (expr), ORDER BY must start with the DISTINCT exprs
+// -- Expected: most recent order per user
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct LatestOrder {
+    user_id: String,
+    name: String,
+    order_id: i64,
+    total: f64,
+    status: String,
+}
+
+#[tokio::test]
+async fn test_pg_q1_distinct_on() {
+    let rows: Vec<LatestOrder> = check_and_run(
+        &PostgresSelect::new()
+            .with_distinct_on(ident("user_id").dot_of("o"))
+            .with_source_as("orders", "o")
+            .with_expression(ident("user_id").dot_of("o"), None)
+            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(ident("id").dot_of("o").with_alias("order_id"), None)
+            .with_expression(ident("total").dot_of("o"), None)
+            .with_expression(ident("status").dot_of("o"), None)
+            .with_join(PostgresSelectJoin::inner(
+                "users",
+                "u",
+                ident("id").dot_of("u").eq(ident("user_id").dot_of("o")),
+            ))
+            .with_order(ident("user_id").dot_of("o"), Order::Asc)
+            .with_order(ident("created_at").dot_of("o"), Order::Desc),
+        concat!(
+            r#"SELECT DISTINCT ON ("o"."user_id") "#,
+            r#""o"."user_id", "u"."name", "o"."id" AS "order_id", "#,
+            r#""o"."total", "o"."status" "#,
+            r#"FROM "orders" AS "o" "#,
+            r#"INNER JOIN "users" AS "u" ON "u"."id" = "o"."user_id" "#,
+            r#"ORDER BY "o"."user_id", "o"."created_at" DESC"#,
+        ),
+    )
+    .await;
+
+    // 8 users have orders, one row each (most recent)
+    assert_eq!(rows.len(), 8);
+
+    // Alice's most recent order is #15 (pending, $50)
+    let alice = rows.iter().find(|r| r.name == "Alice Chen").unwrap();
+    assert_eq!(alice.order_id, 15);
+    assert_eq!(alice.status, "pending");
+
+    // Leo's most recent order is #14 (completed, $275)
+    let leo = rows.iter().find(|r| r.name == "Leo Russo").unwrap();
+    assert_eq!(leo.order_id, 14);
+    assert_eq!(leo.total, 275.0);
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 2. Array operators — ANY, @>, array_length
+// -- Features: @> (array contains), = ANY(array), array_length(), NULLS LAST
+// -- Expected: users who have 'rust' or 'python' in their skills
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct UserSkills {
+    id: String,
+    name: String,
+    skills: Vec<String>,
+    skill_count: Option<i64>,
+}
+
+#[tokio::test]
+async fn test_pg_q2_array_ops() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let skills = ident("skills").dot_of("u");
+
+    let rows: Vec<UserSkills> = check_and_run(
+        &PostgresSelect::new()
+            .with_source_as("users", "u")
+            .with_expression(ident("id").dot_of("u"), None)
+            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(skills.clone(), None)
+            .with_expression(
+                Fx::new("array_length", [skills.expr(), postgres_expr!("{}", 1i32)]),
+                Some("skill_count".into()),
+            )
+            .with_condition(postgres_expr!(
+                "{} @> ARRAY[{}] OR {} = ANY({})",
+                (skills.clone()),
+                "rust",
+                "python",
+                (skills)
+            ))
+            .with_order(ident("skill_count"), Order::Desc.nulls_last()),
+        concat!(
+            r#"SELECT "u"."id", "u"."name", "u"."skills", "#,
+            r#"ARRAY_LENGTH("u"."skills", 1) AS "skill_count" "#,
+            r#"FROM "users" AS "u" "#,
+            r#"WHERE "u"."skills" @> ARRAY['rust'] OR 'python' = ANY("u"."skills") "#,
+            r#"ORDER BY "skill_count" DESC NULLS LAST"#,
+        ),
+    )
+    .await;
+
+    // Alice (rust), Bob (python), Grace (python)
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].name, "Alice Chen");
+    assert_eq!(rows[0].skill_count, Some(3));
+    assert!(rows[0].skills.contains(&"rust".to_string()));
+
+    // Bob and Grace both have 2 skills
+    assert_eq!(rows[1].skill_count, Some(2));
+    assert_eq!(rows[2].skill_count, Some(2));
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 3. JSONB operators — ->, ->>, @>, ?, #>, nested path, ::NUMERIC cast
+// -- Features: -> (json object), ->> (text), @> containment,
+// --           jsonb_exists (? operator), #> path, cast
+// -- Expected: black electronics with specs.voltage, rating >= 4.0
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct ProductJsonb {
+    id: i64,
+    name: String,
+    color: String,
+    rating: f64,
+    voltage: Option<String>,
+    watts_json: Option<serde_json::Value>,
+}
+
+#[tokio::test]
+async fn test_pg_q3_jsonb_ops() {
+    use vantage_expressions::expr_any;
+    use vantage_sql::primitives::fx::Fx;
+    use vantage_sql::primitives::json_extract::JsonExtract;
+
+    let metadata = ident("metadata").dot_of("p");
+    let rating = JsonExtract::new(metadata.clone(), "rating").cast("NUMERIC");
+
+    // Inline SQL literal — not a bind parameter
+    let lit = |s: &str| -> vantage_expressions::Expression<_> { expr_any!(format!("'{s}'")) };
+
+    let rows: Vec<ProductJsonb> = check_and_run(
+        &PostgresSelect::new()
+            .with_source_as("products", "p")
+            .with_expression(ident("id").dot_of("p"), None)
+            .with_expression(ident("name").dot_of("p"), None)
+            .with_expression(
+                JsonExtract::new(metadata.clone(), "color").with_alias("color"),
+                None,
+            )
+            .with_expression(rating.clone(), Some("rating".into()))
+            .with_expression(
+                JsonExtract::new(metadata.clone(), ["specs", "voltage"]).with_alias("voltage"),
+                None,
+            )
+            .with_expression(
+                postgres_expr!("{} #> {}", (metadata.clone()), (lit("{specs,watts}"))),
+                Some("watts_json".into()),
+            )
+            .with_condition(postgres_expr!(
+                "{} @> {}",
+                (metadata.clone()),
+                (lit(r#"{"color": "black"}"#))
+            ))
+            .with_condition(Fx::new(
+                "jsonb_exists",
+                [metadata.expr(), postgres_expr!("{}", "rating")],
+            ))
+            .with_condition(rating.gte(4.0f64))
+            .with_order(ident("rating"), Order::Desc),
+        concat!(
+            r#"SELECT "p"."id", "p"."name", "#,
+            r#""p"."metadata" ->> 'color' AS "color", "#,
+            r#"CAST("p"."metadata" ->> 'rating' AS NUMERIC) AS "rating", "#,
+            r#""p"."metadata" -> 'specs' ->> 'voltage' AS "voltage", "#,
+            r#""p"."metadata" #> '{specs,watts}' AS "watts_json" "#,
+            r#"FROM "products" AS "p" "#,
+            r#"WHERE "p"."metadata" @> '{"color": "black"}' "#,
+            r#"AND JSONB_EXISTS("p"."metadata", 'rating') "#,
+            r#"AND CAST("p"."metadata" ->> 'rating' AS NUMERIC) >= 4.0 "#,
+            r#"ORDER BY "rating" DESC"#,
+        ),
+    )
+    .await;
+
+    // Widget Pro (4.7), Monitor 27" (4.6), USB-C Cable (4.0) — all black, rating >= 4.0
+    assert_eq!(rows.len(), 3);
+    assert_eq!(rows[0].name, "Widget Pro");
+    assert_eq!(rows[0].color, "black");
+    assert_eq!(rows[0].voltage, Some("5".to_string()));
+
+    // USB-C Cable has no specs
+    assert_eq!(rows[2].name, "USB-C Cable");
+    assert_eq!(rows[2].voltage, None);
+    assert_eq!(rows[2].watts_json, None);
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 4. LATERAL JOIN — correlated subquery in FROM
+// -- Features: LEFT JOIN LATERAL, ON TRUE, LIMIT inside lateral
+// -- Expected: each user with their 2 most recent orders
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct UserRecentOrder {
+    name: String,
+    order_id: Option<i64>,
+    total: Option<f64>,
+    status: Option<String>,
+}
+
+#[tokio::test]
+async fn test_pg_q4_lateral_join() {
+    let lateral_subquery = PostgresSelect::new()
+        .with_source_as("orders", "o")
+        .with_expression(ident("id").dot_of("o").with_alias("order_id"), None)
+        .with_expression(ident("total").dot_of("o"), None)
+        .with_expression(ident("status").dot_of("o"), None)
+        .with_expression(ident("created_at").dot_of("o"), None)
+        .with_condition(ident("user_id").dot_of("o").eq(ident("id").dot_of("u")))
+        .with_order(ident("created_at").dot_of("o"), Order::Desc)
+        .with_limit(Some(2), None);
+
+    let rows: Vec<UserRecentOrder> = check_and_run(
+        &PostgresSelect::new()
+            .with_source_as("users", "u")
+            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(ident("order_id").dot_of("recent"), None)
+            .with_expression(ident("total").dot_of("recent"), None)
+            .with_expression(ident("status").dot_of("recent"), None)
+            .with_join(PostgresSelectJoin::left_lateral(lateral_subquery, "recent"))
+            .with_order(ident("name").dot_of("u"), Order::Asc)
+            .with_order(ident("created_at").dot_of("recent"), Order::Desc.nulls_last()),
+        concat!(
+            r#"SELECT "u"."name", "recent"."order_id", "recent"."total", "recent"."status" "#,
+            r#"FROM "users" AS "u" "#,
+            r#"LEFT JOIN LATERAL (SELECT "o"."id" AS "order_id", "o"."total", "o"."status", "o"."created_at" "#,
+            r#"FROM "orders" AS "o" "#,
+            r#"WHERE "o"."user_id" = "u"."id" "#,
+            r#"ORDER BY "o"."created_at" DESC "#,
+            r#"LIMIT 2) AS "recent" ON TRUE "#,
+            r#"ORDER BY "u"."name", "recent"."created_at" DESC NULLS LAST"#,
+        ),
+    )
+    .await;
+
+    // 12 users, 8 have orders (some have 2), 4 have none → 17 rows
+    assert_eq!(rows.len(), 17);
+
+    // Alice has 2 most recent orders: #15 (pending) and #3 (shipped)
+    let alice_rows: Vec<&UserRecentOrder> =
+        rows.iter().filter(|r| r.name == "Alice Chen").collect();
+    assert_eq!(alice_rows.len(), 2);
+    assert_eq!(alice_rows[0].order_id, Some(15));
+    assert_eq!(alice_rows[0].status, Some("pending".to_string()));
+
+    // Dan Brown has no orders → null fields
+    let dan = rows.iter().find(|r| r.name == "Dan Brown").unwrap();
+    assert_eq!(dan.order_id, None);
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 5. generate_series as table source — synthetic date grid
+// -- Features: generate_series(), ::DATE cast, LEFT JOIN on cast, COALESCE
+// -- Expected: daily order counts for April 1-10, including zero-days
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct DailyRevenue {
+    day: String,
+    order_count: i64,
+    daily_revenue: f64,
+}
+
+#[tokio::test]
+async fn test_pg_q5_generate_series() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let series = Fx::new(
+        "generate_series",
+        [
+            postgres_expr!("{}::DATE", "2025-04-01"),
+            postgres_expr!("{}::DATE", "2025-04-10"),
+            postgres_expr!("{}::INTERVAL", "1 day"),
+        ],
+    );
+
+    let rows: Vec<DailyRevenue> = check_and_run(
+        &PostgresSelect::new()
+            .with_source(postgres_expr!("{} AS d(day)", (series)))
+            .with_expression(ident("day").dot_of("d"), None)
+            .with_expression(
+                Fx::new(
+                    "coalesce",
+                    [
+                        Fx::new("count", [ident("id").dot_of("o").expr()]).expr(),
+                        postgres_expr!("{}", 0i64),
+                    ],
+                ),
+                Some("order_count".into()),
+            )
+            .with_expression(
+                Fx::new(
+                    "coalesce",
+                    [
+                        Fx::new("sum", [ident("total").dot_of("o").expr()]).expr(),
+                        postgres_expr!("{}", 0i64),
+                    ],
+                ),
+                Some("daily_revenue".into()),
+            )
+            .with_join(PostgresSelectJoin::left(
+                "orders",
+                "o",
+                postgres_expr!(
+                    "{}::DATE = {}",
+                    (ident("created_at").dot_of("o")),
+                    (ident("day").dot_of("d"))
+                ),
+            ))
+            .with_group_by(ident("day").dot_of("d"))
+            .with_order(ident("day").dot_of("d"), Order::Asc),
+        concat!(
+            r#"SELECT "d"."day", "#,
+            r#"COALESCE(COUNT("o"."id"), 0) AS "order_count", "#,
+            r#"COALESCE(SUM("o"."total"), 0) AS "daily_revenue" "#,
+            r#"FROM GENERATE_SERIES('2025-04-01'::DATE, '2025-04-10'::DATE, '1 day'::INTERVAL) AS d(day) "#,
+            r#"LEFT JOIN "orders" AS "o" ON "o"."created_at"::DATE = "d"."day" "#,
+            r#"GROUP BY "d"."day" "#,
+            r#"ORDER BY "d"."day""#,
+        ),
+    )
+    .await;
+
+    // 10 days from April 1-10
+    assert_eq!(rows.len(), 10);
+
+    // April 1: Jake's order ($420)
+    assert_eq!(rows[0].order_count, 1);
+    assert_eq!(rows[0].daily_revenue, 420.0);
+
+    // April 4: no orders
+    assert_eq!(rows[3].order_count, 0);
+    assert_eq!(rows[3].daily_revenue, 0.0);
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 6. Array aggregation — array_agg, string_agg, FILTER
+// -- Features: array_agg(DISTINCT ... ORDER BY), string_agg, FILTER (WHERE)
+// -- Expected: per-category product stats
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct CategoryAgg {
+    category: String,
+    total: i64,
+    product_names: Vec<String>,
+    names_by_price_desc: String,
+    featured_count: i64,
+    sale_count: i64,
+}
+
+#[tokio::test]
+async fn test_pg_q6_array_aggregation() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let name = ident("name").dot_of("p");
+    let tags = ident("tags").dot_of("p");
+
+    let rows: Vec<CategoryAgg> = check_and_run(
+        &PostgresSelect::new()
+            .with_source_as("products", "p")
+            .with_expression(ident("category").dot_of("p"), None)
+            .with_expression(
+                Fx::new("count", [postgres_expr!("*")]),
+                Some("total".into()),
+            )
+            .with_expression(
+                postgres_expr!(
+                    "array_agg(DISTINCT {} ORDER BY {})",
+                    (name.clone()),
+                    (name.clone())
+                ),
+                Some("product_names".into()),
+            )
+            .with_expression(
+                postgres_expr!(
+                    "string_agg({}, {} ORDER BY {} DESC)",
+                    (name),
+                    ", ",
+                    (ident("price").dot_of("p"))
+                ),
+                Some("names_by_price_desc".into()),
+            )
+            .with_expression(
+                postgres_expr!(
+                    "COUNT(*) FILTER (WHERE {} @> ARRAY[{}])",
+                    (tags.clone()),
+                    "featured"
+                ),
+                Some("featured_count".into()),
+            )
+            .with_expression(
+                postgres_expr!("COUNT(*) FILTER (WHERE {} @> ARRAY[{}])", (tags), "sale"),
+                Some("sale_count".into()),
+            )
+            .with_group_by(ident("category").dot_of("p"))
+            .with_order(ident("total"), Order::Desc),
+        concat!(
+            r#"SELECT "p"."category", COUNT(*) AS "total", "#,
+            r#"array_agg(DISTINCT "p"."name" ORDER BY "p"."name") AS "product_names", "#,
+            r#"string_agg("p"."name", ', ' ORDER BY "p"."price" DESC) AS "names_by_price_desc", "#,
+            r#"COUNT(*) FILTER (WHERE "p"."tags" @> ARRAY['featured']) AS "featured_count", "#,
+            r#"COUNT(*) FILTER (WHERE "p"."tags" @> ARRAY['sale']) AS "sale_count" "#,
+            r#"FROM "products" AS "p" "#,
+            r#"GROUP BY "p"."category" "#,
+            r#"ORDER BY "total" DESC"#,
+        ),
+    )
+    .await;
+
+    assert_eq!(rows.len(), 5);
+
+    // electronics: 7 products, 3 featured, 3 on sale
+    assert_eq!(rows[0].category, "electronics");
+    assert_eq!(rows[0].total, 7);
+    assert_eq!(rows[0].featured_count, 3);
+    assert_eq!(rows[0].sale_count, 3);
+    assert_eq!(rows[0].product_names[0], "Gadget Pro Max");
+
+    // furniture: 2 products, 1 featured
+    assert_eq!(rows[1].category, "furniture");
+    assert_eq!(rows[1].total, 2);
+    assert_eq!(rows[1].featured_count, 1);
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 7. GROUPING SETS / ROLLUP — multi-level aggregation
+// -- Features: ROLLUP, GROUPING() function, sub-totals and grand total
+// -- Expected: revenue broken down by status + month, with rollup totals
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct RollupRevenue {
+    status: String,
+    month: Option<String>,
+    order_count: i64,
+    revenue: f64,
+}
+
+#[tokio::test]
+async fn test_pg_q7_rollup() {
+    use vantage_sql::primitives::case::Case;
+    use vantage_sql::primitives::fx::Fx;
+
+    let status = ident("status").dot_of("o");
+    let date_trunc = postgres_expr!("DATE_TRUNC('month', {})", (ident("created_at").dot_of("o")));
+    let grouping_status = Fx::new("grouping", [status.expr()]);
+    let grouping_month = Fx::new("grouping", [date_trunc.expr()]);
+
+    let rows: Vec<RollupRevenue> = check_and_run(
+        &PostgresSelect::new()
+            .with_source_as("orders", "o")
+            .with_expression(
+                Case::new()
+                    .when(grouping_status.clone().eq(1i64), "** ALL **")
+                    .else_(status.clone()),
+                Some("status".into()),
+            )
+            .with_expression(
+                Case::new()
+                    .when(grouping_month.eq(1i64), postgres_expr!("NULL"))
+                    .else_(date_trunc.clone()),
+                Some("month".into()),
+            )
+            .with_expression(
+                Fx::new("count", [postgres_expr!("*")]),
+                Some("order_count".into()),
+            )
+            .with_expression(
+                Fx::new("sum", [ident("total").dot_of("o").expr()]),
+                Some("revenue".into()),
+            )
+            .with_condition(status.ne("cancelled"))
+            .with_group_by(postgres_expr!("ROLLUP ({}, {})", (status.clone()), (date_trunc)))
+            .with_order(grouping_status, Order::Asc)
+            .with_order(status, Order::Asc)
+            .with_order(ident("month"), Order::Asc.nulls_last()),
+        concat!(
+            r#"SELECT CASE WHEN GROUPING("o"."status") = 1 THEN '** ALL **' ELSE "o"."status" END AS "status", "#,
+            r#"CASE WHEN GROUPING(DATE_TRUNC('month', "o"."created_at")) = 1 THEN NULL ELSE DATE_TRUNC('month', "o"."created_at") END AS "month", "#,
+            r#"COUNT(*) AS "order_count", "#,
+            r#"SUM("o"."total") AS "revenue" "#,
+            r#"FROM "orders" AS "o" "#,
+            r#"WHERE "o"."status" != 'cancelled' "#,
+            r#"GROUP BY ROLLUP ("o"."status", DATE_TRUNC('month', "o"."created_at")) "#,
+            r#"ORDER BY GROUPING("o"."status"), "o"."status", "month" NULLS LAST"#,
+        ),
+    )
+    .await;
+
+    assert_eq!(rows.len(), 10);
+
+    // Grand total row: "** ALL **" with NULL month
+    let grand_total = rows.iter().find(|r| r.status == "** ALL **").unwrap();
+    assert_eq!(grand_total.month, None);
+    assert_eq!(grand_total.order_count, 13);
+    assert_eq!(grand_total.revenue, 4490.5);
+
+    // completed subtotal: 8 orders
+    let completed_sub = rows
+        .iter()
+        .find(|r| r.status == "completed" && r.month.is_none())
+        .unwrap();
+    assert_eq!(completed_sub.order_count, 8);
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 8. Date/time — INTERVAL arithmetic, DATE_TRUNC, EXTRACT, AGE
+// -- Features: INTERVAL literal, AGE(), EXTRACT(EPOCH/DOW), DATE_TRUNC, NOW()
+// -- Expected: active users with computed tenure and cohort labels
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct UserTenure {
+    name: String,
+    signup_day_of_week: f64,
+    cohort: String,
+}
+
+#[tokio::test]
+async fn test_pg_q8_date_time() {
+    use vantage_sql::primitives::case::Case;
+    use vantage_sql::primitives::fx::Fx;
+    use vantage_sql::primitives::interval::Interval;
+
+    let created = ident("created_at").dot_of("u");
+    let now = Fx::new("now", Vec::<vantage_expressions::Expression<_>>::new());
+    let age = postgres_expr!("AGE({}, {})", (now), (created.clone()));
+
+    let rows: Vec<UserTenure> = check_and_run(
+        &PostgresSelect::new()
+            .with_source_as("users", "u")
+            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(
+                postgres_expr!("EXTRACT(DOW FROM {})", (created.clone())),
+                Some("signup_day_of_week".into()),
+            )
+            .with_expression(
+                Case::new()
+                    .when(age.clone().gte(Interval::new(1, "year")), "veteran")
+                    .when(age.clone().gte(Interval::new(6, "month")), "established")
+                    .else_(postgres_expr!("{}", "new")),
+                Some("cohort".into()),
+            )
+            .with_condition(ident("is_active").dot_of("u").eq(true))
+            .with_order(created, Order::Asc)
+            .with_limit(Some(5), None),
+        concat!(
+            r#"SELECT "u"."name", "#,
+            r#"EXTRACT(DOW FROM "u"."created_at") AS "signup_day_of_week", "#,
+            r#"CASE WHEN AGE(NOW(), "u"."created_at") >= INTERVAL '1 year' THEN 'veteran' "#,
+            r#"WHEN AGE(NOW(), "u"."created_at") >= INTERVAL '6 month' THEN 'established' "#,
+            r#"ELSE 'new' END AS "cohort" "#,
+            r#"FROM "users" AS "u" "#,
+            r#"WHERE "u"."is_active" = true "#,
+            r#"ORDER BY "u"."created_at" "#,
+            r#"LIMIT 5"#,
+        ),
+    )
+    .await;
+
+    assert_eq!(rows.len(), 5);
+
+    // Alice signed up Jan 15, 2024 (Monday = DOW 1), over 1 year ago
+    assert_eq!(rows[0].name, "Alice Chen");
+    assert_eq!(rows[0].signup_day_of_week, 1.0);
+    assert_eq!(rows[0].cohort, "veteran");
+
+    // All first 5 users are veterans (signed up 2024)
+    assert!(rows.iter().all(|r| r.cohort == "veteran"));
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 9. ENUM ordering + casting
+// -- Features: enum comparison (>=), enum::TEXT cast, CASE with enum values
+// -- Expected: high/critical tickets with priority rank
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct TicketPriority {
+    id: i64,
+    title: String,
+    priority_text: String,
+    status_text: String,
+    priority_rank: i64,
+}
+
+#[tokio::test]
+async fn test_pg_q9_enum() {
+    use vantage_sql::primitives::case::Case;
+
+    let priority = ident("priority").dot_of("t");
+
+    let rows: Vec<TicketPriority> = check_and_run(
+        &PostgresSelect::new()
+            .with_source_as("tickets", "t")
+            .with_expression(ident("id").dot_of("t"), None)
+            .with_expression(ident("title").dot_of("t"), None)
+            .with_expression(priority.cast("TEXT"), Some("priority_text".into()))
+            .with_expression(
+                ident("status").dot_of("t").cast("TEXT"),
+                Some("status_text".into()),
+            )
+            .with_expression(
+                {
+                    let p = priority.cast("TEXT");
+                    Case::new()
+                        .when(p.clone().eq("critical"), postgres_expr!("{}", 1i64))
+                        .when(p.clone().eq("high"), postgres_expr!("{}", 2i64))
+                        .when(p.clone().eq("medium"), postgres_expr!("{}", 3i64))
+                        .when(p.eq("low"), postgres_expr!("{}", 4i64))
+                },
+                Some("priority_rank".into()),
+            )
+            .with_condition(postgres_expr!("{} >= 'high'", (priority)))
+            .with_order(priority, Order::Desc)
+            .with_order(ident("updated_at").dot_of("t"), Order::Desc),
+        concat!(
+            r#"SELECT "t"."id", "t"."title", "#,
+            r#"CAST("t"."priority" AS TEXT) AS "priority_text", "#,
+            r#"CAST("t"."status" AS TEXT) AS "status_text", "#,
+            r#"CASE WHEN CAST("t"."priority" AS TEXT) = 'critical' THEN 1 "#,
+            r#"WHEN CAST("t"."priority" AS TEXT) = 'high' THEN 2 "#,
+            r#"WHEN CAST("t"."priority" AS TEXT) = 'medium' THEN 3 "#,
+            r#"WHEN CAST("t"."priority" AS TEXT) = 'low' THEN 4 END AS "priority_rank" "#,
+            r#"FROM "tickets" AS "t" "#,
+            r#"WHERE "t"."priority" >= 'high' "#,
+            r#"ORDER BY "t"."priority" DESC, "t"."updated_at" DESC"#,
+        ),
+    )
+    .await;
+
+    // critical (1) and high (3, 6) — priority >= 'high' in enum order
+    assert_eq!(rows.len(), 3);
+
+    // First: critical ticket (#1)
+    assert_eq!(rows[0].id, 1);
+    assert_eq!(rows[0].priority_text, "critical");
+    assert_eq!(rows[0].priority_rank, 1);
+
+    // Next two: high tickets, ordered by updated_at DESC
+    assert_eq!(rows[1].priority_text, "high");
+    assert_eq!(rows[2].priority_text, "high");
+    assert_eq!(rows[1].priority_rank, 2);
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 10. DATERANGE operators — containment, overlap, bounds
+// -- Features: && (overlap), lower(), upper(), daterange(), date arithmetic
+// -- Expected: bookings overlapping April 7-10
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct Booking {
+    id: i64,
+    room: String,
+    booked_by: String,
+    check_in: String,
+    check_out: String,
+    duration_days: i32,
+}
+
+#[tokio::test]
+async fn test_pg_q10_daterange() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let during = ident("during").dot_of("b");
+
+    let rows: Vec<Booking> = check_and_run(
+        &PostgresSelect::new()
+            .with_source_as("bookings", "b")
+            .with_expression(ident("id").dot_of("b"), None)
+            .with_expression(ident("room").dot_of("b"), None)
+            .with_expression(ident("name").dot_of("u"), Some("booked_by".into()))
+            .with_expression(Fx::new("lower", [during.expr()]), Some("check_in".into()))
+            .with_expression(Fx::new("upper", [during.expr()]), Some("check_out".into()))
+            .with_expression(
+                Fx::new("upper", [during.expr()]).expr() - Fx::new("lower", [during.expr()]).expr(),
+                Some("duration_days".into()),
+            )
+            .with_join(PostgresSelectJoin::inner(
+                "users",
+                "u",
+                ident("id").dot_of("u").eq(ident("user_id").dot_of("b")),
+            ))
+            .with_condition(postgres_expr!(
+                "{} && daterange('2025-04-07', '2025-04-10')",
+                (during)
+            ))
+            .with_order(ident("room").dot_of("b"), Order::Asc)
+            .with_order(Fx::new("lower", [during.expr()]), Order::Asc),
+        concat!(
+            r#"SELECT "b"."id", "b"."room", "#,
+            r#""u"."name" AS "booked_by", "#,
+            r#"LOWER("b"."during") AS "check_in", "#,
+            r#"UPPER("b"."during") AS "check_out", "#,
+            r#"UPPER("b"."during") - LOWER("b"."during") AS "duration_days" "#,
+            r#"FROM "bookings" AS "b" "#,
+            r#"INNER JOIN "users" AS "u" ON "u"."id" = "b"."user_id" "#,
+            r#"WHERE "b"."during" && daterange('2025-04-07', '2025-04-10') "#,
+            r#"ORDER BY "b"."room", LOWER("b"."during")"#,
+        ),
+    )
+    .await;
+
+    // 6 bookings overlap April 7-10
+    assert_eq!(rows.len(), 6);
+
+    // Room A: Alice (1 day), Bob (1 day), Alice (2 days)
+    assert_eq!(rows[0].room, "Room A");
+    assert_eq!(rows[0].booked_by, "Alice Chen");
+    assert_eq!(rows[0].duration_days, 1);
+    assert_eq!(rows[2].booked_by, "Alice Chen");
+    assert_eq!(rows[2].duration_days, 2);
+
+    // Room C: Leo (7 days)
+    assert_eq!(rows[5].room, "Room C");
+    assert_eq!(rows[5].booked_by, "Leo Russo");
+    assert_eq!(rows[5].duration_days, 7);
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 11. UNNEST WITH ORDINALITY — expand arrays preserving position
+// -- Features: CROSS JOIN LATERAL, UNNEST, WITH ORDINALITY, column alias
+// -- Expected: each user's skills as individual rows with position
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct UserSkillRow {
+    name: String,
+    skill: String,
+    skill_position: i64,
+}
+
+#[tokio::test]
+async fn test_pg_q11_unnest_ordinality() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let skills = ident("skills").dot_of("u");
+
+    let rows: Vec<UserSkillRow> = check_and_run(
+        &PostgresSelect::new()
+            .with_source_as("users", "u")
+            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(ident("value").dot_of("skill"), Some("skill".into()))
+            .with_expression(ident("pos").dot_of("skill"), Some("skill_position".into()))
+            .with_join(PostgresSelectJoin::cross_lateral_raw(postgres_expr!(
+                "UNNEST({}) WITH ORDINALITY AS skill(value, pos)",
+                (skills.clone())
+            )))
+            .with_condition(postgres_expr!(
+                "{} > {}",
+                (Fx::new("array_length", [skills.expr(), postgres_expr!("{}", 1i32)])),
+                0i32
+            ))
+            .with_order(ident("name").dot_of("u"), Order::Asc)
+            .with_order(ident("pos").dot_of("skill"), Order::Asc),
+        concat!(
+            r#"SELECT "u"."name", "skill"."value" AS "skill", "skill"."pos" AS "skill_position" "#,
+            r#"FROM "users" AS "u" "#,
+            r#"CROSS JOIN LATERAL UNNEST("u"."skills") WITH ORDINALITY AS skill(value, pos) "#,
+            r#"WHERE ARRAY_LENGTH("u"."skills", 1) > 0 "#,
+            r#"ORDER BY "u"."name", "skill"."pos""#,
+        ),
+    )
+    .await;
+
+    // 11 users with skills (Karen has empty array), multiple rows each
+    assert!(!rows.is_empty());
+
+    // Alice has 3 skills: rust, postgresql, kubernetes
+    let alice: Vec<&UserSkillRow> = rows.iter().filter(|r| r.name == "Alice Chen").collect();
+    assert_eq!(alice.len(), 3);
+    assert_eq!(alice[0].skill, "rust");
+    assert_eq!(alice[0].skill_position, 1);
+    assert_eq!(alice[2].skill, "kubernetes");
+    assert_eq!(alice[2].skill_position, 3);
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 12. Recursive CTE with PG-specific cast
+// -- Features: WITH RECURSIVE, ::TEXT cast, || concat, depth tracking
+// -- Expected: department tree with breadcrumb path
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct DeptTree {
+    id: i32,
+    name: String,
+    depth: i64,
+    path: String,
+}
+
+#[tokio::test]
+async fn test_pg_q12_recursive_cte() {
+    use vantage_sql::concat_sql;
+    use vantage_sql::primitives::union::Union;
+
+    let base = PostgresSelect::new()
+        .with_source("departments")
+        .with_field("id")
+        .with_field("name")
+        .with_expression(ident("parent_id"), None)
+        .with_expression(postgres_expr!("0"), None)
+        .with_expression(ident("name").cast("TEXT"), None)
+        .with_condition(postgres_expr!("{} IS NULL", (ident("parent_id"))));
+
+    let recursive = PostgresSelect::new()
+        .with_source_as("departments", "d")
+        .with_expression(ident("id").dot_of("d"), None)
+        .with_expression(ident("name").dot_of("d"), None)
+        .with_expression(ident("parent_id").dot_of("d"), None)
+        .with_expression(
+            ident("depth").dot_of("dt").expr() + postgres_expr!("1"),
+            None,
+        )
+        .with_expression(
+            concat_sql!(ident("path").dot_of("dt"), " > ", ident("name").dot_of("d")),
+            None,
+        )
+        .with_join(PostgresSelectJoin::inner(
+            "dept_tree",
+            "dt",
+            ident("id").dot_of("dt").eq(ident("parent_id").dot_of("d")),
+        ));
+
+    let rows: Vec<DeptTree> = check_and_run(
+        &PostgresSelect::new()
+            .with_cte(
+                "dept_tree(id, name, parent_id, depth, path)",
+                Union::new(base).union_all(recursive),
+                true,
+            )
+            .with_source("dept_tree")
+            .with_field("id")
+            .with_field("name")
+            .with_field("depth")
+            .with_field("path")
+            .with_order(ident("path"), Order::Asc),
+        concat!(
+            r#"WITH RECURSIVE dept_tree(id, name, parent_id, depth, path) AS "#,
+            r#"(SELECT "id", "name", "parent_id", 0, CAST("name" AS TEXT) "#,
+            r#"FROM "departments" WHERE "parent_id" IS NULL "#,
+            r#"UNION ALL "#,
+            r#"SELECT "d"."id", "d"."name", "d"."parent_id", "dt"."depth" + 1, "#,
+            r#""dt"."path" || ' > ' || "d"."name" "#,
+            r#"FROM "departments" AS "d" "#,
+            r#"INNER JOIN "dept_tree" AS "dt" ON "dt"."id" = "d"."parent_id") "#,
+            r#"SELECT "id", "name", "depth", "path" "#,
+            r#"FROM "dept_tree" "#,
+            r#"ORDER BY "path""#,
+        ),
+    )
+    .await;
+
+    assert_eq!(rows.len(), 8);
+
+    let roots: Vec<&DeptTree> = rows.iter().filter(|r| r.depth == 0).collect();
+    assert_eq!(roots.len(), 3);
+
+    let backend = rows.iter().find(|r| r.name == "Backend").unwrap();
+    assert_eq!(backend.depth, 1);
+    assert_eq!(backend.path, "Engineering > Backend");
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 13. Window functions with PG-specific features
+// -- Features: DENSE_RANK, named WINDOW, ROWS frame, AVG window
+// -- Expected: salary distribution stats per department
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct SalaryStats {
+    name: String,
+    department: String,
+    salary: f64,
+    salary_dense_rank: i64,
+    running_total: f64,
+    dept_avg_salary: f64,
+}
+
+#[tokio::test]
+async fn test_pg_q13_window_functions() {
+    use vantage_sql::primitives::fx::Fx;
+    use vantage_sql::primitives::select::window::Window;
+
+    let dept_id = ident("department_id").dot_of("u");
+    let salary = ident("salary").dot_of("u");
+
+    let rows: Vec<SalaryStats> = check_and_run(
+        &PostgresSelect::new()
+            .with_source_as("users", "u")
+            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(ident("name").dot_of("d"), Some("department".into()))
+            .with_expression(salary.clone(), None)
+            .with_expression(
+                Window::named("dept_sal").apply(Fx::new("dense_rank", vec![])),
+                Some("salary_dense_rank".into()),
+            )
+            .with_expression(
+                Window::new()
+                    .partition_by(dept_id.clone())
+                    .order_by(salary.clone(), Order::Desc)
+                    .rows("UNBOUNDED PRECEDING", "CURRENT ROW")
+                    .apply(Fx::new("sum", [salary.expr()])),
+                Some("running_total".into()),
+            )
+            .with_expression(
+                Window::named("dept_sal").apply(Fx::new("avg", [salary.expr()])),
+                Some("dept_avg_salary".into()),
+            )
+            .with_join(PostgresSelectJoin::inner(
+                "departments",
+                "d",
+                ident("id").dot_of("d").eq(dept_id.clone()),
+            ))
+            .with_condition(ident("is_active").dot_of("u").eq(true))
+            .with_window(
+                "dept_sal",
+                Window::new()
+                    .partition_by(dept_id)
+                    .order_by(salary, Order::Desc),
+            )
+            .with_order(ident("department"), Order::Asc)
+            .with_order(ident("salary_dense_rank"), Order::Asc),
+        concat!(
+            r#"SELECT "u"."name", "d"."name" AS "department", "u"."salary", "#,
+            r#"DENSE_RANK() OVER dept_sal AS "salary_dense_rank", "#,
+            r#"SUM("u"."salary") OVER (PARTITION BY "u"."department_id" ORDER BY "u"."salary" DESC "#,
+            r#"ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS "running_total", "#,
+            r#"AVG("u"."salary") OVER dept_sal AS "dept_avg_salary" "#,
+            r#"FROM "users" AS "u" "#,
+            r#"INNER JOIN "departments" AS "d" ON "d"."id" = "u"."department_id" "#,
+            r#"WHERE "u"."is_active" = true "#,
+            r#"WINDOW dept_sal AS (PARTITION BY "u"."department_id" ORDER BY "u"."salary" DESC) "#,
+            r#"ORDER BY "department", "salary_dense_rank""#,
+        ),
+    )
+    .await;
+
+    assert_eq!(rows.len(), 10);
+
+    // Backend: Alice (rank 1, 120k), Bob (rank 2, 95k)
+    let backend: Vec<&SalaryStats> = rows.iter().filter(|r| r.department == "Backend").collect();
+    assert_eq!(backend.len(), 2);
+    assert_eq!(backend[0].name, "Alice Chen");
+    assert_eq!(backend[0].salary_dense_rank, 1);
+    assert_eq!(backend[0].running_total, 120000.0);
+    assert_eq!(backend[1].running_total, 215000.0);
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 14. JSONB aggregation — jsonb_build_object, jsonb_agg, correlated subquery
+// -- Features: jsonb_build_object(), to_jsonb(), jsonb_agg(DISTINCT), subquery
+// -- Expected: per-user summary as a single JSONB document
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct UserProfile {
+    name: String,
+    user_profile: serde_json::Value,
+}
+
+#[tokio::test]
+async fn test_pg_q14_jsonb_aggregation() {
+    use vantage_sql::primitives::fx::Fx;
+
+    let o_total = ident("total").dot_of("o");
+    let o_status = ident("status").dot_of("o");
+
+    let order_summary_subquery = PostgresSelect::new()
+        .with_source_as("orders", "o")
+        .with_expression(
+            Fx::new(
+                "jsonb_build_object",
+                [
+                    postgres_expr!("{}", "count"),
+                    Fx::new("count", [postgres_expr!("*")]).expr(),
+                    postgres_expr!("{}", "total"),
+                    Fx::new(
+                        "coalesce",
+                        [
+                            Fx::new("sum", [o_total.expr()]).expr(),
+                            postgres_expr!("{}", 0i64),
+                        ],
+                    )
+                    .expr(),
+                    postgres_expr!("{}", "statuses"),
+                    postgres_expr!("jsonb_agg(DISTINCT {})", (o_status)),
+                ],
+            ),
+            None,
+        )
+        .with_condition(ident("user_id").dot_of("o").eq(ident("id").dot_of("u")));
+
+    let rows: Vec<UserProfile> = check_and_run(
+        &PostgresSelect::new()
+            .with_source_as("users", "u")
+            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(
+                Fx::new(
+                    "jsonb_build_object",
+                    [
+                        postgres_expr!("{}", "user_id"),
+                        ident("id").dot_of("u").expr(),
+                        postgres_expr!("{}", "email"),
+                        ident("email").dot_of("u").expr(),
+                        postgres_expr!("{}", "role"),
+                        ident("role").dot_of("u").expr(),
+                        postgres_expr!("{}", "skills"),
+                        Fx::new("to_jsonb", [ident("skills").dot_of("u").expr()]).expr(),
+                        postgres_expr!("{}", "order_summary"),
+                        postgres_expr!("({})", (order_summary_subquery)),
+                    ],
+                ),
+                Some("user_profile".into()),
+            )
+            .with_condition(ident("is_active").dot_of("u").eq(true))
+            .with_order(ident("name").dot_of("u"), Order::Asc)
+            .with_limit(Some(3), None),
+        concat!(
+            r#"SELECT "u"."name", "#,
+            r#"JSONB_BUILD_OBJECT('user_id', "u"."id", 'email', "u"."email", "#,
+            r#"'role', "u"."role", 'skills', TO_JSONB("u"."skills"), "#,
+            r#"'order_summary', (SELECT JSONB_BUILD_OBJECT("#,
+            r#"'count', COUNT(*), "#,
+            r#"'total', COALESCE(SUM("o"."total"), 0), "#,
+            r#"'statuses', jsonb_agg(DISTINCT "o"."status")) "#,
+            r#"FROM "orders" AS "o" "#,
+            r#"WHERE "o"."user_id" = "u"."id")) AS "user_profile" "#,
+            r#"FROM "users" AS "u" "#,
+            r#"WHERE "u"."is_active" = true "#,
+            r#"ORDER BY "u"."name" "#,
+            r#"LIMIT 3"#,
+        ),
+    )
+    .await;
+
+    assert_eq!(rows.len(), 3);
+
+    // Alice's profile
+    let alice = &rows[0];
+    assert_eq!(alice.name, "Alice Chen");
+    let profile = &alice.user_profile;
+    assert_eq!(profile["role"], "admin");
+    assert_eq!(profile["email"], "alice@example.com");
+    assert_eq!(profile["order_summary"]["count"], 4);
+}
+
+// -- ---------------------------------------------------------------------------
+// -- 15. INET operators + ILIKE + FULL OUTER JOIN + COALESCE + NULLIF
+// -- Features: <<= (subnet containment), ILIKE, FULL OUTER JOIN, COALESCE, NULLIF
+// -- Expected: user network info with department, including orphaned rows
+// -- ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct UserNetwork {
+    name: String,
+    department: String,
+    network_class: String,
+    notable_role: Option<String>,
+}
+
+#[tokio::test]
+async fn test_pg_q15_inet_ilike_full_join() {
+    use vantage_sql::primitives::case::Case;
+    use vantage_sql::primitives::fx::Fx;
+
+    let ip = ident("last_login_ip").dot_of("u");
+
+    let rows: Vec<UserNetwork> = check_and_run(
+        &PostgresSelect::new()
+            .with_source_as("users", "u")
+            .with_expression(
+                Fx::new(
+                    "coalesce",
+                    [
+                        ident("name").dot_of("u").expr(),
+                        postgres_expr!("{}", "(no user)"),
+                    ],
+                ),
+                Some("name".into()),
+            )
+            .with_expression(
+                Fx::new(
+                    "coalesce",
+                    [
+                        ident("name").dot_of("d").expr(),
+                        postgres_expr!("{}", "(no department)"),
+                    ],
+                ),
+                Some("department".into()),
+            )
+            .with_expression(
+                Case::new()
+                    .when(
+                        postgres_expr!("{} <<= '192.168.0.0/16'::INET", (ip.clone())),
+                        "private-class-c",
+                    )
+                    .when(
+                        postgres_expr!("{} <<= '10.0.0.0/8'::INET", (ip.clone())),
+                        "private-class-a",
+                    )
+                    .when(
+                        postgres_expr!("{} <<= '172.16.0.0/12'::INET", (ip.clone())),
+                        "private-class-b",
+                    )
+                    .when(postgres_expr!("{} IS NULL", (ip)), "unknown")
+                    .else_(postgres_expr!("{}", "public")),
+                Some("network_class".into()),
+            )
+            .with_expression(
+                Fx::new(
+                    "nullif",
+                    [
+                        ident("role").dot_of("u").expr(),
+                        postgres_expr!("{}", "viewer"),
+                    ],
+                ),
+                Some("notable_role".into()),
+            )
+            .with_join(PostgresSelectJoin::full_outer(
+                "departments",
+                "d",
+                ident("id")
+                    .dot_of("d")
+                    .eq(ident("department_id").dot_of("u")),
+            ))
+            .with_condition(postgres_expr!(
+                "{} ILIKE {} OR {} ILIKE {}",
+                (ident("name").dot_of("u")),
+                "%a%",
+                (ident("name").dot_of("d")),
+                "%design%"
+            ))
+            .with_order(ident("name").dot_of("u"), Order::Asc.nulls_last()),
+        concat!(
+            r#"SELECT COALESCE("u"."name", '(no user)') AS "name", "#,
+            r#"COALESCE("d"."name", '(no department)') AS "department", "#,
+            r#"CASE WHEN "u"."last_login_ip" <<= '192.168.0.0/16'::INET THEN 'private-class-c' "#,
+            r#"WHEN "u"."last_login_ip" <<= '10.0.0.0/8'::INET THEN 'private-class-a' "#,
+            r#"WHEN "u"."last_login_ip" <<= '172.16.0.0/12'::INET THEN 'private-class-b' "#,
+            r#"WHEN "u"."last_login_ip" IS NULL THEN 'unknown' "#,
+            r#"ELSE 'public' END AS "network_class", "#,
+            r#"NULLIF("u"."role", 'viewer') AS "notable_role" "#,
+            r#"FROM "users" AS "u" "#,
+            r#"FULL OUTER JOIN "departments" AS "d" ON "d"."id" = "u"."department_id" "#,
+            r#"WHERE "u"."name" ILIKE '%a%' OR "d"."name" ILIKE '%design%' "#,
+            r#"ORDER BY "u"."name" NULLS LAST"#,
+        ),
+    )
+    .await;
+
+    assert_eq!(rows.len(), 10);
+
+    // Alice: private-class-c, admin
+    let alice = rows.iter().find(|r| r.name == "Alice Chen").unwrap();
+    assert_eq!(alice.network_class, "private-class-c");
+    assert_eq!(alice.notable_role, Some("admin".to_string()));
+
+    // Frank: no IP → unknown, viewer → notable_role is None
+    let frank = rows.iter().find(|r| r.name == "Frank Lee").unwrap();
+    assert_eq!(frank.network_class, "unknown");
+    assert_eq!(frank.notable_role, None);
+
+    // Karen: no department
+    let karen = rows.iter().find(|r| r.name == "Karen Hill").unwrap();
+    assert_eq!(karen.department, "(no department)");
+}

--- a/vantage-sql/tests/postgres/3_select.rs
+++ b/vantage-sql/tests/postgres/3_select.rs
@@ -1,6 +1,6 @@
 //! Test 3a: PostgresSelect via Selectable trait + SelectableDataSource execution.
 
-use vantage_expressions::{ExprDataSource, Expressive, Selectable};
+use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 #[allow(unused_imports)]
 use vantage_sql::postgres::PostgresType;
 use vantage_sql::postgres::statements::PostgresSelect;
@@ -82,7 +82,7 @@ fn test_select_with_condition() {
 fn test_select_order_and_limit() {
     let s = PostgresSelect::new()
         .with_source("product")
-        .with_order(postgres_expr!("\"price\""), false)
+        .with_order(postgres_expr!("\"price\""), Order::Desc)
         .with_limit(Some(2), None);
     assert_eq!(
         s.preview(),
@@ -205,7 +205,7 @@ async fn test_execute_order_and_limit() {
 
     let select = PostgresSelect::new()
         .with_source("sel_order")
-        .with_order(postgres_expr!("\"price\""), false)
+        .with_order(postgres_expr!("\"price\""), Order::Desc)
         .with_limit(Some(1), None);
 
     let record: Record<AnyPostgresType> = db.associate(select.expr()).get().await.unwrap();

--- a/vantage-sql/tests/sqlite/3_complex_queries.rs
+++ b/vantage-sql/tests/sqlite/3_complex_queries.rs
@@ -4,7 +4,7 @@
 #![allow(dead_code)]
 
 use serde::Deserialize;
-use vantage_expressions::{ExprDataSource, Expressive, Selectable};
+use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 use vantage_sql::primitives::identifier::ident;
 use vantage_sql::sqlite::SqliteDB;
 use vantage_sql::sqlite::statements::SqliteSelect;
@@ -69,7 +69,7 @@ async fn test_q1() {
             .with_field("email")
             .with_condition(sqlite_expr!("\"role\" = {}", "admin"))
             .with_condition(sqlite_expr!("\"salary\" > {}", 50000.0f64))
-            .with_order(sqlite_expr!("\"name\""), true),
+            .with_order(sqlite_expr!("\"name\""), Order::Asc),
         "SELECT \"id\", \"name\", \"email\" FROM \"users\" \
          WHERE \"role\" = 'admin' AND \"salary\" > 50000.0 \
          ORDER BY \"name\"",
@@ -124,8 +124,8 @@ async fn test_q2() {
                 (ident("salary").dot_of("u")),
                 30000.0f64
             ))
-            .with_order(ident("name").dot_of("d"), true)
-            .with_order(ident("name").dot_of("u"), true),
+            .with_order(ident("name").dot_of("d"), Order::Asc)
+            .with_order(ident("name").dot_of("u"), Order::Asc),
         "SELECT \"u\".\"id\", \"u\".\"name\", \"d\".\"name\" AS \"department_name\" \
          FROM \"users\" AS \"u\" \
          INNER JOIN \"departments\" AS \"d\" ON \"d\".\"id\" = \"u\".\"department_id\" \
@@ -195,7 +195,7 @@ async fn test_q3() {
         ))
         .with_group_by(ident("id").dot_of("u"))
         .with_group_by(ident("name").dot_of("u"))
-        .with_order(ident("total_spent"), false);
+        .with_order(ident("total_spent"), Order::Desc);
 
     let users: Vec<UserSpend> = check_and_run(
         &select,
@@ -280,7 +280,7 @@ async fn test_q4() {
                 (Fx::new("avg", [price.expr()])),
                 500.0f64
             ))
-            .with_order(ident("product_count"), false),
+            .with_order(ident("product_count"), Order::Desc),
         "SELECT \"category\", COUNT(*) AS \"product_count\", AVG(\"price\") AS \"avg_price\", \
          MIN(\"price\") AS \"cheapest\", MAX(\"price\") AS \"most_expensive\" \
          FROM \"products\" \
@@ -357,7 +357,7 @@ async fn test_q5() {
                 Some("order_count".into()),
             )
             .with_condition(Fx::new("exists", [exists_subquery.expr()]))
-            .with_order(ident("order_count"), false)
+            .with_order(ident("order_count"), Order::Desc)
             .with_limit(Some(20), None),
         concat!(
             r#"SELECT "u"."id", "u"."name", "#,
@@ -442,7 +442,7 @@ async fn test_q6() {
                 (ident("order_count").dot_of("stats")),
                 2i64
             ))
-            .with_order(ident("avg_total").dot_of("stats"), false),
+            .with_order(ident("avg_total").dot_of("stats"), Order::Desc),
         concat!(
             r#"SELECT "u"."name", "stats"."order_count", "stats"."avg_total" "#,
             r#"FROM "users" AS "u" "#,
@@ -531,7 +531,7 @@ async fn test_q7() {
                 None,
             )
             .with_field("display_name")
-            .with_order(ident("salary"), false),
+            .with_order(ident("salary"), Order::Desc),
         "SELECT \"id\", \"name\", \"salary\", \
          CASE WHEN \"salary\" >= 100000.0 THEN 'senior' WHEN \"salary\" >= 60000.0 THEN 'mid' \
          WHEN \"salary\" >= 30000.0 THEN 'junior' ELSE 'intern' END AS \"band\", \
@@ -688,7 +688,7 @@ async fn test_q9() {
             .with_expression(
                 Window::new()
                     .partition_by(dept.clone())
-                    .order_by(salary.clone(), false)
+                    .order_by(salary.clone(), Order::Desc)
                     .rows("UNBOUNDED PRECEDING", "CURRENT ROW")
                     .apply(Fx::new("sum", [salary.expr()])),
                 Some("running_total".into()),
@@ -696,7 +696,7 @@ async fn test_q9() {
             .with_condition(sqlite_expr!("{} IS NOT NULL", (dept)))
             .with_window("win", Window::new()
                 .partition_by(dept.clone())
-                .order_by(salary.clone(), false)),
+                .order_by(salary.clone(), Order::Desc)),
         concat!(
             r#"SELECT "u"."department_id", "u"."name", "u"."salary", "#,
             r#"ROW_NUMBER() OVER win AS "row_num", "#,
@@ -777,7 +777,7 @@ async fn test_q10() {
                 sqlite_expr!("{} = {}",
                     (ident("id").dot_of("u")),
                     (ident("user_id").dot_of("t")))))
-            .with_order(ident("revenue").dot_of("t"), false)
+            .with_order(ident("revenue").dot_of("t"), Order::Desc)
             .with_limit(Some(10), None),
         concat!(
             r#"WITH active_orders AS (SELECT "user_id", COUNT(*) AS "cnt", SUM("total") AS "revenue" "#,
@@ -875,7 +875,7 @@ async fn test_q11() {
             .with_field("name")
             .with_field("depth")
             .with_field("path")
-            .with_order(ident("path"), true),
+            .with_order(ident("path"), Order::Asc),
         concat!(
             r#"WITH RECURSIVE dept_tree(id, name, depth, path) AS "#,
             r#"(SELECT "id", "name", 0, "name" FROM "departments" WHERE "parent_id" IS NULL "#,
@@ -963,7 +963,7 @@ async fn test_q12() {
                 "%Pro%"
             ))
             .with_condition(sqlite_expr!("{} > {}", (ident("stock").dot_of("p")), 0i64))
-            .with_order(ident("price").dot_of("p"), true)
+            .with_order(ident("price").dot_of("p"), Order::Asc)
             .with_limit(Some(50), None),
         concat!(
             r#"SELECT DISTINCT "p"."id", "p"."name", "p"."price" "#,
@@ -1053,7 +1053,7 @@ async fn test_q13() {
                 5.0f64
             ))
             .with_condition(JsonExtract::new(metadata.clone(), "in_stock").eq(1i64))
-            .with_order(ident("rating"), false),
+            .with_order(ident("rating"), Order::Desc),
         concat!(
             r#"SELECT "id", "name", "#,
             r#"JSON_EXTRACT("metadata", '$.color') AS "color", "#,
@@ -1157,8 +1157,8 @@ async fn test_q14() {
             .with_group_by(month_expr)
             .with_group_by(ident("name").dot_of("d"))
             .with_having(sqlite_expr!("{} > {}", (sum_total), 100.0f64))
-            .with_order(ident("month"), false)
-            .with_order(ident("monthly_revenue"), false),
+            .with_order(ident("month"), Order::Desc)
+            .with_order(ident("monthly_revenue"), Order::Desc),
         concat!(
             r#"SELECT STRFTIME('%Y-%m', "o"."created_at") AS "month", "#,
             r#""d"."name" AS "department", "#,
@@ -1238,7 +1238,7 @@ async fn test_q15() {
 
     let dept_salary_win = Window::new()
         .partition_by(dept.clone())
-        .order_by(salary.clone(), false);
+        .order_by(salary.clone(), Order::Desc);
 
     let rows: Vec<UserWindowStats> = check_and_run(
         &SqliteSelect::new()
@@ -1256,12 +1256,12 @@ async fn test_q15() {
                 Some("completed_count".into()),
             )
             .with_expression(
-                Window::new().order_by(salary.clone(), true)
+                Window::new().order_by(salary.clone(), Order::Asc)
                     .apply(sqlite_expr!("LAG({}, 1)", (salary.clone()))),
                 Some("prev_salary".into()),
             )
             .with_expression(
-                Window::new().order_by(salary.clone(), true)
+                Window::new().order_by(salary.clone(), Order::Asc)
                     .apply(sqlite_expr!("LEAD({}, 1)", (salary.clone()))),
                 Some("next_salary".into()),
             )
@@ -1282,8 +1282,8 @@ async fn test_q15() {
                     (ident("user_id").dot_of("o")),
                     (ident("id").dot_of("u")))))
             .with_condition(sqlite_expr!("{} IS NOT NULL", (dept.clone())))
-            .with_order(dept, true)
-            .with_order(salary, false),
+            .with_order(dept, Order::Asc)
+            .with_order(salary, Order::Desc),
         concat!(
             r#"SELECT "u"."id", "u"."name", "u"."salary", "u"."department_id", "#,
             r#"COUNT(*) FILTER (WHERE "o"."status" = 'completed') OVER (PARTITION BY "u"."id") AS "completed_count", "#,

--- a/vantage-sql/tests/sqlite/3_select.rs
+++ b/vantage-sql/tests/sqlite/3_select.rs
@@ -2,7 +2,7 @@
 //!
 //! All queries built using the Selectable trait methods, not custom builders.
 
-use vantage_expressions::{ExprDataSource, Expressive, Selectable};
+use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 #[allow(unused_imports)]
 use vantage_sql::sqlite::SqliteType;
 use vantage_sql::sqlite::statements::SqliteSelect;
@@ -85,7 +85,7 @@ fn test_select_with_condition() {
 fn test_select_order_and_limit() {
     let s = SqliteSelect::new()
         .with_source("product")
-        .with_order(sqlite_expr!("\"price\""), false)
+        .with_order(sqlite_expr!("\"price\""), Order::Desc)
         .with_limit(Some(2), None);
     assert_eq!(
         s.preview(),
@@ -206,7 +206,7 @@ async fn test_execute_order_and_limit() {
 
     let select = SqliteSelect::new()
         .with_source("product")
-        .with_order(sqlite_expr!("\"price\""), false)
+        .with_order(sqlite_expr!("\"price\""), Order::Desc)
         .with_limit(Some(1), None);
 
     let record: Record<AnySqliteType> = db.associate(select.expr()).get().await.unwrap();

--- a/vantage-sql/tests/sqlite/bakery.rs
+++ b/vantage-sql/tests/sqlite/bakery.rs
@@ -3,7 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
-use vantage_expressions::{ExprDataSource, Expressive, Selectable};
+use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 use vantage_sql::sqlite::SqliteDB;
 use vantage_sql::sqlite::statements::SqliteSelect;
 use vantage_sql::sqlite_expr;
@@ -119,7 +119,7 @@ async fn test_select_with_order_and_limit() {
     let db = get_db().await;
     let select = SqliteSelect::new()
         .with_source("product")
-        .with_order(sqlite_expr!("\"price\""), false)
+        .with_order(sqlite_expr!("\"price\""), Order::Desc)
         .with_limit(Some(2), None);
     let rows = exec_rows(db.execute(&select.expr()).await.unwrap().into_value());
 

--- a/vantage-surrealdb/README.md
+++ b/vantage-surrealdb/README.md
@@ -81,7 +81,7 @@ use vantage_expressions::Selectable;
 let select = SurrealSelect::new()
     .with_source("product")
     .with_condition(Field::new("is_deleted").eq(false))
-    .with_order(surreal_expr!("name"), true);
+    .with_order(surreal_expr!("name"), Order::Asc);
 // SELECT * FROM product WHERE is_deleted = false ORDER BY name
 
 // Aggregation

--- a/vantage-surrealdb/src/associated_query.rs
+++ b/vantage-surrealdb/src/associated_query.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use vantage_core::{Context, Result, vantage_error};
 use vantage_expressions::protocol::result::{self, QueryResult};
-use vantage_expressions::{AssociatedQueryable, Expression, Selectable};
+use vantage_expressions::{AssociatedQueryable, Expression, Order, Selectable};
 use vantage_table::Entity;
 
 use crate::select::SurrealSelect;
@@ -64,9 +64,9 @@ impl<T: QueryResult, R> SurrealAssociated<SurrealSelect<T>, R> {
     pub fn with_order_by(
         mut self,
         expression: vantage_expressions::Expression,
-        ascending: bool,
+        order: Order,
     ) -> Self {
-        self.query.add_order_by(expression, ascending);
+        self.query.add_order_by(expression, order);
         self
     }
 
@@ -123,8 +123,8 @@ impl<Q: SurrealQueriable + Selectable + Clone, R: Send + Sync> Selectable
         self.query.set_distinct(distinct)
     }
 
-    fn add_order_by(&mut self, expression: vantage_expressions::Expression, ascending: bool) {
-        self.query.add_order_by(expression, ascending)
+    fn add_order_by(&mut self, expression: Expression, order: Order) {
+        self.query.add_order_by(expression, order)
     }
 
     fn add_group_by(&mut self, expression: vantage_expressions::Expression) {

--- a/vantage-surrealdb/src/statements/select/builder.rs
+++ b/vantage-surrealdb/src/statements/select/builder.rs
@@ -7,7 +7,7 @@ use super::SurrealSelect;
 use super::select_field::SelectField;
 use super::select_target::SelectTarget;
 use vantage_core::IntoVec;
-use vantage_expressions::Expressive;
+use vantage_expressions::{Expressive, Order};
 
 impl SurrealSelect {
     /// Creates a new SELECT query builder
@@ -55,9 +55,9 @@ impl<T: QueryResult> SurrealSelect<T> {
     pub fn with_order_by(
         mut self,
         field: impl ExpressiveOr<AnySurrealType, Identifier>,
-        ascending: bool,
+        order: Order,
     ) -> Self {
-        self.order_by.push((field.field_expr(), ascending));
+        self.order_by.push((field.field_expr(), order.ascending));
         self
     }
 

--- a/vantage-surrealdb/src/statements/select/impls/selectable.rs
+++ b/vantage-surrealdb/src/statements/select/impls/selectable.rs
@@ -3,7 +3,7 @@ use crate::sum::{Fx, Sum};
 use crate::{AnySurrealType, Expr, surreal_expr};
 use vantage_expressions::result::QueryResult;
 use vantage_expressions::traits::expressive::Expressive;
-use vantage_expressions::traits::selectable::{Selectable, SourceRef};
+use vantage_expressions::traits::selectable::{Order, Selectable, SourceRef};
 
 use super::super::SurrealSelect;
 use super::super::select_field::SelectField;
@@ -38,8 +38,8 @@ impl<T: QueryResult> Selectable<AnySurrealType> for SurrealSelect<T> {
         self.distinct = distinct;
     }
 
-    fn add_order_by(&mut self, expression: impl Expressive<AnySurrealType>, ascending: bool) {
-        self.order_by.push((expression.expr(), ascending));
+    fn add_order_by(&mut self, expression: impl Expressive<AnySurrealType>, order: Order) {
+        self.order_by.push((expression.expr(), order.ascending));
     }
 
     fn add_group_by(&mut self, expression: impl Expressive<AnySurrealType>) {

--- a/vantage-surrealdb/src/statements/select/tests.rs
+++ b/vantage-surrealdb/src/statements/select/tests.rs
@@ -4,7 +4,7 @@ mod tests {
     use crate::select::SurrealSelect;
     use crate::select::select_field::SelectField;
     use crate::surreal_expr;
-    use vantage_expressions::traits::selectable::Selectable;
+    use vantage_expressions::traits::selectable::{Order, Selectable};
 
     #[test]
     fn test_basic_select() {
@@ -58,7 +58,7 @@ mod tests {
         let select = SurrealSelect::new()
             .from("users")
             .field("name")
-            .with_order_by(surreal_expr!("name"), true);
+            .with_order_by(surreal_expr!("name"), Order::Asc);
 
         assert_eq!(select.preview(), "SELECT name FROM users ORDER BY name");
     }
@@ -68,7 +68,7 @@ mod tests {
         let select = SurrealSelect::new()
             .from("users")
             .field("name")
-            .with_order_by(surreal_expr!("created_at"), false);
+            .with_order_by(surreal_expr!("created_at"), Order::Desc);
 
         assert_eq!(
             select.preview(),
@@ -122,7 +122,7 @@ mod tests {
             )
             .with_where(surreal_expr!("status = 'completed'"))
             .with_group_by(surreal_expr!("customer_id"))
-            .with_order_by(surreal_expr!("total_amount"), false)
+            .with_order_by(surreal_expr!("total_amount"), Order::Desc)
             .with_limit(5);
 
         assert_eq!(
@@ -141,7 +141,7 @@ mod tests {
         select.add_field("email".to_string());
         select.add_expression(surreal_expr!("age * 2"), Some("double_age".to_string()));
         select.add_where_condition(surreal_expr!("age > 18"));
-        select.add_order_by(surreal_expr!("name"), true);
+        select.add_order_by(surreal_expr!("name"), Order::Asc);
         select.add_group_by(surreal_expr!("department"));
         select.set_limit(Some(10), Some(5));
         select.set_distinct(true);

--- a/vantage-surrealdb/tests/graph_traversal.rs
+++ b/vantage-surrealdb/tests/graph_traversal.rs
@@ -3,7 +3,7 @@
 //! Requires: `cd scripts && ./ingress.sh` to populate the v1 database.
 //! These tests are read-only — they don't modify the v1 data.
 
-use vantage_expressions::{ExprDataSource, Expressive, Selectable};
+use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 use vantage_surrealdb::{
     operation::RefOperation, select::SurrealSelect, surreal_expr, surrealdb::SurrealDB,
     thing::Thing, types::AnySurrealType,
@@ -36,7 +36,7 @@ async fn query01_bakery_products_via_graph() {
     // Wrap in subquery to get ORDER BY working
     let mut outer = SurrealSelect::new();
     outer.set_source(inner.expr(), None);
-    outer.add_order_by(surreal_expr!("name"), true);
+    outer.add_order_by(surreal_expr!("name"), Order::Asc);
 
     let rows = outer.get(&db).await.unwrap();
     assert_eq!(rows.len(), 5);
@@ -61,7 +61,7 @@ async fn query02_bakery_clients_via_reverse_graph() {
     // Wrap to get ordered results
     let mut outer = SurrealSelect::new();
     outer.set_source(inner.expr(), None);
-    outer.add_order_by(surreal_expr!("name"), true);
+    outer.add_order_by(surreal_expr!("name"), Order::Asc);
 
     let rows = outer.get(&db).await.unwrap();
     assert_eq!(rows.len(), 3);
@@ -85,7 +85,7 @@ async fn query03_product_stock() {
         .field("price")
         .with_expression(surreal_expr!("inventory.stock"), Some("stock".into()))
         .with_where(surreal_expr!("is_deleted = {}", false))
-        .with_order_by("name", true);
+        .with_order_by("name", Order::Asc);
 
     let rows = select.get(&db).await.unwrap();
     assert_eq!(rows.len(), 5);
@@ -147,7 +147,7 @@ async fn query10_low_stock_products() {
         )
         .with_where(surreal_expr!("inventory.stock < {}", 20i64))
         .with_where(surreal_expr!("is_deleted = {}", false))
-        .with_order_by("name", true);
+        .with_order_by("name", Order::Asc);
 
     let rows = select.get(&db).await.unwrap();
 
@@ -175,7 +175,7 @@ async fn subquery_paying_clients() {
     // Wrap to get ordered results
     let mut outer = SurrealSelect::new();
     outer.set_source(inner.expr(), None);
-    outer.add_order_by(surreal_expr!("name"), true);
+    outer.add_order_by(surreal_expr!("name"), Order::Asc);
 
     let rows = outer.get(&db).await.unwrap();
     assert_eq!(rows.len(), 2); // Marty + Doc are paying
@@ -214,7 +214,7 @@ fn render_query01_wrapped() {
 
     let mut outer = SurrealSelect::new();
     outer.set_source(inner.expr(), None);
-    outer.add_order_by(surreal_expr!("name"), true);
+    outer.add_order_by(surreal_expr!("name"), Order::Asc);
 
     assert_eq!(
         outer.preview(),
@@ -229,7 +229,7 @@ fn render_query02_wrapped() {
 
     let mut outer = SurrealSelect::new();
     outer.set_source(inner.expr(), None);
-    outer.add_order_by(surreal_expr!("name"), true);
+    outer.add_order_by(surreal_expr!("name"), Order::Asc);
 
     assert_eq!(
         outer.preview(),

--- a/vantage-surrealdb/tests/select.rs
+++ b/vantage-surrealdb/tests/select.rs
@@ -1,6 +1,6 @@
 use ciborium::Value as CborValue;
 use serde_json::Value;
-use vantage_expressions::{Expressive, Selectable};
+use vantage_expressions::{Expressive, Order, Selectable};
 use vantage_surrealdb::{
     field::Field,
     identifier::{Identifier, Parent},
@@ -35,7 +35,7 @@ fn query01() {
         (Thing::new("bakery", "hill_valley"))
     ));
     select.add_where_condition(surreal_expr!("is_deleted = {}", false));
-    select.add_order_by(surreal_expr!("name"), true);
+    select.add_order_by(surreal_expr!("name"), Order::Asc);
 
     let result = select.preview();
 
@@ -51,7 +51,7 @@ fn query01() {
         None,
     );
     select.add_where_condition(surreal_expr!("is_deleted = {}", false));
-    select.add_order_by(surreal_expr!("name"), true);
+    select.add_order_by(surreal_expr!("name"), Order::Asc);
 
     let result2 = select.preview();
 
@@ -70,7 +70,7 @@ fn query02() {
         Thing::new("bakery", "hill_valley").lref("belongs_to", "client"),
         None,
     );
-    select.add_order_by(surreal_expr!("name"), true);
+    select.add_order_by(surreal_expr!("name"), Order::Asc);
 
     let result = select.preview();
     assert_eq!(
@@ -86,7 +86,7 @@ fn query02() {
         "bakery = {}",
         (Thing::new("bakery", "hill_valley"))
     ));
-    select.add_order_by(surreal_expr!("name"), true);
+    select.add_order_by(surreal_expr!("name"), Order::Asc);
 
     let result = select.preview();
     assert_eq!(
@@ -165,7 +165,7 @@ fn query07() {
 #[test]
 fn query11() {
     let select = SurrealSelect::new()
-        .with_order(surreal_expr!("product_name"), true)
+        .with_order(surreal_expr!("product_name"), Order::Asc)
         .with_condition(surreal_expr!("total_items_ordered > current_inventory"))
         .with_source(
             SurrealSelect::new()

--- a/vantage-surrealdb/tests/statements.rs
+++ b/vantage-surrealdb/tests/statements.rs
@@ -5,7 +5,7 @@
 
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use vantage_expressions::{ExprDataSource, Expressive, Selectable};
+use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 use vantage_surrealdb::field::Field;
 use vantage_surrealdb::statements::delete::SurrealDelete;
 use vantage_surrealdb::statements::insert::SurrealInsert;
@@ -127,7 +127,7 @@ fn select_order_by() {
     let select = SurrealSelect::new()
         .from("products")
         .with_field("name")
-        .with_order_by(Field::new("price"), false);
+        .with_order_by(Field::new("price"), Order::Desc);
 
     assert!(select.preview().contains("ORDER BY price DESC"));
 }
@@ -136,7 +136,7 @@ fn select_order_by() {
 fn select_order_by_asc() {
     let select = SurrealSelect::new()
         .from("products")
-        .with_order_by(Field::new("name"), true);
+        .with_order_by(Field::new("name"), Order::Asc);
 
     let p = select.preview();
     assert!(p.contains("ORDER BY name"), "got: {}", p);
@@ -204,7 +204,7 @@ fn select_clear_methods() {
         .from("t")
         .with_field("a")
         .with_where(Field::new("x").eq(1i64))
-        .with_order_by(Field::new("a"), true)
+        .with_order_by(Field::new("a"), Order::Asc)
         .with_group_by(Field::new("a"));
 
     assert!(select.has_fields());
@@ -308,7 +308,7 @@ fn select_complex_query() {
         .with_expression(surreal_expr!("count()"), Some("cnt".to_string()))
         .with_where(Field::new("order.status").eq("confirmed"))
         .with_group_by(Field::new("product"))
-        .with_order_by(Field::new("total"), false)
+        .with_order_by(Field::new("total"), Order::Desc)
         .with_limit(10);
 
     let p = select.preview();
@@ -372,7 +372,7 @@ async fn select_live_with_where_and_order() {
         .with_field("name")
         .with_field("score")
         .with_where(Field::new("score").gt(60i64))
-        .with_order_by(Field::new("score"), false);
+        .with_order_by(Field::new("score"), Order::Desc);
 
     let result = db.execute(&select.expr()).await.unwrap();
     let rows: Vec<indexmap::IndexMap<String, AnySurrealType>> = result.try_get().unwrap();
@@ -1122,7 +1122,7 @@ async fn insert_select_update_flow() {
         .with_field("name")
         .with_field("score")
         .with_where(Field::new("score").gte(50i64))
-        .with_order_by(Field::new("score"), false);
+        .with_order_by(Field::new("score"), Order::Desc);
 
     let result = db.execute(&select.expr()).await.unwrap();
     let rows: Vec<indexmap::IndexMap<String, AnySurrealType>> = result.try_get().unwrap();

--- a/vantage-table/src/operation.rs
+++ b/vantage-table/src/operation.rs
@@ -87,6 +87,14 @@ pub trait Operation<T>: Expressive<T> {
             ],
         )
     }
+
+    /// Casts the expression to a SQL type: `CAST(expr AS type_name)`
+    fn cast(&self, type_name: &str) -> Expression<T> {
+        Expression::new(
+            format!("CAST({{}} AS {type_name})"),
+            vec![ExpressiveEnum::Nested(self.expr())],
+        )
+    }
 }
 
 /// Blanket implementation: any type that implements `Expressive<T>` gets `Operation<T>` for free.

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -39,8 +39,11 @@ where
 
         // Add all order clauses
         for (expr, direction) in self.order_by.values() {
-            let ascending = matches!(direction, crate::sorting::SortDirection::Ascending);
-            select.add_order_by(expr.clone(), ascending);
+            let order = match direction {
+                crate::sorting::SortDirection::Ascending => vantage_expressions::Order::Asc,
+                crate::sorting::SortDirection::Descending => vantage_expressions::Order::Desc,
+            };
+            select.add_order_by(expr.clone(), order);
         }
 
         // Apply pagination


### PR DESCRIPTION
Adds PostgreSQL-specific query builder surface and the suite that exercises it. PG support graduates from "renders SQL" to "renders the SQL you'd actually write by hand."

### Breaking: `with_order` takes `Order`, not `bool`

```rust
// before
.with_order(ident("name"), true)
// after
.with_order(ident("name"), Order::Asc)
.with_order(ident("score"), Order::Desc.nulls_last())
```

The `bool` flag couldn't express `NULLS FIRST/LAST`, which PG and the new test suite both need. Same flip on `Window::order_by`. Touches every backend (`SqliteSelect`, `MysqlSelect`, `PostgresSelect`, `SurrealSelect`).

### New on PostgreSQL

- `PostgresSelect::with_distinct_on(expr)` — `SELECT DISTINCT ON (...)`.
- `PostgresSelectJoin::full_outer`, `left_lateral`, `cross_lateral`, `cross_lateral_raw` — including the `UNNEST(...) WITH ORDINALITY` shape.
- `JsonExtract::new(col, ["specs", "voltage"])` accepts a path — renders `col->'specs'->>'voltage'` on PG, `JSON_EXTRACT(col, '$.specs.voltage')` elsewhere.

### Cross-vendor

`Interval::new(1, "year")` (vendor-aware), `Operation::cast("NUMERIC")`, and `+`/`-`/`*`/`/` operators on `Expression<T>` so arithmetic composes without a macro.

### Tests

`tests/postgres/3_complex_queries_pg.rs` — 15 queries against a new `vantage_pg` schema (UUID, JSONB, TEXT[], ENUM, DATERANGE, INET, POINT, MONEY, GENERATED). Covers `DISTINCT ON`, array operators, JSONB paths, `LATERAL`, `generate_series`, `array_agg`/`string_agg`/`FILTER`, `ROLLUP`, recursive CTE, `DENSE_RANK` over named windows. CI matrix populates the schema in a separate database and runs the suite alongside SQLite/MySQL.

PG dialect divergence (`@>`, `?`, `#>`, `::TYPE`) still goes through `postgres_expr!` rather than dedicated primitives — those are the obvious follow-ups.