### PR TITLE
implement more of mongodb

### DIFF
--- a/vantage-expressions/src/traits/datasource.rs
+++ b/vantage-expressions/src/traits/datasource.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 use std::future::Future;
 
+use crate::Expression;
 use crate::Selectable;
 use crate::traits::associated_expressions::AssociatedExpression;
 use crate::traits::expressive::DeferredFn;
@@ -38,8 +39,8 @@ pub trait ExprDataSource<T = Value>: DataSource {
 }
 
 /// Datasource that support creation and execution of select queries
-pub trait SelectableDataSource<T = Value>: DataSource {
-    type Select: Selectable<T>;
+pub trait SelectableDataSource<T = Value, C = Expression<T>>: DataSource {
+    type Select: Selectable<T, C>;
 
     // Return SelectQuery
     fn select(&self) -> Self::Select;

--- a/vantage-mongodb/src/id.rs
+++ b/vantage-mongodb/src/id.rs
@@ -1,0 +1,170 @@
+//! MongoDB ID type — wraps either `ObjectId` or `String`.
+//!
+//! MongoDB `_id` can be any BSON type, but in practice it's almost always
+//! either an auto-generated `ObjectId` or a user-supplied string. `MongoId`
+//! handles both transparently.
+
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::str::FromStr;
+
+use bson::{Bson, oid::ObjectId};
+
+/// A MongoDB document identifier — either an `ObjectId` or a `String`.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum MongoId {
+    ObjectId(ObjectId),
+    String(String),
+}
+
+impl MongoId {
+    /// Create from a BSON value. Returns `None` for unsupported types.
+    pub fn from_bson(value: &Bson) -> Option<Self> {
+        match value {
+            Bson::ObjectId(oid) => Some(MongoId::ObjectId(*oid)),
+            Bson::String(s) => Some(MongoId::String(s.clone())),
+            _ => None,
+        }
+    }
+
+    /// Convert to a BSON value for use in queries.
+    pub fn to_bson(&self) -> Bson {
+        match self {
+            MongoId::ObjectId(oid) => Bson::ObjectId(*oid),
+            MongoId::String(s) => Bson::String(s.clone()),
+        }
+    }
+}
+
+impl Hash for MongoId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Discriminant ensures ObjectId("abc...") and String("abc...") don't collide
+        std::mem::discriminant(self).hash(state);
+        match self {
+            MongoId::ObjectId(oid) => oid.hash(state),
+            MongoId::String(s) => s.hash(state),
+        }
+    }
+}
+
+impl fmt::Display for MongoId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MongoId::ObjectId(oid) => write!(f, "{}", oid),
+            MongoId::String(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl FromStr for MongoId {
+    type Err = std::convert::Infallible;
+
+    /// Parses a string as MongoId. If it's a valid 24-char hex string,
+    /// treats it as ObjectId; otherwise stores as String.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(oid) = ObjectId::parse_str(s) {
+            Ok(MongoId::ObjectId(oid))
+        } else {
+            Ok(MongoId::String(s.to_string()))
+        }
+    }
+}
+
+impl From<MongoId> for Bson {
+    fn from(id: MongoId) -> Self {
+        id.to_bson()
+    }
+}
+
+impl From<ObjectId> for MongoId {
+    fn from(oid: ObjectId) -> Self {
+        MongoId::ObjectId(oid)
+    }
+}
+
+impl From<String> for MongoId {
+    fn from(s: String) -> Self {
+        MongoId::String(s)
+    }
+}
+
+impl From<&str> for MongoId {
+    fn from(s: &str) -> Self {
+        MongoId::String(s.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_from_bson_objectid() {
+        let oid = ObjectId::new();
+        let id = MongoId::from_bson(&Bson::ObjectId(oid)).unwrap();
+        assert_eq!(id, MongoId::ObjectId(oid));
+    }
+
+    #[test]
+    fn test_from_bson_string() {
+        let id = MongoId::from_bson(&Bson::String("flux_cupcake".into())).unwrap();
+        assert_eq!(id, MongoId::String("flux_cupcake".into()));
+    }
+
+    #[test]
+    fn test_from_bson_unsupported() {
+        assert!(MongoId::from_bson(&Bson::Int32(42)).is_none());
+    }
+
+    #[test]
+    fn test_to_bson() {
+        let oid = ObjectId::new();
+        assert_eq!(MongoId::ObjectId(oid).to_bson(), Bson::ObjectId(oid));
+        assert_eq!(
+            MongoId::String("abc".into()).to_bson(),
+            Bson::String("abc".into())
+        );
+    }
+
+    #[test]
+    fn test_display() {
+        let oid = ObjectId::new();
+        assert_eq!(MongoId::ObjectId(oid).to_string(), oid.to_string());
+        assert_eq!(MongoId::String("hello".into()).to_string(), "hello");
+    }
+
+    #[test]
+    fn test_from_str_objectid() {
+        let oid = ObjectId::new();
+        let parsed: MongoId = oid.to_hex().parse().unwrap();
+        assert_eq!(parsed, MongoId::ObjectId(oid));
+    }
+
+    #[test]
+    fn test_from_str_string() {
+        let parsed: MongoId = "flux_cupcake".parse().unwrap();
+        assert_eq!(parsed, MongoId::String("flux_cupcake".into()));
+    }
+
+    #[test]
+    fn test_hash_distinct() {
+        let mut set = HashSet::new();
+        set.insert(MongoId::String("abc".into()));
+        set.insert(MongoId::String("def".into()));
+        set.insert(MongoId::ObjectId(ObjectId::new()));
+        assert_eq!(set.len(), 3);
+    }
+
+    #[test]
+    fn test_from_conversions() {
+        let id: MongoId = ObjectId::new().into();
+        assert!(matches!(id, MongoId::ObjectId(_)));
+
+        let id: MongoId = "hello".into();
+        assert!(matches!(id, MongoId::String(_)));
+
+        let id: MongoId = String::from("world").into();
+        assert!(matches!(id, MongoId::String(_)));
+    }
+}

--- a/vantage-mongodb/src/lib.rs
+++ b/vantage-mongodb/src/lib.rs
@@ -5,11 +5,13 @@
 //! the condition type — no SQL expressions involved.
 
 pub mod condition;
+pub mod id;
 pub mod mongodb;
 pub mod select;
 pub mod types;
 
 pub use condition::MongoCondition;
+pub use id::MongoId;
 pub use mongodb::MongoDB;
 pub use select::MongoSelect;
 pub use types::{AnyMongoType, MongoType, MongoTypeVariants};

--- a/vantage-mongodb/src/mongodb/impls/mod.rs
+++ b/vantage-mongodb/src/mongodb/impls/mod.rs
@@ -1,3 +1,4 @@
 pub mod data_source;
 pub mod expr_data_source;
+pub mod selectable_data_source;
 pub mod table_source;

--- a/vantage-mongodb/src/mongodb/impls/selectable_data_source.rs
+++ b/vantage-mongodb/src/mongodb/impls/selectable_data_source.rs
@@ -1,0 +1,57 @@
+//! SelectableDataSource implementation for MongoDB.
+//!
+//! Wires `MongoSelect` into the Vantage query pipeline so `table.select()` works.
+//! `execute_select` runs the built query against MongoDB using the driver directly.
+
+use futures_util::TryStreamExt;
+
+use vantage_expressions::traits::datasource::SelectableDataSource;
+
+use crate::condition::MongoCondition;
+use crate::mongodb::MongoDB;
+use crate::select::MongoSelect;
+use crate::types::AnyMongoType;
+
+impl SelectableDataSource<AnyMongoType, MongoCondition> for MongoDB {
+    type Select = MongoSelect;
+
+    fn select(&self) -> Self::Select {
+        MongoSelect::new()
+    }
+
+    async fn execute_select(
+        &self,
+        select: &Self::Select,
+    ) -> vantage_core::Result<Vec<AnyMongoType>> {
+        let coll_name = select
+            .collection
+            .as_deref()
+            .ok_or_else(|| vantage_core::error!("MongoSelect has no collection set"))?;
+
+        let filter = select.build_filter().await?;
+        let options = select.build_find_options();
+        let coll = self.doc_collection(coll_name);
+
+        let cursor = coll.find(filter).with_options(options).await.map_err(|e| {
+            vantage_core::error!(
+                "MongoDB execute_select find failed",
+                details = e.to_string()
+            )
+        })?;
+
+        let docs: Vec<bson::Document> = cursor.try_collect().await.map_err(|e| {
+            vantage_core::error!(
+                "MongoDB execute_select cursor failed",
+                details = e.to_string()
+            )
+        })?;
+
+        docs.into_iter()
+            .map(|doc| {
+                AnyMongoType::from_bson(&bson::Bson::Document(doc)).ok_or_else(|| {
+                    vantage_core::error!("Failed to convert Document to AnyMongoType")
+                })
+            })
+            .collect()
+    }
+}

--- a/vantage-mongodb/src/mongodb/impls/table_source.rs
+++ b/vantage-mongodb/src/mongodb/impls/table_source.rs
@@ -6,7 +6,7 @@
 //! Write operations use the `mongodb` driver directly.
 
 use async_trait::async_trait;
-use bson::{Bson, doc, oid::ObjectId};
+use bson::{Bson, doc};
 use futures_util::TryStreamExt;
 use indexmap::IndexMap;
 
@@ -18,25 +18,24 @@ use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
 
 use crate::condition::MongoCondition;
+use crate::id::MongoId;
 use crate::mongodb::MongoDB;
 use crate::select::MongoSelect;
 use crate::types::AnyMongoType;
 
 /// Convert a bson::Document into a Record<AnyMongoType>, optionally extracting the _id.
-fn doc_to_record(doc: bson::Document) -> (Option<ObjectId>, Record<AnyMongoType>) {
+fn doc_to_record(doc: bson::Document) -> (Option<MongoId>, Record<AnyMongoType>) {
     let mut fields = IndexMap::new();
-    let mut oid: Option<ObjectId> = None;
+    let mut id: Option<MongoId> = None;
 
     for (k, v) in doc {
-        if k == "_id"
-            && let Bson::ObjectId(id) = &v
-        {
-            oid = Some(*id);
+        if k == "_id" {
+            id = MongoId::from_bson(&v);
         }
         fields.insert(k, AnyMongoType::untyped(v));
     }
 
-    (oid, Record::from_indexmap(fields))
+    (id, Record::from_indexmap(fields))
 }
 
 /// Build a `MongoSelect` from a `Table`'s current state (conditions, ordering, pagination).
@@ -77,7 +76,7 @@ impl TableSource for MongoDB {
         Type: ColumnType;
     type AnyType = AnyMongoType;
     type Value = AnyMongoType;
-    type Id = ObjectId;
+    type Id = MongoId;
     type Condition = MongoCondition;
 
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
@@ -167,7 +166,7 @@ impl TableSource for MongoDB {
             .find_one(doc! { "_id": id })
             .await
             .map_err(|e| error!("MongoDB find_one failed", details = e.to_string()))?
-            .ok_or_else(|| error!("Document not found", id = id.to_hex()))?;
+            .ok_or_else(|| error!("Document not found", id = id.to_string()))?;
 
         let (_oid, record) = doc_to_record(d);
         Ok(record)
@@ -316,7 +315,7 @@ impl TableSource for MongoDB {
     {
         let coll = self.doc_collection(table.table_name());
         let mut doc = bson::Document::new();
-        doc.insert("_id", Bson::ObjectId(*id));
+        doc.insert("_id", id);
         for (k, v) in record.iter() {
             doc.insert(k, v.value().clone());
         }
@@ -381,7 +380,7 @@ impl TableSource for MongoDB {
         E: Entity<Self::Value>,
     {
         let coll = self.doc_collection(table.table_name());
-        coll.delete_one(doc! { "_id": *id })
+        coll.delete_one(doc! { "_id": id })
             .await
             .map_err(|e| error!("MongoDB delete_one failed", details = e.to_string()))?;
         Ok(())
@@ -419,10 +418,8 @@ impl TableSource for MongoDB {
             .await
             .map_err(|e| error!("MongoDB insert_one failed", details = e.to_string()))?;
 
-        result
-            .inserted_id
-            .as_object_id()
-            .ok_or_else(|| error!("MongoDB insert did not return ObjectId"))
+        MongoId::from_bson(&result.inserted_id)
+            .ok_or_else(|| error!("MongoDB insert did not return a valid id"))
     }
 
     fn column_table_values_expr<'a, E, Type: ColumnType>(

--- a/vantage-mongodb/src/types/mod.rs
+++ b/vantage-mongodb/src/types/mod.rs
@@ -64,8 +64,8 @@ impl std::fmt::Display for AnyMongoType {
             bson::Bson::Int32(i) => write!(f, "{}", i),
             bson::Bson::Int64(i) => write!(f, "{}", i),
             bson::Bson::Double(d) => write!(f, "{}", d),
-            bson::Bson::String(s) => write!(f, "\"{}\"", s),
-            bson::Bson::ObjectId(oid) => write!(f, "ObjectId(\"{}\")", oid),
+            bson::Bson::String(s) => write!(f, "{:?}", s),
+            bson::Bson::ObjectId(oid) => write!(f, "ObjectId({:?})", oid.to_string()),
             bson::Bson::DateTime(dt) => write!(f, "{}", dt),
             bson::Bson::Array(arr) => write!(f, "{:?}", arr),
             bson::Bson::Document(doc) => write!(f, "{}", doc),
@@ -115,13 +115,7 @@ impl TryFrom<AnyMongoType> for Record<AnyMongoType> {
         match value {
             bson::Bson::Document(doc) => Ok(doc
                 .into_iter()
-                .map(|(k, v)| {
-                    let any = AnyMongoType::from_bson(&v).unwrap_or_else(|| AnyMongoType {
-                        value: v,
-                        type_variant: None,
-                    });
-                    (k, any)
-                })
+                .map(|(k, v)| (k, AnyMongoType::untyped(v)))
                 .collect()),
             bson::Bson::Array(arr) => {
                 // Extract first document from array result
@@ -134,13 +128,7 @@ impl TryFrom<AnyMongoType> for Record<AnyMongoType> {
                     .ok_or_else(|| vantage_core::error!("Expected document in array result"))?;
                 Ok(doc
                     .into_iter()
-                    .map(|(k, v)| {
-                        let any = AnyMongoType::from_bson(&v).unwrap_or_else(|| AnyMongoType {
-                            value: v,
-                            type_variant: None,
-                        });
-                        (k, any)
-                    })
+                    .map(|(k, v)| (k, AnyMongoType::untyped(v)))
                     .collect())
             }
             _ => Err(vantage_core::error!("Expected document or array result")),

--- a/vantage-mongodb/src/types/value.rs
+++ b/vantage-mongodb/src/types/value.rs
@@ -94,14 +94,15 @@ impl Expressive<AnyMongoType> for AnyMongoType {
 impl From<AnyMongoType> for serde_json::Value {
     fn from(val: AnyMongoType) -> Self {
         // Bson implements Serialize, serde_json::Value implements Deserialize
-        serde_json::to_value(val.into_value()).unwrap_or(serde_json::Value::Null)
+        serde_json::to_value(val.into_value()).expect("Bson value should always serialize to JSON")
     }
 }
 
 impl From<serde_json::Value> for AnyMongoType {
     fn from(val: serde_json::Value) -> Self {
         // serde_json::Value implements Serialize, Bson implements Deserialize
-        let bson: bson::Bson = serde_json::from_value(val).unwrap_or(bson::Bson::Null);
+        let bson: bson::Bson =
+            serde_json::from_value(val).expect("JSON value should always deserialize to Bson");
         AnyMongoType::untyped(bson)
     }
 }

--- a/vantage-mongodb/tests/1_table_source.rs
+++ b/vantage-mongodb/tests/1_table_source.rs
@@ -4,8 +4,9 @@
 //! to mongodb://localhost:27017. Uses a randomised database name so tests
 //! don't collide.
 
-use bson::{doc, oid::ObjectId};
+use bson::doc;
 use vantage_dataset::prelude::*;
+use vantage_mongodb::MongoId;
 use vantage_mongodb::{AnyMongoType, MongoDB};
 use vantage_table::table::Table;
 use vantage_table::traits::table_source::TableSource;
@@ -16,7 +17,7 @@ fn mongo_url() -> String {
 }
 
 async fn setup() -> (MongoDB, String) {
-    let db_name = format!("vantage_test_{}", ObjectId::new().to_hex());
+    let db_name = format!("vantage_test_{}", bson::oid::ObjectId::new().to_hex());
     let db = MongoDB::connect(&mongo_url(), &db_name)
         .await
         .expect("Failed to connect to MongoDB");
@@ -63,7 +64,7 @@ async fn test_insert_and_list() {
     let (db, db_name) = setup().await;
     let table = product_table(db.clone());
 
-    let id = ObjectId::new();
+    let id = MongoId::from(bson::oid::ObjectId::new());
     let rec = record(&[
         ("name", AnyMongoType::new("Cupcake".to_string())),
         ("price", AnyMongoType::new(250i64)),
@@ -89,7 +90,7 @@ async fn test_get_value_by_id() {
     let (db, db_name) = setup().await;
     let table = product_table(db.clone());
 
-    let id = ObjectId::new();
+    let id = MongoId::from(bson::oid::ObjectId::new());
     let rec = record(&[
         ("name", AnyMongoType::new("Tart".to_string())),
         ("price", AnyMongoType::new(180i64)),
@@ -112,7 +113,7 @@ async fn test_get_some_value() {
     // Empty table → None
     assert!(table.get_some_value().await.unwrap().is_none());
 
-    let id = ObjectId::new();
+    let id = MongoId::from(bson::oid::ObjectId::new());
     let rec = record(&[("name", AnyMongoType::new("Pie".to_string()))]);
     table.insert_value(&id, &rec).await.unwrap();
 
@@ -134,7 +135,10 @@ async fn test_count() {
 
     for i in 0..3 {
         let rec = record(&[("name", AnyMongoType::new(format!("Item {}", i)))]);
-        table.insert_value(&ObjectId::new(), &rec).await.unwrap();
+        table
+            .insert_value(&MongoId::from(bson::oid::ObjectId::new()), &rec)
+            .await
+            .unwrap();
     }
 
     assert_eq!(table.get_count().await.unwrap(), 3);
@@ -155,7 +159,10 @@ async fn test_sum_max_min() {
             ("name", AnyMongoType::new(format!("P{}", p))),
             ("price", AnyMongoType::new(p)),
         ]);
-        table.insert_value(&ObjectId::new(), &rec).await.unwrap();
+        table
+            .insert_value(&MongoId::from(bson::oid::ObjectId::new()), &rec)
+            .await
+            .unwrap();
     }
 
     let price_col = db.to_any_column(db.create_column::<i64>("price"));
@@ -179,7 +186,7 @@ async fn test_replace() {
     let (db, db_name) = setup().await;
     let table = product_table(db.clone());
 
-    let id = ObjectId::new();
+    let id = MongoId::from(bson::oid::ObjectId::new());
     let rec = record(&[
         ("name", AnyMongoType::new("Old".to_string())),
         ("price", AnyMongoType::new(10i64)),
@@ -204,7 +211,7 @@ async fn test_patch() {
     let (db, db_name) = setup().await;
     let table = product_table(db.clone());
 
-    let id = ObjectId::new();
+    let id = MongoId::from(bson::oid::ObjectId::new());
     let rec = record(&[
         ("name", AnyMongoType::new("Original".to_string())),
         ("price", AnyMongoType::new(50i64)),
@@ -229,7 +236,7 @@ async fn test_delete() {
     let (db, db_name) = setup().await;
     let table = product_table(db.clone());
 
-    let id = ObjectId::new();
+    let id = MongoId::from(bson::oid::ObjectId::new());
     let rec = record(&[("name", AnyMongoType::new("Gone".to_string()))]);
     table.insert_value(&id, &rec).await.unwrap();
     assert_eq!(table.get_count().await.unwrap(), 1);
@@ -247,7 +254,10 @@ async fn test_delete_all() {
 
     for i in 0..4 {
         let rec = record(&[("name", AnyMongoType::new(format!("X{}", i)))]);
-        table.insert_value(&ObjectId::new(), &rec).await.unwrap();
+        table
+            .insert_value(&MongoId::from(bson::oid::ObjectId::new()), &rec)
+            .await
+            .unwrap();
     }
     assert_eq!(table.get_count().await.unwrap(), 4);
 
@@ -287,7 +297,10 @@ async fn test_condition_filter() {
             ("name", AnyMongoType::new(name.to_string())),
             ("is_deleted", AnyMongoType::new(deleted)),
         ]);
-        table.insert_value(&ObjectId::new(), &rec).await.unwrap();
+        table
+            .insert_value(&MongoId::from(bson::oid::ObjectId::new()), &rec)
+            .await
+            .unwrap();
     }
 
     // Add native MongoDB condition
@@ -317,7 +330,10 @@ async fn test_condition_gt() {
             ("name", AnyMongoType::new(name.to_string())),
             ("price", AnyMongoType::new(price)),
         ]);
-        table.insert_value(&ObjectId::new(), &rec).await.unwrap();
+        table
+            .insert_value(&MongoId::from(bson::oid::ObjectId::new()), &rec)
+            .await
+            .unwrap();
     }
 
     table.add_condition(doc! { "price": { "$gt": 100 } });
@@ -352,7 +368,10 @@ async fn test_multiple_conditions() {
             ("price", AnyMongoType::new(price)),
             ("is_deleted", AnyMongoType::new(deleted)),
         ]);
-        table.insert_value(&ObjectId::new(), &rec).await.unwrap();
+        table
+            .insert_value(&MongoId::from(bson::oid::ObjectId::new()), &rec)
+            .await
+            .unwrap();
     }
 
     // price > 100 AND not deleted

--- a/vantage-mongodb/tests/1_table_source.rs
+++ b/vantage-mongodb/tests/1_table_source.rs
@@ -8,7 +8,6 @@ use bson::{doc, oid::ObjectId};
 use vantage_dataset::prelude::*;
 use vantage_mongodb::{AnyMongoType, MongoDB};
 use vantage_table::table::Table;
-use vantage_table::traits::table_like::TableLike;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{EmptyEntity, Record};
 

--- a/vantage-mongodb/tests/3_select.rs
+++ b/vantage-mongodb/tests/3_select.rs
@@ -1,0 +1,405 @@
+//! Test 3: MongoSelect builder + SelectableDataSource execution against seeded v2 data.
+//!
+//! Requires a running MongoDB with v2.js loaded.
+//! Builder tests (preview, build_*) are sync. Live tests need the database.
+
+use bson::doc;
+use vantage_expressions::{Order, Selectable};
+use vantage_mongodb::{AnyMongoType, MongoDB, MongoSelect};
+
+fn mongo_url() -> String {
+    std::env::var("MONGODB_URL").unwrap_or_else(|_| "mongodb://localhost:27017".into())
+}
+
+async fn db() -> MongoDB {
+    MongoDB::connect(&mongo_url(), "vantage")
+        .await
+        .expect("Failed to connect to MongoDB")
+}
+
+// ── Builder / preview tests (no database needed) ─────────────────────────
+
+#[test]
+fn test_select_all() {
+    let s = MongoSelect::new().with_source("product");
+    assert_eq!(s.preview(), "db.product.find({})");
+}
+
+#[test]
+fn test_select_fields() {
+    let s = MongoSelect::new()
+        .with_source("product")
+        .with_field("name")
+        .with_field("price");
+    let p = s.preview();
+    assert!(p.starts_with("db.product.find({})"));
+    assert!(p.contains(".projection("));
+}
+
+#[test]
+fn test_select_with_condition() {
+    let s = MongoSelect::new()
+        .with_source("product")
+        .with_condition(doc! { "price": { "$gt": 100 } });
+    assert!(s.preview().contains("<1 conditions>"));
+}
+
+#[test]
+fn test_select_order_and_limit() {
+    let s = MongoSelect::new()
+        .with_source("product")
+        .with_order(doc! { "price": 1 }, Order::Desc)
+        .with_limit(Some(2), None);
+    let p = s.preview();
+    assert!(p.contains(".sort("));
+    assert!(p.contains(".limit(2)"));
+}
+
+#[test]
+fn test_select_distinct() {
+    let mut s = MongoSelect::new().with_source("product").with_field("name");
+    s.set_distinct(true);
+    assert!(s.is_distinct());
+}
+
+#[test]
+fn test_as_count_preview() {
+    let s = MongoSelect::new().with_source("product");
+    let expr = s.as_count();
+    assert_eq!(expr.preview(), "db.product.countDocuments()");
+}
+
+#[test]
+fn test_build_projection() {
+    let s = MongoSelect::new().with_field("name").with_field("price");
+    let proj = s.build_projection().unwrap();
+    assert_eq!(proj, doc! { "name": 1, "price": 1 });
+}
+
+#[test]
+fn test_build_projection_empty_means_all() {
+    let s = MongoSelect::new();
+    assert!(s.build_projection().is_none());
+}
+
+#[test]
+fn test_build_sort() {
+    let s = MongoSelect::new()
+        .with_order(doc! { "price": 1 }, Order::Asc)
+        .with_order(doc! { "name": 1 }, Order::Desc);
+    let sort = s.build_sort().unwrap();
+    assert_eq!(sort, doc! { "price": 1, "name": -1 });
+}
+
+#[test]
+fn test_build_find_options() {
+    let s = MongoSelect::new()
+        .with_field("name")
+        .with_limit(Some(5), Some(10));
+    let opts = s.build_find_options();
+    assert!(opts.projection.is_some());
+    assert_eq!(opts.limit, Some(5));
+    assert_eq!(opts.skip, Some(10));
+}
+
+#[tokio::test]
+async fn test_build_filter_empty() {
+    let s = MongoSelect::new();
+    let filter = s.build_filter().await.unwrap();
+    assert_eq!(filter, doc! {});
+}
+
+#[tokio::test]
+async fn test_build_filter_single() {
+    let s = MongoSelect::new().with_condition(doc! { "active": true });
+    let filter = s.build_filter().await.unwrap();
+    assert_eq!(filter, doc! { "active": true });
+}
+
+#[tokio::test]
+async fn test_build_filter_multiple_uses_and() {
+    let s = MongoSelect::new()
+        .with_condition(doc! { "active": true })
+        .with_condition(doc! { "price": { "$gt": 100 } });
+    let filter = s.build_filter().await.unwrap();
+    assert_eq!(
+        filter,
+        doc! { "$and": [{ "active": true }, { "price": { "$gt": 100 } }] }
+    );
+}
+
+#[tokio::test]
+async fn test_count_pipeline_empty() {
+    let s = MongoSelect::new();
+    let pipeline = s.as_count_pipeline().await.unwrap();
+    assert_eq!(pipeline.len(), 1);
+    assert_eq!(pipeline[0], doc! { "$count": "count" });
+}
+
+#[tokio::test]
+async fn test_count_pipeline_with_filter() {
+    let s = MongoSelect::new().with_condition(doc! { "is_deleted": false });
+    let pipeline = s.as_count_pipeline().await.unwrap();
+    assert_eq!(pipeline.len(), 2);
+    assert_eq!(pipeline[0], doc! { "$match": { "is_deleted": false } });
+    assert_eq!(pipeline[1], doc! { "$count": "count" });
+}
+
+#[tokio::test]
+async fn test_aggregate_pipeline_sum() {
+    let s = MongoSelect::new();
+    let pipeline = s.as_aggregate_pipeline("$sum", "price").await.unwrap();
+    assert_eq!(pipeline.len(), 1);
+    assert_eq!(
+        pipeline[0],
+        doc! { "$group": { "_id": null, "val": { "$sum": "$price" } } }
+    );
+}
+
+// ── Clear / has methods ──────────────────────────────────────────────────
+
+#[test]
+fn test_clear_and_has() {
+    let mut s = MongoSelect::new()
+        .with_source("product")
+        .with_field("name")
+        .with_condition(doc! { "a": 1 })
+        .with_order(doc! { "price": 1 }, Order::Asc)
+        .with_limit(Some(10), None);
+
+    assert!(s.has_fields());
+    assert!(s.has_where_conditions());
+    assert!(s.has_order_by());
+    assert_eq!(s.get_limit(), Some(10));
+    assert_eq!(s.get_skip(), None);
+
+    s.clear_fields();
+    s.clear_where_conditions();
+    s.clear_order_by();
+
+    assert!(!s.has_fields());
+    assert!(!s.has_where_conditions());
+    assert!(!s.has_order_by());
+    // limit untouched
+    assert_eq!(s.get_limit(), Some(10));
+}
+
+// ── Live execution via SelectableDataSource (seeded v2 data) ─────────────
+
+#[tokio::test]
+async fn test_execute_select_all_products() {
+    use vantage_expressions::SelectableDataSource;
+
+    let db = db().await;
+    let select = MongoSelect::new().with_source("product");
+    let results = db.execute_select(&select).await.unwrap();
+
+    // v2 seeds 5 products
+    assert_eq!(results.len(), 5);
+}
+
+#[tokio::test]
+async fn test_execute_select_with_fields() {
+    use vantage_expressions::SelectableDataSource;
+
+    let db = db().await;
+    let select = MongoSelect::new()
+        .with_source("product")
+        .with_field("name")
+        .with_field("price");
+    let results = db.execute_select(&select).await.unwrap();
+
+    assert_eq!(results.len(), 5);
+    // Each result should be a document with projected fields
+    let first: vantage_types::Record<AnyMongoType> = results[0].clone().try_into().unwrap();
+    assert!(first.get("name").is_some());
+    assert!(first.get("price").is_some());
+}
+
+#[tokio::test]
+async fn test_execute_select_with_condition() {
+    use vantage_expressions::SelectableDataSource;
+
+    let db = db().await;
+    let select = MongoSelect::new()
+        .with_source("product")
+        .with_condition(doc! { "price": { "$gt": 200 } });
+    let results = db.execute_select(&select).await.unwrap();
+
+    // sea_pie (299) and time_tart (220) have price > 200
+    assert_eq!(results.len(), 2);
+}
+
+#[tokio::test]
+async fn test_execute_select_with_order() {
+    use vantage_expressions::SelectableDataSource;
+
+    let db = db().await;
+    let select = MongoSelect::new()
+        .with_source("product")
+        .with_order(doc! { "price": 1 }, Order::Asc);
+    let results = db.execute_select(&select).await.unwrap();
+
+    // Verify ascending price order
+    let mut prices: Vec<i64> = Vec::new();
+    for r in &results {
+        let rec: vantage_types::Record<AnyMongoType> = r.clone().try_into().unwrap();
+        if let Some(p) = rec
+            .get("price")
+            .and_then(|v| v.try_get::<i64>().or(v.try_get::<i32>().map(|i| i as i64)))
+        {
+            prices.push(p);
+        }
+    }
+    assert_eq!(prices.len(), 5);
+    for w in prices.windows(2) {
+        assert!(w[0] <= w[1], "Expected ascending: {} <= {}", w[0], w[1]);
+    }
+}
+
+#[tokio::test]
+async fn test_execute_select_with_limit() {
+    use vantage_expressions::SelectableDataSource;
+
+    let db = db().await;
+    let select = MongoSelect::new()
+        .with_source("product")
+        .with_limit(Some(2), None);
+    let results = db.execute_select(&select).await.unwrap();
+
+    assert_eq!(results.len(), 2);
+}
+
+#[tokio::test]
+async fn test_execute_select_with_skip_and_limit() {
+    use vantage_expressions::SelectableDataSource;
+
+    let db = db().await;
+    let select = MongoSelect::new()
+        .with_source("product")
+        .with_order(doc! { "price": 1 }, Order::Asc)
+        .with_limit(Some(2), Some(1));
+    let results = db.execute_select(&select).await.unwrap();
+
+    assert_eq!(results.len(), 2);
+    // Skipped the cheapest (120), should start from 135
+    let rec: vantage_types::Record<AnyMongoType> = results[0].clone().try_into().unwrap();
+    let price = rec["price"]
+        .try_get::<i64>()
+        .or(rec["price"].try_get::<i32>().map(|i| i as i64))
+        .unwrap();
+    assert_eq!(price, 135);
+}
+
+#[tokio::test]
+async fn test_execute_select_multiple_conditions() {
+    use vantage_expressions::SelectableDataSource;
+
+    let db = db().await;
+    let select = MongoSelect::new()
+        .with_source("product")
+        .with_condition(doc! { "is_deleted": false })
+        .with_condition(doc! { "price": { "$gte": 199 } });
+    let results = db.execute_select(&select).await.unwrap();
+
+    // Not deleted AND price >= 199: sea_pie(299), time_tart(220), hover_cookies(199)
+    assert_eq!(results.len(), 3);
+}
+
+#[tokio::test]
+async fn test_execute_select_clients() {
+    use vantage_expressions::SelectableDataSource;
+
+    let db = db().await;
+    let select = MongoSelect::new()
+        .with_source("client")
+        .with_condition(doc! { "is_paying_client": true });
+    let results = db.execute_select(&select).await.unwrap();
+
+    // marty and doc are paying clients
+    assert_eq!(results.len(), 2);
+}
+
+#[tokio::test]
+async fn test_execute_select_empty_result() {
+    use vantage_expressions::SelectableDataSource;
+
+    let db = db().await;
+    let select = MongoSelect::new()
+        .with_source("product")
+        .with_condition(doc! { "price": { "$gt": 10000 } });
+    let results = db.execute_select(&select).await.unwrap();
+
+    assert!(results.is_empty());
+}
+
+// ── table.select() integration ───────────────────────────────────────────
+// Verifies that Table<MongoDB, E> can produce a MongoSelect via table.select()
+
+#[tokio::test]
+async fn test_table_select_products() {
+    use vantage_expressions::SelectableDataSource;
+    use vantage_table::table::Table;
+    use vantage_types::EmptyEntity;
+
+    let db = db().await;
+    let table = Table::<MongoDB, EmptyEntity>::new("product", db.clone())
+        .with_id_column("_id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price")
+        .with_column_of::<bool>("is_deleted");
+
+    let select = table.select();
+
+    assert_eq!(select.collection, Some("product".to_string()));
+    assert!(select.has_fields());
+    // Should have _id, name, price, is_deleted
+    assert_eq!(select.fields.len(), 4);
+
+    // Execute it
+    let results = db.execute_select(&select).await.unwrap();
+    assert_eq!(results.len(), 5);
+}
+
+#[tokio::test]
+async fn test_table_select_with_condition() {
+    use vantage_expressions::SelectableDataSource;
+    use vantage_table::table::Table;
+    use vantage_types::EmptyEntity;
+
+    let db = db().await;
+    let mut table = Table::<MongoDB, EmptyEntity>::new("product", db.clone())
+        .with_id_column("_id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price")
+        .with_column_of::<bool>("is_deleted");
+
+    table.add_condition(doc! { "is_deleted": false });
+
+    let select = table.select();
+    assert!(select.has_where_conditions());
+
+    let results = db.execute_select(&select).await.unwrap();
+    assert_eq!(results.len(), 5); // all v2 products have is_deleted: false
+}
+
+#[tokio::test]
+async fn test_table_select_with_condition_and_limit() {
+    use vantage_expressions::SelectableDataSource;
+    use vantage_table::table::Table;
+    use vantage_types::EmptyEntity;
+
+    let db = db().await;
+    let mut table = Table::<MongoDB, EmptyEntity>::new("product", db.clone())
+        .with_id_column("_id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price");
+
+    table.add_condition(doc! { "price": { "$gt": 130 } });
+
+    let mut select = table.select();
+    select.set_limit(Some(2), None);
+
+    let results = db.execute_select(&select).await.unwrap();
+    assert_eq!(results.len(), 2);
+}

--- a/vantage-mongodb/tests/4_aggregates.rs
+++ b/vantage-mongodb/tests/4_aggregates.rs
@@ -1,0 +1,58 @@
+//! Test 4: Aggregates — COUNT, SUM, MAX, MIN via TableSource against seeded v2 data.
+
+use vantage_mongodb::MongoDB;
+use vantage_table::table::Table;
+use vantage_table::traits::table_like::TableLike;
+use vantage_table::traits::table_source::TableSource;
+use vantage_types::EmptyEntity;
+
+fn mongo_url() -> String {
+    std::env::var("MONGODB_URL").unwrap_or_else(|_| "mongodb://localhost:27017".into())
+}
+
+async fn get_db() -> MongoDB {
+    MongoDB::connect(&mongo_url(), "vantage").await.unwrap()
+}
+
+fn product_table(db: MongoDB) -> Table<MongoDB, EmptyEntity> {
+    Table::new("product", db)
+        .with_id_column("_id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("calories")
+        .with_column_of::<i64>("price")
+        .with_column_of::<String>("bakery_id")
+        .with_column_of::<bool>("is_deleted")
+        .with_column_of::<i64>("inventory_stock")
+}
+
+#[tokio::test]
+async fn test_count() {
+    let db = get_db().await;
+    let table = product_table(db);
+    assert_eq!(table.get_count().await.unwrap(), 5);
+}
+
+#[tokio::test]
+async fn test_max_price() {
+    let db = get_db().await;
+    let table = product_table(db.clone());
+    let max = db.get_table_max(&table, &table["price"]).await.unwrap();
+    assert_eq!(max.try_get::<i64>().unwrap(), 299);
+}
+
+#[tokio::test]
+async fn test_min_price() {
+    let db = get_db().await;
+    let table = product_table(db.clone());
+    let min = db.get_table_min(&table, &table["price"]).await.unwrap();
+    assert_eq!(min.try_get::<i64>().unwrap(), 120);
+}
+
+#[tokio::test]
+async fn test_sum_price() {
+    let db = get_db().await;
+    let table = product_table(db.clone());
+    let sum = db.get_table_sum(&table, &table["price"]).await.unwrap();
+    // 120 + 135 + 220 + 299 + 199 = 973
+    assert_eq!(sum.try_get::<i64>().unwrap(), 973);
+}

--- a/vantage-mongodb/tests/4_conditions.rs
+++ b/vantage-mongodb/tests/4_conditions.rs
@@ -1,0 +1,64 @@
+//! Test 4: Conditions on Table<MongoDB, EmptyEntity> against seeded v2 data.
+
+use bson::doc;
+use vantage_dataset::prelude::*;
+use vantage_mongodb::{MongoDB, MongoId};
+use vantage_table::table::Table;
+use vantage_types::EmptyEntity;
+
+fn mongo_url() -> String {
+    std::env::var("MONGODB_URL").unwrap_or_else(|_| "mongodb://localhost:27017".into())
+}
+
+async fn get_db() -> MongoDB {
+    MongoDB::connect(&mongo_url(), "vantage").await.unwrap()
+}
+
+fn product_table(db: MongoDB) -> Table<MongoDB, EmptyEntity> {
+    Table::new("product", db)
+        .with_id_column("_id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("calories")
+        .with_column_of::<i64>("price")
+        .with_column_of::<String>("bakery_id")
+        .with_column_of::<bool>("is_deleted")
+        .with_column_of::<i64>("inventory_stock")
+}
+
+#[tokio::test]
+async fn test_condition_gt() {
+    let db = get_db().await;
+    let mut table = product_table(db);
+    table.add_condition(doc! { "price": { "$gt": 130 } });
+
+    let products = table.list_values().await.unwrap();
+    assert_eq!(products.len(), 4); // 135, 220, 299, 199
+}
+
+#[tokio::test]
+async fn test_multiple_conditions() {
+    let db = get_db().await;
+    let mut table = product_table(db);
+    table.add_condition(doc! { "price": { "$gt": 130 } });
+    table.add_condition(doc! { "$expr": { "$gt": ["$price", "$calories"] } });
+
+    let products = table.list_values().await.unwrap();
+    // price > 130 AND price > calories:
+    // delorean_donut: 135 > 250? no
+    // time_tart: 220 > 200? yes
+    // sea_pie: 299 > 350? no
+    // hover_cookies: 199 > 150? yes
+    assert_eq!(products.len(), 2);
+    assert!(products.contains_key(&MongoId::from("time_tart")));
+    assert!(products.contains_key(&MongoId::from("hover_cookies")));
+}
+
+#[tokio::test]
+async fn test_condition_eq_bool() {
+    let db = get_db().await;
+    let mut table = product_table(db);
+    table.add_condition(doc! { "is_deleted": false });
+
+    let products = table.list_values().await.unwrap();
+    assert_eq!(products.len(), 5); // all products have is_deleted=false
+}

--- a/vantage-mongodb/tests/4_editable_data_set.rs
+++ b/vantage-mongodb/tests/4_editable_data_set.rs
@@ -1,0 +1,141 @@
+//! Test 4: WritableValueSet and InsertableValueSet for Table<MongoDB, EmptyEntity>.
+//!
+//! Uses temporary collections (cleaned up per test) to avoid mutating seeded data.
+
+use vantage_dataset::prelude::*;
+use vantage_mongodb::{AnyMongoType, MongoDB, MongoId};
+use vantage_table::table::Table;
+use vantage_types::EmptyEntity;
+
+fn mongo_url() -> String {
+    std::env::var("MONGODB_URL").unwrap_or_else(|_| "mongodb://localhost:27017".into())
+}
+
+async fn setup(suffix: &str) -> (MongoDB, Table<MongoDB, EmptyEntity>) {
+    let db = MongoDB::connect(&mongo_url(), "vantage").await.unwrap();
+    let table_name = format!("edit_item_{}", suffix);
+
+    // Clean slate
+    let coll = db.doc_collection(&table_name);
+    coll.drop().await.ok();
+
+    // Seed two records
+    coll.insert_many(vec![
+        bson::doc! { "_id": "a", "name": "Alpha", "price": 10_i64 },
+        bson::doc! { "_id": "b", "name": "Beta", "price": 20_i64 },
+    ])
+    .await
+    .unwrap();
+
+    let table = Table::<MongoDB, EmptyEntity>::new(&table_name, db.clone())
+        .with_id_column("_id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price");
+
+    (db, table)
+}
+
+fn record(fields: &[(&str, AnyMongoType)]) -> vantage_types::Record<AnyMongoType> {
+    fields
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect()
+}
+
+#[tokio::test]
+async fn test_insert() {
+    let (_db, table) = setup("insert").await;
+
+    let rec = record(&[
+        ("name", AnyMongoType::new("Gamma".to_string())),
+        ("price", AnyMongoType::new(30i64)),
+    ]);
+    let result = table.insert_value(&MongoId::from("c"), &rec).await.unwrap();
+    assert_eq!(result["name"].try_get::<String>(), Some("Gamma".into()));
+    assert_eq!(result["price"].try_get::<i64>(), Some(30));
+
+    let fetched = table.get_value(&MongoId::from("c")).await.unwrap();
+    assert_eq!(fetched["name"].try_get::<String>(), Some("Gamma".into()));
+}
+
+#[tokio::test]
+async fn test_replace() {
+    let (_db, table) = setup("replace").await;
+
+    let rec = record(&[
+        ("name", AnyMongoType::new("Alpha Replaced".to_string())),
+        ("price", AnyMongoType::new(99i64)),
+    ]);
+    table
+        .replace_value(&MongoId::from("a"), &rec)
+        .await
+        .unwrap();
+
+    let fetched = table.get_value(&MongoId::from("a")).await.unwrap();
+    assert_eq!(
+        fetched["name"].try_get::<String>(),
+        Some("Alpha Replaced".into())
+    );
+    assert_eq!(fetched["price"].try_get::<i64>(), Some(99));
+}
+
+#[tokio::test]
+async fn test_patch() {
+    let (_db, table) = setup("patch").await;
+
+    let partial = record(&[("price", AnyMongoType::new(55i64))]);
+    table
+        .patch_value(&MongoId::from("a"), &partial)
+        .await
+        .unwrap();
+
+    let fetched = table.get_value(&MongoId::from("a")).await.unwrap();
+    assert_eq!(fetched["price"].try_get::<i64>(), Some(55));
+    // name untouched
+    assert_eq!(fetched["name"].try_get::<String>(), Some("Alpha".into()));
+}
+
+#[tokio::test]
+async fn test_delete() {
+    let (_db, table) = setup("delete").await;
+
+    WritableValueSet::delete(&table, &MongoId::from("a"))
+        .await
+        .unwrap();
+
+    let all = table.list_values().await.unwrap();
+    assert_eq!(all.len(), 1);
+    assert!(!all.contains_key(&MongoId::from("a")));
+}
+
+#[tokio::test]
+async fn test_delete_all() {
+    let (_db, table) = setup("delete_all").await;
+
+    WritableValueSet::delete_all(&table).await.unwrap();
+    assert!(table.list_values().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_insert_return_id() {
+    let (db, _) = setup("auto_id").await;
+
+    let coll_name = "edit_auto_item";
+    db.doc_collection(coll_name).drop().await.ok();
+
+    let table = Table::<MongoDB, EmptyEntity>::new(coll_name, db)
+        .with_id_column("_id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price");
+
+    let rec = record(&[
+        ("name", AnyMongoType::new("Auto".to_string())),
+        ("price", AnyMongoType::new(42i64)),
+    ]);
+    let id = table.insert_return_id_value(&rec).await.unwrap();
+    assert!(!id.to_string().is_empty());
+
+    let fetched = table.get_value(&id).await.unwrap();
+    assert_eq!(fetched["name"].try_get::<String>(), Some("Auto".into()));
+    assert_eq!(fetched["price"].try_get::<i64>(), Some(42));
+}

--- a/vantage-mongodb/tests/4_readable_data_set.rs
+++ b/vantage-mongodb/tests/4_readable_data_set.rs
@@ -1,0 +1,76 @@
+//! Test 4: ReadableValueSet for Table<MongoDB, EmptyEntity> against seeded v2 data.
+
+use vantage_dataset::prelude::*;
+use vantage_mongodb::{MongoDB, MongoId};
+use vantage_table::table::Table;
+use vantage_types::EmptyEntity;
+
+fn mongo_url() -> String {
+    std::env::var("MONGODB_URL").unwrap_or_else(|_| "mongodb://localhost:27017".into())
+}
+
+async fn get_db() -> MongoDB {
+    MongoDB::connect(&mongo_url(), "vantage")
+        .await
+        .expect("Failed to connect — run scripts/start.sh + scripts/ingress.sh first")
+}
+
+fn product_table(db: MongoDB) -> Table<MongoDB, EmptyEntity> {
+    Table::new("product", db)
+        .with_id_column("_id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("calories")
+        .with_column_of::<i64>("price")
+        .with_column_of::<String>("bakery_id")
+        .with_column_of::<bool>("is_deleted")
+        .with_column_of::<i64>("inventory_stock")
+}
+
+#[tokio::test]
+async fn test_list_products() {
+    let db = get_db().await;
+    let table = product_table(db);
+
+    let values = table.list_values().await.unwrap();
+    assert_eq!(values.len(), 5);
+
+    let cupcake = &values[&MongoId::from("flux_cupcake")];
+    assert_eq!(
+        cupcake["name"].try_get::<String>(),
+        Some("Flux Capacitor Cupcake".into())
+    );
+    assert_eq!(cupcake["price"].try_get::<i64>(), Some(120));
+    assert_eq!(cupcake["calories"].try_get::<i64>(), Some(300));
+    assert_eq!(cupcake["is_deleted"].try_get::<bool>(), Some(false));
+}
+
+#[tokio::test]
+async fn test_get_product() {
+    let db = get_db().await;
+    let table = product_table(db);
+
+    let record = table
+        .get_value(&MongoId::from("delorean_donut"))
+        .await
+        .unwrap();
+    assert_eq!(
+        record["name"].try_get::<String>(),
+        Some("DeLorean Doughnut".into())
+    );
+    assert_eq!(record["price"].try_get::<i64>(), Some(135));
+    assert_eq!(record["calories"].try_get::<i64>(), Some(250));
+}
+
+#[tokio::test]
+async fn test_get_some_product() {
+    let db = get_db().await;
+    let table = product_table(db);
+
+    let result = table.get_some_value().await.unwrap();
+    assert!(result.is_some());
+
+    let (id, record) = result.unwrap();
+    assert!(!id.to_string().is_empty());
+    assert!(record.get("name").is_some());
+    assert!(record.get("price").is_some());
+}

--- a/vantage-mongodb/tests/4_table_def.rs
+++ b/vantage-mongodb/tests/4_table_def.rs
@@ -1,0 +1,42 @@
+//! Test 4: Table definition and query generation via TableSource.
+
+use vantage_mongodb::{AnyMongoType, MongoDB};
+use vantage_table::table::Table;
+use vantage_types::EmptyEntity;
+
+fn mongo_url() -> String {
+    std::env::var("MONGODB_URL").unwrap_or_else(|_| "mongodb://localhost:27017".into())
+}
+
+fn product_table(db: MongoDB) -> Table<MongoDB, EmptyEntity> {
+    Table::new("product", db)
+        .with_id_column("_id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("calories")
+        .with_column_of::<i64>("price")
+        .with_column_of::<String>("bakery_id")
+        .with_column_of::<bool>("is_deleted")
+        .with_column_of::<i64>("inventory_stock")
+}
+
+#[tokio::test]
+async fn test_product_select() {
+    let db = MongoDB::connect(&mongo_url(), "vantage").await.unwrap();
+    let table = product_table(db);
+    let select = table.select();
+
+    assert_eq!(select.collection, Some("product".to_string()));
+    assert_eq!(
+        select.fields,
+        vec![
+            "_id",
+            "name",
+            "calories",
+            "price",
+            "bakery_id",
+            "is_deleted",
+            "inventory_stock"
+        ]
+    );
+    assert!(select.preview().starts_with("db.product.find({})"));
+}

--- a/vantage-sql/src/mysql/statements/primitives/fulltext_match.rs
+++ b/vantage-sql/src/mysql/statements/primitives/fulltext_match.rs
@@ -66,6 +66,12 @@ impl FulltextMatch {
     }
 }
 
+impl From<FulltextMatch> for Expr {
+    fn from(fm: FulltextMatch) -> Self {
+        fm.expr()
+    }
+}
+
 impl Expressive<AnyMysqlType> for FulltextMatch {
     fn expr(&self) -> Expr {
         let cols = Expression::from_vec(self.columns.clone(), ", ");

--- a/vantage-sql/src/primitives/fx.rs
+++ b/vantage-sql/src/primitives/fx.rs
@@ -60,3 +60,9 @@ impl<T: Debug + Display + Clone> Expressive<T> for Fx<T> {
         }
     }
 }
+
+impl<T: Debug + Display + Clone> From<Fx<T>> for Expression<T> {
+    fn from(fx: Fx<T>) -> Self {
+        fx.expr()
+    }
+}

--- a/vantage-sql/src/primitives/identifier.rs
+++ b/vantage-sql/src/primitives/identifier.rs
@@ -82,6 +82,13 @@ impl Expressive<crate::sqlite::types::AnySqliteType> for Identifier {
     }
 }
 
+#[cfg(feature = "sqlite")]
+impl From<Identifier> for Expression<crate::sqlite::types::AnySqliteType> {
+    fn from(id: Identifier) -> Self {
+        id.expr()
+    }
+}
+
 #[cfg(feature = "postgres")]
 impl Expressive<crate::postgres::types::AnyPostgresType> for Identifier {
     fn expr(&self) -> Expression<crate::postgres::types::AnyPostgresType> {
@@ -89,9 +96,23 @@ impl Expressive<crate::postgres::types::AnyPostgresType> for Identifier {
     }
 }
 
+#[cfg(feature = "postgres")]
+impl From<Identifier> for Expression<crate::postgres::types::AnyPostgresType> {
+    fn from(id: Identifier) -> Self {
+        id.expr()
+    }
+}
+
 #[cfg(feature = "mysql")]
 impl Expressive<crate::mysql::types::AnyMysqlType> for Identifier {
     fn expr(&self) -> Expression<crate::mysql::types::AnyMysqlType> {
         Expression::new(self.render_with('`'), vec![])
+    }
+}
+
+#[cfg(feature = "mysql")]
+impl From<Identifier> for Expression<crate::mysql::types::AnyMysqlType> {
+    fn from(id: Identifier) -> Self {
+        id.expr()
     }
 }

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -10,8 +10,7 @@ use crate::{
 
 impl<T, E> Table<T, E>
 where
-    T: SelectableDataSource<T::Value> + TableSource,
-    T::Select: Selectable<T::Value, T::Condition>,
+    T: SelectableDataSource<T::Value, T::Condition> + TableSource,
     T::Value: From<String>, // that's because table is specified as a string
     E: Entity<T::Value>,
 {
@@ -92,10 +91,9 @@ where
 // Specific implementation for serde_json::Value that can use QuerySource
 impl<T, E> Table<T, E>
 where
-    T: SelectableDataSource<serde_json::Value>
+    T: SelectableDataSource<serde_json::Value, T::Condition>
         + TableSource<Value = serde_json::Value>
         + vantage_expressions::traits::datasource::ExprDataSource<serde_json::Value>,
-    T::Select: Selectable<serde_json::Value, T::Condition>,
     T::Value: From<String>,
     E: Entity<serde_json::Value>,
 {


### PR DESCRIPTION
Third installment of the mongodb stack — `table.select()` now actually runs against MongoDB, and `_id` no longer has to be an `ObjectId`.

### Breaking: `TableSource::Id` is now `MongoId`

`vantage_mongodb::MongoId` is an enum over `ObjectId` and `String`. Collections seeded with custom string ids (`"flux_cupcake"`, `"delorean_donut"`) round-trip the same way auto-generated `ObjectId`s do — `from_str` parses 24-char hex as `ObjectId` and falls back to `String`, so the dispatcher doesn't have to. If you held an `ObjectId` directly, swap it for `MongoId::from(oid)` (or `MongoId::from("my_string_id")`).

### `SelectableDataSource` is wired up

`MongoDB` now implements `SelectableDataSource<AnyMongoType, MongoCondition>`, so `table.select()` returns a `MongoSelect` that `execute_select` turns into a real `find` with projection, sort, limit, skip, and `$and`-merged filters. The trait itself gained a `C` generic (`SelectableDataSource<T, C = Expression<T>>`) so non-SQL condition types fit; existing SQL impls are unchanged thanks to the default. `Fx`, `Identifier`, and `FulltextMatch` got `From<_> for Expression<_>` impls so they slot into the new bound.

Six new test files (~820 lines) cover builder previews, projection/sort/limit math, multi-condition `$and`, count/sum/max/min aggregate pipelines, and full CRUD against seeded `vantage` data. Aggregations on the `MongoSelect` side itself (group-by, `$lookup` joins) are still ahead — that's the next part of the stack.