### PR TITLE
add condition type

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,15 +44,15 @@ jobs:
         run: cargo build --workspace
 
       - name: Run all tests
-        run: cargo test --workspace --exclude surreal-client --exclude vantage-surrealdb --exclude vantage-sql --exclude bakery_model3
+        run: cargo test --workspace --exclude surreal-client --exclude vantage-surrealdb --exclude vantage-sql --exclude bakery_model3 --exclude vantage-mongodb
 
       - name: Check formatting
         run: cargo fmt --all -- --check
 
       - name: Run clippy
-        run: cargo clippy --workspace --exclude surreal-client --exclude vantage-surrealdb --exclude vantage-sql --exclude bakery_model3 --all-targets -- -D warnings
+        run: cargo clippy --workspace --exclude surreal-client --exclude vantage-surrealdb --exclude vantage-sql --exclude bakery_model3 --exclude vantage-mongodb --all-targets -- -D warnings
 
       - name: Check documentation
-        run: cargo doc --workspace --exclude surreal-client --exclude vantage-surrealdb --exclude vantage-sql --exclude bakery_model3 --no-deps --document-private-items
+        run: cargo doc --workspace --exclude surreal-client --exclude vantage-surrealdb --exclude vantage-sql --exclude bakery_model3 --exclude vantage-mongodb --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: "-D warnings"

--- a/.github/workflows/mongodb.yaml
+++ b/.github/workflows/mongodb.yaml
@@ -1,0 +1,55 @@
+name: MongoDB Tests
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "vantage-mongodb/**"
+      - ".github/workflows/mongodb.yaml"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --eval 'db.runCommand({ping:1})'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          key: "mongodb-workspace-v03"
+          cache-workspace-crates: true
+          cache-all-crates: true
+
+      - name: Seed database
+        run: |
+          docker exec ${{ job.services.mongodb.id }} mongosh vantage < vantage-mongodb/scripts/db/v2.js
+
+      - name: Build vantage-mongodb
+        run: cargo build -p vantage-mongodb
+
+      - name: Run unit tests
+        run: cargo test -p vantage-mongodb --lib
+
+      - name: Run integration tests
+        run: cargo test -p vantage-mongodb --test 1_table_source --test 1_types_record
+        env:
+          MONGODB_URL: mongodb://localhost:27017
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker stop ${{ job.services.mongodb.id }} || true

--- a/.rules
+++ b/.rules
@@ -314,10 +314,16 @@ SurrealTableExt adds type-narrowing query methods (select_first, select_column,
 select_single). Includes From/Into conversions between AnySurrealType and
 serde_json::Value, enabling AnyTable integration via from_table().
 
-**vantage-mongodb** generates native MongoDB JSON queries using Vantage
-patterns. It supports full CRUD operations and all common MongoDB operators
-($gt, $lt, $in, $or, $regex, etc.) through a fluent Document builder API that
-feels natural to MongoDB developers.
+**vantage-mongodb** provides a MongoDB persistence backend using the official
+`mongodb` crate with `bson::Bson` as the native value type. Unlike SQL/SurrealDB
+backends, it skips `Expression`-based queries entirely — `TableSource` methods
+use the mongodb driver directly and `type Condition = bson::Document` enables
+native MongoDB filters (`doc! { "price": { "$gt": 100 } }`). Includes
+`AnyMongoType` type system via `vantage_type_system!` macro with bson v2.
+Stub `ExprDataSource` provided for trait compatibility; `SelectableDataSource`
+intentionally skipped. Conditions, aggregates ($sum/$max/$min), and full CRUD
+work natively. Relationship traversal (`with_one`/`with_many`) not yet
+supported — requires further trait boundary work (see TODO.md).
 
 **vantage-dataset** defines internal traits that categorize different data
 source capabilities. ReadableDataSet handles read-only sources like CSV files,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,28 +287,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bson"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f109694c4f45353972af96bf97d8a057f82e2d6e496457f4d135b9867a518c"
-dependencies = [
- "ahash 0.8.12",
- "base64",
- "bitvec",
- "getrandom 0.3.4",
- "hex",
- "indexmap",
- "js-sys",
- "rand 0.9.2",
- "serde",
- "serde_bytes",
- "simdutf8",
- "thiserror 2.0.18",
- "time",
- "uuid",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,7 +1813,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da0cd419a51a5fb44819e290fbdb0665a54f21dead8923446a799c7f4d26ad9"
 dependencies = [
- "bson 2.15.0",
+ "bson",
  "mongocrypt-sys",
  "once_cell",
  "serde",
@@ -1855,7 +1833,7 @@ checksum = "2c5941683db2ab2697f71e58dc0319024e808d3b28e7cf20f4bfb445fe54a30b"
 dependencies = [
  "base64",
  "bitflags",
- "bson 2.15.0",
+ "bson",
  "derive-where",
  "derive_more",
  "futures-core",
@@ -3831,7 +3809,8 @@ name = "vantage-mongodb"
 version = "0.3.0"
 dependencies = [
  "async-trait",
- "bson 3.1.0",
+ "bson",
+ "futures-util",
  "indexmap",
  "mongodb",
  "paste",
@@ -3840,7 +3819,9 @@ dependencies = [
  "serde_json",
  "tokio",
  "vantage-core",
+ "vantage-dataset",
  "vantage-expressions",
+ "vantage-table",
  "vantage-types",
 ]
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,52 @@
+# MongoDB PoC & Trait Boundary Improvements (from MongoDB work, 2026-04)
+
+## Completed
+
+- [x] Added `type Condition` associated type to `TableSource` — allows non-Expression condition
+      types (e.g. `bson::Document` for MongoDB). SQL/SurrealDB backends use
+      `type Condition = Expression<Self::Value>` (no change). References (`with_one`/`with_many`)
+      require `T::Condition: From<Expression<T::Value>>` bound.
+- [x] MongoDB type system (`AnyMongoType`, `bson::Bson` value type, bson v2)
+- [x] MongoDB `TableSource` impl — full CRUD using mongodb driver directly, no Expression queries.
+      `type Condition = bson::Document` for native MongoDB filters.
+
+## Trait boundary fixes needed
+
+- [ ] **Move `get_count`/`get_sum`/`get_max`/`get_min` off `SelectableDataSource`** — currently in
+      `table/impls/selectable.rs` behind `T: SelectableDataSource`. They just delegate to
+      `TableSource` methods. Move to a separate impl block requiring only `T: TableSource` so
+      MongoDB and other non-query backends can use them directly.
+- [ ] **Remove `delete`/`delete_all` from `WritableDataSet`** — `WritableValueSet` is the canonical
+      place for deletion (doesn't require entity type). Having both causes ambiguity when calling
+      `table.delete()`. Keep only in `WritableValueSet`.
+- [ ] **Decouple `column_table_values_expr` from `ExprDataSource`** — the method returns
+      `AssociatedExpression` which forces `ExprDataSource` dependency. The actual work is "get
+      column values from table" which `TableSource` can already do via `list_table_values`. Explore
+      returning a `Condition`-based result instead, or refactor `AssociatedExpression` to not
+      require `ExprDataSource`.
+- [ ] **Explore `Selectable` parameterized on condition type** — currently `add_where_condition`
+      takes `impl Expressive<T>`, hardcoding Expression-based conditions. MongoDB could implement
+      its own `select()` if `Selectable` (or a parallel trait) accepted `Condition` type directly.
+      Investigate parameterizing `Selectable<T, C>` where `C` is the condition type, or creating
+      `DocumentSelectable` for document-oriented backends.
+- [ ] **Analyse `with_one`/`with_many` for non-Expression backends** — currently requires
+      `T::Condition: From<Expression<T::Value>>`. For MongoDB, need to either: (a) implement
+      `From<Expression<AnyMongoType>> for bson::Document` by parsing common Operation templates
+      (`"{} = {}"` → `doc!{field: value}`, `"{} IN ({})"` → `doc!{field: {"$in": [...]}}`), (b)
+      create MongoDB-native reference types that produce `bson::Document` conditions directly, or
+      (c) refactor the reference system to work with `Condition` generically. Goal: relationship
+      traversal (`ref products list`) working for MongoDB.
+
 # Query Builder Improvements (from MySQL work, 2026-04)
 
-- [ ] `expr.as_alias()` — add alias method on `Expression<T>`, then remove `Option<String>` from `with_expression` and all `with_alias()` from primitives (Fx, Iif, Concat, GroupConcat, JsonExtract, DateFormat, Case). Also fixes Fx alias hardcoding `"` instead of backticks.
-- [ ] `sql_fx!()` macro — mixed-type args for function calls: `sql_fx!("find_in_set", "write", (ident("permissions")))` instead of wrapping every arg in `mysql_expr!`
-- [ ] PostgreSQL ingress — split into `vantage_v2`, `vantage_v3`, `vantage_v4_pg` with DROP+CREATE, matching MySQL pattern
+- [ ] `expr.as_alias()` — add alias method on `Expression<T>`, then remove `Option<String>` from
+      `with_expression` and all `with_alias()` from primitives (Fx, Iif, Concat, GroupConcat,
+      JsonExtract, DateFormat, Case). Also fixes Fx alias hardcoding `"` instead of backticks.
+- [ ] `sql_fx!()` macro — mixed-type args for function calls:
+      `sql_fx!("find_in_set", "write", (ident("permissions")))` instead of wrapping every arg in
+      `mysql_expr!`
+- [ ] PostgreSQL ingress — split into `vantage_v2`, `vantage_v3`, `vantage_v4_pg` with DROP+CREATE,
+      matching MySQL pattern
 - [ ] `Expression::empty()` sweep — replace all `Expression::new("", vec![])` across the codebase
 
 # v0.2 (eta January 2025)
@@ -13,7 +57,8 @@
 
 - [ ] Implement `only_column()` method for SurrealSelect query builder
 - [x] Implement prelude for vantage_surrealdb to avoid manual imports
-- [x] Fix get() method to accept (&select) instead of requiring select.expr() - should work with IntoExpression trait
+- [x] Fix get() method to accept (&select) instead of requiring select.expr() - should work with
+      IntoExpression trait
 - [ ] **BUG**: SurrealDB IN subquery returns record objects not scalar values
   - Reference traversal generates `WHERE bakery IN (SELECT id FROM bakery WHERE ...)`
   - SurrealDB returns `{id: "bakery:hill_valley"}` from subquery, not `"bakery:hill_valley"`
@@ -95,9 +140,8 @@ Minor Cases:
 
 ## Implement cross-datasource operations
 
-Developers who operate with the models do not have to be aware of the data source.
-If you want to implement this, then you can define your data sets to rely on
-factories for the data-set:
+Developers who operate with the models do not have to be aware of the data source. If you want to
+implement this, then you can define your data sets to rely on factories for the data-set:
 
 ```rust
 let client_set = ClientSet::factory();
@@ -116,14 +160,11 @@ basket.archive();  // stores archived basked into BigQuery
 
 ## Implement in-memory cache concept
 
-This allows to create in-memory cache of a dataset. Finding a record
-in a cache is faster. Cache will automatically invalidate items if
-they happen to change in the database, if the datasource allows
-subscription for the changes. There can also be other invalidation
-mechanics.
+This allows to create in-memory cache of a dataset. Finding a record in a cache is faster. Cache
+will automatically invalidate items if they happen to change in the database, if the datasource
+allows subscription for the changes. There can also be other invalidation mechanics.
 
-Cache provides a transparent layer, so that the business logic code
-would not be affected.
+Cache provides a transparent layer, so that the business logic code would not be affected.
 
 ```rust
 let client_set = ClientSet::new(ClientCache::new(postgres));

--- a/vantage-api-client/src/table_source.rs
+++ b/vantage-api-client/src/table_source.rs
@@ -55,6 +55,7 @@ impl TableSource for RestApi {
     type AnyType = Value;
     type Value = Value;
     type Id = String;
+    type Condition = vantage_expressions::Expression<Self::Value>;
 
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         Column::new(name)

--- a/vantage-api-pool/src/pool_api.rs
+++ b/vantage-api-pool/src/pool_api.rs
@@ -92,6 +92,7 @@ impl TableSource for PoolApi {
     type AnyType = Value;
     type Value = Value;
     type Id = String;
+    type Condition = vantage_expressions::Expression<Self::Value>;
 
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         Column::new(name)

--- a/vantage-csv/src/table_source.rs
+++ b/vantage-csv/src/table_source.rs
@@ -26,6 +26,7 @@ impl TableSource for Csv {
     type AnyType = AnyCsvType;
     type Value = AnyCsvType;
     type Id = String;
+    type Condition = vantage_expressions::Expression<Self::Value>;
 
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         Column::new(name)

--- a/vantage-expressions/src/mocks/select.rs
+++ b/vantage-expressions/src/mocks/select.rs
@@ -145,16 +145,16 @@ impl Selectable<serde_json::Value> for MockSelect {
         panic!("You may only use field() in this mock")
     }
 
-    fn add_where_condition(&mut self, condition: impl Expressive<Value>) {
-        self.where_conditions.push(condition.expr());
+    fn add_where_condition(&mut self, condition: impl Into<Expression<Value>>) {
+        self.where_conditions.push(condition.into());
     }
 
     fn set_distinct(&mut self, distinct: bool) {
         self.distinct = distinct;
     }
 
-    fn add_order_by(&mut self, expression: impl Expressive<Value>, order: crate::Order) {
-        self.order_by.push((expression.expr(), order.ascending));
+    fn add_order_by(&mut self, order: impl Into<Expression<Value>>, direction: crate::Order) {
+        self.order_by.push((order.into(), direction.ascending));
     }
 
     fn add_group_by(&mut self, _expression: impl Expressive<Value>) {

--- a/vantage-expressions/src/traits/selectable.rs
+++ b/vantage-expressions/src/traits/selectable.rs
@@ -67,10 +67,16 @@ impl Order {
 /// and aggregations. This allows the same query building patterns to work across
 /// SQL databases, SurrealDB, MongoDB, and other backends.
 ///
+/// The trait is parameterized on:
+/// - `T` — the value/expression type (e.g. `AnySqliteType`, `AnyMongoType`)
+/// - `C` — the condition type, defaults to `Expression<T>` for SQL backends.
+///   Document-oriented backends like MongoDB can use `bson::Document` or a custom
+///   condition type.
+///
 /// Implementations handle database-specific syntax while exposing a consistent API
 /// for field selection, filtering, sorting, grouping, and aggregation operations.
 /// The trait supports both mutable builder methods and fluent chainable methods.
-pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
+pub trait Selectable<T, C = Expression<T>>: Send + Sync + Debug + Clone {
     /// Adds a data source to the FROM clause (table name, subquery, etc.).
     /// This is additive — calling it multiple times adds comma-separated sources.
     fn add_source(&mut self, source: impl Into<SourceRef<T>>, alias: Option<String>);
@@ -82,13 +88,13 @@ pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
     fn add_expression(&mut self, expression: impl Expressive<T>, alias: Option<String>);
 
     /// Adds a condition to the WHERE clause.
-    fn add_where_condition(&mut self, condition: impl Expressive<T>);
+    fn add_where_condition(&mut self, condition: impl Into<C>);
 
     /// Sets whether the query should return distinct results.
     fn set_distinct(&mut self, distinct: bool);
 
     /// Adds an ORDER BY clause with direction and optional null handling.
-    fn add_order_by(&mut self, expression: impl Expressive<T>, order: Order);
+    fn add_order_by(&mut self, order: impl Into<C>, direction: Order);
 
     /// Adds a GROUP BY clause.
     fn add_group_by(&mut self, expression: impl Expressive<T>);
@@ -162,7 +168,7 @@ pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
     }
 
     /// Builder pattern method identical to [`Self::add_where_condition`].
-    fn with_condition(mut self, condition: impl Expressive<T>) -> Self
+    fn with_condition(mut self, condition: impl Into<C>) -> Self
     where
         Self: Sized,
     {
@@ -171,11 +177,11 @@ pub trait Selectable<T>: Send + Sync + Debug + Clone + Expressive<T> {
     }
 
     /// Builder pattern method identical to [`Self::add_order_by`].
-    fn with_order(mut self, expression: impl Expressive<T>, order: Order) -> Self
+    fn with_order(mut self, order: impl Into<C>, direction: Order) -> Self
     where
         Self: Sized,
     {
-        Self::add_order_by(&mut self, expression, order);
+        Self::add_order_by(&mut self, order, direction);
         self
     }
 

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -9,8 +9,10 @@ description = "MongoDB persistence backend for Vantage framework"
 vantage-core = { path = "../vantage-core" }
 vantage-types = { path = "../vantage-types" }
 vantage-expressions = { path = "../vantage-expressions" }
+vantage-table = { path = "../vantage-table" }
+vantage-dataset = { path = "../vantage-dataset" }
 
-bson = { version = "3", features = ["serde"] }
+bson = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 indexmap = { version = "2", features = ["serde"] }
@@ -18,6 +20,7 @@ paste = "1"
 async-trait = "0.1"
 mongodb = "3"
 tokio = { version = "1", features = ["full"] }
+futures-util = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/vantage-mongodb/scripts/db/v2.js
+++ b/vantage-mongodb/scripts/db/v2.js
@@ -1,0 +1,145 @@
+// Hill Valley Bakery Database - MongoDB Version
+// Translated from PostgreSQL v2.sql
+//
+// Usage: docker exec -i mongo-vantage mongosh vantage < scripts/db/v2.js
+
+// Clean slate
+db.bakery.drop();
+db.client.drop();
+db.product.drop();
+db.client_order.drop();
+db.order_line.drop();
+
+// Bakery
+db.bakery.insertOne({
+  _id: "hill_valley",
+  name: "Hill Valley Bakery",
+  profit_margin: 15
+});
+
+// Clients
+db.client.insertMany([
+  {
+    _id: "marty",
+    name: "Marty McFly",
+    email: "marty@gmail.com",
+    contact_details: "555-1955",
+    is_paying_client: true,
+    balance: 150.00,
+    bakery_id: "hill_valley"
+  },
+  {
+    _id: "doc",
+    name: "Doc Brown",
+    email: "doc@brown.com",
+    contact_details: "555-1885",
+    is_paying_client: true,
+    balance: 500.50,
+    bakery_id: "hill_valley"
+  },
+  {
+    _id: "biff",
+    name: "Biff Tannen",
+    email: "biff-3293@hotmail.com",
+    contact_details: "555-1955",
+    is_paying_client: false,
+    balance: -50.25,
+    bakery_id: "hill_valley"
+  }
+]);
+
+// Products
+db.product.insertMany([
+  {
+    _id: "flux_cupcake",
+    name: "Flux Capacitor Cupcake",
+    calories: 300,
+    price: 120,
+    bakery_id: "hill_valley",
+    is_deleted: false,
+    inventory_stock: 50,
+    sticker: "cat"
+  },
+  {
+    _id: "delorean_donut",
+    name: "DeLorean Doughnut",
+    calories: 250,
+    price: 135,
+    bakery_id: "hill_valley",
+    is_deleted: false,
+    inventory_stock: 30,
+    sticker: "dog"
+  },
+  {
+    _id: "time_tart",
+    name: "Time Traveler Tart",
+    calories: 200,
+    price: 220,
+    bakery_id: "hill_valley",
+    is_deleted: false,
+    inventory_stock: 20,
+    sticker: null
+  },
+  {
+    _id: "sea_pie",
+    name: "Enchantment Under the Sea Pie",
+    calories: 350,
+    price: 299,
+    bakery_id: "hill_valley",
+    is_deleted: false,
+    inventory_stock: 15,
+    sticker: "pig"
+  },
+  {
+    _id: "hover_cookies",
+    name: "Hoverboard Cookies",
+    calories: 150,
+    price: 199,
+    bakery_id: "hill_valley",
+    is_deleted: false,
+    inventory_stock: 40,
+    sticker: "chicken"
+  }
+]);
+
+// Orders
+db.client_order.insertMany([
+  {
+    _id: "order1",
+    bakery_id: "hill_valley",
+    client_id: "marty",
+    is_deleted: false,
+    created_at: new Date().toISOString()
+  },
+  {
+    _id: "order2",
+    bakery_id: "hill_valley",
+    client_id: "doc",
+    is_deleted: false,
+    created_at: new Date().toISOString()
+  },
+  {
+    _id: "order3",
+    bakery_id: "hill_valley",
+    client_id: "doc",
+    is_deleted: false,
+    created_at: new Date().toISOString()
+  }
+]);
+
+// Order lines
+db.order_line.insertMany([
+  { order_id: "order1", product_id: "flux_cupcake",   quantity: 3,   price: 120 },
+  { order_id: "order1", product_id: "delorean_donut", quantity: 1,   price: 135 },
+  { order_id: "order1", product_id: "hover_cookies",  quantity: 2,   price: 199 },
+  { order_id: "order2", product_id: "time_tart",      quantity: 1,   price: 220 },
+  { order_id: "order3", product_id: "hover_cookies",  quantity: 500, price: 199 }
+]);
+
+print("Seeded: " +
+  db.bakery.countDocuments() + " bakeries, " +
+  db.client.countDocuments() + " clients, " +
+  db.product.countDocuments() + " products, " +
+  db.client_order.countDocuments() + " orders, " +
+  db.order_line.countDocuments() + " order lines"
+);

--- a/vantage-mongodb/scripts/ingress.sh
+++ b/vantage-mongodb/scripts/ingress.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONTAINER_NAME="mongo-vantage"
+DB="vantage"
+
+echo "Loading MongoDB data..."
+
+for db_file in "$SCRIPT_DIR"/db/v[0-3]*.js; do
+    db_name=$(basename "$db_file" .js)
+    echo "Loading $db_name..."
+    docker exec -i $CONTAINER_NAME mongosh $DB < "$db_file"
+    echo "  done."
+done
+
+echo "MongoDB data loaded."

--- a/vantage-mongodb/scripts/start.sh
+++ b/vantage-mongodb/scripts/start.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+# Configuration
+CONTAINER_NAME="mongo-vantage"
+PORT="27017"
+DB="vantage"
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+    echo "Error: Docker is not running. Please start Docker and try again."
+    exit 1
+fi
+
+# Stop existing container if running
+if docker ps -q -f name=$CONTAINER_NAME | grep -q .; then
+    echo "Stopping existing MongoDB container..."
+    docker stop $CONTAINER_NAME > /dev/null 2>&1 || true
+fi
+
+# Remove existing container
+if docker ps -aq -f name=$CONTAINER_NAME | grep -q .; then
+    echo "Removing existing MongoDB container..."
+    docker rm $CONTAINER_NAME > /dev/null 2>&1 || true
+fi
+
+echo "Starting MongoDB local instance..."
+echo "Container: $CONTAINER_NAME"
+echo "Port: $PORT"
+echo "Database: $DB"
+
+# Start MongoDB container (no auth for local dev)
+docker run -d \
+    --name $CONTAINER_NAME \
+    -p $PORT:27017 \
+    mongo:7
+
+# Wait for MongoDB to be ready
+echo "Waiting for MongoDB to start..."
+for i in $(seq 1 30); do
+    if docker exec $CONTAINER_NAME mongosh --quiet --eval "db.runCommand({ping:1})" > /dev/null 2>&1; then
+        echo "MongoDB is ready!"
+        break
+    fi
+    sleep 1
+done
+
+if docker ps -q -f name=$CONTAINER_NAME | grep -q .; then
+    echo ""
+    echo "Connection details:"
+    echo "  URL: mongodb://localhost:$PORT"
+    echo "  Database: $DB"
+    echo ""
+    echo "To connect with mongosh:"
+    echo "  docker exec -it $CONTAINER_NAME mongosh $DB"
+    echo ""
+    echo "To stop: ./stop.sh"
+else
+    echo "Failed to start MongoDB container"
+    docker logs $CONTAINER_NAME
+    exit 1
+fi

--- a/vantage-mongodb/scripts/stop.sh
+++ b/vantage-mongodb/scripts/stop.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+CONTAINER_NAME="mongo-vantage"
+
+if docker ps -q -f name=$CONTAINER_NAME | grep -q .; then
+    echo "Stopping MongoDB container..."
+    docker stop $CONTAINER_NAME > /dev/null 2>&1
+    echo "Stopped."
+else
+    echo "MongoDB container is not running."
+fi

--- a/vantage-mongodb/src/condition.rs
+++ b/vantage-mongodb/src/condition.rs
@@ -1,0 +1,216 @@
+//! MongoDB condition type — analogous to `Expression<T>` for SQL backends.
+//!
+//! `MongoCondition` can hold immediate `bson::Document` filters, async-deferred
+//! values (resolved at query time via `DeferredFn`), or nested combinations.
+
+use bson::{Bson, Document};
+use vantage_expressions::{DeferredFn, ExpressiveEnum};
+
+use crate::types::AnyMongoType;
+
+/// A MongoDB filter condition that can contain deferred values.
+///
+/// # Variants
+///
+/// - `Doc` — an immediate `bson::Document` filter, e.g. `doc! { "price": { "$gt": 100 } }`
+/// - `Deferred` — resolves async at query time via `DeferredFn<AnyMongoType>`.
+///   The resolved `AnyMongoType` must be a `Bson::Document`.
+/// - `And` — combines multiple conditions with `$and` semantics.
+#[derive(Clone)]
+pub enum MongoCondition {
+    /// Immediate filter document.
+    Doc(Document),
+    /// Async-resolved filter — the `DeferredFn` should produce an `AnyMongoType`
+    /// wrapping a `Bson::Document`.
+    Deferred(DeferredFn<AnyMongoType>),
+    /// Multiple conditions combined with `$and`.
+    And(Vec<MongoCondition>),
+}
+
+impl MongoCondition {
+    /// Resolve all deferred values and merge into a single `bson::Document`.
+    pub fn resolve(
+        &self,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = vantage_core::Result<Document>> + Send + '_>,
+    > {
+        Box::pin(async move {
+            match self {
+                MongoCondition::Doc(doc) => Ok(doc.clone()),
+                MongoCondition::Deferred(deferred) => {
+                    let result = deferred.call().await?;
+                    let resolved = match result {
+                        ExpressiveEnum::Scalar(val) => val,
+                        other => {
+                            return Err(vantage_core::error!(
+                                "MongoCondition::Deferred resolved to non-scalar",
+                                result = format!("{:?}", other)
+                            ));
+                        }
+                    };
+                    bson_to_document(resolved.into_value())
+                }
+                MongoCondition::And(conditions) => {
+                    let mut docs = Vec::with_capacity(conditions.len());
+                    for c in conditions {
+                        docs.push(c.resolve().await?);
+                    }
+                    merge_documents(docs)
+                }
+            }
+        })
+    }
+}
+
+// ── Conversions ──────────────────────────────────────────────────────
+
+impl From<Document> for MongoCondition {
+    fn from(doc: Document) -> Self {
+        MongoCondition::Doc(doc)
+    }
+}
+
+impl std::fmt::Debug for MongoCondition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MongoCondition::Doc(doc) => write!(f, "Doc({doc})"),
+            MongoCondition::Deferred(_) => write!(f, "Deferred(...)"),
+            MongoCondition::And(conditions) => f.debug_tuple("And").field(conditions).finish(),
+        }
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/// Convert a `Bson` value into a `Document`, or error if it's not one.
+fn bson_to_document(value: Bson) -> vantage_core::Result<Document> {
+    match value {
+        Bson::Document(doc) => Ok(doc),
+        other => Err(vantage_core::error!(
+            "Expected Bson::Document from deferred condition",
+            actual = format!("{:?}", other)
+        )),
+    }
+}
+
+/// Merge multiple documents into a single filter.
+///
+/// - Empty list → `{}`
+/// - Single doc → returned as-is
+/// - Multiple docs → `{ "$and": [ doc1, doc2, ... ] }`
+fn merge_documents(docs: Vec<Document>) -> vantage_core::Result<Document> {
+    Ok(match docs.len() {
+        0 => Document::new(),
+        1 => docs.into_iter().next().unwrap(),
+        _ => {
+            let array: Vec<Bson> = docs.into_iter().map(Bson::Document).collect();
+            bson::doc! { "$and": array }
+        }
+    })
+}
+
+/// Resolve an iterator of `MongoCondition` references into a single filter document.
+pub async fn resolve_conditions<'a>(
+    conditions: impl Iterator<Item = &'a MongoCondition>,
+) -> vantage_core::Result<Document> {
+    let mut docs = Vec::new();
+    for c in conditions {
+        docs.push(c.resolve().await?);
+    }
+    merge_documents(docs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_document() {
+        let doc = bson::doc! { "price": { "$gt": 100 } };
+        let cond: MongoCondition = doc.clone().into();
+        match cond {
+            MongoCondition::Doc(d) => assert_eq!(d, doc),
+            _ => panic!("expected Doc variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_doc() {
+        let cond = MongoCondition::Doc(bson::doc! { "active": true });
+        let resolved = cond.resolve().await.unwrap();
+        assert_eq!(resolved, bson::doc! { "active": true });
+    }
+
+    #[tokio::test]
+    async fn test_resolve_and() {
+        let cond = MongoCondition::And(vec![
+            bson::doc! { "a": 1 }.into(),
+            bson::doc! { "b": 2 }.into(),
+        ]);
+        let resolved = cond.resolve().await.unwrap();
+        assert_eq!(resolved, bson::doc! { "$and": [{ "a": 1 }, { "b": 2 }] });
+    }
+
+    #[tokio::test]
+    async fn test_resolve_and_single() {
+        let cond = MongoCondition::And(vec![bson::doc! { "x": 1 }.into()]);
+        let resolved = cond.resolve().await.unwrap();
+        assert_eq!(resolved, bson::doc! { "x": 1 });
+    }
+
+    #[tokio::test]
+    async fn test_resolve_and_empty() {
+        let cond = MongoCondition::And(vec![]);
+        let resolved = cond.resolve().await.unwrap();
+        assert_eq!(resolved, bson::doc! {});
+    }
+
+    #[tokio::test]
+    async fn test_resolve_conditions_helper() {
+        let conds = [
+            MongoCondition::Doc(bson::doc! { "a": 1 }),
+            MongoCondition::Doc(bson::doc! { "b": 2 }),
+        ];
+        let resolved = resolve_conditions(conds.iter()).await.unwrap();
+        assert_eq!(resolved, bson::doc! { "$and": [{ "a": 1 }, { "b": 2 }] });
+    }
+
+    #[tokio::test]
+    async fn test_deferred_resolves_document() {
+        let deferred = DeferredFn::new(move || {
+            Box::pin(async move {
+                let doc = bson::doc! { "status": "active" };
+                Ok(ExpressiveEnum::Scalar(AnyMongoType::untyped(
+                    Bson::Document(doc),
+                )))
+            })
+        });
+        let cond = MongoCondition::Deferred(deferred);
+        let resolved = cond.resolve().await.unwrap();
+        assert_eq!(resolved, bson::doc! { "status": "active" });
+    }
+
+    #[tokio::test]
+    async fn test_nested_and_with_deferred() {
+        let deferred = DeferredFn::new(move || {
+            Box::pin(async move {
+                let doc = bson::doc! { "owner_id": { "$in": ["a", "b"] } };
+                Ok(ExpressiveEnum::Scalar(AnyMongoType::untyped(
+                    Bson::Document(doc),
+                )))
+            })
+        });
+        let cond = MongoCondition::And(vec![
+            bson::doc! { "active": true }.into(),
+            MongoCondition::Deferred(deferred),
+        ]);
+        let resolved = cond.resolve().await.unwrap();
+        assert_eq!(
+            resolved,
+            bson::doc! { "$and": [
+                { "active": true },
+                { "owner_id": { "$in": ["a", "b"] } }
+            ] }
+        );
+    }
+}

--- a/vantage-mongodb/src/lib.rs
+++ b/vantage-mongodb/src/lib.rs
@@ -1,8 +1,15 @@
 //! # Vantage MongoDB Extension
 //!
 //! Persistence backend for MongoDB using the official `mongodb` crate.
-//! Uses `bson::Bson` as the native value type.
+//! Uses `bson::Bson` as the native value type and `bson::Document` as
+//! the condition type — no SQL expressions involved.
 
+pub mod condition;
+pub mod mongodb;
+pub mod select;
 pub mod types;
 
+pub use condition::MongoCondition;
+pub use mongodb::MongoDB;
+pub use select::MongoSelect;
 pub use types::{AnyMongoType, MongoType, MongoTypeVariants};

--- a/vantage-mongodb/src/mongodb/impls/data_source.rs
+++ b/vantage-mongodb/src/mongodb/impls/data_source.rs
@@ -1,0 +1,5 @@
+use vantage_expressions::traits::datasource::DataSource;
+
+use crate::mongodb::MongoDB;
+
+impl DataSource for MongoDB {}

--- a/vantage-mongodb/src/mongodb/impls/expr_data_source.rs
+++ b/vantage-mongodb/src/mongodb/impls/expr_data_source.rs
@@ -1,0 +1,27 @@
+//! Stub ExprDataSource — MongoDB doesn't use Expression-based queries,
+//! but this is needed to satisfy the `column_table_values_expr` bound.
+
+use vantage_expressions::{DeferredFn, ExprDataSource, Expression};
+
+use crate::mongodb::MongoDB;
+use crate::types::AnyMongoType;
+
+impl ExprDataSource<AnyMongoType> for MongoDB {
+    async fn execute(
+        &self,
+        _expr: &Expression<AnyMongoType>,
+    ) -> vantage_core::Result<AnyMongoType> {
+        Err(vantage_core::error!(
+            "MongoDB does not support Expression-based execution"
+        ))
+    }
+
+    fn defer(&self, expr: Expression<AnyMongoType>) -> DeferredFn<AnyMongoType> {
+        let db = self.clone();
+        DeferredFn::from_fn(move || {
+            let db = db.clone();
+            let expr = expr.clone();
+            Box::pin(async move { db.execute(&expr).await })
+        })
+    }
+}

--- a/vantage-mongodb/src/mongodb/impls/mod.rs
+++ b/vantage-mongodb/src/mongodb/impls/mod.rs
@@ -1,0 +1,3 @@
+pub mod data_source;
+pub mod expr_data_source;
+pub mod table_source;

--- a/vantage-mongodb/src/mongodb/impls/table_source.rs
+++ b/vantage-mongodb/src/mongodb/impls/table_source.rs
@@ -1,0 +1,439 @@
+//! TableSource implementation for MongoDB.
+//!
+//! Uses `MongoCondition` as the condition type. Read/aggregate operations
+//! build a `MongoSelect` from table state and use its helper methods
+//! (`build_filter`, `build_find_options`, `as_aggregate_pipeline`).
+//! Write operations use the `mongodb` driver directly.
+
+use async_trait::async_trait;
+use bson::{Bson, doc, oid::ObjectId};
+use futures_util::TryStreamExt;
+use indexmap::IndexMap;
+
+use vantage_core::{Result, error};
+use vantage_expressions::{AssociatedExpression, ExprDataSource, Expression, ExpressiveEnum};
+use vantage_table::column::core::{Column, ColumnType};
+use vantage_table::table::Table;
+use vantage_table::traits::table_source::TableSource;
+use vantage_types::{Entity, Record};
+
+use crate::condition::MongoCondition;
+use crate::mongodb::MongoDB;
+use crate::select::MongoSelect;
+use crate::types::AnyMongoType;
+
+/// Convert a bson::Document into a Record<AnyMongoType>, optionally extracting the _id.
+fn doc_to_record(doc: bson::Document) -> (Option<ObjectId>, Record<AnyMongoType>) {
+    let mut fields = IndexMap::new();
+    let mut oid: Option<ObjectId> = None;
+
+    for (k, v) in doc {
+        if k == "_id"
+            && let Bson::ObjectId(id) = &v
+        {
+            oid = Some(*id);
+        }
+        fields.insert(k, AnyMongoType::untyped(v));
+    }
+
+    (oid, Record::from_indexmap(fields))
+}
+
+/// Build a `MongoSelect` from a `Table`'s current state (conditions, ordering, pagination).
+fn select_from_table<E: Entity<AnyMongoType>>(table: &Table<MongoDB, E>) -> MongoSelect {
+    let mut select = MongoSelect::new();
+    select.collection = Some(table.table_name().to_string());
+
+    for condition in table.conditions() {
+        select.conditions.push(condition.clone());
+    }
+
+    for (cond, direction) in table.orders() {
+        // Order entries are MongoCondition — extract field name, apply direction
+        if let MongoCondition::Doc(doc) = cond
+            && let Some((key, _)) = doc.iter().next()
+        {
+            let dir = match direction {
+                vantage_table::sorting::SortDirection::Ascending => 1,
+                vantage_table::sorting::SortDirection::Descending => -1,
+            };
+            select.sort.push((key.to_string(), dir));
+        }
+    }
+
+    if let Some(pagination) = table.pagination() {
+        select.limit = Some(pagination.limit());
+        select.skip = Some(pagination.skip());
+    }
+
+    select
+}
+
+#[async_trait]
+impl TableSource for MongoDB {
+    type Column<Type>
+        = Column<Type>
+    where
+        Type: ColumnType;
+    type AnyType = AnyMongoType;
+    type Value = AnyMongoType;
+    type Id = ObjectId;
+    type Condition = MongoCondition;
+
+    fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
+        Column::new(name)
+    }
+
+    fn to_any_column<Type: ColumnType>(
+        &self,
+        column: Self::Column<Type>,
+    ) -> Self::Column<Self::AnyType> {
+        Column::from_column(column)
+    }
+
+    fn convert_any_column<Type: ColumnType>(
+        &self,
+        any_column: Self::Column<Self::AnyType>,
+    ) -> Option<Self::Column<Type>> {
+        Some(Column::from_column(any_column))
+    }
+
+    fn expr(
+        &self,
+        template: impl Into<String>,
+        parameters: Vec<ExpressiveEnum<Self::Value>>,
+    ) -> Expression<Self::Value> {
+        Expression::new(template, parameters)
+    }
+
+    fn search_table_expr<E>(
+        &self,
+        _table: &Table<Self, E>,
+        search_value: &str,
+    ) -> Expression<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        // Preview-only expression
+        Expression::new(format!("{{\"$regex\": \"{}\"}}", search_value), vec![])
+    }
+
+    // ── Read ─────────────────────────────────────────────────────────
+
+    async fn list_table_values<E>(
+        &self,
+        table: &Table<Self, E>,
+    ) -> Result<IndexMap<Self::Id, Record<Self::Value>>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let select = select_from_table(table);
+        let filter = select.build_filter().await?;
+        let options = select.build_find_options();
+        let coll = self.doc_collection(table.table_name());
+
+        let cursor = coll
+            .find(filter)
+            .with_options(options)
+            .await
+            .map_err(|e| error!("MongoDB find failed", details = e.to_string()))?;
+
+        let docs: Vec<bson::Document> = cursor
+            .try_collect()
+            .await
+            .map_err(|e| error!("MongoDB cursor failed", details = e.to_string()))?;
+
+        let mut records = IndexMap::new();
+        for d in docs {
+            let (oid, record) = doc_to_record(d);
+            let id = oid.ok_or_else(|| error!("Document missing _id field"))?;
+            records.insert(id, record);
+        }
+
+        Ok(records)
+    }
+
+    async fn get_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let coll = self.doc_collection(table.table_name());
+
+        let d = coll
+            .find_one(doc! { "_id": id })
+            .await
+            .map_err(|e| error!("MongoDB find_one failed", details = e.to_string()))?
+            .ok_or_else(|| error!("Document not found", id = id.to_hex()))?;
+
+        let (_oid, record) = doc_to_record(d);
+        Ok(record)
+    }
+
+    async fn get_table_some_value<E>(
+        &self,
+        table: &Table<Self, E>,
+    ) -> Result<Option<(Self::Id, Record<Self::Value>)>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let select = select_from_table(table);
+        let filter = select.build_filter().await?;
+        let coll = self.doc_collection(table.table_name());
+
+        let d = coll
+            .find_one(filter)
+            .await
+            .map_err(|e| error!("MongoDB find_one failed", details = e.to_string()))?;
+
+        match d {
+            Some(d) => {
+                let (oid, record) = doc_to_record(d);
+                Ok(oid.map(|id| (id, record)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    // ── Aggregates ───────────────────────────────────────────────────
+
+    async fn get_table_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
+    where
+        E: Entity<Self::Value>,
+    {
+        let select = select_from_table(table);
+        let filter = select.build_filter().await?;
+        let coll = self.doc_collection(table.table_name());
+
+        let count = coll
+            .count_documents(filter)
+            .await
+            .map_err(|e| error!("MongoDB count_documents failed", details = e.to_string()))?;
+
+        Ok(count as i64)
+    }
+
+    async fn get_table_sum<E>(
+        &self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        let select = select_from_table(table);
+        let pipeline = select.as_aggregate_pipeline("$sum", column.name()).await?;
+        let coll = self.doc_collection(table.table_name());
+
+        let mut cursor = coll
+            .aggregate(pipeline)
+            .await
+            .map_err(|e| error!("MongoDB aggregate (sum) failed", details = e.to_string()))?;
+
+        if let Some(result) = cursor
+            .try_next()
+            .await
+            .map_err(|e| error!("MongoDB aggregate cursor failed", details = e.to_string()))?
+        {
+            let val = result.get("val").cloned().unwrap_or(Bson::Int64(0));
+            Ok(AnyMongoType::untyped(val))
+        } else {
+            Ok(AnyMongoType::untyped(Bson::Int64(0)))
+        }
+    }
+
+    async fn get_table_max<E>(
+        &self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        let select = select_from_table(table);
+        let pipeline = select.as_aggregate_pipeline("$max", column.name()).await?;
+        let coll = self.doc_collection(table.table_name());
+
+        let mut cursor = coll
+            .aggregate(pipeline)
+            .await
+            .map_err(|e| error!("MongoDB aggregate (max) failed", details = e.to_string()))?;
+
+        if let Some(result) = cursor
+            .try_next()
+            .await
+            .map_err(|e| error!("MongoDB aggregate cursor failed", details = e.to_string()))?
+        {
+            let val = result.get("val").cloned().unwrap_or(Bson::Null);
+            Ok(AnyMongoType::untyped(val))
+        } else {
+            Ok(AnyMongoType::untyped(Bson::Null))
+        }
+    }
+
+    async fn get_table_min<E>(
+        &self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        let select = select_from_table(table);
+        let pipeline = select.as_aggregate_pipeline("$min", column.name()).await?;
+        let coll = self.doc_collection(table.table_name());
+
+        let mut cursor = coll
+            .aggregate(pipeline)
+            .await
+            .map_err(|e| error!("MongoDB aggregate (min) failed", details = e.to_string()))?;
+
+        if let Some(result) = cursor
+            .try_next()
+            .await
+            .map_err(|e| error!("MongoDB aggregate cursor failed", details = e.to_string()))?
+        {
+            let val = result.get("val").cloned().unwrap_or(Bson::Null);
+            Ok(AnyMongoType::untyped(val))
+        } else {
+            Ok(AnyMongoType::untyped(Bson::Null))
+        }
+    }
+
+    // ── Write ────────────────────────────────────────────────────────
+
+    async fn insert_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        record: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let coll = self.doc_collection(table.table_name());
+        let mut doc = bson::Document::new();
+        doc.insert("_id", Bson::ObjectId(*id));
+        for (k, v) in record.iter() {
+            doc.insert(k, v.value().clone());
+        }
+
+        coll.insert_one(doc)
+            .await
+            .map_err(|e| error!("MongoDB insert_one failed", details = e.to_string()))?;
+
+        self.get_table_value(table, id).await
+    }
+
+    async fn replace_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        record: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let coll = self.doc_collection(table.table_name());
+        let filter = doc! { "_id": id };
+        let mut replacement = bson::Document::new();
+        for (k, v) in record.iter() {
+            replacement.insert(k, v.value().clone());
+        }
+
+        coll.replace_one(filter, replacement)
+            .upsert(true)
+            .await
+            .map_err(|e| error!("MongoDB replace_one failed", details = e.to_string()))?;
+
+        self.get_table_value(table, id).await
+    }
+
+    async fn patch_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        partial: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let coll = self.doc_collection(table.table_name());
+        let filter = doc! { "_id": id };
+        let mut set_doc = bson::Document::new();
+        for (k, v) in partial.iter() {
+            set_doc.insert(k, v.value().clone());
+        }
+        let update = doc! { "$set": set_doc };
+
+        coll.update_one(filter, update)
+            .await
+            .map_err(|e| error!("MongoDB update_one failed", details = e.to_string()))?;
+
+        self.get_table_value(table, id).await
+    }
+
+    async fn delete_table_value<E>(&self, table: &Table<Self, E>, id: &Self::Id) -> Result<()>
+    where
+        E: Entity<Self::Value>,
+    {
+        let coll = self.doc_collection(table.table_name());
+        coll.delete_one(doc! { "_id": *id })
+            .await
+            .map_err(|e| error!("MongoDB delete_one failed", details = e.to_string()))?;
+        Ok(())
+    }
+
+    async fn delete_table_all_values<E>(&self, table: &Table<Self, E>) -> Result<()>
+    where
+        E: Entity<Self::Value>,
+    {
+        let select = select_from_table(table);
+        let filter = select.build_filter().await?;
+        let coll = self.doc_collection(table.table_name());
+        coll.delete_many(filter)
+            .await
+            .map_err(|e| error!("MongoDB delete_many failed", details = e.to_string()))?;
+        Ok(())
+    }
+
+    async fn insert_table_return_id_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        record: &Record<Self::Value>,
+    ) -> Result<Self::Id>
+    where
+        E: Entity<Self::Value>,
+    {
+        let coll = self.doc_collection(table.table_name());
+        let mut doc = bson::Document::new();
+        for (k, v) in record.iter() {
+            doc.insert(k, v.value().clone());
+        }
+
+        let result = coll
+            .insert_one(doc)
+            .await
+            .map_err(|e| error!("MongoDB insert_one failed", details = e.to_string()))?;
+
+        result
+            .inserted_id
+            .as_object_id()
+            .ok_or_else(|| error!("MongoDB insert did not return ObjectId"))
+    }
+
+    fn column_table_values_expr<'a, E, Type: ColumnType>(
+        &'a self,
+        _table: &Table<Self, E>,
+        _column: &Self::Column<Type>,
+    ) -> AssociatedExpression<'a, Self, Self::Value, Vec<Type>>
+    where
+        E: Entity<Self::Value> + 'static,
+        Self: ExprDataSource<Self::Value> + Sized,
+    {
+        todo!("column_table_values_expr not yet implemented for MongoDB")
+    }
+}

--- a/vantage-mongodb/src/mongodb/mod.rs
+++ b/vantage-mongodb/src/mongodb/mod.rs
@@ -1,0 +1,48 @@
+//! MongoDB data source for Vantage.
+//!
+//! Wraps the official `mongodb` crate. Uses `bson::Document` as the native
+//! condition type — no SQL expressions involved.
+
+pub mod impls;
+
+use mongodb::Client;
+
+/// MongoDB data source. Cloneable (Arc-wrapped client).
+#[derive(Clone, Debug)]
+pub struct MongoDB {
+    client: Client,
+    database: String,
+}
+
+impl MongoDB {
+    /// Create from an existing `mongodb::Client` and database name.
+    pub fn new(client: Client, database: impl Into<String>) -> Self {
+        Self {
+            client,
+            database: database.into(),
+        }
+    }
+
+    /// Connect using a MongoDB connection string.
+    pub async fn connect(uri: &str, database: impl Into<String>) -> vantage_core::Result<Self> {
+        let client = Client::with_uri_str(uri).await.map_err(|e| {
+            vantage_core::error!("Failed to connect to MongoDB", details = e.to_string())
+        })?;
+        Ok(Self::new(client, database))
+    }
+
+    /// Get the underlying `mongodb::Database` handle.
+    pub fn database(&self) -> mongodb::Database {
+        self.client.database(&self.database)
+    }
+
+    /// Get a collection handle.
+    pub fn collection<T: Send + Sync>(&self, name: &str) -> mongodb::Collection<T> {
+        self.database().collection(name)
+    }
+
+    /// Get a collection handle for raw BSON documents.
+    pub fn doc_collection(&self, name: &str) -> mongodb::Collection<bson::Document> {
+        self.database().collection(name)
+    }
+}

--- a/vantage-mongodb/src/select/builder.rs
+++ b/vantage-mongodb/src/select/builder.rs
@@ -1,0 +1,114 @@
+//! Builder methods for MongoSelect — produce native MongoDB types
+//! (filter Document, projection Document, sort Document, FindOptions).
+
+use bson::Document;
+
+use super::MongoSelect;
+
+impl MongoSelect {
+    /// Build the filter `Document` by resolving all conditions.
+    pub async fn build_filter(&self) -> vantage_core::Result<Document> {
+        crate::condition::resolve_conditions(self.conditions.iter()).await
+    }
+
+    /// Build the projection `Document`. Returns `None` if all fields requested.
+    pub fn build_projection(&self) -> Option<Document> {
+        if self.fields.is_empty() {
+            return None;
+        }
+        let mut proj = Document::new();
+        for f in &self.fields {
+            proj.insert(f.as_str(), 1);
+        }
+        Some(proj)
+    }
+
+    /// Build the sort `Document`. Returns `None` if no ordering.
+    pub fn build_sort(&self) -> Option<Document> {
+        if self.sort.is_empty() {
+            return None;
+        }
+        let mut doc = Document::new();
+        for (field, dir) in &self.sort {
+            doc.insert(field.as_str(), *dir);
+        }
+        Some(doc)
+    }
+
+    /// Build `mongodb::options::FindOptions` from the current state.
+    pub fn build_find_options(&self) -> mongodb::options::FindOptions {
+        let mut opts = mongodb::options::FindOptions::default();
+        opts.projection = self.build_projection();
+        opts.sort = self.build_sort();
+        opts.limit = self.limit;
+        opts.skip = self.skip.map(|s| s as u64);
+        opts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bson::doc;
+
+    use super::*;
+    use vantage_expressions::Selectable;
+
+    #[test]
+    fn test_build_projection() {
+        let s = MongoSelect::new().with_field("name").with_field("price");
+        let proj = s.build_projection().unwrap();
+        assert_eq!(proj, doc! { "name": 1, "price": 1 });
+    }
+
+    #[test]
+    fn test_build_projection_empty() {
+        let s = MongoSelect::new();
+        assert!(s.build_projection().is_none());
+    }
+
+    #[test]
+    fn test_build_sort() {
+        let mut s = MongoSelect::new();
+        s.sort.push(("price".into(), 1));
+        s.sort.push(("name".into(), -1));
+        let sort = s.build_sort().unwrap();
+        assert_eq!(sort, doc! { "price": 1, "name": -1 });
+    }
+
+    #[test]
+    fn test_build_find_options() {
+        let s = MongoSelect::new()
+            .with_field("name")
+            .with_limit(Some(5), Some(10));
+        let opts = s.build_find_options();
+        assert!(opts.projection.is_some());
+        assert_eq!(opts.limit, Some(5));
+        assert_eq!(opts.skip, Some(10));
+    }
+
+    #[tokio::test]
+    async fn test_build_filter_empty() {
+        let s = MongoSelect::new();
+        let filter = s.build_filter().await.unwrap();
+        assert_eq!(filter, doc! {});
+    }
+
+    #[tokio::test]
+    async fn test_build_filter_single() {
+        let s = MongoSelect::new().with_condition(doc! { "active": true });
+        let filter = s.build_filter().await.unwrap();
+        assert_eq!(filter, doc! { "active": true });
+    }
+
+    #[tokio::test]
+    async fn test_build_filter_multiple() {
+        let s = MongoSelect::new()
+            .with_condition(doc! { "active": true })
+            .with_condition(doc! { "price": { "$gt": 100 } });
+        let filter = s.build_filter().await.unwrap();
+        assert_eq!(
+            filter,
+            doc! { "$and": [{ "active": true }, { "price": { "$gt": 100 } }] }
+        );
+    }
+}

--- a/vantage-mongodb/src/select/impls/mod.rs
+++ b/vantage-mongodb/src/select/impls/mod.rs
@@ -1,0 +1,1 @@
+pub mod selectable;

--- a/vantage-mongodb/src/select/impls/selectable.rs
+++ b/vantage-mongodb/src/select/impls/selectable.rs
@@ -1,0 +1,138 @@
+//! Selectable<AnyMongoType, MongoCondition> implementation for MongoSelect.
+
+use vantage_expressions::traits::selectable::SourceRef;
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, Order, Selectable};
+
+use crate::condition::MongoCondition;
+use crate::select::MongoSelect;
+use crate::types::AnyMongoType;
+
+impl Selectable<AnyMongoType, MongoCondition> for MongoSelect {
+    fn add_source(&mut self, source: impl Into<SourceRef<AnyMongoType>>, _alias: Option<String>) {
+        let source_ref = source.into().into_expressive_enum();
+        if let ExpressiveEnum::Scalar(val) = source_ref
+            && let Some(name) = val.try_get::<String>()
+        {
+            self.collection = Some(name);
+        }
+    }
+
+    fn add_field(&mut self, field: impl Into<String>) {
+        self.fields.push(field.into());
+    }
+
+    fn add_expression(
+        &mut self,
+        _expression: impl Expressive<AnyMongoType>,
+        alias: Option<String>,
+    ) {
+        // MongoDB projections don't support arbitrary expressions in find().
+        // If an alias is given, treat it as a renamed field.
+        if let Some(alias) = alias {
+            self.fields.push(alias);
+        }
+    }
+
+    fn add_where_condition(&mut self, condition: impl Into<MongoCondition>) {
+        self.conditions.push(condition.into());
+    }
+
+    fn set_distinct(&mut self, distinct: bool) {
+        self.distinct = distinct;
+    }
+
+    fn add_order_by(&mut self, order: impl Into<MongoCondition>, direction: Order) {
+        // Convention: a MongoCondition::Doc with a single key → use that key.
+        // The direction from the Order param overrides whatever value is in the doc.
+        let cond = order.into();
+        if let MongoCondition::Doc(doc) = &cond
+            && let Some((key, _)) = doc.iter().next()
+        {
+            let dir = if direction.ascending { 1 } else { -1 };
+            self.sort.push((key.to_string(), dir));
+        }
+    }
+
+    fn add_group_by(&mut self, expression: impl Expressive<AnyMongoType>) {
+        let preview = expression.preview();
+        self.group_by.push(preview);
+    }
+
+    fn set_limit(&mut self, limit: Option<i64>, skip: Option<i64>) {
+        self.limit = limit;
+        self.skip = skip;
+    }
+
+    fn clear_fields(&mut self) {
+        self.fields.clear();
+    }
+
+    fn clear_where_conditions(&mut self) {
+        self.conditions.clear();
+    }
+
+    fn clear_order_by(&mut self) {
+        self.sort.clear();
+    }
+
+    fn clear_group_by(&mut self) {
+        self.group_by.clear();
+    }
+
+    fn has_fields(&self) -> bool {
+        !self.fields.is_empty()
+    }
+
+    fn has_where_conditions(&self) -> bool {
+        !self.conditions.is_empty()
+    }
+
+    fn has_order_by(&self) -> bool {
+        !self.sort.is_empty()
+    }
+
+    fn has_group_by(&self) -> bool {
+        !self.group_by.is_empty()
+    }
+
+    fn is_distinct(&self) -> bool {
+        self.distinct
+    }
+
+    fn get_limit(&self) -> Option<i64> {
+        self.limit
+    }
+
+    fn get_skip(&self) -> Option<i64> {
+        self.skip
+    }
+
+    fn as_count(&self) -> Expression<AnyMongoType> {
+        let coll = self.collection.as_deref().unwrap_or("?");
+        Expression::new(format!("db.{}.countDocuments()", coll), vec![])
+    }
+
+    fn as_sum(&self, column: impl Expressive<AnyMongoType>) -> Expression<AnyMongoType> {
+        let coll = self.collection.as_deref().unwrap_or("?");
+        Expression::new(
+            format!("db.{}.aggregate($sum: {})", coll, column.preview()),
+            vec![],
+        )
+    }
+
+    fn as_max(&self, column: impl Expressive<AnyMongoType>) -> Expression<AnyMongoType> {
+        let coll = self.collection.as_deref().unwrap_or("?");
+        Expression::new(
+            format!("db.{}.aggregate($max: {})", coll, column.preview()),
+            vec![],
+        )
+    }
+
+    fn as_min(&self, column: impl Expressive<AnyMongoType>) -> Expression<AnyMongoType> {
+        let coll = self.collection.as_deref().unwrap_or("?");
+        Expression::new(
+            format!("db.{}.aggregate($min: {})", coll, column.preview()),
+            vec![],
+        )
+    }
+}

--- a/vantage-mongodb/src/select/mod.rs
+++ b/vantage-mongodb/src/select/mod.rs
@@ -1,0 +1,42 @@
+//! MongoDB SELECT (find) query builder.
+//!
+//! Accumulates collection name, field projection, filter conditions, sort,
+//! limit/skip — all as native MongoDB types. Implements
+//! `Selectable<AnyMongoType, MongoCondition>` so `table.select()` works.
+
+pub mod builder;
+pub mod impls;
+pub mod pipeline;
+pub mod render;
+
+use crate::condition::MongoCondition;
+
+/// MongoDB query builder — the equivalent of `SqliteSelect` / `SurrealSelect`.
+///
+/// Instead of rendering SQL, it accumulates native `bson::Document` parts
+/// that map directly onto the `mongodb` driver's find/aggregate API.
+#[derive(Debug, Clone, Default)]
+pub struct MongoSelect {
+    /// Collection name (equivalent to FROM).
+    pub collection: Option<String>,
+    /// Field names to include in projection. Empty = all fields.
+    pub fields: Vec<String>,
+    /// Filter conditions (combined with $and at resolve time).
+    pub conditions: Vec<MongoCondition>,
+    /// Sort specification: field name → 1 (asc) or -1 (desc).
+    pub sort: Vec<(String, i32)>,
+    /// GROUP BY fields (for aggregation pipeline).
+    pub group_by: Vec<String>,
+    /// Whether to return distinct results.
+    pub distinct: bool,
+    /// Max number of documents to return.
+    pub limit: Option<i64>,
+    /// Number of documents to skip.
+    pub skip: Option<i64>,
+}
+
+impl MongoSelect {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/vantage-mongodb/src/select/pipeline.rs
+++ b/vantage-mongodb/src/select/pipeline.rs
@@ -1,0 +1,83 @@
+//! Aggregation pipeline builders for MongoSelect.
+
+use bson::{Bson, Document, doc};
+
+use super::MongoSelect;
+
+impl MongoSelect {
+    /// Build a count aggregation pipeline: [$match, $count].
+    pub async fn as_count_pipeline(&self) -> vantage_core::Result<Vec<Document>> {
+        let filter = self.build_filter().await?;
+        let mut pipeline = Vec::new();
+        if !filter.is_empty() {
+            pipeline.push(doc! { "$match": filter });
+        }
+        pipeline.push(doc! { "$count": "count" });
+        Ok(pipeline)
+    }
+
+    /// Build a $group aggregation pipeline with an accumulator.
+    /// `func` is e.g. "$sum", "$max", "$min". `field` is the column name.
+    pub async fn as_aggregate_pipeline(
+        &self,
+        func: &str,
+        field: &str,
+    ) -> vantage_core::Result<Vec<Document>> {
+        let filter = self.build_filter().await?;
+        let field_ref = format!("${}", field);
+        let mut pipeline = Vec::new();
+        if !filter.is_empty() {
+            pipeline.push(doc! { "$match": filter });
+        }
+        pipeline.push(doc! { "$group": { "_id": Bson::Null, "val": { func: field_ref } } });
+        Ok(pipeline)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bson::doc;
+    use vantage_expressions::Selectable;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_count_pipeline_empty() {
+        let s = MongoSelect::new();
+        let pipeline = s.as_count_pipeline().await.unwrap();
+        assert_eq!(pipeline.len(), 1);
+        assert_eq!(pipeline[0], doc! { "$count": "count" });
+    }
+
+    #[tokio::test]
+    async fn test_count_pipeline_with_filter() {
+        let s = MongoSelect::new().with_condition(doc! { "active": true });
+        let pipeline = s.as_count_pipeline().await.unwrap();
+        assert_eq!(pipeline.len(), 2);
+        assert_eq!(pipeline[0], doc! { "$match": { "active": true } });
+        assert_eq!(pipeline[1], doc! { "$count": "count" });
+    }
+
+    #[tokio::test]
+    async fn test_aggregate_pipeline_sum() {
+        let s = MongoSelect::new();
+        let pipeline = s.as_aggregate_pipeline("$sum", "price").await.unwrap();
+        assert_eq!(pipeline.len(), 1);
+        assert_eq!(
+            pipeline[0],
+            doc! { "$group": { "_id": Bson::Null, "val": { "$sum": "$price" } } }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_aggregate_pipeline_max_with_filter() {
+        let s = MongoSelect::new().with_condition(doc! { "is_deleted": false });
+        let pipeline = s.as_aggregate_pipeline("$max", "price").await.unwrap();
+        assert_eq!(pipeline.len(), 2);
+        assert_eq!(pipeline[0], doc! { "$match": { "is_deleted": false } });
+        assert_eq!(
+            pipeline[1],
+            doc! { "$group": { "_id": Bson::Null, "val": { "$max": "$price" } } }
+        );
+    }
+}

--- a/vantage-mongodb/src/select/render.rs
+++ b/vantage-mongodb/src/select/render.rs
@@ -1,0 +1,85 @@
+//! Human-readable preview rendering for MongoSelect.
+
+use super::MongoSelect;
+
+impl MongoSelect {
+    /// Render a human-readable preview string (for debug/logging).
+    pub fn preview(&self) -> String {
+        let coll = self.collection.as_deref().unwrap_or("?");
+
+        let filter_str = if self.conditions.is_empty() {
+            "{}".to_string()
+        } else {
+            format!("<{} conditions>", self.conditions.len())
+        };
+
+        let mut parts = vec![format!("db.{}.find({})", coll, filter_str)];
+
+        if let Some(proj) = self.build_projection() {
+            parts.push(format!(".projection({})", proj));
+        }
+        if let Some(sort) = self.build_sort() {
+            parts.push(format!(".sort({})", sort));
+        }
+        if let Some(skip) = self.skip {
+            parts.push(format!(".skip({})", skip));
+        }
+        if let Some(limit) = self.limit {
+            parts.push(format!(".limit({})", limit));
+        }
+
+        parts.join("")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bson::doc;
+    use vantage_expressions::Selectable;
+
+    use super::*;
+
+    #[test]
+    fn test_empty_preview() {
+        let s = MongoSelect::new();
+        assert_eq!(s.preview(), "db.?.find({})");
+    }
+
+    #[test]
+    fn test_preview_with_source_and_fields() {
+        let s = MongoSelect::new()
+            .with_source("product")
+            .with_field("name")
+            .with_field("price");
+        let p = s.preview();
+        assert!(p.starts_with("db.product.find({})"));
+        assert!(p.contains("projection"));
+    }
+
+    #[test]
+    fn test_preview_with_conditions() {
+        let s = MongoSelect::new()
+            .with_source("product")
+            .with_condition(doc! { "price": { "$gt": 100 } });
+        assert!(s.preview().contains("<1 conditions>"));
+    }
+
+    #[test]
+    fn test_preview_with_limit_skip() {
+        let s = MongoSelect::new()
+            .with_source("x")
+            .with_limit(Some(10), Some(20));
+        let p = s.preview();
+        assert!(p.contains(".skip(20)"));
+        assert!(p.contains(".limit(10)"));
+    }
+
+    #[test]
+    fn test_preview_with_sort() {
+        use vantage_expressions::Order;
+        let s = MongoSelect::new()
+            .with_source("x")
+            .with_order(doc! { "price": 1 }, Order::Asc);
+        assert!(s.preview().contains(".sort("));
+    }
+}

--- a/vantage-mongodb/src/types/mod.rs
+++ b/vantage-mongodb/src/types/mod.rs
@@ -4,7 +4,7 @@
 //! MongoDB's BSON type set.
 
 use vantage_core::VantageError;
-use vantage_types::{vantage_type_system, Record};
+use vantage_types::{Record, vantage_type_system};
 
 vantage_type_system! {
     type_trait: MongoType,
@@ -182,9 +182,9 @@ mod tests {
 
     #[test]
     fn test_f64_round_trip() {
-        let val = AnyMongoType::new(3.14f64);
+        let val = AnyMongoType::new(2.72f64);
         assert_eq!(val.type_variant(), Some(MongoTypeVariants::Double));
-        assert_eq!(val.try_get::<f64>(), Some(3.14));
+        assert_eq!(val.try_get::<f64>(), Some(2.72));
     }
 
     #[test]

--- a/vantage-mongodb/tests/1_table_source.rs
+++ b/vantage-mongodb/tests/1_table_source.rs
@@ -1,0 +1,374 @@
+//! Integration tests for MongoDB TableSource.
+//!
+//! Requires a running MongoDB instance. Set MONGODB_URL env var or defaults
+//! to mongodb://localhost:27017. Uses a randomised database name so tests
+//! don't collide.
+
+use bson::{doc, oid::ObjectId};
+use vantage_dataset::prelude::*;
+use vantage_mongodb::{AnyMongoType, MongoDB};
+use vantage_table::table::Table;
+use vantage_table::traits::table_like::TableLike;
+use vantage_table::traits::table_source::TableSource;
+use vantage_types::{EmptyEntity, Record};
+
+fn mongo_url() -> String {
+    std::env::var("MONGODB_URL").unwrap_or_else(|_| "mongodb://localhost:27017".into())
+}
+
+async fn setup() -> (MongoDB, String) {
+    let db_name = format!("vantage_test_{}", ObjectId::new().to_hex());
+    let db = MongoDB::connect(&mongo_url(), &db_name)
+        .await
+        .expect("Failed to connect to MongoDB");
+    (db, db_name)
+}
+
+async fn teardown(db: &MongoDB, db_name: &str) {
+    db.database()
+        .drop()
+        .await
+        .unwrap_or_else(|e| eprintln!("Failed to drop test db {}: {}", db_name, e));
+}
+
+fn product_table(db: MongoDB) -> Table<MongoDB, EmptyEntity> {
+    Table::new("product", db)
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price")
+        .with_column_of::<i64>("calories")
+        .with_column_of::<bool>("is_deleted")
+}
+
+fn record(fields: &[(&str, AnyMongoType)]) -> Record<AnyMongoType> {
+    fields
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect()
+}
+
+// ── Read operations ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_list_empty() {
+    let (db, db_name) = setup().await;
+    let table = product_table(db.clone());
+
+    let values = table.list_values().await.unwrap();
+    assert_eq!(values.len(), 0);
+
+    teardown(&db, &db_name).await;
+}
+
+#[tokio::test]
+async fn test_insert_and_list() {
+    let (db, db_name) = setup().await;
+    let table = product_table(db.clone());
+
+    let id = ObjectId::new();
+    let rec = record(&[
+        ("name", AnyMongoType::new("Cupcake".to_string())),
+        ("price", AnyMongoType::new(250i64)),
+        ("calories", AnyMongoType::new(300i64)),
+        ("is_deleted", AnyMongoType::new(false)),
+    ]);
+
+    table.insert_value(&id, &rec).await.unwrap();
+
+    let values = table.list_values().await.unwrap();
+    assert_eq!(values.len(), 1);
+    assert!(values.contains_key(&id));
+
+    let fetched = &values[&id];
+    assert_eq!(fetched["name"].try_get::<String>(), Some("Cupcake".into()));
+    assert_eq!(fetched["price"].try_get::<i64>(), Some(250));
+
+    teardown(&db, &db_name).await;
+}
+
+#[tokio::test]
+async fn test_get_value_by_id() {
+    let (db, db_name) = setup().await;
+    let table = product_table(db.clone());
+
+    let id = ObjectId::new();
+    let rec = record(&[
+        ("name", AnyMongoType::new("Tart".to_string())),
+        ("price", AnyMongoType::new(180i64)),
+        ("calories", AnyMongoType::new(200i64)),
+        ("is_deleted", AnyMongoType::new(false)),
+    ]);
+    table.insert_value(&id, &rec).await.unwrap();
+
+    let fetched = table.get_value(&id).await.unwrap();
+    assert_eq!(fetched["name"].try_get::<String>(), Some("Tart".into()));
+
+    teardown(&db, &db_name).await;
+}
+
+#[tokio::test]
+async fn test_get_some_value() {
+    let (db, db_name) = setup().await;
+    let table = product_table(db.clone());
+
+    // Empty table → None
+    assert!(table.get_some_value().await.unwrap().is_none());
+
+    let id = ObjectId::new();
+    let rec = record(&[("name", AnyMongoType::new("Pie".to_string()))]);
+    table.insert_value(&id, &rec).await.unwrap();
+
+    let (got_id, got_rec) = table.get_some_value().await.unwrap().unwrap();
+    assert_eq!(got_id, id);
+    assert_eq!(got_rec["name"].try_get::<String>(), Some("Pie".into()));
+
+    teardown(&db, &db_name).await;
+}
+
+// ── Count ────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_count() {
+    let (db, db_name) = setup().await;
+    let table = product_table(db.clone());
+
+    assert_eq!(table.get_count().await.unwrap(), 0);
+
+    for i in 0..3 {
+        let rec = record(&[("name", AnyMongoType::new(format!("Item {}", i)))]);
+        table.insert_value(&ObjectId::new(), &rec).await.unwrap();
+    }
+
+    assert_eq!(table.get_count().await.unwrap(), 3);
+
+    teardown(&db, &db_name).await;
+}
+
+// ── Aggregates ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_sum_max_min() {
+    let (db, db_name) = setup().await;
+    let table = product_table(db.clone());
+
+    let prices = [100i64, 250, 400];
+    for p in prices {
+        let rec = record(&[
+            ("name", AnyMongoType::new(format!("P{}", p))),
+            ("price", AnyMongoType::new(p)),
+        ]);
+        table.insert_value(&ObjectId::new(), &rec).await.unwrap();
+    }
+
+    let price_col = db.to_any_column(db.create_column::<i64>("price"));
+
+    let sum = db.get_table_sum(&table, &price_col).await.unwrap();
+    assert_eq!(sum.try_get::<i64>(), Some(750));
+
+    let max = db.get_table_max(&table, &price_col).await.unwrap();
+    assert_eq!(max.try_get::<i64>(), Some(400));
+
+    let min = db.get_table_min(&table, &price_col).await.unwrap();
+    assert_eq!(min.try_get::<i64>(), Some(100));
+
+    teardown(&db, &db_name).await;
+}
+
+// ── Write operations ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_replace() {
+    let (db, db_name) = setup().await;
+    let table = product_table(db.clone());
+
+    let id = ObjectId::new();
+    let rec = record(&[
+        ("name", AnyMongoType::new("Old".to_string())),
+        ("price", AnyMongoType::new(10i64)),
+    ]);
+    table.insert_value(&id, &rec).await.unwrap();
+
+    let replacement = record(&[
+        ("name", AnyMongoType::new("New".to_string())),
+        ("price", AnyMongoType::new(99i64)),
+    ]);
+    table.replace_value(&id, &replacement).await.unwrap();
+
+    let fetched = table.get_value(&id).await.unwrap();
+    assert_eq!(fetched["name"].try_get::<String>(), Some("New".into()));
+    assert_eq!(fetched["price"].try_get::<i64>(), Some(99));
+
+    teardown(&db, &db_name).await;
+}
+
+#[tokio::test]
+async fn test_patch() {
+    let (db, db_name) = setup().await;
+    let table = product_table(db.clone());
+
+    let id = ObjectId::new();
+    let rec = record(&[
+        ("name", AnyMongoType::new("Original".to_string())),
+        ("price", AnyMongoType::new(50i64)),
+        ("calories", AnyMongoType::new(200i64)),
+    ]);
+    table.insert_value(&id, &rec).await.unwrap();
+
+    // Patch only the price — name and calories should be untouched
+    let patch = record(&[("price", AnyMongoType::new(75i64))]);
+    table.patch_value(&id, &patch).await.unwrap();
+
+    let fetched = table.get_value(&id).await.unwrap();
+    assert_eq!(fetched["name"].try_get::<String>(), Some("Original".into()));
+    assert_eq!(fetched["price"].try_get::<i64>(), Some(75));
+    assert_eq!(fetched["calories"].try_get::<i64>(), Some(200));
+
+    teardown(&db, &db_name).await;
+}
+
+#[tokio::test]
+async fn test_delete() {
+    let (db, db_name) = setup().await;
+    let table = product_table(db.clone());
+
+    let id = ObjectId::new();
+    let rec = record(&[("name", AnyMongoType::new("Gone".to_string()))]);
+    table.insert_value(&id, &rec).await.unwrap();
+    assert_eq!(table.get_count().await.unwrap(), 1);
+
+    WritableValueSet::delete(&table, &id).await.unwrap();
+    assert_eq!(table.get_count().await.unwrap(), 0);
+
+    teardown(&db, &db_name).await;
+}
+
+#[tokio::test]
+async fn test_delete_all() {
+    let (db, db_name) = setup().await;
+    let table = product_table(db.clone());
+
+    for i in 0..4 {
+        let rec = record(&[("name", AnyMongoType::new(format!("X{}", i)))]);
+        table.insert_value(&ObjectId::new(), &rec).await.unwrap();
+    }
+    assert_eq!(table.get_count().await.unwrap(), 4);
+
+    WritableValueSet::delete_all(&table).await.unwrap();
+    assert_eq!(table.get_count().await.unwrap(), 0);
+
+    teardown(&db, &db_name).await;
+}
+
+#[tokio::test]
+async fn test_insert_return_id() {
+    let (db, db_name) = setup().await;
+    let table = product_table(db.clone());
+
+    let rec = record(&[
+        ("name", AnyMongoType::new("Auto".to_string())),
+        ("price", AnyMongoType::new(42i64)),
+    ]);
+    let id = table.insert_return_id_value(&rec).await.unwrap();
+
+    let fetched = table.get_value(&id).await.unwrap();
+    assert_eq!(fetched["name"].try_get::<String>(), Some("Auto".into()));
+
+    teardown(&db, &db_name).await;
+}
+
+// ── Conditions (native bson::Document) ───────────────────────────────
+
+#[tokio::test]
+async fn test_condition_filter() {
+    let (db, db_name) = setup().await;
+    let mut table = product_table(db.clone());
+
+    // Insert mix of deleted / not deleted
+    for (name, deleted) in [("A", false), ("B", true), ("C", false)] {
+        let rec = record(&[
+            ("name", AnyMongoType::new(name.to_string())),
+            ("is_deleted", AnyMongoType::new(deleted)),
+        ]);
+        table.insert_value(&ObjectId::new(), &rec).await.unwrap();
+    }
+
+    // Add native MongoDB condition
+    table.add_condition(doc! { "is_deleted": false });
+
+    assert_eq!(table.get_count().await.unwrap(), 2);
+
+    let values = table.list_values().await.unwrap();
+    assert_eq!(values.len(), 2);
+    let names: Vec<String> = values
+        .values()
+        .filter_map(|r| r["name"].try_get::<String>())
+        .collect();
+    assert!(names.contains(&"A".to_string()));
+    assert!(names.contains(&"C".to_string()));
+
+    teardown(&db, &db_name).await;
+}
+
+#[tokio::test]
+async fn test_condition_gt() {
+    let (db, db_name) = setup().await;
+    let mut table = product_table(db.clone());
+
+    for (name, price) in [("Cheap", 50i64), ("Mid", 150), ("Expensive", 300)] {
+        let rec = record(&[
+            ("name", AnyMongoType::new(name.to_string())),
+            ("price", AnyMongoType::new(price)),
+        ]);
+        table.insert_value(&ObjectId::new(), &rec).await.unwrap();
+    }
+
+    table.add_condition(doc! { "price": { "$gt": 100 } });
+
+    assert_eq!(table.get_count().await.unwrap(), 2);
+
+    let values = table.list_values().await.unwrap();
+    let names: Vec<String> = values
+        .values()
+        .filter_map(|r| r["name"].try_get::<String>())
+        .collect();
+    assert!(names.contains(&"Mid".to_string()));
+    assert!(names.contains(&"Expensive".to_string()));
+    assert!(!names.contains(&"Cheap".to_string()));
+
+    teardown(&db, &db_name).await;
+}
+
+#[tokio::test]
+async fn test_multiple_conditions() {
+    let (db, db_name) = setup().await;
+    let mut table = product_table(db.clone());
+
+    for (name, price, deleted) in [
+        ("A", 50i64, false),
+        ("B", 200, false),
+        ("C", 300, true),
+        ("D", 400, false),
+    ] {
+        let rec = record(&[
+            ("name", AnyMongoType::new(name.to_string())),
+            ("price", AnyMongoType::new(price)),
+            ("is_deleted", AnyMongoType::new(deleted)),
+        ]);
+        table.insert_value(&ObjectId::new(), &rec).await.unwrap();
+    }
+
+    // price > 100 AND not deleted
+    table.add_condition(doc! { "price": { "$gt": 100 } });
+    table.add_condition(doc! { "is_deleted": false });
+
+    assert_eq!(table.get_count().await.unwrap(), 2);
+
+    let values = table.list_values().await.unwrap();
+    let names: Vec<String> = values
+        .values()
+        .filter_map(|r| r["name"].try_get::<String>())
+        .collect();
+    assert!(names.contains(&"B".to_string()));
+    assert!(names.contains(&"D".to_string()));
+
+    teardown(&db, &db_name).await;
+}

--- a/vantage-mongodb/tests/1_types_record.rs
+++ b/vantage-mongodb/tests/1_types_record.rs
@@ -1,0 +1,224 @@
+//! Test 1b: Record<AnyMongoType> conversions — typed (write path) and
+//! untyped (read path) round-trips, error cases.
+
+use bson::Bson;
+use vantage_mongodb::AnyMongoType;
+use vantage_types::Record;
+
+// ── Typed records (write path) ─────────────────────────────────────────────
+// Values created with AnyMongoType::new() carry variant tags.
+
+#[test]
+fn test_typed_record_creation() {
+    let mut record: Record<AnyMongoType> = Record::new();
+    record.insert("name".into(), AnyMongoType::new("Cupcake".to_string()));
+    record.insert("price".into(), AnyMongoType::new(120i64));
+    record.insert("is_deleted".into(), AnyMongoType::new(false));
+
+    assert_eq!(
+        record["name"].try_get::<String>(),
+        Some("Cupcake".to_string())
+    );
+    assert_eq!(record["price"].try_get::<i64>(), Some(120));
+    assert_eq!(record["is_deleted"].try_get::<bool>(), Some(false));
+
+    // Type markers enforce boundaries — wrong type → None
+    assert_eq!(record["name"].try_get::<i64>(), None);
+    assert_eq!(record["price"].try_get::<String>(), None);
+}
+
+#[test]
+fn test_typed_record_with_option() {
+    let mut record: Record<AnyMongoType> = Record::new();
+    record.insert(
+        "nickname".into(),
+        AnyMongoType::new(Some("Ali".to_string())),
+    );
+    record.insert("note".into(), AnyMongoType::new(None::<String>));
+
+    assert_eq!(
+        record["nickname"].try_get::<Option<String>>(),
+        Some(Some("Ali".to_string()))
+    );
+    assert_eq!(record["note"].try_get::<Option<String>>(), Some(None));
+}
+
+#[test]
+fn test_typed_record_i32_vs_i64() {
+    let mut record: Record<AnyMongoType> = Record::new();
+    record.insert("small".into(), AnyMongoType::new(42i32));
+    record.insert("big".into(), AnyMongoType::new(42i64));
+
+    // i32 → Int32, i64 → Int64: different variants
+    assert_eq!(record["small"].try_get::<i32>(), Some(42));
+    assert_eq!(record["big"].try_get::<i64>(), Some(42));
+
+    // Cross-variant blocked
+    assert_eq!(record["small"].try_get::<i64>(), None); // Int32 ≠ Int64
+    assert_eq!(record["big"].try_get::<i32>(), None); // Int64 ≠ Int32
+}
+
+// ── Untyped records (read path) ────────────────────────────────────────────
+// Values created with AnyMongoType::untyped() have type_variant: None.
+// try_get is permissive — it attempts conversion without variant check.
+
+#[test]
+fn test_untyped_record_creation() {
+    let mut record: Record<AnyMongoType> = Record::new();
+    record.insert(
+        "name".into(),
+        AnyMongoType::untyped(Bson::String("Cupcake".into())),
+    );
+    record.insert("price".into(), AnyMongoType::untyped(Bson::Int64(120)));
+    record.insert("active".into(), AnyMongoType::untyped(Bson::Boolean(true)));
+
+    assert_eq!(
+        record["name"].try_get::<String>(),
+        Some("Cupcake".to_string())
+    );
+    assert_eq!(record["price"].try_get::<i64>(), Some(120));
+    assert_eq!(record["active"].try_get::<bool>(), Some(true));
+
+    // Still fails when underlying value can't convert
+    assert_eq!(record["name"].try_get::<i64>(), None);
+    assert_eq!(record["price"].try_get::<String>(), None);
+}
+
+#[test]
+fn test_untyped_null() {
+    let mut record: Record<AnyMongoType> = Record::new();
+    record.insert("note".into(), AnyMongoType::untyped(Bson::Null));
+
+    assert_eq!(record["note"].try_get::<Option<String>>(), Some(None));
+    assert_eq!(record["note"].try_get::<Option<i64>>(), Some(None));
+}
+
+#[test]
+fn test_untyped_int64_as_i32_permissive() {
+    // Untyped: no variant check, Bson::Int64(42) can convert to i32 via from_bson
+    let val = AnyMongoType::untyped(Bson::Int64(42));
+    assert_eq!(val.try_get::<i64>(), Some(42));
+    assert_eq!(val.try_get::<i32>(), Some(42)); // permissive — from_bson accepts Int64 → i32
+}
+
+#[test]
+fn test_untyped_int32_as_i64_permissive() {
+    let val = AnyMongoType::untyped(Bson::Int32(42));
+    assert_eq!(val.try_get::<i32>(), Some(42));
+    assert_eq!(val.try_get::<i64>(), Some(42)); // from_bson accepts Int32 → i64
+}
+
+#[test]
+fn test_untyped_int_as_f64_permissive() {
+    // Bson::Int64(42) can convert to f64 via from_bson
+    let val = AnyMongoType::untyped(Bson::Int64(42));
+    assert_eq!(val.try_get::<f64>(), Some(42.0));
+}
+
+// ── Typed vs untyped comparison ────────────────────────────────────────────
+
+#[test]
+fn test_typed_blocks_cross_variant() {
+    let typed = AnyMongoType::new(42i64);
+    assert_eq!(typed.try_get::<i64>(), Some(42));
+    assert_eq!(typed.try_get::<f64>(), None); // Int64 ≠ Double → blocked
+    assert_eq!(typed.try_get::<i32>(), None); // Int64 ≠ Int32 → blocked
+
+    let untyped = AnyMongoType::untyped(Bson::Int64(42));
+    assert_eq!(untyped.try_get::<i64>(), Some(42));
+    assert_eq!(untyped.try_get::<f64>(), Some(42.0)); // permissive
+    assert_eq!(untyped.try_get::<i32>(), Some(42)); // permissive
+}
+
+// ── MongoDB-specific: bool is native ───────────────────────────────────────
+
+#[test]
+fn test_typed_bool_in_record() {
+    let mut record: Record<AnyMongoType> = Record::new();
+    record.insert("active".into(), AnyMongoType::new(true));
+
+    assert_eq!(*record["active"].value(), Bson::Boolean(true));
+    assert_eq!(record["active"].try_get::<bool>(), Some(true));
+    // Bool ≠ Int64 → blocked
+    assert_eq!(record["active"].try_get::<i64>(), None);
+}
+
+// ── MongoDB-specific: ObjectId in records ──────────────────────────────────
+
+#[test]
+fn test_objectid_in_record() {
+    let oid = bson::oid::ObjectId::new();
+    let mut record: Record<AnyMongoType> = Record::new();
+    record.insert("_id".into(), AnyMongoType::new(oid));
+
+    assert_eq!(record["_id"].try_get::<bson::oid::ObjectId>(), Some(oid));
+    // ObjectId ≠ String → blocked for typed
+    assert_eq!(record["_id"].try_get::<String>(), None);
+}
+
+#[test]
+fn test_untyped_objectid_from_string() {
+    // When reading from DB, ObjectId comes back as Bson::ObjectId
+    let oid = bson::oid::ObjectId::new();
+    let val = AnyMongoType::untyped(Bson::ObjectId(oid));
+    assert_eq!(val.try_get::<bson::oid::ObjectId>(), Some(oid));
+}
+
+#[test]
+fn test_untyped_string_as_objectid() {
+    // A hex string stored as Bson::String can parse into ObjectId via from_bson
+    let oid = bson::oid::ObjectId::new();
+    let val = AnyMongoType::untyped(Bson::String(oid.to_hex()));
+    assert_eq!(val.try_get::<bson::oid::ObjectId>(), Some(oid));
+}
+
+// ── Error cases ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_missing_field_in_record() {
+    let record: Record<AnyMongoType> = Record::new();
+    assert!(record.get("name").is_none());
+}
+
+#[test]
+fn test_typed_wrong_extraction() {
+    let mut record: Record<AnyMongoType> = Record::new();
+    record.insert("name".into(), AnyMongoType::new(42i64));
+    assert_eq!(record["name"].try_get::<String>(), None);
+}
+
+// ── TryFrom<AnyMongoType> for Record<AnyMongoType> ────────────────────────
+
+#[test]
+fn test_try_from_document() {
+    let doc = bson::doc! {
+        "name": "Cupcake",
+        "price": 120_i64,
+        "active": true
+    };
+    let any = AnyMongoType::untyped(Bson::Document(doc));
+    let record: Record<AnyMongoType> = any.try_into().unwrap();
+
+    assert_eq!(record["name"].try_get::<String>(), Some("Cupcake".into()));
+    assert_eq!(record["price"].try_get::<i64>(), Some(120));
+    assert_eq!(record["active"].try_get::<bool>(), Some(true));
+}
+
+#[test]
+fn test_try_from_array_extracts_first() {
+    let doc1 = bson::doc! { "name": "First" };
+    let doc2 = bson::doc! { "name": "Second" };
+    let arr = Bson::Array(vec![Bson::Document(doc1), Bson::Document(doc2)]);
+    let any = AnyMongoType::untyped(arr);
+    let record: Record<AnyMongoType> = any.try_into().unwrap();
+
+    // Should extract the first document
+    assert_eq!(record["name"].try_get::<String>(), Some("First".into()));
+}
+
+#[test]
+fn test_try_from_non_document_fails() {
+    let any = AnyMongoType::untyped(Bson::String("not a doc".into()));
+    let result: Result<Record<AnyMongoType>, _> = any.try_into();
+    assert!(result.is_err());
+}

--- a/vantage-sql/src/mysql/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/mysql/statements/select/impls/selectable.rs
@@ -65,8 +65,8 @@ impl Selectable<AnyMysqlType> for MysqlSelect {
         self.fields.push(field);
     }
 
-    fn add_where_condition(&mut self, condition: impl Expressive<AnyMysqlType>) {
-        self.where_conditions.push(condition.expr());
+    fn add_where_condition(&mut self, condition: impl Into<Expression<AnyMysqlType>>) {
+        self.where_conditions.push(condition.into());
     }
 
     fn set_distinct(&mut self, distinct: bool) {
@@ -75,10 +75,10 @@ impl Selectable<AnyMysqlType> for MysqlSelect {
 
     fn add_order_by(
         &mut self,
-        expression: impl Expressive<AnyMysqlType>,
-        order: vantage_expressions::Order,
+        order: impl Into<Expression<AnyMysqlType>>,
+        direction: vantage_expressions::Order,
     ) {
-        self.order_by.push((expression.expr(), order));
+        self.order_by.push((order.into(), direction));
     }
 
     fn add_group_by(&mut self, expression: impl Expressive<AnyMysqlType>) {

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -68,6 +68,7 @@ impl TableSource for MysqlDB {
     type AnyType = AnyMysqlType;
     type Value = AnyMysqlType;
     type Id = String;
+    type Condition = vantage_expressions::Expression<Self::Value>;
 
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         Column::new(name)

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -71,6 +71,7 @@ impl TableSource for PostgresDB {
     type AnyType = AnyPostgresType;
     type Value = AnyPostgresType;
     type Id = String;
+    type Condition = vantage_expressions::Expression<Self::Value>;
 
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         Column::new(name)

--- a/vantage-sql/src/postgres/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/postgres/statements/select/impls/selectable.rs
@@ -69,8 +69,8 @@ impl Selectable<AnyPostgresType> for PostgresSelect {
         self.fields.push(field);
     }
 
-    fn add_where_condition(&mut self, condition: impl Expressive<AnyPostgresType>) {
-        self.where_conditions.push(condition.expr());
+    fn add_where_condition(&mut self, condition: impl Into<Expression<AnyPostgresType>>) {
+        self.where_conditions.push(condition.into());
     }
 
     fn set_distinct(&mut self, distinct: bool) {
@@ -79,10 +79,10 @@ impl Selectable<AnyPostgresType> for PostgresSelect {
 
     fn add_order_by(
         &mut self,
-        expression: impl Expressive<AnyPostgresType>,
-        order: vantage_expressions::Order,
+        order: impl Into<Expression<AnyPostgresType>>,
+        direction: vantage_expressions::Order,
     ) {
-        self.order_by.push((expression.expr(), order));
+        self.order_by.push((order.into(), direction));
     }
 
     fn add_group_by(&mut self, expression: impl Expressive<AnyPostgresType>) {

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -61,6 +61,7 @@ impl TableSource for SqliteDB {
     type AnyType = AnySqliteType;
     type Value = AnySqliteType;
     type Id = String;
+    type Condition = vantage_expressions::Expression<Self::Value>;
 
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         Column::new(name)

--- a/vantage-sql/src/sqlite/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/sqlite/statements/select/impls/selectable.rs
@@ -60,8 +60,8 @@ impl Selectable<AnySqliteType> for SqliteSelect {
         self.fields.push(field);
     }
 
-    fn add_where_condition(&mut self, condition: impl Expressive<AnySqliteType>) {
-        self.where_conditions.push(condition.expr());
+    fn add_where_condition(&mut self, condition: impl Into<Expression<AnySqliteType>>) {
+        self.where_conditions.push(condition.into());
     }
 
     fn set_distinct(&mut self, distinct: bool) {
@@ -70,10 +70,10 @@ impl Selectable<AnySqliteType> for SqliteSelect {
 
     fn add_order_by(
         &mut self,
-        expression: impl Expressive<AnySqliteType>,
-        order: vantage_expressions::Order,
+        order: impl Into<Expression<AnySqliteType>>,
+        direction: vantage_expressions::Order,
     ) {
-        self.order_by.push((expression.expr(), order));
+        self.order_by.push((order.into(), direction));
     }
 
     fn add_group_by(&mut self, expression: impl Expressive<AnySqliteType>) {

--- a/vantage-surrealdb/src/statements/select/impls/selectable.rs
+++ b/vantage-surrealdb/src/statements/select/impls/selectable.rs
@@ -29,16 +29,16 @@ impl<T: QueryResult> Selectable<AnySurrealType> for SurrealSelect<T> {
         self.fields.push(field);
     }
 
-    fn add_where_condition(&mut self, condition: impl Expressive<AnySurrealType>) {
-        self.where_conditions.push(condition.expr());
+    fn add_where_condition(&mut self, condition: impl Into<Expr>) {
+        self.where_conditions.push(condition.into());
     }
 
     fn set_distinct(&mut self, distinct: bool) {
         self.distinct = distinct;
     }
 
-    fn add_order_by(&mut self, expression: impl Expressive<AnySurrealType>, order: Order) {
-        self.order_by.push((expression.expr(), order.ascending));
+    fn add_order_by(&mut self, order: impl Into<Expr>, direction: Order) {
+        self.order_by.push((order.into(), direction.ascending));
     }
 
     fn add_group_by(&mut self, expression: impl Expressive<AnySurrealType>) {

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -81,6 +81,7 @@ impl TableSource for SurrealDB {
     type AnyType = AnySurrealType;
     type Value = AnySurrealType;
     type Id = Thing;
+    type Condition = vantage_expressions::Expression<Self::Value>;
 
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         Column::new(name)

--- a/vantage-table/src/mocks/mock_table_source.rs
+++ b/vantage-table/src/mocks/mock_table_source.rs
@@ -107,6 +107,7 @@ impl TableSource for MockTableSource {
     type AnyType = AnyMockType;
     type Value = Value;
     type Id = String;
+    type Condition = vantage_expressions::Expression<Self::Value>;
 
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         use std::any::TypeId;

--- a/vantage-table/src/references/many.rs
+++ b/vantage-table/src/references/many.rs
@@ -1,8 +1,8 @@
 use std::{any::Any, marker::PhantomData, sync::Arc};
 
 use vantage_core::{Result, error};
-use vantage_expressions::Expressive;
 use vantage_expressions::traits::datasource::ExprDataSource;
+use vantage_expressions::{Expression, Expressive};
 use vantage_types::Entity;
 
 use crate::{
@@ -65,6 +65,7 @@ where
     T: ExprDataSource<T::Value>,
     T::Value: Clone + Send + Sync + 'static,
     T::Column<T::AnyType>: Operation<T::Value>,
+    T::Condition: From<Expression<T::Value>>,
 {
     fn get_related_table(&self, source_table: &dyn Any) -> Result<Box<dyn Any>> {
         let source = source_table

--- a/vantage-table/src/references/one.rs
+++ b/vantage-table/src/references/one.rs
@@ -1,8 +1,8 @@
 use std::{any::Any, marker::PhantomData, sync::Arc};
 
 use vantage_core::{Result, error};
-use vantage_expressions::Expressive;
 use vantage_expressions::traits::datasource::ExprDataSource;
+use vantage_expressions::{Expression, Expressive};
 use vantage_types::Entity;
 
 use crate::{
@@ -68,6 +68,7 @@ where
     T: ExprDataSource<T::Value>,
     T::Value: Clone + Send + Sync + 'static,
     T::Column<T::AnyType>: Operation<T::Value>,
+    T::Condition: From<Expression<T::Value>>,
 {
     fn get_related_table(&self, source_table: &dyn Any) -> Result<Box<dyn Any>> {
         let source = source_table

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -2,7 +2,6 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use indexmap::IndexMap;
-use vantage_expressions::Expression;
 use vantage_types::Entity;
 
 use crate::{
@@ -20,9 +19,9 @@ where
     pub(super) _phantom: PhantomData<E>,
     pub(super) table_name: String,
     pub(super) columns: IndexMap<String, T::Column<T::AnyType>>,
-    pub(super) conditions: IndexMap<i64, Expression<T::Value>>,
+    pub(super) conditions: IndexMap<i64, T::Condition>,
     pub(super) next_condition_id: i64,
-    pub(super) order_by: IndexMap<i64, (Expression<T::Value>, SortDirection)>,
+    pub(super) order_by: IndexMap<i64, (T::Condition, SortDirection)>,
     pub(super) next_order_id: i64,
     pub(super) refs: Option<IndexMap<String, Arc<dyn RelatedTable>>>,
     pub(super) pagination: Option<Pagination>,
@@ -87,7 +86,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
     }
 
     /// Get mutable access to conditions (pub(crate) for TableLike impl)
-    pub(crate) fn conditions_mut(&mut self) -> &mut IndexMap<i64, Expression<T::Value>> {
+    pub(crate) fn conditions_mut(&mut self) -> &mut IndexMap<i64, T::Condition> {
         &mut self.conditions
     }
 

--- a/vantage-table/src/table/impls/conditions.rs
+++ b/vantage-table/src/table/impls/conditions.rs
@@ -1,22 +1,21 @@
 use vantage_core::{Result, error};
-use vantage_expressions::Expression;
 use vantage_types::Entity;
 
 use crate::{conditions::ConditionHandle, table::Table, traits::table_source::TableSource};
 
 impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
     /// Add a permanent condition to limit what records the table represents
-    pub fn add_condition(&mut self, condition: Expression<T::Value>) {
+    pub fn add_condition(&mut self, condition: impl Into<T::Condition>) {
         let id = -self.next_condition_id;
         self.next_condition_id += 1;
-        self.conditions.insert(id, condition);
+        self.conditions.insert(id, condition.into());
     }
 
     /// Add a temporary condition that can be removed later
-    pub fn temp_add_condition(&mut self, condition: Expression<T::Value>) -> ConditionHandle {
+    pub fn temp_add_condition(&mut self, condition: impl Into<T::Condition>) -> ConditionHandle {
         let id = self.next_condition_id;
         self.next_condition_id += 1;
-        self.conditions.insert(id, condition);
+        self.conditions.insert(id, condition.into());
         ConditionHandle::new(id)
     }
 
@@ -30,12 +29,12 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
     }
 
     /// Get all conditions
-    pub fn conditions(&self) -> impl Iterator<Item = &Expression<T::Value>> {
+    pub fn conditions(&self) -> impl Iterator<Item = &T::Condition> {
         self.conditions.values()
     }
 
     /// Add a condition using the builder pattern
-    pub fn with_condition(mut self, condition: Expression<T::Value>) -> Self {
+    pub fn with_condition(mut self, condition: impl Into<T::Condition>) -> Self {
         self.add_condition(condition);
         self
     }

--- a/vantage-table/src/table/impls/refereces.rs
+++ b/vantage-table/src/table/impls/refereces.rs
@@ -6,6 +6,7 @@ use indexmap::IndexMap;
 use std::sync::Arc;
 
 use vantage_core::{Result, error};
+use vantage_expressions::Expression;
 use vantage_expressions::traits::datasource::ExprDataSource;
 use vantage_types::Entity;
 
@@ -38,6 +39,7 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
         T: ExprDataSource<T::Value>,
         T::Value: Clone + Send + Sync + 'static,
         T::Column<T::AnyType>: crate::operation::Operation<T::Value>,
+        T::Condition: From<Expression<T::Value>>,
     {
         let reference = ReferenceOne::<T, E, E2>::new(foreign_key, get_table);
         self.add_ref(relation, Box::new(reference));
@@ -66,6 +68,7 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
         T: ExprDataSource<T::Value>,
         T::Value: Clone + Send + Sync + 'static,
         T::Column<T::AnyType>: crate::operation::Operation<T::Value>,
+        T::Condition: From<Expression<T::Value>>,
     {
         let reference = ReferenceMany::<T, E, E2>::new(foreign_key, get_table);
         self.add_ref(relation, Box::new(reference));

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -1,5 +1,6 @@
 use vantage_core::Result;
-use vantage_expressions::{Expression, Expressive, Selectable, SelectableDataSource};
+use vantage_expressions::traits::selectable::Selectable;
+use vantage_expressions::{Expression, Expressive, SelectableDataSource};
 use vantage_types::Entity;
 
 use crate::{
@@ -10,7 +11,7 @@ use crate::{
 impl<T, E> Table<T, E>
 where
     T: SelectableDataSource<T::Value> + TableSource,
-    T::Select: Selectable<T::Value>,
+    T::Select: Selectable<T::Value, T::Condition>,
     T::Value: From<String>, // that's because table is specified as a string
     E: Entity<T::Value>,
 {
@@ -94,7 +95,8 @@ where
     T: SelectableDataSource<serde_json::Value>
         + TableSource<Value = serde_json::Value>
         + vantage_expressions::traits::datasource::ExprDataSource<serde_json::Value>,
-    T::Select: Selectable<serde_json::Value>,
+    T::Select: Selectable<serde_json::Value, T::Condition>,
+    T::Value: From<String>,
     E: Entity<serde_json::Value>,
 {
     /// Get count using QuerySource for serde_json::Value

--- a/vantage-table/src/table/impls/sorting.rs
+++ b/vantage-table/src/table/impls/sorting.rs
@@ -1,12 +1,11 @@
 use vantage_core::{Result, error};
-use vantage_expressions::Expression;
 use vantage_types::Entity;
 
 use crate::{sorting::*, table::Table, traits::table_source::TableSource};
 
 impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
     /// Add a permanent order clause
-    pub fn add_order(&mut self, order: OrderBy<Expression<T::Value>>) {
+    pub fn add_order(&mut self, order: OrderBy<T::Condition>) {
         let id = -self.next_order_id;
         self.next_order_id += 1;
         self.order_by
@@ -14,7 +13,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
     }
 
     /// Add a temporary order clause that can be removed later
-    pub fn temp_add_order(&mut self, order: OrderBy<Expression<T::Value>>) -> OrderHandle {
+    pub fn temp_add_order(&mut self, order: OrderBy<T::Condition>) -> OrderHandle {
         let id = self.next_order_id;
         self.next_order_id += 1;
         self.order_by
@@ -36,36 +35,33 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
     }
 
     /// Get all order clauses
-    pub fn orders(&self) -> impl Iterator<Item = &(Expression<T::Value>, SortDirection)> {
+    pub fn orders(&self) -> impl Iterator<Item = &(T::Condition, SortDirection)> {
         self.order_by.values()
     }
 
     /// Add an order clause using the builder pattern
-    pub fn with_order(mut self, order: OrderBy<Expression<T::Value>>) -> Self {
+    pub fn with_order(mut self, order: OrderBy<T::Condition>) -> Self {
         self.add_order(order);
         self
     }
 }
 
 /// Extension trait for creating OrderBy from expressions and columns
-pub trait OrderByExt<V> {
+pub trait OrderByExt<C> {
     /// Create an ascending order specification
-    fn ascending(&self) -> OrderBy<Expression<V>>;
+    fn ascending(&self) -> OrderBy<C>;
 
     /// Create a descending order specification
-    fn descending(&self) -> OrderBy<Expression<V>>;
+    fn descending(&self) -> OrderBy<C>;
 }
 
-// Note: ColumnLike implementation removed since ColumnLike doesn't have expr() method
-// Users should create expressions from columns using other means
-
-// Direct implementation for Expression
-impl<T: Clone + Send + Sync + 'static> OrderByExt<T> for Expression<T> {
-    fn ascending(&self) -> OrderBy<Expression<T>> {
+// Direct implementation for any Clone type (Expression, bson::Document, etc.)
+impl<C: Clone> OrderByExt<C> for C {
+    fn ascending(&self) -> OrderBy<C> {
         OrderBy::ascending(self.clone())
     }
 
-    fn descending(&self) -> OrderBy<Expression<T>> {
+    fn descending(&self) -> OrderBy<C> {
         OrderBy::descending(self.clone())
     }
 }

--- a/vantage-table/src/table/impls/table_like.rs
+++ b/vantage-table/src/table/impls/table_like.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use vantage_core::{Result, error};
-use vantage_expressions::{AnyExpression, Expression};
+use vantage_expressions::AnyExpression;
 use vantage_types::Entity;
 
 use crate::{
@@ -25,29 +25,29 @@ where
     }
 
     fn add_condition(&mut self, condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()> {
-        // Downcast the boxed Any to Expression<T::Value>
-        let expr = condition
-            .downcast::<Expression<T::Value>>()
-            .map_err(|_| error!("Failed to downcast condition expression"))?;
+        // Downcast the boxed Any to T::Condition
+        let cond = condition
+            .downcast::<T::Condition>()
+            .map_err(|_| error!("Failed to downcast condition to datasource condition type"))?;
 
         // Add permanent condition
         let next_id = *self.next_condition_id_mut();
         let id = -next_id;
         *self.next_condition_id_mut() = next_id + 1;
-        self.conditions_mut().insert(id, *expr);
+        self.conditions_mut().insert(id, *cond);
         Ok(())
     }
 
     fn temp_add_condition(&mut self, condition: AnyExpression) -> Result<ConditionHandle> {
-        // Downcast AnyExpression to Expression<T::Value>
-        let expr = condition.downcast::<Expression<T::Value>>().map_err(|_| {
-            error!("Failed to downcast AnyExpression to datasource expression type")
-        })?;
+        // Downcast AnyExpression to T::Condition
+        let cond = condition
+            .downcast::<T::Condition>()
+            .map_err(|_| error!("Failed to downcast AnyExpression to datasource condition type"))?;
 
         // Add temporary condition
         let next_id = *self.next_condition_id_mut();
         *self.next_condition_id_mut() = next_id + 1;
-        self.conditions_mut().insert(next_id, expr);
+        self.conditions_mut().insert(next_id, cond);
         Ok(ConditionHandle::new(next_id))
     }
 

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -26,6 +26,11 @@ pub trait TableSource: DataSource + Clone + 'static {
     type Value: Clone + Send + Sync + 'static;
     type Id: Send + Sync + Clone + Hash + Eq + 'static;
 
+    /// The condition type stored by `Table`. SQL/SurrealDB backends use
+    /// `Expression<Self::Value>`; document-oriented backends like MongoDB
+    /// can use a native filter type (e.g. `bson::Document`).
+    type Condition: Clone + Send + Sync + 'static;
+
     /// Create a new column with the given name
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type>;
 

--- a/vantage-table/tests/column_type_system.rs
+++ b/vantage-table/tests/column_type_system.rs
@@ -235,6 +235,7 @@ impl TableSource for Type3TableSource {
     type AnyType = AnyType3;
     type Value = ciborium::Value;
     type Id = usize;
+    type Condition = vantage_expressions::Expression<Self::Value>;
 
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         // Runtime check for Type3 compatibility


### PR DESCRIPTION
### MongoDB backend, plus `TableSource::Condition` is now an associated type

`vantage-mongodb` ships: `MongoDB` data source over the official driver, `MongoCondition` (immediate `bson::Document` / async-`Deferred` / `And`), `MongoSelect`, full `TableSource`, ingress scripts, integration tests, and a `mongodb.yaml` CI workflow.

MongoDB filters are BSON, not SQL expressions, so jamming them through `Expression<T::Value>` would have meant serializing documents into strings and parsing them back at execute time. Pulling the condition type out as an associated type was cheaper than that — and it touches every backend.

### Breaking — `Selectable` and `TableSource`

`TableSource` now has an associated `Condition` type. SQL/SurrealDB keep `Expression<T::Value>`; MongoDB uses `MongoCondition`. `Table` stores `T::Condition` instead of hardcoded `Expression`.

`Selectable<T, C = Expression<T>>` gains a second parameter:

- `set_source` → `add_source` (now additive — was clearing previous sources)
- `add_where_condition` takes `impl Into<C>` instead of `impl Expressive<T>`
- `add_order_by` takes `impl Into<C>`

If you implemented `Selectable` for your own backend, rename `set_source` and switch the condition/order parameters to `impl Into<C>`. If you only consume tables (`add_condition`, `with_condition`), nothing changes for SQL backends — `Into<T::Condition>` accepts `Expression<T::Value>`.

References gained a `T::Condition: From<Expression<T::Value>>` bound. `AnyTable::add_condition` now downcasts to `T::Condition` — generic UI code boxing expressions for type-erased tables needs to box the backend's condition type instead.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #181 
- <kbd>&nbsp;1&nbsp;</kbd> #180 👈 
<!-- GitButler Footer Boundary Bottom -->