### PR TITLE
mongodb-core-impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 name = "bakery_model3"
 version = "0.1.0"
 dependencies = [
+ "bson",
  "clap",
  "indexmap",
  "serde_json",
@@ -182,6 +183,7 @@ dependencies = [
  "vantage-csv",
  "vantage-dataset",
  "vantage-expressions",
+ "vantage-mongodb",
  "vantage-sql",
  "vantage-surrealdb",
  "vantage-table",

--- a/bakery_model3/Cargo.toml
+++ b/bakery_model3/Cargo.toml
@@ -11,8 +11,10 @@ vantage-expressions = { path = "../vantage-expressions" }
 vantage-dataset = { path = "../vantage-dataset" }
 vantage-types = { path = "../vantage-types" }
 vantage-sql = { path = "../vantage-sql", features = ["sqlite", "postgres"] }
+vantage-mongodb = { path = "../vantage-mongodb" }
 vantage-surrealdb = { path = "../vantage-surrealdb" }
 surreal-client = { path = "../surreal-client", features = ["decimal"] }
+bson = "2"
 serde_json = "1"
 indexmap = "2.0"
 tokio = { version = "1.48", features = ["full"] }

--- a/bakery_model3/examples/cli.rs
+++ b/bakery_model3/examples/cli.rs
@@ -2,7 +2,7 @@
 //!
 //! Usage: db [--debug] <source> <entity> [command ...]
 //!
-//! Sources: csv, surreal, sqlite, postgres
+//! Sources: csv, surreal, sqlite, postgres, mongo
 //! Entities: bakery, client, product, order
 //!
 //! Commands:
@@ -45,7 +45,7 @@ async fn run() -> vantage_core::Result<()> {
         )
         .arg(
             Arg::new("source")
-                .help("Data source: csv, surreal, sqlite, postgres")
+                .help("Data source: csv, surreal, sqlite, postgres, mongo")
                 .required(true),
         )
         .arg(
@@ -86,7 +86,7 @@ async fn run() -> vantage_core::Result<()> {
         None => return Ok(()),
     };
 
-    handle_commands(table, commands).await
+    handle_commands(table, commands, source).await
 }
 
 async fn build_table(
@@ -163,9 +163,28 @@ async fn build_table(
             };
             Ok(Some(table))
         }
+        "mongo" => {
+            let url = std::env::var("MONGODB_URL")
+                .unwrap_or_else(|_| "mongodb://localhost:27017".to_string());
+            let db_name = std::env::var("MONGODB_DB").unwrap_or_else(|_| "vantage".to_string());
+            let db = MongoDB::connect(&url, &db_name).await.map_err(|e| {
+                vantage_core::error!("Failed to connect to MongoDB", details = e.to_string())
+            })?;
+            let table = match entity_name {
+                "bakery" => AnyTable::from_table(Bakery::mongo_table(db)),
+                "client" => AnyTable::from_table(Client::mongo_table(db)),
+                "product" => AnyTable::from_table(Product::mongo_table(db)),
+                "order" => AnyTable::from_table(Order::mongo_table(db)),
+                _ => {
+                    println!("Unknown entity: {}", entity_name);
+                    return Ok(None);
+                }
+            };
+            Ok(Some(table))
+        }
         _ => {
             println!(
-                "Unknown source: {}. Use: csv, surreal, sqlite, postgres",
+                "Unknown source: {}. Use: csv, surreal, sqlite, postgres, mongo",
                 source
             );
             Ok(None)
@@ -177,7 +196,7 @@ fn print_usage() {
     println!();
     println!("Usage: db [--debug] <source> <entity> <command>");
     println!();
-    println!("Sources: csv, surreal, sqlite, postgres");
+    println!("Sources: csv, surreal, sqlite, postgres, mongo");
     println!();
     println!("Commands:");
     println!("  list              List all records");
@@ -189,12 +208,12 @@ fn print_usage() {
     println!("Examples:");
     println!("  db csv bakery list");
     println!("  db surreal product list");
-    println!("  db surreal bakery count");
+    println!("  db mongo bakery count");
     println!(r#"  db surreal bakery add myid '{{"name":"Test","profit_margin":10}}'"#);
     println!("  db surreal bakery delete myid");
 }
 
-async fn handle_commands(table: AnyTable, commands: Vec<String>) -> vantage_core::Result<()> {
+async fn handle_commands(table: AnyTable, commands: Vec<String>, source: &str) -> vantage_core::Result<()> {
     if commands.is_empty() {
         println!("No command. Try: list, get, count, add, delete");
         return Ok(());
@@ -243,7 +262,7 @@ async fn handle_commands(table: AnyTable, commands: Vec<String>) -> vantage_core
                     break;
                 }
 
-                let id = qualify_id(table.table_name(), id_str);
+                let id = qualify_id(source, table.table_name(), id_str);
                 let record = vantage_types::Record::from(json_val);
                 table.insert_value(&id, &record).await?;
                 println!("Inserted: {}", id);
@@ -256,7 +275,7 @@ async fn handle_commands(table: AnyTable, commands: Vec<String>) -> vantage_core
                 let id_str = &commands[i];
                 i += 1;
 
-                let id = qualify_id(table.table_name(), id_str);
+                let id = qualify_id(source, table.table_name(), id_str);
                 table.delete(&id).await?;
                 println!("Deleted: {}", id);
             }
@@ -269,14 +288,12 @@ async fn handle_commands(table: AnyTable, commands: Vec<String>) -> vantage_core
     Ok(())
 }
 
-/// Qualify a bare id with the table name if it doesn't already contain ':'.
-///
-/// "foo" stays "foo" for CSV, but SurrealDB ids pass through JsonAdapter's
-/// `T::Id::from(String)` which parses "table:id" into a Thing.
-fn qualify_id(table_name: &str, id: &str) -> String {
-    if id.contains(':') {
-        id.to_string()
-    } else {
+/// Qualify a bare id for SurrealDB (which needs "table:id" format).
+/// All other backends use the id as-is.
+fn qualify_id(source: &str, table_name: &str, id: &str) -> String {
+    if source == "surreal" && !id.contains(':') {
         format!("{}:{}", table_name, id)
+    } else {
+        id.to_string()
     }
 }

--- a/bakery_model3/examples/cli.rs
+++ b/bakery_model3/examples/cli.rs
@@ -213,7 +213,11 @@ fn print_usage() {
     println!("  db surreal bakery delete myid");
 }
 
-async fn handle_commands(table: AnyTable, commands: Vec<String>, source: &str) -> vantage_core::Result<()> {
+async fn handle_commands(
+    table: AnyTable,
+    commands: Vec<String>,
+    source: &str,
+) -> vantage_core::Result<()> {
     if commands.is_empty() {
         println!("No command. Try: list, get, count, add, delete");
         return Ok(());

--- a/bakery_model3/src/animal.rs
+++ b/bakery_model3/src/animal.rs
@@ -1,5 +1,8 @@
+use bson::Bson;
 use serde_json::Value as JsonValue;
 use vantage_csv::{CsvType, type_system::CsvTypeAnimalMarker};
+use vantage_mongodb::types::MongoTypeStringMarker;
+use vantage_mongodb::MongoType;
 use vantage_sql::postgres::{PostgresType, types::PostgresTypeTextMarker};
 use vantage_sql::sqlite::{SqliteType, types::SqliteTypeTextMarker};
 use vantage_surrealdb::types::SurrealTypeStringMarker;
@@ -107,6 +110,21 @@ impl SurrealType for Animal {
     fn from_cbor(cbor: CborValue) -> Option<Self> {
         match cbor {
             CborValue::Text(s) => s.parse().ok(),
+            _ => None,
+        }
+    }
+}
+
+impl MongoType for Animal {
+    type Target = MongoTypeStringMarker;
+
+    fn to_bson(&self) -> Bson {
+        Bson::String(self.as_str().to_string())
+    }
+
+    fn from_bson(value: Bson) -> Option<Self> {
+        match value {
+            Bson::String(s) => s.parse().ok(),
             _ => None,
         }
     }

--- a/bakery_model3/src/animal.rs
+++ b/bakery_model3/src/animal.rs
@@ -1,8 +1,8 @@
 use bson::Bson;
 use serde_json::Value as JsonValue;
 use vantage_csv::{CsvType, type_system::CsvTypeAnimalMarker};
-use vantage_mongodb::types::MongoTypeStringMarker;
 use vantage_mongodb::MongoType;
+use vantage_mongodb::types::MongoTypeStringMarker;
 use vantage_sql::postgres::{PostgresType, types::PostgresTypeTextMarker};
 use vantage_sql::sqlite::{SqliteType, types::SqliteTypeTextMarker};
 use vantage_surrealdb::types::SurrealTypeStringMarker;

--- a/bakery_model3/src/bakery.rs
+++ b/bakery_model3/src/bakery.rs
@@ -1,4 +1,5 @@
 use vantage_csv::{AnyCsvType, Csv};
+use vantage_mongodb::{AnyMongoType, MongoDB};
 #[allow(unused_imports)]
 use vantage_sql::postgres::AnyPostgresType;
 use vantage_sql::postgres::PostgresDB;
@@ -8,7 +9,7 @@ use vantage_surrealdb::types::AnySurrealType;
 use vantage_table::table::Table;
 use vantage_types::entity;
 
-#[entity(CsvType, SurrealType, SqliteType, PostgresType)]
+#[entity(CsvType, SurrealType, SqliteType, PostgresType, MongoType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Bakery {
     pub name: String,
@@ -43,6 +44,13 @@ impl Bakery {
     pub fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Bakery> {
         Table::new("bakery", db)
             .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("profit_margin")
+    }
+
+    pub fn mongo_table(db: MongoDB) -> Table<MongoDB, Bakery> {
+        Table::new("bakery", db)
+            .with_id_column("_id")
             .with_column_of::<String>("name")
             .with_column_of::<i64>("profit_margin")
     }

--- a/bakery_model3/src/client.rs
+++ b/bakery_model3/src/client.rs
@@ -1,4 +1,5 @@
 use vantage_csv::{AnyCsvType, Csv};
+use vantage_mongodb::{AnyMongoType, MongoDB};
 #[allow(unused_imports)]
 use vantage_sql::postgres::AnyPostgresType;
 use vantage_sql::postgres::PostgresDB;
@@ -10,7 +11,7 @@ use vantage_types::entity;
 
 use crate::{Bakery, Order};
 
-#[entity(CsvType, SurrealType, SqliteType, PostgresType)]
+#[entity(CsvType, SurrealType, SqliteType, PostgresType, MongoType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Client {
     pub name: String,
@@ -84,6 +85,24 @@ impl Client {
             })
             .with_many("orders", "client_id", move || {
                 Order::postgres_table(db3.clone())
+            })
+    }
+
+    pub fn mongo_table(db: MongoDB) -> Table<MongoDB, Client> {
+        let db2 = db.clone();
+        let db3 = db.clone();
+        Table::new("client", db)
+            .with_id_column("_id")
+            .with_column_of::<String>("name")
+            .with_column_of::<String>("email")
+            .with_column_of::<String>("contact_details")
+            .with_column_of::<bool>("is_paying_client")
+            .with_column_of::<String>("bakery_id")
+            .with_one("bakery", "bakery_id", move || {
+                Bakery::mongo_table(db2.clone())
+            })
+            .with_many("orders", "client_id", move || {
+                Order::mongo_table(db3.clone())
             })
     }
 }

--- a/bakery_model3/src/lib.rs
+++ b/bakery_model3/src/lib.rs
@@ -1,4 +1,5 @@
 pub use vantage_csv::{AnyCsvType, Csv, CsvType};
+pub use vantage_mongodb::{AnyMongoType, MongoDB, MongoType};
 pub use vantage_sql::postgres::{AnyPostgresType, PostgresDB, PostgresType};
 pub use vantage_sql::sqlite::{AnySqliteType, SqliteDB, SqliteType};
 

--- a/bakery_model3/src/order.rs
+++ b/bakery_model3/src/order.rs
@@ -1,4 +1,5 @@
 use vantage_csv::{AnyCsvType, Csv};
+use vantage_mongodb::{AnyMongoType, MongoDB};
 #[allow(unused_imports)]
 use vantage_sql::postgres::AnyPostgresType;
 use vantage_sql::postgres::PostgresDB;
@@ -10,7 +11,7 @@ use vantage_types::entity;
 
 use crate::Client;
 
-#[entity(CsvType, SurrealType, SqliteType, PostgresType)]
+#[entity(CsvType, SurrealType, SqliteType, PostgresType, MongoType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Order {
     pub client_id: Option<String>,
@@ -57,6 +58,17 @@ impl Order {
             .with_column_of::<bool>("is_deleted")
             .with_one("client", "client_id", move || {
                 Client::postgres_table(db2.clone())
+            })
+    }
+
+    pub fn mongo_table(db: MongoDB) -> Table<MongoDB, Order> {
+        let db2 = db.clone();
+        Table::new("client_order", db)
+            .with_id_column("_id")
+            .with_column_of::<String>("client_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_one("client", "client_id", move || {
+                Client::mongo_table(db2.clone())
             })
     }
 }

--- a/bakery_model3/src/product.rs
+++ b/bakery_model3/src/product.rs
@@ -1,4 +1,5 @@
 use vantage_csv::{AnyCsvType, Csv};
+use vantage_mongodb::{AnyMongoType, MongoDB};
 #[allow(unused_imports)]
 use vantage_sql::postgres::AnyPostgresType;
 use vantage_sql::postgres::PostgresDB;
@@ -10,7 +11,7 @@ use vantage_types::entity;
 
 use crate::{Animal, Bakery};
 
-#[entity(CsvType, SurrealType, SqliteType, PostgresType)]
+#[entity(CsvType, SurrealType, SqliteType, PostgresType, MongoType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Product {
     pub name: String,
@@ -71,5 +72,15 @@ impl Product {
             .with_one("bakery", "bakery_id", move || {
                 Bakery::postgres_table(db2.clone())
             })
+    }
+
+    pub fn mongo_table(db: MongoDB) -> Table<MongoDB, Product> {
+        Table::new("product", db)
+            .with_id_column("_id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<Option<Animal>>("sticker")
     }
 }

--- a/surreal-client/tests/surrealdb.rs
+++ b/surreal-client/tests/surrealdb.rs
@@ -194,7 +194,7 @@ async fn test_bulk_operations() {
     let _ = client.delete("products").await;
 
     // Test bulk CREATE
-    let products = vec![
+    let products = [
         json!({
             "name": "Laptop",
             "price": 999.99,
@@ -685,7 +685,7 @@ async fn test_import_export() {
     let _ = client.delete("import_test").await;
 
     // Create some test data
-    let test_data = vec![
+    let test_data = [
         json!({"name": "Item 1", "value": 100}),
         json!({"name": "Item 2", "value": 200}),
         json!({"name": "Item 3", "value": 300}),

--- a/vantage-api-client/src/table_source.rs
+++ b/vantage-api-client/src/table_source.rs
@@ -83,7 +83,7 @@ impl TableSource for RestApi {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr<E>(
+    fn search_table_condition<E>(
         &self,
         _table: &Table<Self, E>,
         search_value: &str,

--- a/vantage-api-client/src/table_source.rs
+++ b/vantage-api-client/src/table_source.rs
@@ -252,6 +252,18 @@ impl TableSource for RestApi {
         Err(error!("REST API is a read-only data source"))
     }
 
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        _target_field: &str,
+        _source_table: &Table<Self, SourceE>,
+        _source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized,
+    {
+        unimplemented!("related_in_condition not yet supported for REST API")
+    }
+
     fn column_table_values_expr<'a, E, Type: ColumnType>(
         &'a self,
         _table: &Table<Self, E>,
@@ -261,7 +273,6 @@ impl TableSource for RestApi {
         E: Entity<Self::Value> + 'static,
         Self: Sized,
     {
-        // TODO: implement when conditions/expressions are added
         unimplemented!("column_table_values_expr not yet supported for REST API")
     }
 }

--- a/vantage-api-pool/src/pool_api.rs
+++ b/vantage-api-pool/src/pool_api.rs
@@ -361,6 +361,18 @@ impl TableSource for PoolApi {
         Err(error!("REST API pool is a read-only data source"))
     }
 
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        _target_field: &str,
+        _source_table: &Table<Self, SourceE>,
+        _source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized,
+    {
+        unimplemented!("related_in_condition not yet supported for API pool")
+    }
+
     fn column_table_values_expr<'a, E, Type: ColumnType>(
         &'a self,
         _table: &Table<Self, E>,

--- a/vantage-api-pool/src/pool_api.rs
+++ b/vantage-api-pool/src/pool_api.rs
@@ -120,7 +120,7 @@ impl TableSource for PoolApi {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr<E>(
+    fn search_table_condition<E>(
         &self,
         _table: &Table<Self, E>,
         search_value: &str,

--- a/vantage-csv/src/table_source.rs
+++ b/vantage-csv/src/table_source.rs
@@ -3,10 +3,12 @@ use indexmap::IndexMap;
 use vantage_core::error;
 use vantage_dataset::traits::Result;
 use vantage_expressions::Expression;
+use vantage_expressions::Expressive;
 use vantage_expressions::traits::associated_expressions::AssociatedExpression;
 use vantage_expressions::traits::datasource::DataSource;
 use vantage_expressions::traits::expressive::{DeferredFn, ExpressiveEnum};
 use vantage_table::column::core::{Column, ColumnType};
+use vantage_table::operation::Operation;
 use vantage_table::table::Table;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
@@ -220,6 +222,21 @@ impl TableSource for Csv {
         Self: Sized,
     {
         Err(error!("CSV is a read-only data source"))
+    }
+
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        target_field: &str,
+        source_table: &Table<Self, SourceE>,
+        source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized,
+    {
+        let src_col = self.create_column::<Self::AnyType>(source_column);
+        let fk_values = self.column_table_values_expr(source_table, &src_col);
+        let tgt_col = self.create_column::<Self::AnyType>(target_field);
+        tgt_col.in_(fk_values.expr())
     }
 
     fn column_table_values_expr<'a, E, Type: ColumnType>(

--- a/vantage-csv/src/table_source.rs
+++ b/vantage-csv/src/table_source.rs
@@ -54,7 +54,7 @@ impl TableSource for Csv {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr<E>(
+    fn search_table_condition<E>(
         &self,
         _table: &Table<Self, E>,
         search_value: &str,

--- a/vantage-mongodb/README.md
+++ b/vantage-mongodb/README.md
@@ -1,0 +1,210 @@
+# vantage-mongodb
+
+MongoDB backend for the [Vantage](https://github.com/romaninsh/vantage) persistence framework. Uses the official `mongodb` crate and `bson` types natively — no SQL generation, no expression templates, no ORM mapping layer. Conditions are `doc!{}` documents, queries are MongoDB pipelines, and relationships resolve through deferred `$in` lookups.
+
+## What Problem Does Vantage MongoDB Solve?
+
+You've chosen MongoDB for its flexible documents and powerful query language. Now you need to build an application that reads, writes, and traverses relationships across collections — while keeping the door open to support other backends (PostgreSQL, SQLite, CSV) with the same entity definitions.
+
+You could use the `mongodb` driver directly, but then your application logic is coupled to BSON documents everywhere. You could build a repository layer, but then you're reinventing typed records, condition composition, and relationship traversal from scratch.
+
+Vantage MongoDB gives you the table-level abstraction — typed entities, conditions, relationships, aggregates — while staying native to MongoDB's document model. You write `doc! { "price": { "$gt": 100 } }`, not a SQL-flavoured DSL that gets translated. The full MongoDB query language is available because conditions *are* BSON documents.
+
+## Conditions Are Documents
+
+This is the fundamental difference from SQL backends. Where `vantage-sql` builds expression trees with templates like `"{} > {}"`, MongoDB uses native BSON documents:
+
+```rust
+let mut products = product_table(db.clone());
+
+// Filter with standard MongoDB operators
+products.add_condition(doc! { "price": { "$gt": 130 } });
+
+// Combine conditions — they merge with $and automatically
+products.add_condition(doc! { "is_deleted": false });
+
+// Use $expr for field-to-field comparisons
+products.add_condition(doc! { "$expr": { "$gt": ["$price", "$calories"] } });
+
+let results = products.list().await?;
+```
+
+Multiple `add_condition` calls combine with `$and` semantics. Each condition is a `MongoCondition`, which can be:
+
+- **`Doc`** — an immediate `bson::Document` filter
+- **`Deferred`** — an async function that resolves to a document at query time (used by relationships)
+- **`And`** — a list of conditions merged at resolution time
+
+No expression parsing, no template rendering. The `doc!{}` you write is the filter MongoDB receives.
+
+## Defining Tables
+
+Tables are defined the same way as other Vantage backends — a struct with `#[entity]`, and a constructor that declares columns and relationships:
+
+```rust
+#[entity(MongoType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Client {
+    name: String,
+    email: String,
+    is_paying_client: bool,
+    bakery_id: String,
+}
+
+impl Client {
+    fn mongo_table(db: MongoDB) -> Table<MongoDB, Client> {
+        let db2 = db.clone();
+        let db3 = db.clone();
+        Table::new("client", db)
+            .with_id_column("_id")
+            .with_column_of::<String>("name")
+            .with_column_of::<String>("email")
+            .with_column_of::<bool>("is_paying_client")
+            .with_column_of::<String>("bakery_id")
+            .with_one("bakery", "bakery_id", move || {
+                Bakery::mongo_table(db2.clone())
+            })
+            .with_many("orders", "client_id", move || {
+                Order::mongo_table(db3.clone())
+            })
+    }
+}
+```
+
+A few things to notice:
+
+**`.with_id_column("_id")`** — MongoDB uses `_id` as the primary key, not `id`. This matters for relationship traversal, which needs to know the source table's ID field.
+
+**`#[entity(MongoType)]`** — the same entity struct can support multiple backends. Add `SqliteType`, `PostgresType` etc. to get table constructors for each.
+
+**`.with_one` and `.with_many`** — relationship definitions are identical to SQL backends. The difference is in how they execute.
+
+## Relationship Traversal
+
+SQL backends resolve relationships with subqueries — `WHERE id IN (SELECT bakery_id FROM client WHERE ...)`. MongoDB can't do subqueries across collections, so Vantage takes a different approach: it fetches the foreign key values from the source collection, then builds a native `$in` filter on the target collection.
+
+```rust
+let mut clients = client_table(db.clone());
+clients.add_condition(doc! { "is_paying_client": true });
+
+// Traverse: paying clients -> their orders
+let orders = clients
+    .get_ref_as::<MongoDB, ClientOrder>("orders")
+    .unwrap();
+
+let order_list = orders.list().await?;
+// Returns orders where client_id IN [ids of paying clients]
+```
+
+Under the hood, this calls `related_in_condition`, which:
+
+1. Queries the `client` collection for `_id` values matching the current conditions
+2. Builds `doc! { "client_id": { "$in": ["marty", "doc"] } }`
+3. Adds that as a deferred condition on the `client_order` collection
+
+The traversal is application-side, not database-side — but the API is identical to SQL backends. Code that uses `get_ref_as` works the same whether the backend is PostgreSQL, SQLite, or MongoDB.
+
+The reverse direction works too:
+
+```rust
+let mut orders = order_table(db.clone());
+orders.add_condition(doc! { "_id": "order1" });
+
+// Traverse: order -> its client
+let client = orders
+    .get_ref_as::<MongoDB, Client>("client")
+    .unwrap();
+
+let client_list = client.list().await?;
+assert_eq!(client_list.values().next().unwrap().name, "Marty McFly");
+```
+
+## IDs: ObjectId or String
+
+MongoDB's `_id` field can be an ObjectId or a plain string. `MongoId` handles both:
+
+```rust
+// 24-char hex strings are parsed as ObjectId
+let id: MongoId = "507f1f77bcf86cd799439011".parse().unwrap();
+
+// Everything else stays as a string
+let id: MongoId = "hill_valley".parse().unwrap();
+```
+
+When you insert a record with a string ID, it's stored as a string `_id`. When you let MongoDB generate the ID, you get an ObjectId back. Both work transparently with `get`, `delete`, and relationship traversal.
+
+## The Type System
+
+MongoDB uses BSON, not JSON. `AnyMongoType` wraps `bson::Bson` with variant tracking so the framework knows the difference between an `Int32` and an `Int64`, a `String` and an `ObjectId`:
+
+```rust
+let val = AnyMongoType::new(42i64);
+assert_eq!(val.type_variant(), Some(MongoTypeVariants::Int64));
+assert_eq!(val.try_get::<i64>(), Some(42));
+assert_eq!(val.try_get::<String>(), None); // Type-safe: won't coerce
+```
+
+Supported BSON types: Null, Bool, Int32, Int64, Double, String, ObjectId, DateTime, Binary, Array, Document, Decimal128, Regex, Timestamp.
+
+Values from the database come back as "untyped" — no variant marker — so `try_get` checks the BSON discriminant directly. Values you create with `AnyMongoType::new()` carry a variant marker for stricter checking.
+
+## Aggregates
+
+Count, sum, max, and min use MongoDB's aggregation pipeline:
+
+```rust
+let count = products.get_count().await?;
+
+let price_col = db.create_column::<AnyMongoType>("price");
+let total = db.get_table_sum(&products, &price_col).await?;
+let max_price = db.get_table_max(&products, &price_col).await?;
+```
+
+Conditions on the table are applied as a `$match` stage before the aggregation. So `products.add_condition(doc! { "is_deleted": false })` followed by `get_count()` counts only active products.
+
+## Search
+
+Full-text search across columns uses `$regex` with case-insensitive matching:
+
+```rust
+let condition = db.search_table_condition(&products, "cupcake");
+products.add_condition(condition);
+// Generates: { "$or": [{ "name": { "$regex": "cupcake", "$options": "i" } }, ...] }
+```
+
+Each column in the table gets an `$or` branch. This is a simple substring search — for more sophisticated text search, use MongoDB's `$text` operator directly via `doc!{}`.
+
+## Multi-Backend Applications
+
+Because `vantage-mongodb` implements the same `TableSource` trait as every other backend, your entities can have constructors for multiple backends:
+
+```rust
+// Same entity, different backends
+let pg_products = Product::postgres_table(pg_db);
+let mongo_products = Product::mongo_table(mongo_db);
+let csv_products = Product::csv_table(csv);
+
+// Type-erased — works with any backend
+let any_table = AnyTable::from_table(Product::mongo_table(db));
+let records = any_table.list_values().await?;
+```
+
+The `bakery_model3` example in the Vantage repo demonstrates a CLI tool that queries the same entities across CSV, SQLite, PostgreSQL, SurrealDB, and MongoDB — choosing the backend at runtime.
+
+## Beyond CRUD
+
+The `MongoDB` struct exposes the underlying driver for anything Vantage doesn't abstract:
+
+```rust
+let collection = db.collection::<bson::Document>("products");
+
+// Use the driver directly for complex aggregation pipelines,
+// change streams, transactions, etc.
+let pipeline = vec![
+    doc! { "$unwind": "$tags" },
+    doc! { "$group": { "_id": "$tags", "count": { "$sum": 1 } } },
+];
+let cursor = collection.aggregate(pipeline).await?;
+```
+
+Vantage MongoDB handles the common patterns — typed CRUD, conditions, relationships, aggregates. For MongoDB-specific features like change streams, transactions, or custom pipelines, the driver is one method call away.

--- a/vantage-mongodb/src/condition.rs
+++ b/vantage-mongodb/src/condition.rs
@@ -70,6 +70,15 @@ impl From<Document> for MongoCondition {
     }
 }
 
+/// Required by `ReferenceOne`/`ReferenceMany` trait bounds for `get_linked_table`
+/// (JOIN-style queries). MongoDB does not support JOINs — this will never be called
+/// via `get_related_table` (which uses `related_in_condition` instead).
+impl From<vantage_expressions::Expression<AnyMongoType>> for MongoCondition {
+    fn from(_expr: vantage_expressions::Expression<AnyMongoType>) -> Self {
+        unimplemented!("MongoDB does not support Expression-based conditions (JOINs)")
+    }
+}
+
 impl std::fmt::Debug for MongoCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/vantage-mongodb/src/mongodb/impls/table_source.rs
+++ b/vantage-mongodb/src/mongodb/impls/table_source.rs
@@ -115,19 +115,21 @@ impl TableSource for MongoDB {
     where
         E: Entity<Self::Value>,
     {
+        // Escape regex metacharacters so the search is a literal substring match
+        let escaped = regex_escape(search_value);
+
         // Build $or across all string-like columns with case-insensitive regex
         let conditions: Vec<bson::Bson> = table
             .columns()
             .values()
             .map(|col| {
-                bson::Bson::Document(
-                    doc! { col.name(): { "$regex": search_value, "$options": "i" } },
-                )
+                bson::Bson::Document(doc! { col.name(): { "$regex": &escaped, "$options": "i" } })
             })
             .collect();
 
         if conditions.is_empty() {
-            doc! {}.into()
+            // No columns — return always-false filter (consistent with SQL backends)
+            doc! { "_id": { "$exists": false } }.into()
         } else if conditions.len() == 1 {
             match conditions.into_iter().next().unwrap() {
                 bson::Bson::Document(d) => d.into(),
@@ -463,11 +465,43 @@ impl TableSource for MongoDB {
             let col = col.clone();
             let field = field.clone();
             Box::pin(async move {
-                let records = db.list_table_values(&source).await?;
-                let values: Vec<Bson> = records
-                    .values()
-                    .filter_map(|r| r.get(&col).map(|v| v.value().clone()))
-                    .collect();
+                // Build a projected query that only fetches the source column
+                let select = select_from_table(&source);
+                let filter = select.build_filter().await?;
+                let collection_name = select
+                    .collection
+                    .as_deref()
+                    .ok_or_else(|| error!("No collection name for related_in_condition"))?;
+
+                let mut projection = doc! { &col: 1 };
+                if col != "_id" {
+                    projection.insert("_id", 0);
+                }
+                let opts = mongodb::options::FindOptions::builder()
+                    .projection(projection)
+                    .build();
+
+                let coll = db.collection::<bson::Document>(collection_name);
+                let mut cursor = coll
+                    .find(filter)
+                    .with_options(opts)
+                    .await
+                    .map_err(|e| error!("MongoDB find failed", details = e.to_string()))?;
+
+                let mut values = Vec::new();
+                while cursor
+                    .advance()
+                    .await
+                    .map_err(|e| error!("MongoDB cursor error", details = e.to_string()))?
+                {
+                    let doc = cursor.deserialize_current().map_err(|e| {
+                        error!("MongoDB deserialize error", details = e.to_string())
+                    })?;
+                    if let Some(v) = doc.get(&col) {
+                        values.push(v.clone());
+                    }
+                }
+
                 let doc = doc! { &field: { "$in": values } };
                 Ok(ExpressiveEnum::Scalar(AnyMongoType::untyped(
                     Bson::Document(doc),
@@ -508,4 +542,17 @@ impl TableSource for MongoDB {
         let expr = expr_any!("{}", { self.defer(inner) });
         AssociatedExpression::new(expr, self)
     }
+}
+
+/// Escape regex metacharacters so a user-provided string is treated as a
+/// literal substring in a `$regex` filter.
+fn regex_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if ".*+?^${}()|[]\\".contains(c) {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
 }

--- a/vantage-mongodb/src/mongodb/impls/table_source.rs
+++ b/vantage-mongodb/src/mongodb/impls/table_source.rs
@@ -105,16 +105,35 @@ impl TableSource for MongoDB {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr<E>(
+    fn search_table_condition<E>(
         &self,
-        _table: &Table<Self, E>,
+        table: &Table<Self, E>,
         search_value: &str,
-    ) -> Expression<Self::Value>
+    ) -> Self::Condition
     where
         E: Entity<Self::Value>,
     {
-        // Preview-only expression
-        Expression::new(format!("{{\"$regex\": \"{}\"}}", search_value), vec![])
+        // Build $or across all string-like columns with case-insensitive regex
+        let conditions: Vec<bson::Bson> = table
+            .columns()
+            .values()
+            .map(|col| {
+                bson::Bson::Document(
+                    doc! { col.name(): { "$regex": search_value, "$options": "i" } },
+                )
+            })
+            .collect();
+
+        if conditions.is_empty() {
+            doc! {}.into()
+        } else if conditions.len() == 1 {
+            match conditions.into_iter().next().unwrap() {
+                bson::Bson::Document(d) => d.into(),
+                _ => unreachable!(),
+            }
+        } else {
+            doc! { "$or": conditions }.into()
+        }
     }
 
     // ── Read ─────────────────────────────────────────────────────────

--- a/vantage-mongodb/src/mongodb/impls/table_source.rs
+++ b/vantage-mongodb/src/mongodb/impls/table_source.rs
@@ -11,7 +11,9 @@ use futures_util::TryStreamExt;
 use indexmap::IndexMap;
 
 use vantage_core::{Result, error};
-use vantage_expressions::{AssociatedExpression, ExprDataSource, Expression, ExpressiveEnum};
+use vantage_expressions::{
+    AssociatedExpression, DeferredFn, ExprDataSource, Expression, ExpressiveEnum, expr_any,
+};
 use vantage_table::column::core::{Column, ColumnType};
 use vantage_table::table::Table;
 use vantage_table::traits::table_source::TableSource;
@@ -441,15 +443,69 @@ impl TableSource for MongoDB {
             .ok_or_else(|| error!("MongoDB insert did not return a valid id"))
     }
 
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        target_field: &str,
+        source_table: &Table<Self, SourceE>,
+        source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized,
+    {
+        let db = self.clone();
+        let source = source_table.clone();
+        let col = source_column.to_string();
+        let field = target_field.to_string();
+
+        MongoCondition::Deferred(DeferredFn::new(move || {
+            let db = db.clone();
+            let source = source.clone();
+            let col = col.clone();
+            let field = field.clone();
+            Box::pin(async move {
+                let records = db.list_table_values(&source).await?;
+                let values: Vec<Bson> = records
+                    .values()
+                    .filter_map(|r| r.get(&col).map(|v| v.value().clone()))
+                    .collect();
+                let doc = doc! { &field: { "$in": values } };
+                Ok(ExpressiveEnum::Scalar(AnyMongoType::untyped(
+                    Bson::Document(doc),
+                )))
+            })
+        }))
+    }
+
     fn column_table_values_expr<'a, E, Type: ColumnType>(
         &'a self,
-        _table: &Table<Self, E>,
-        _column: &Self::Column<Type>,
+        table: &Table<Self, E>,
+        column: &Self::Column<Type>,
     ) -> AssociatedExpression<'a, Self, Self::Value, Vec<Type>>
     where
         E: Entity<Self::Value> + 'static,
         Self: ExprDataSource<Self::Value> + Sized,
     {
-        todo!("column_table_values_expr not yet implemented for MongoDB")
+        let table_clone = table.clone();
+        let col = column.name().to_string();
+        let db = self.clone();
+
+        let inner = expr_any!("{}", {
+            DeferredFn::new(move || {
+                let db = db.clone();
+                let table = table_clone.clone();
+                let col = col.clone();
+                Box::pin(async move {
+                    let records = db.list_table_values(&table).await?;
+                    let values: Vec<AnyMongoType> = records
+                        .values()
+                        .filter_map(|r| r.get(&col).cloned())
+                        .collect();
+                    Ok(ExpressiveEnum::Scalar(AnyMongoType::new(values)))
+                })
+            })
+        });
+
+        let expr = expr_any!("{}", { self.defer(inner) });
+        AssociatedExpression::new(expr, self)
     }
 }

--- a/vantage-mongodb/src/types/value.rs
+++ b/vantage-mongodb/src/types/value.rs
@@ -1,6 +1,6 @@
 //! AnyMongoType extras: untyped constructor, From impls, Expressive impls.
 
-use super::{AnyMongoType, MongoType, MongoTypeNullMarker};
+use super::{AnyMongoType, MongoType, MongoTypeArrayMarker, MongoTypeNullMarker};
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
 impl AnyMongoType {
@@ -25,6 +25,35 @@ impl MongoType for AnyMongoType {
 
     fn from_bson(value: bson::Bson) -> Option<Self> {
         AnyMongoType::from_bson(&value)
+    }
+}
+
+/// Vec<AnyMongoType> is a MongoType — used by column_table_values_expr to
+/// return a list of column values wrapped in an AnyMongoType.
+impl MongoType for Vec<AnyMongoType> {
+    type Target = MongoTypeArrayMarker;
+
+    fn to_bson(&self) -> bson::Bson {
+        bson::Bson::Array(self.iter().map(|v| v.value().clone()).collect())
+    }
+
+    fn from_bson(value: bson::Bson) -> Option<Self> {
+        match value {
+            bson::Bson::Array(arr) => Some(arr.into_iter().map(AnyMongoType::untyped).collect()),
+            _ => None,
+        }
+    }
+}
+
+impl TryFrom<AnyMongoType> for Vec<AnyMongoType> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnyMongoType) -> Result<Self, Self::Error> {
+        val.try_get::<Vec<AnyMongoType>>().ok_or_else(|| {
+            vantage_core::error!(
+                "Cannot convert AnyMongoType to Vec<AnyMongoType>",
+                value = format!("{}", val)
+            )
+        })
     }
 }
 

--- a/vantage-mongodb/tests/4_aggregates.rs
+++ b/vantage-mongodb/tests/4_aggregates.rs
@@ -2,7 +2,6 @@
 
 use vantage_mongodb::MongoDB;
 use vantage_table::table::Table;
-use vantage_table::traits::table_like::TableLike;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::EmptyEntity;
 

--- a/vantage-mongodb/tests/4_table_def.rs
+++ b/vantage-mongodb/tests/4_table_def.rs
@@ -1,6 +1,6 @@
 //! Test 4: Table definition and query generation via TableSource.
 
-use vantage_mongodb::{AnyMongoType, MongoDB};
+use vantage_mongodb::MongoDB;
 use vantage_table::table::Table;
 use vantage_types::EmptyEntity;
 

--- a/vantage-mongodb/tests/5_references.rs
+++ b/vantage-mongodb/tests/5_references.rs
@@ -1,0 +1,104 @@
+//! Test 5: Relationship traversal — with_one, with_many, get_ref_as.
+//!
+//! Uses the seeded `vantage` database (scripts/db/v2.js).
+
+use bson::doc;
+use vantage_dataset::ReadableDataSet;
+#[allow(unused_imports)]
+use vantage_mongodb::AnyMongoType;
+use vantage_mongodb::MongoDB;
+use vantage_table::table::Table;
+use vantage_types::{entity, Entity};
+
+fn mongo_url() -> String {
+    std::env::var("MONGODB_URL").unwrap_or_else(|_| "mongodb://localhost:27017".into())
+}
+
+async fn get_db() -> MongoDB {
+    MongoDB::connect(&mongo_url(), "vantage")
+        .await
+        .expect("Failed to connect to MongoDB")
+}
+
+#[entity(MongoType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Client {
+    name: String,
+    email: String,
+    contact_details: String,
+    is_paying_client: bool,
+    bakery_id: String,
+}
+
+#[entity(MongoType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct ClientOrder {
+    client_id: String,
+    is_deleted: bool,
+}
+
+fn client_table(db: MongoDB) -> Table<MongoDB, Client> {
+    let db2 = db.clone();
+    Table::new("client", db)
+        .with_id_column("_id")
+        .with_column_of::<String>("name")
+        .with_column_of::<String>("email")
+        .with_column_of::<String>("contact_details")
+        .with_column_of::<bool>("is_paying_client")
+        .with_column_of::<String>("bakery_id")
+        .with_many("orders", "client_id", move || order_table(db2.clone()))
+}
+
+fn order_table(db: MongoDB) -> Table<MongoDB, ClientOrder> {
+    let db2 = db.clone();
+    Table::new("client_order", db)
+        .with_id_column("_id")
+        .with_column_of::<String>("client_id")
+        .with_column_of::<bool>("is_deleted")
+        .with_one("client", "client_id", move || client_table(db2.clone()))
+}
+
+/// Traverse has_many: paying clients -> their orders
+#[tokio::test]
+async fn test_has_many_orders_for_paying_clients() {
+    let db = get_db().await;
+    let mut clients = client_table(db.clone());
+    clients.add_condition(doc! { "is_paying_client": true });
+
+    let orders = clients
+        .get_ref_as::<MongoDB, ClientOrder>("orders")
+        .unwrap();
+
+    let order_list = orders.list().await.unwrap();
+    // Marty has 1 order, Doc has 2 orders -> 3 total
+    assert_eq!(order_list.len(), 3);
+}
+
+/// Traverse has_many: single client -> orders
+#[tokio::test]
+async fn test_has_many_orders_for_single_client() {
+    let db = get_db().await;
+    let mut clients = client_table(db.clone());
+    clients.add_condition(doc! { "name": "Doc Brown" });
+
+    let orders = clients
+        .get_ref_as::<MongoDB, ClientOrder>("orders")
+        .unwrap();
+
+    let order_list = orders.list().await.unwrap();
+    assert_eq!(order_list.len(), 2);
+}
+
+/// Traverse has_one: order -> client
+#[tokio::test]
+async fn test_has_one_client_for_order() {
+    let db = get_db().await;
+    let mut orders = order_table(db.clone());
+    orders.add_condition(doc! { "_id": "order1" });
+
+    let client = orders.get_ref_as::<MongoDB, Client>("client").unwrap();
+
+    let client_list = client.list().await.unwrap();
+    assert_eq!(client_list.len(), 1);
+    assert_eq!(client_list.values().next().unwrap().name, "Marty McFly");
+}

--- a/vantage-mongodb/tests/5_references.rs
+++ b/vantage-mongodb/tests/5_references.rs
@@ -8,7 +8,7 @@ use vantage_dataset::ReadableDataSet;
 use vantage_mongodb::AnyMongoType;
 use vantage_mongodb::MongoDB;
 use vantage_table::table::Table;
-use vantage_types::{entity, Entity};
+use vantage_types::entity;
 
 fn mongo_url() -> String {
     std::env::var("MONGODB_URL").unwrap_or_else(|_| "mongodb://localhost:27017".into())

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -96,7 +96,7 @@ impl TableSource for MysqlDB {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr<E>(
+    fn search_table_condition<E>(
         &self,
         table: &Table<Self, E>,
         search_value: &str,

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -6,6 +6,7 @@ use vantage_expressions::traits::datasource::ExprDataSource;
 use vantage_expressions::traits::expressive::ExpressiveEnum;
 use vantage_expressions::{Expression, Expressive, Selectable};
 use vantage_table::column::core::{Column, ColumnType};
+use vantage_table::operation::Operation;
 use vantage_table::table::Table;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
@@ -426,6 +427,21 @@ impl TableSource for MysqlDB {
             .map_err(|e| error!("MySQL get id failed", details = e.to_string()))?;
 
         Ok(id.to_string())
+    }
+
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        target_field: &str,
+        source_table: &Table<Self, SourceE>,
+        source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized,
+    {
+        let src_col = self.create_column::<Self::AnyType>(source_column);
+        let fk_values = self.column_table_values_expr(source_table, &src_col);
+        let tgt_col = self.create_column::<Self::AnyType>(target_field);
+        tgt_col.in_(fk_values.expr())
     }
 
     fn column_table_values_expr<'a, E, Type: ColumnType>(

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -6,6 +6,7 @@ use vantage_expressions::traits::datasource::ExprDataSource;
 use vantage_expressions::traits::expressive::ExpressiveEnum;
 use vantage_expressions::{Expression, Expressive, Selectable};
 use vantage_table::column::core::{Column, ColumnType};
+use vantage_table::operation::Operation;
 use vantage_table::table::Table;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
@@ -384,6 +385,21 @@ impl TableSource for PostgresDB {
         rows.swap_remove_index(0)
             .map(|(id, _)| id)
             .ok_or_else(|| error!("insert_table_return_id_value: no id returned"))
+    }
+
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        target_field: &str,
+        source_table: &Table<Self, SourceE>,
+        source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized,
+    {
+        let src_col = self.create_column::<Self::AnyType>(source_column);
+        let fk_values = self.column_table_values_expr(source_table, &src_col);
+        let tgt_col = self.create_column::<Self::AnyType>(target_field);
+        tgt_col.in_(fk_values.expr())
     }
 
     fn column_table_values_expr<'a, E, Type: ColumnType>(

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -99,7 +99,7 @@ impl TableSource for PostgresDB {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr<E>(
+    fn search_table_condition<E>(
         &self,
         table: &Table<Self, E>,
         search_value: &str,

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -89,7 +89,7 @@ impl TableSource for SqliteDB {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr<E>(
+    fn search_table_condition<E>(
         &self,
         table: &Table<Self, E>,
         search_value: &str,

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -6,6 +6,7 @@ use vantage_expressions::traits::datasource::ExprDataSource;
 use vantage_expressions::traits::expressive::ExpressiveEnum;
 use vantage_expressions::{Expression, Expressive, Selectable};
 use vantage_table::column::core::{Column, ColumnType};
+use vantage_table::operation::Operation;
 use vantage_table::table::Table;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
@@ -353,6 +354,21 @@ impl TableSource for SqliteDB {
             .ok_or_else(|| error!("insert_table_return_id_value: no id returned"))
     }
 
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        target_field: &str,
+        source_table: &Table<Self, SourceE>,
+        source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized,
+    {
+        let src_col = self.create_column::<Self::AnyType>(source_column);
+        let fk_values = self.column_table_values_expr(source_table, &src_col);
+        let tgt_col = self.create_column::<Self::AnyType>(target_field);
+        tgt_col.in_(fk_values.expr())
+    }
+
     fn column_table_values_expr<'a, E, Type: ColumnType>(
         &'a self,
         table: &Table<Self, E>,
@@ -362,13 +378,11 @@ impl TableSource for SqliteDB {
         E: Entity<Self::Value> + 'static,
         Self: ExprDataSource<Self::Value> + Sized,
     {
-        // Build a subquery: SELECT "column" FROM "table" WHERE ...
         let mut select = table.select();
         select.clear_fields();
         select.clear_order_by();
         select.add_field(column.name());
 
-        // Render as a nested subquery expression
         let subquery = select.expr();
         AssociatedExpression::new(subquery, self)
     }

--- a/vantage-sql/tests/mysql/2_search.rs
+++ b/vantage-sql/tests/mysql/2_search.rs
@@ -1,4 +1,4 @@
-//! Test 2f: search_table_expr LIKE escaping — verifies that %, _, and \ in
+//! Test 2f: search_table_condition LIKE escaping — verifies that %, _, and \ in
 //! search values don't act as wildcards.
 
 use vantage_dataset::ReadableDataSet;
@@ -54,7 +54,7 @@ async fn setup(suffix: &str, rows: &[&str]) -> (MysqlDB, Table<MysqlDB, Item>) {
 #[tokio::test]
 async fn test_search_percent_literal() {
     let (db, table) = setup("pct", &["100% organic", "regular item", "50% off"]).await;
-    let condition = db.search_table_expr(&table, "100%");
+    let condition = db.search_table_condition(&table, "100%");
     let mut table = table;
     table.add_condition(condition);
     let results = table.list().await.unwrap();
@@ -65,7 +65,7 @@ async fn test_search_percent_literal() {
 #[tokio::test]
 async fn test_search_underscore_literal() {
     let (db, table) = setup("usc", &["a_b", "axb", "a__b", "axxb"]).await;
-    let condition = db.search_table_expr(&table, "a_b");
+    let condition = db.search_table_condition(&table, "a_b");
     let mut table = table;
     table.add_condition(condition);
     let results = table.list().await.unwrap();
@@ -77,7 +77,7 @@ async fn test_search_underscore_literal() {
 #[tokio::test]
 async fn test_search_backslash_literal() {
     let (db, table) = setup("bs", &["path\\to\\file", "pathXtoXfile", "other"]).await;
-    let condition = db.search_table_expr(&table, "\\to\\");
+    let condition = db.search_table_condition(&table, "\\to\\");
     let mut table = table;
     table.add_condition(condition);
     let results = table.list().await.unwrap();

--- a/vantage-sql/tests/postgres/2_search.rs
+++ b/vantage-sql/tests/postgres/2_search.rs
@@ -1,4 +1,4 @@
-//! Test 2f: search_table_expr LIKE escaping — verifies that %, _, and \ in
+//! Test 2f: search_table_condition LIKE escaping — verifies that %, _, and \ in
 //! search values don't act as wildcards.
 
 use vantage_dataset::ReadableDataSet;
@@ -54,7 +54,7 @@ async fn setup(suffix: &str, rows: &[&str]) -> (PostgresDB, Table<PostgresDB, It
 #[tokio::test]
 async fn test_search_percent_literal() {
     let (db, table) = setup("pct", &["100% organic", "regular item", "50% off"]).await;
-    let condition = db.search_table_expr(&table, "100%");
+    let condition = db.search_table_condition(&table, "100%");
     let mut table = table;
     table.add_condition(condition);
     let results = table.list().await.unwrap();
@@ -65,7 +65,7 @@ async fn test_search_percent_literal() {
 #[tokio::test]
 async fn test_search_underscore_literal() {
     let (db, table) = setup("usc", &["a_b", "axb", "a__b", "axxb"]).await;
-    let condition = db.search_table_expr(&table, "a_b");
+    let condition = db.search_table_condition(&table, "a_b");
     let mut table = table;
     table.add_condition(condition);
     let results = table.list().await.unwrap();
@@ -76,7 +76,7 @@ async fn test_search_underscore_literal() {
 #[tokio::test]
 async fn test_search_backslash_literal() {
     let (db, table) = setup("bs", &["path\\to\\file", "pathXtoXfile", "other"]).await;
-    let condition = db.search_table_expr(&table, "\\to\\");
+    let condition = db.search_table_condition(&table, "\\to\\");
     let mut table = table;
     table.add_condition(condition);
     let results = table.list().await.unwrap();

--- a/vantage-sql/tests/sqlite/2_search.rs
+++ b/vantage-sql/tests/sqlite/2_search.rs
@@ -1,4 +1,4 @@
-//! Test 2f: search_table_expr LIKE escaping — verifies that %, _, and \ in
+//! Test 2f: search_table_condition LIKE escaping — verifies that %, _, and \ in
 //! search values don't act as wildcards.
 
 use vantage_dataset::ReadableDataSet;
@@ -40,7 +40,7 @@ async fn setup(rows: &[&str]) -> (SqliteDB, Table<SqliteDB, Item>) {
 #[tokio::test]
 async fn test_search_percent_literal() {
     let (db, table) = setup(&["100% organic", "regular item", "50% off"]).await;
-    let condition = db.search_table_expr(&table, "100%");
+    let condition = db.search_table_condition(&table, "100%");
     let mut table = table;
     table.add_condition(condition);
     let results = table.list().await.unwrap();
@@ -51,7 +51,7 @@ async fn test_search_percent_literal() {
 #[tokio::test]
 async fn test_search_underscore_literal() {
     let (db, table) = setup(&["a_b", "axb", "a__b", "axxb"]).await;
-    let condition = db.search_table_expr(&table, "a_b");
+    let condition = db.search_table_condition(&table, "a_b");
     let mut table = table;
     table.add_condition(condition);
     let results = table.list().await.unwrap();
@@ -62,7 +62,7 @@ async fn test_search_underscore_literal() {
 #[tokio::test]
 async fn test_search_backslash_literal() {
     let (db, table) = setup(&["path\\to\\file", "pathXtoXfile", "other"]).await;
-    let condition = db.search_table_expr(&table, "\\to\\");
+    let condition = db.search_table_condition(&table, "\\to\\");
     let mut table = table;
     table.add_condition(condition);
     let results = table.list().await.unwrap();

--- a/vantage-surrealdb/src/statements/delete/tests.rs
+++ b/vantage-surrealdb/src/statements/delete/tests.rs
@@ -1,50 +1,47 @@
-#[cfg(test)]
-mod tests {
-    use crate::statements::delete::SurrealDelete;
-    use crate::thing::Thing;
-    use vantage_expressions::Expressive;
+use crate::statements::delete::SurrealDelete;
+use crate::thing::Thing;
+use vantage_expressions::Expressive;
 
-    #[test]
-    fn test_delete_table() {
-        let del = SurrealDelete::table("users");
-        assert_eq!(del.preview(), "DELETE users");
-    }
+#[test]
+fn test_delete_table() {
+    let del = SurrealDelete::table("users");
+    assert_eq!(del.preview(), "DELETE users");
+}
 
-    #[test]
-    fn test_delete_record() {
-        let del = SurrealDelete::new(Thing::new("users", "john"));
-        assert_eq!(del.preview(), "DELETE users:john");
-    }
+#[test]
+fn test_delete_record() {
+    let del = SurrealDelete::new(Thing::new("users", "john"));
+    assert_eq!(del.preview(), "DELETE users:john");
+}
 
-    #[test]
-    fn test_delete_with_condition() {
-        let del = SurrealDelete::table("users")
-            .with_condition(crate::surreal_expr!("active = {}", false));
-        assert_eq!(del.preview(), "DELETE users WHERE active = false");
-    }
+#[test]
+fn test_delete_with_condition() {
+    let del =
+        SurrealDelete::table("users").with_condition(crate::surreal_expr!("active = {}", false));
+    assert_eq!(del.preview(), "DELETE users WHERE active = false");
+}
 
-    #[test]
-    fn test_delete_with_multiple_conditions() {
-        let del = SurrealDelete::table("logs")
-            .with_condition(crate::surreal_expr!("level = {}", "debug"))
-            .with_condition(crate::surreal_expr!("age > {}", 30i64));
-        assert_eq!(
-            del.preview(),
-            "DELETE logs WHERE level = \"debug\" AND age > 30"
-        );
-    }
+#[test]
+fn test_delete_with_multiple_conditions() {
+    let del = SurrealDelete::table("logs")
+        .with_condition(crate::surreal_expr!("level = {}", "debug"))
+        .with_condition(crate::surreal_expr!("age > {}", 30i64));
+    assert_eq!(
+        del.preview(),
+        "DELETE logs WHERE level = \"debug\" AND age > 30"
+    );
+}
 
-    #[test]
-    fn test_delete_identifier_escaping() {
-        let del = SurrealDelete::table("SELECT");
-        assert_eq!(del.preview(), "DELETE ⟨SELECT⟩");
-    }
+#[test]
+fn test_delete_identifier_escaping() {
+    let del = SurrealDelete::table("SELECT");
+    assert_eq!(del.preview(), "DELETE ⟨SELECT⟩");
+}
 
-    #[test]
-    fn test_delete_produces_parameterized_expression() {
-        let del =
-            SurrealDelete::table("users").with_condition(crate::surreal_expr!("score < {}", 10i64));
-        let expr = del.expr();
-        assert!(expr.template.contains("{}"));
-    }
+#[test]
+fn test_delete_produces_parameterized_expression() {
+    let del =
+        SurrealDelete::table("users").with_condition(crate::surreal_expr!("score < {}", 10i64));
+    let expr = del.expr();
+    assert!(expr.template.contains("{}"));
 }

--- a/vantage-surrealdb/src/statements/insert/tests.rs
+++ b/vantage-surrealdb/src/statements/insert/tests.rs
@@ -1,91 +1,88 @@
-#[cfg(test)]
-mod tests {
-    use crate::statements::insert::SurrealInsert;
-    use crate::types::AnySurrealType;
-    use vantage_expressions::Expressive;
+use crate::statements::insert::SurrealInsert;
+use crate::types::AnySurrealType;
+use vantage_expressions::Expressive;
 
-    #[test]
-    fn test_basic_insert() {
-        let insert = SurrealInsert::new("users")
-            .with_field("name", "John".to_string())
-            .with_field("age", 30i64);
+#[test]
+fn test_basic_insert() {
+    let insert = SurrealInsert::new("users")
+        .with_field("name", "John".to_string())
+        .with_field("age", 30i64);
 
-        let rendered = insert.preview();
-        assert!(rendered.starts_with("CREATE users SET"));
-        assert!(rendered.contains("name = \"John\""));
-        assert!(rendered.contains("age = 30"));
-    }
+    let rendered = insert.preview();
+    assert!(rendered.starts_with("CREATE users SET"));
+    assert!(rendered.contains("name = \"John\""));
+    assert!(rendered.contains("age = 30"));
+}
 
-    #[test]
-    fn test_insert_with_id() {
-        let insert = SurrealInsert::new("users")
-            .with_id("john")
-            .with_field("name", "John".to_string());
+#[test]
+fn test_insert_with_id() {
+    let insert = SurrealInsert::new("users")
+        .with_id("john")
+        .with_field("name", "John".to_string());
 
-        let rendered = insert.preview();
-        assert!(rendered.starts_with("CREATE users:john SET"));
-        assert!(rendered.contains("name = \"John\""));
-    }
+    let rendered = insert.preview();
+    assert!(rendered.starts_with("CREATE users:john SET"));
+    assert!(rendered.contains("name = \"John\""));
+}
 
-    #[test]
-    fn test_empty_insert() {
-        let insert = SurrealInsert::new("users");
-        assert_eq!(insert.preview(), "CREATE users");
-    }
+#[test]
+fn test_empty_insert() {
+    let insert = SurrealInsert::new("users");
+    assert_eq!(insert.preview(), "CREATE users");
+}
 
-    #[test]
-    fn test_empty_insert_with_id() {
-        let insert = SurrealInsert::new("users").with_id("john");
-        assert_eq!(insert.preview(), "CREATE users:john");
-    }
+#[test]
+fn test_empty_insert_with_id() {
+    let insert = SurrealInsert::new("users").with_id("john");
+    assert_eq!(insert.preview(), "CREATE users:john");
+}
 
-    #[test]
-    fn test_identifier_escaping() {
-        let insert = SurrealInsert::new("SELECT").with_field("FROM", "value".to_string());
+#[test]
+fn test_identifier_escaping() {
+    let insert = SurrealInsert::new("SELECT").with_field("FROM", "value".to_string());
 
-        let rendered = insert.preview();
-        assert!(rendered.contains("CREATE ⟨SELECT⟩"));
-        assert!(rendered.contains("⟨FROM⟩ = \"value\""));
-    }
+    let rendered = insert.preview();
+    assert!(rendered.contains("CREATE ⟨SELECT⟩"));
+    assert!(rendered.contains("⟨FROM⟩ = \"value\""));
+}
 
-    #[test]
-    fn test_insert_produces_parameterized_expression() {
-        let insert = SurrealInsert::new("users")
-            .with_field("name", "Alice".to_string())
-            .with_field("age", 25i64);
+#[test]
+fn test_insert_produces_parameterized_expression() {
+    let insert = SurrealInsert::new("users")
+        .with_field("name", "Alice".to_string())
+        .with_field("age", 25i64);
 
-        let expr = insert.expr();
-        assert!(expr.template.contains("{}"));
-        assert_eq!(expr.parameters.len(), 3); // target + 2 fields
-    }
+    let expr = insert.expr();
+    assert!(expr.template.contains("{}"));
+    assert_eq!(expr.parameters.len(), 3); // target + 2 fields
+}
 
-    #[test]
-    fn test_with_any_field() {
-        let val = AnySurrealType::new(42i64);
-        let insert = SurrealInsert::new("data").with_any_field("count", val);
-        let rendered = insert.preview();
-        assert!(rendered.contains("count = 42"));
-    }
+#[test]
+fn test_with_any_field() {
+    let val = AnySurrealType::new(42i64);
+    let insert = SurrealInsert::new("data").with_any_field("count", val);
+    let rendered = insert.preview();
+    assert!(rendered.contains("count = 42"));
+}
 
-    #[test]
-    fn test_with_record() {
-        let mut record = vantage_types::Record::new();
-        record.insert("a".to_string(), AnySurrealType::new(1i64));
-        record.insert("b".to_string(), AnySurrealType::new("hi".to_string()));
+#[test]
+fn test_with_record() {
+    let mut record = vantage_types::Record::new();
+    record.insert("a".to_string(), AnySurrealType::new(1i64));
+    record.insert("b".to_string(), AnySurrealType::new("hi".to_string()));
 
-        let insert = SurrealInsert::new("t").with_id("1").with_record(&record);
-        let p = insert.preview();
-        assert!(p.contains("a = 1"));
-        assert!(p.contains("b = \"hi\""));
-    }
+    let insert = SurrealInsert::new("t").with_id("1").with_record(&record);
+    let p = insert.preview();
+    assert!(p.contains("a = 1"));
+    assert!(p.contains("b = \"hi\""));
+}
 
-    #[test]
-    fn test_thing_field() {
-        use crate::thing::Thing;
-        let insert =
-            SurrealInsert::new("order").with_field("customer", Thing::new("user", "alice"));
+#[test]
+fn test_thing_field() {
+    use crate::thing::Thing;
+    let insert =
+        SurrealInsert::new("order").with_field("customer", Thing::new("user", "alice"));
 
-        let rendered = insert.preview();
-        assert!(rendered.contains("CREATE order SET"));
-    }
+    let rendered = insert.preview();
+    assert!(rendered.contains("CREATE order SET"));
 }

--- a/vantage-surrealdb/src/statements/insert/tests.rs
+++ b/vantage-surrealdb/src/statements/insert/tests.rs
@@ -80,8 +80,7 @@ fn test_with_record() {
 #[test]
 fn test_thing_field() {
     use crate::thing::Thing;
-    let insert =
-        SurrealInsert::new("order").with_field("customer", Thing::new("user", "alice"));
+    let insert = SurrealInsert::new("order").with_field("customer", Thing::new("user", "alice"));
 
     let rendered = insert.preview();
     assert!(rendered.contains("CREATE order SET"));

--- a/vantage-surrealdb/src/statements/select/tests.rs
+++ b/vantage-surrealdb/src/statements/select/tests.rs
@@ -1,169 +1,166 @@
-#[cfg(test)]
-mod tests {
-    use crate::field::Field;
-    use crate::select::SurrealSelect;
-    use crate::select::select_field::SelectField;
-    use crate::surreal_expr;
-    use vantage_expressions::traits::selectable::{Order, Selectable};
+use crate::field::Field;
+use crate::select::SurrealSelect;
+use crate::select::select_field::SelectField;
+use crate::surreal_expr;
+use vantage_expressions::traits::selectable::{Order, Selectable};
 
-    #[test]
-    fn test_basic_select() {
-        let select = SurrealSelect::new()
-            .fields(vec![
-                SelectField::new(Field::new("name")),
-                SelectField::new(Field::new("set")),
-            ])
-            .from("users");
+#[test]
+fn test_basic_select() {
+    let select = SurrealSelect::new()
+        .fields(vec![
+            SelectField::new(Field::new("name")),
+            SelectField::new(Field::new("set")),
+        ])
+        .from("users");
 
-        let sql = select.preview();
+    let sql = select.preview();
 
-        assert_eq!(sql, "SELECT name, ⟨set⟩ FROM users");
-    }
+    assert_eq!(sql, "SELECT name, ⟨set⟩ FROM users");
+}
 
-    #[test]
-    fn test_select_all() {
-        let select = SurrealSelect::new().from("users");
+#[test]
+fn test_select_all() {
+    let select = SurrealSelect::new().from("users");
 
-        let sql = select.preview();
+    let sql = select.preview();
 
-        assert_eq!(sql, "SELECT * FROM users");
-    }
+    assert_eq!(sql, "SELECT * FROM users");
+}
 
-    #[test]
-    fn test_select_with_where_condition() {
-        let select = SurrealSelect::new()
-            .from("users")
-            .field("name")
-            .with_where(surreal_expr!("age > 18"));
+#[test]
+fn test_select_with_where_condition() {
+    let select = SurrealSelect::new()
+        .from("users")
+        .field("name")
+        .with_where(surreal_expr!("age > 18"));
 
-        assert_eq!(select.preview(), "SELECT name FROM users WHERE age > 18");
-    }
+    assert_eq!(select.preview(), "SELECT name FROM users WHERE age > 18");
+}
 
-    #[test]
-    fn test_select_with_multiple_where_conditions() {
-        let select = SurrealSelect::new()
-            .from("users")
-            .field("name")
-            .with_where(surreal_expr!("age > 18"))
-            .with_where(surreal_expr!("active = true"));
+#[test]
+fn test_select_with_multiple_where_conditions() {
+    let select = SurrealSelect::new()
+        .from("users")
+        .field("name")
+        .with_where(surreal_expr!("age > 18"))
+        .with_where(surreal_expr!("active = true"));
 
-        assert_eq!(
-            select.preview(),
-            "SELECT name FROM users WHERE age > 18 AND active = true"
-        );
-    }
+    assert_eq!(
+        select.preview(),
+        "SELECT name FROM users WHERE age > 18 AND active = true"
+    );
+}
 
-    #[test]
-    fn test_select_with_order_by() {
-        let select = SurrealSelect::new()
-            .from("users")
-            .field("name")
-            .with_order_by(surreal_expr!("name"), Order::Asc);
+#[test]
+fn test_select_with_order_by() {
+    let select = SurrealSelect::new()
+        .from("users")
+        .field("name")
+        .with_order_by(surreal_expr!("name"), Order::Asc);
 
-        assert_eq!(select.preview(), "SELECT name FROM users ORDER BY name");
-    }
+    assert_eq!(select.preview(), "SELECT name FROM users ORDER BY name");
+}
 
-    #[test]
-    fn test_select_with_order_by_desc() {
-        let select = SurrealSelect::new()
-            .from("users")
-            .field("name")
-            .with_order_by(surreal_expr!("created_at"), Order::Desc);
+#[test]
+fn test_select_with_order_by_desc() {
+    let select = SurrealSelect::new()
+        .from("users")
+        .field("name")
+        .with_order_by(surreal_expr!("created_at"), Order::Desc);
 
-        assert_eq!(
-            select.preview(),
-            "SELECT name FROM users ORDER BY created_at DESC"
-        );
-    }
+    assert_eq!(
+        select.preview(),
+        "SELECT name FROM users ORDER BY created_at DESC"
+    );
+}
 
-    #[test]
-    fn test_select_with_group_by() {
-        let select = SurrealSelect::new()
-            .from("users")
-            .field("department")
-            .with_expression(surreal_expr!("count()"), Some("count".to_string()))
-            .with_group_by(surreal_expr!("department"));
+#[test]
+fn test_select_with_group_by() {
+    let select = SurrealSelect::new()
+        .from("users")
+        .field("department")
+        .with_expression(surreal_expr!("count()"), Some("count".to_string()))
+        .with_group_by(surreal_expr!("department"));
 
-        assert_eq!(
-            select.preview(),
-            "SELECT department, count() AS count FROM users GROUP BY department"
-        );
-    }
+    assert_eq!(
+        select.preview(),
+        "SELECT department, count() AS count FROM users GROUP BY department"
+    );
+}
 
-    #[test]
-    fn test_select_with_limit() {
-        let select = SurrealSelect::new()
-            .from("users")
-            .field("name")
-            .with_limit(10);
+#[test]
+fn test_select_with_limit() {
+    let select = SurrealSelect::new()
+        .from("users")
+        .field("name")
+        .with_limit(10);
 
-        assert_eq!(select.preview(), "SELECT name FROM users LIMIT 10");
-    }
+    assert_eq!(select.preview(), "SELECT name FROM users LIMIT 10");
+}
 
-    #[test]
-    fn test_select_with_limit_and_start() {
-        let select = SurrealSelect::new()
-            .from("users")
-            .field("name")
-            .with_limit(10)
-            .with_skip(20);
+#[test]
+fn test_select_with_limit_and_start() {
+    let select = SurrealSelect::new()
+        .from("users")
+        .field("name")
+        .with_limit(10)
+        .with_skip(20);
 
-        assert_eq!(select.preview(), "SELECT name FROM users LIMIT 10 START 20");
-    }
+    assert_eq!(select.preview(), "SELECT name FROM users LIMIT 10 START 20");
+}
 
-    #[test]
-    fn test_complex_select_query() {
-        let select = SurrealSelect::new()
-            .from("orders")
-            .field("customer_id")
-            .with_expression(
-                surreal_expr!("SUM(total)"),
-                Some("total_amount".to_string()),
-            )
-            .with_where(surreal_expr!("status = 'completed'"))
-            .with_group_by(surreal_expr!("customer_id"))
-            .with_order_by(surreal_expr!("total_amount"), Order::Desc)
-            .with_limit(5);
+#[test]
+fn test_complex_select_query() {
+    let select = SurrealSelect::new()
+        .from("orders")
+        .field("customer_id")
+        .with_expression(
+            surreal_expr!("SUM(total)"),
+            Some("total_amount".to_string()),
+        )
+        .with_where(surreal_expr!("status = 'completed'"))
+        .with_group_by(surreal_expr!("customer_id"))
+        .with_order_by(surreal_expr!("total_amount"), Order::Desc)
+        .with_limit(5);
 
-        assert_eq!(
-            select.preview(),
-            "SELECT customer_id, SUM(total) AS total_amount FROM orders WHERE status = 'completed' GROUP BY customer_id ORDER BY total_amount DESC LIMIT 5"
-        );
-    }
+    assert_eq!(
+        select.preview(),
+        "SELECT customer_id, SUM(total) AS total_amount FROM orders WHERE status = 'completed' GROUP BY customer_id ORDER BY total_amount DESC LIMIT 5"
+    );
+}
 
-    #[test]
-    fn test_selectable_trait_methods() {
-        let mut select = SurrealSelect::new();
+#[test]
+fn test_selectable_trait_methods() {
+    let mut select = SurrealSelect::new();
 
-        // Test Selectable trait methods
-        select.add_source("users", None);
-        select.add_field("name".to_string());
-        select.add_field("email".to_string());
-        select.add_expression(surreal_expr!("age * 2"), Some("double_age".to_string()));
-        select.add_where_condition(surreal_expr!("age > 18"));
-        select.add_order_by(surreal_expr!("name"), Order::Asc);
-        select.add_group_by(surreal_expr!("department"));
-        select.set_limit(Some(10), Some(5));
-        select.set_distinct(true);
+    // Test Selectable trait methods
+    select.add_source("users", None);
+    select.add_field("name".to_string());
+    select.add_field("email".to_string());
+    select.add_expression(surreal_expr!("age * 2"), Some("double_age".to_string()));
+    select.add_where_condition(surreal_expr!("age > 18"));
+    select.add_order_by(surreal_expr!("name"), Order::Asc);
+    select.add_group_by(surreal_expr!("department"));
+    select.set_limit(Some(10), Some(5));
+    select.set_distinct(true);
 
-        // Test trait query methods
-        assert!(select.has_fields());
-        assert!(select.has_where_conditions());
-        assert!(select.has_order_by());
-        assert!(select.has_group_by());
-        assert!(select.is_distinct());
-        assert_eq!(select.get_limit(), Some(10));
-        assert_eq!(select.get_skip(), Some(5));
+    // Test trait query methods
+    assert!(select.has_fields());
+    assert!(select.has_where_conditions());
+    assert!(select.has_order_by());
+    assert!(select.has_group_by());
+    assert!(select.is_distinct());
+    assert_eq!(select.get_limit(), Some(10));
+    assert_eq!(select.get_skip(), Some(5));
 
-        // Test clear methods
-        select.clear_fields();
-        select.clear_where_conditions();
-        select.clear_order_by();
-        select.clear_group_by();
+    // Test clear methods
+    select.clear_fields();
+    select.clear_where_conditions();
+    select.clear_order_by();
+    select.clear_group_by();
 
-        assert!(!select.has_fields());
-        assert!(!select.has_where_conditions());
-        assert!(!select.has_order_by());
-        assert!(!select.has_group_by());
-    }
+    assert!(!select.has_fields());
+    assert!(!select.has_where_conditions());
+    assert!(!select.has_order_by());
+    assert!(!select.has_group_by());
 }

--- a/vantage-surrealdb/src/statements/update/tests.rs
+++ b/vantage-surrealdb/src/statements/update/tests.rs
@@ -1,175 +1,172 @@
-#[cfg(test)]
-mod tests {
-    use crate::statements::update::SurrealUpdate;
-    use crate::thing::Thing;
-    use crate::types::AnySurrealType;
-    use vantage_expressions::Expressive;
+use crate::statements::update::SurrealUpdate;
+use crate::thing::Thing;
+use crate::types::AnySurrealType;
+use vantage_expressions::Expressive;
 
-    #[test]
-    fn test_update_set_basic() {
-        let update = SurrealUpdate::new(Thing::new("users", "john"))
-            .with_field("name", "John".to_string())
-            .with_field("age", 30i64);
+#[test]
+fn test_update_set_basic() {
+    let update = SurrealUpdate::new(Thing::new("users", "john"))
+        .with_field("name", "John".to_string())
+        .with_field("age", 30i64);
 
-        let rendered = update.preview();
-        assert!(rendered.starts_with("UPDATE users:john SET"));
-        assert!(rendered.contains("name = \"John\""));
-        assert!(rendered.contains("age = 30"));
-    }
+    let rendered = update.preview();
+    assert!(rendered.starts_with("UPDATE users:john SET"));
+    assert!(rendered.contains("name = \"John\""));
+    assert!(rendered.contains("age = 30"));
+}
 
-    #[test]
-    fn test_update_set_empty() {
-        let update = SurrealUpdate::new(Thing::new("users", "john"));
-        assert_eq!(update.preview(), "UPDATE users:john");
-    }
+#[test]
+fn test_update_set_empty() {
+    let update = SurrealUpdate::new(Thing::new("users", "john"));
+    assert_eq!(update.preview(), "UPDATE users:john");
+}
 
-    #[test]
-    fn test_update_content() {
-        let update = SurrealUpdate::new(Thing::new("users", "john"))
-            .content()
-            .with_field("name", "Replaced".to_string())
-            .with_field("score", 99i64);
+#[test]
+fn test_update_content() {
+    let update = SurrealUpdate::new(Thing::new("users", "john"))
+        .content()
+        .with_field("name", "Replaced".to_string())
+        .with_field("score", 99i64);
 
-        let rendered = update.preview();
-        assert!(rendered.starts_with("UPDATE users:john CONTENT"));
-    }
+    let rendered = update.preview();
+    assert!(rendered.starts_with("UPDATE users:john CONTENT"));
+}
 
-    #[test]
-    fn test_update_merge() {
-        let update = SurrealUpdate::new(Thing::new("users", "john"))
-            .merge()
-            .with_field("score", 75i64);
+#[test]
+fn test_update_merge() {
+    let update = SurrealUpdate::new(Thing::new("users", "john"))
+        .merge()
+        .with_field("score", 75i64);
 
-        let rendered = update.preview();
-        assert!(rendered.starts_with("UPDATE users:john MERGE"));
-    }
+    let rendered = update.preview();
+    assert!(rendered.starts_with("UPDATE users:john MERGE"));
+}
 
-    #[test]
-    fn test_with_any_field() {
-        let val = AnySurrealType::new(42i64);
-        let update = SurrealUpdate::new(Thing::new("data", "x")).with_any_field("count", val);
-        let rendered = update.preview();
-        assert!(rendered.contains("count = 42"));
-    }
+#[test]
+fn test_with_any_field() {
+    let val = AnySurrealType::new(42i64);
+    let update = SurrealUpdate::new(Thing::new("data", "x")).with_any_field("count", val);
+    let rendered = update.preview();
+    assert!(rendered.contains("count = 42"));
+}
 
-    #[test]
-    fn test_with_record() {
-        let mut record = vantage_types::Record::new();
-        record.insert("a".to_string(), AnySurrealType::new(1i64));
-        record.insert("b".to_string(), AnySurrealType::new("hi".to_string()));
+#[test]
+fn test_with_record() {
+    let mut record = vantage_types::Record::new();
+    record.insert("a".to_string(), AnySurrealType::new(1i64));
+    record.insert("b".to_string(), AnySurrealType::new("hi".to_string()));
 
-        let update = SurrealUpdate::new(Thing::new("t", "1")).with_record(&record);
-        let rendered = update.preview();
-        assert!(rendered.contains("a = 1"));
-        assert!(rendered.contains("b = \"hi\""));
-    }
+    let update = SurrealUpdate::new(Thing::new("t", "1")).with_record(&record);
+    let rendered = update.preview();
+    assert!(rendered.contains("a = 1"));
+    assert!(rendered.contains("b = \"hi\""));
+}
 
-    #[test]
-    fn test_update_identifier_escaping() {
-        let update = SurrealUpdate::new(crate::surreal_expr!("⟨SELECT⟩:test"))
-            .with_field("FROM", "value".to_string());
+#[test]
+fn test_update_identifier_escaping() {
+    let update = SurrealUpdate::new(crate::surreal_expr!("⟨SELECT⟩:test"))
+        .with_field("FROM", "value".to_string());
 
-        let rendered = update.preview();
-        assert!(rendered.contains("⟨FROM⟩ = \"value\""));
-    }
+    let rendered = update.preview();
+    assert!(rendered.contains("⟨FROM⟩ = \"value\""));
+}
 
-    #[test]
-    fn test_update_produces_parameterized_expression() {
-        let update = SurrealUpdate::new(Thing::new("t", "1"))
-            .with_field("x", 10i64)
-            .with_field("y", 20i64);
+#[test]
+fn test_update_produces_parameterized_expression() {
+    let update = SurrealUpdate::new(Thing::new("t", "1"))
+        .with_field("x", 10i64)
+        .with_field("y", 20i64);
 
-        let expr = update.expr();
-        assert!(expr.template.contains("{}"));
-        assert_eq!(expr.parameters.len(), 3); // target + 2 fields
-    }
+    let expr = update.expr();
+    assert!(expr.template.contains("{}"));
+    assert_eq!(expr.parameters.len(), 3); // target + 2 fields
+}
 
-    #[test]
-    fn test_update_with_thing_field() {
-        let update = SurrealUpdate::new(Thing::new("order", "o1"))
-            .with_field("customer", Thing::new("user", "alice"));
+#[test]
+fn test_update_with_thing_field() {
+    let update = SurrealUpdate::new(Thing::new("order", "o1"))
+        .with_field("customer", Thing::new("user", "alice"));
 
-        let rendered = update.preview();
-        assert!(rendered.contains("UPDATE order:o1 SET"));
-        assert!(rendered.contains("customer ="));
-    }
+    let rendered = update.preview();
+    assert!(rendered.contains("UPDATE order:o1 SET"));
+    assert!(rendered.contains("customer ="));
+}
 
-    #[test]
-    fn test_mode_switching() {
-        let update = SurrealUpdate::new(Thing::new("t", "1"))
-            .content()
-            .with_field("a", 1i64);
-        assert!(update.preview().contains("CONTENT"));
+#[test]
+fn test_mode_switching() {
+    let update = SurrealUpdate::new(Thing::new("t", "1"))
+        .content()
+        .with_field("a", 1i64);
+    assert!(update.preview().contains("CONTENT"));
 
-        let update = update.merge();
-        assert!(update.preview().contains("MERGE"));
+    let update = update.merge();
+    assert!(update.preview().contains("MERGE"));
 
-        let update = update.set();
-        assert!(update.preview().contains("SET"));
-    }
+    let update = update.set();
+    assert!(update.preview().contains("SET"));
+}
 
-    #[test]
-    fn test_with_condition() {
-        let update = SurrealUpdate::table("users")
-            .with_field("active", false)
-            .with_condition(crate::surreal_expr!("last_login < {}", "2020-01-01"));
+#[test]
+fn test_with_condition() {
+    let update = SurrealUpdate::table("users")
+        .with_field("active", false)
+        .with_condition(crate::surreal_expr!("last_login < {}", "2020-01-01"));
 
-        let p = update.preview();
-        assert!(p.contains("UPDATE users SET"));
-        assert!(p.contains("active = false"));
-        assert!(p.contains("WHERE last_login < \"2020-01-01\""));
-    }
+    let p = update.preview();
+    assert!(p.contains("UPDATE users SET"));
+    assert!(p.contains("active = false"));
+    assert!(p.contains("WHERE last_login < \"2020-01-01\""));
+}
 
-    #[test]
-    fn test_with_multiple_conditions() {
-        let update = SurrealUpdate::table("logs")
-            .with_field("archived", true)
-            .with_condition(crate::surreal_expr!("level = {}", "debug"))
-            .with_condition(crate::surreal_expr!("age > {}", 30i64));
+#[test]
+fn test_with_multiple_conditions() {
+    let update = SurrealUpdate::table("logs")
+        .with_field("archived", true)
+        .with_condition(crate::surreal_expr!("level = {}", "debug"))
+        .with_condition(crate::surreal_expr!("age > {}", 30i64));
 
-        assert_eq!(
-            update.preview(),
-            "UPDATE logs SET archived = true WHERE level = \"debug\" AND age > 30"
-        );
-    }
+    assert_eq!(
+        update.preview(),
+        "UPDATE logs SET archived = true WHERE level = \"debug\" AND age > 30"
+    );
+}
 
-    #[test]
-    fn test_table_constructor() {
-        let update = SurrealUpdate::table("products").with_field("in_stock", true);
-        let p = update.preview();
-        assert!(p.starts_with("UPDATE products SET"));
-    }
+#[test]
+fn test_table_constructor() {
+    let update = SurrealUpdate::table("products").with_field("in_stock", true);
+    let p = update.preview();
+    assert!(p.starts_with("UPDATE products SET"));
+}
 
-    #[test]
-    fn test_with_arbitrary_target_expression() {
-        let upd = SurrealUpdate::new(crate::surreal_expr!("user WHERE active = true"))
-            .with_field("checked", true);
+#[test]
+fn test_with_arbitrary_target_expression() {
+    let upd = SurrealUpdate::new(crate::surreal_expr!("user WHERE active = true"))
+        .with_field("checked", true);
 
-        let p = upd.preview();
-        assert!(p.contains("UPDATE user WHERE active = true SET"));
-    }
+    let p = upd.preview();
+    assert!(p.contains("UPDATE user WHERE active = true SET"));
+}
 
-    #[test]
-    fn test_content_with_condition() {
-        let update = SurrealUpdate::table("cache")
-            .content()
-            .with_field("data", "refreshed".to_string())
-            .with_condition(crate::surreal_expr!("expired = {}", true));
+#[test]
+fn test_content_with_condition() {
+    let update = SurrealUpdate::table("cache")
+        .content()
+        .with_field("data", "refreshed".to_string())
+        .with_condition(crate::surreal_expr!("expired = {}", true));
 
-        let p = update.preview();
-        assert!(p.contains("CONTENT"));
-        assert!(p.contains("WHERE expired = true"));
-    }
+    let p = update.preview();
+    assert!(p.contains("CONTENT"));
+    assert!(p.contains("WHERE expired = true"));
+}
 
-    #[test]
-    fn test_merge_with_condition() {
-        let update = SurrealUpdate::table("users")
-            .merge()
-            .with_field("verified", true)
-            .with_condition(crate::surreal_expr!("email_confirmed = {}", true));
+#[test]
+fn test_merge_with_condition() {
+    let update = SurrealUpdate::table("users")
+        .merge()
+        .with_field("verified", true)
+        .with_condition(crate::surreal_expr!("email_confirmed = {}", true));
 
-        let p = update.preview();
-        assert!(p.contains("MERGE"));
-        assert!(p.contains("WHERE email_confirmed = true"));
-    }
+    let p = update.preview();
+    assert!(p.contains("MERGE"));
+    assert!(p.contains("WHERE email_confirmed = true"));
 }

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -8,7 +8,7 @@ use vantage_expressions::traits::datasource::ExprDataSource;
 use vantage_expressions::traits::expressive::ExpressiveEnum;
 use vantage_expressions::{Expression, Expressive};
 use vantage_table::column::core::{Column, ColumnType};
-
+use vantage_table::operation::Operation;
 use vantage_table::table::Table;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
@@ -381,6 +381,21 @@ impl TableSource for SurrealDB {
         let map = extract_first_map(result)?;
         let (thing, _rec) = parse_cbor_row(map, "id");
         thing.ok_or_else(|| error!("insert_table_return_id_value: no id returned"))
+    }
+
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        target_field: &str,
+        source_table: &Table<Self, SourceE>,
+        source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized,
+    {
+        let src_col = self.create_column::<Self::AnyType>(source_column);
+        let fk_values = self.column_table_values_expr(source_table, &src_col);
+        let tgt_col = self.create_column::<Self::AnyType>(target_field);
+        tgt_col.in_(fk_values.expr())
     }
 
     fn column_table_values_expr<'a, E, Type: ColumnType>(

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -109,7 +109,7 @@ impl TableSource for SurrealDB {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr<E>(
+    fn search_table_condition<E>(
         &self,
         _table: &Table<Self, E>,
         search_value: &str,

--- a/vantage-surrealdb/tests/graph_traversal.rs
+++ b/vantage-surrealdb/tests/graph_traversal.rs
@@ -152,7 +152,7 @@ async fn query10_low_stock_products() {
     let rows = select.get(&db).await.unwrap();
 
     // sea_pie (15) and time_tart (20 — not < 20) => only sea_pie
-    assert!(rows.len() >= 1);
+    assert!(!rows.is_empty());
     let names: Vec<String> = rows
         .iter()
         .map(|r| r.get("name").unwrap().try_get::<String>().unwrap())

--- a/vantage-surrealdb/tests/search_expression.rs
+++ b/vantage-surrealdb/tests/search_expression.rs
@@ -26,9 +26,9 @@ fn test_search_expression_basic() {
         .with_column(Column::<String>::new("password").with_flag(ColumnFlag::Hidden))
         .with_column(Column::<i64>::new("age"));
 
-    // search_table_expr currently returns a simple SEARCH expression
+    // search_table_condition currently returns a simple SEARCH expression
     // TODO: once implementation iterates searchable columns, update assertions
-    let search_expr = db.search_table_expr(&table, "john");
+    let search_expr = db.search_table_condition(&table, "john");
     let preview = search_expr.preview();
 
     assert!(
@@ -51,7 +51,7 @@ fn test_search_expression_special_characters() {
         .with_column(Column::<String>::new("id").with_flag(ColumnFlag::IdField))
         .with_column(Column::<String>::new("name").with_flag(ColumnFlag::Searchable));
 
-    let search_expr = db.search_table_expr(&table, "O'Brien");
+    let search_expr = db.search_table_condition(&table, "O'Brien");
     let preview = search_expr.preview();
 
     assert!(

--- a/vantage-table/src/mocks/mock_table_source.rs
+++ b/vantage-table/src/mocks/mock_table_source.rs
@@ -356,6 +356,18 @@ impl TableSource for MockTableSource {
         im_table.insert_return_id_value(record).await
     }
 
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        _target_field: &str,
+        _source_table: &Table<Self, SourceE>,
+        _source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized,
+    {
+        unimplemented!("related_in_condition not yet supported for MockTableSource")
+    }
+
     fn column_table_values_expr<'a, E, Type: ColumnType>(
         &'a self,
         table: &Table<Self, E>,

--- a/vantage-table/src/mocks/mock_table_source.rs
+++ b/vantage-table/src/mocks/mock_table_source.rs
@@ -155,7 +155,7 @@ impl TableSource for MockTableSource {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr<E>(
+    fn search_table_condition<E>(
         &self,
         _table: &Table<Self, E>,
         search_value: &str,

--- a/vantage-table/src/references/many.rs
+++ b/vantage-table/src/references/many.rs
@@ -1,8 +1,8 @@
 use std::{any::Any, marker::PhantomData, sync::Arc};
 
 use vantage_core::{Result, error};
-use vantage_expressions::traits::datasource::ExprDataSource;
 use vantage_expressions::Expression;
+use vantage_expressions::traits::datasource::ExprDataSource;
 use vantage_types::Entity;
 
 use crate::{
@@ -78,11 +78,10 @@ where
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let condition = target.data_source().related_in_condition(
-            &self.target_foreign_key,
-            source,
-            &source_id,
-        );
+        let condition =
+            target
+                .data_source()
+                .related_in_condition(&self.target_foreign_key, source, &source_id);
         target.add_condition(condition);
         Ok(Box::new(target))
     }

--- a/vantage-table/src/references/many.rs
+++ b/vantage-table/src/references/many.rs
@@ -2,11 +2,12 @@ use std::{any::Any, marker::PhantomData, sync::Arc};
 
 use vantage_core::{Result, error};
 use vantage_expressions::traits::datasource::ExprDataSource;
-use vantage_expressions::{Expression, Expressive};
+use vantage_expressions::Expression;
 use vantage_types::Entity;
 
 use crate::{
-    operation::Operation, references::RelatedTable, table::Table, traits::table_source::TableSource,
+    references::RelatedTable, table::Table, traits::column_like::ColumnLike,
+    traits::table_source::TableSource,
 };
 
 /// One-to-many relationship reference
@@ -64,7 +65,6 @@ impl<T: TableSource, SourceE: Entity<T::Value> + 'static, TargetE: Entity<T::Val
 where
     T: ExprDataSource<T::Value>,
     T::Value: Clone + Send + Sync + 'static,
-    T::Column<T::AnyType>: Operation<T::Value>,
     T::Condition: From<Expression<T::Value>>,
 {
     fn get_related_table(&self, source_table: &dyn Any) -> Result<Box<dyn Any>> {
@@ -73,13 +73,17 @@ where
             .ok_or_else(|| error!("Source table type mismatch in ReferenceMany"))?;
         let mut target = (self.get_table)();
 
-        // Get source ID values, apply as IN condition on target FK
-        let id_col = source.data_source().create_column::<T::AnyType>("id");
-        let id_values = source
-            .data_source()
-            .column_table_values_expr(source, &id_col);
+        let source_id = source
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
 
-        target.add_condition(target[self.target_foreign_key.as_str()].in_(id_values.expr()));
+        let condition = target.data_source().related_in_condition(
+            &self.target_foreign_key,
+            source,
+            &source_id,
+        );
+        target.add_condition(condition);
         Ok(Box::new(target))
     }
 

--- a/vantage-table/src/references/one.rs
+++ b/vantage-table/src/references/one.rs
@@ -1,8 +1,8 @@
 use std::{any::Any, marker::PhantomData, sync::Arc};
 
 use vantage_core::{Result, error};
-use vantage_expressions::traits::datasource::ExprDataSource;
 use vantage_expressions::Expression;
+use vantage_expressions::traits::datasource::ExprDataSource;
 use vantage_types::Entity;
 
 use crate::{
@@ -79,11 +79,10 @@ where
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let condition = target.data_source().related_in_condition(
-            &id_field,
-            source,
-            &self.our_foreign_key,
-        );
+        let condition =
+            target
+                .data_source()
+                .related_in_condition(&id_field, source, &self.our_foreign_key);
         target.add_condition(condition);
         Ok(Box::new(target))
     }

--- a/vantage-table/src/references/one.rs
+++ b/vantage-table/src/references/one.rs
@@ -2,11 +2,10 @@ use std::{any::Any, marker::PhantomData, sync::Arc};
 
 use vantage_core::{Result, error};
 use vantage_expressions::traits::datasource::ExprDataSource;
-use vantage_expressions::{Expression, Expressive};
+use vantage_expressions::Expression;
 use vantage_types::Entity;
 
 use crate::{
-    operation::Operation,
     references::RelatedTable,
     table::Table,
     traits::{column_like::ColumnLike, table_source::TableSource},
@@ -67,7 +66,6 @@ impl<T: TableSource, SourceE: Entity<T::Value> + 'static, TargetE: Entity<T::Val
 where
     T: ExprDataSource<T::Value>,
     T::Value: Clone + Send + Sync + 'static,
-    T::Column<T::AnyType>: Operation<T::Value>,
     T::Condition: From<Expression<T::Value>>,
 {
     fn get_related_table(&self, source_table: &dyn Any) -> Result<Box<dyn Any>> {
@@ -76,19 +74,17 @@ where
             .ok_or_else(|| error!("Source table type mismatch in ReferenceOne"))?;
         let mut target = (self.get_table)();
 
-        let fk_col = source
-            .data_source()
-            .create_column::<T::AnyType>(&self.our_foreign_key);
-        let fk_values = source
-            .data_source()
-            .column_table_values_expr(source, &fk_col);
-
         let id_field = target
             .id_field()
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        target.add_condition(target[id_field.as_str()].in_(fk_values.expr()));
+        let condition = target.data_source().related_in_condition(
+            &id_field,
+            source,
+            &self.our_foreign_key,
+        );
+        target.add_condition(condition);
         Ok(Box::new(target))
     }
 

--- a/vantage-table/src/table/impls/sorting.rs
+++ b/vantage-table/src/table/impls/sorting.rs
@@ -1,4 +1,5 @@
 use vantage_core::{Result, error};
+use vantage_expressions::Expression;
 use vantage_types::Entity;
 
 use crate::{sorting::*, table::Table, traits::table_source::TableSource};
@@ -46,7 +47,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
     }
 }
 
-/// Extension trait for creating OrderBy from expressions and columns
+/// Extension trait for creating OrderBy from expressions.
 pub trait OrderByExt<C> {
     /// Create an ascending order specification
     fn ascending(&self) -> OrderBy<C>;
@@ -55,13 +56,13 @@ pub trait OrderByExt<C> {
     fn descending(&self) -> OrderBy<C>;
 }
 
-// Direct implementation for any Clone type (Expression, bson::Document, etc.)
-impl<C: Clone> OrderByExt<C> for C {
-    fn ascending(&self) -> OrderBy<C> {
+// Implementation for Expression<T> — the standard condition type for SQL/SurrealDB backends.
+impl<T: Clone + Send + Sync + 'static> OrderByExt<Expression<T>> for Expression<T> {
+    fn ascending(&self) -> OrderBy<Expression<T>> {
         OrderBy::ascending(self.clone())
     }
 
-    fn descending(&self) -> OrderBy<C> {
+    fn descending(&self) -> OrderBy<Expression<T>> {
         OrderBy::descending(self.clone())
     }
 }

--- a/vantage-table/src/table/impls/table_like.rs
+++ b/vantage-table/src/table/impls/table_like.rs
@@ -60,8 +60,10 @@ where
     }
 
     fn search_expression(&self, search_value: &str) -> Result<AnyExpression> {
-        let expr = self.data_source().search_table_expr(self, search_value);
-        Ok(AnyExpression::new(expr))
+        let cond = self
+            .data_source()
+            .search_table_condition(self, search_value);
+        Ok(AnyExpression::new(cond))
     }
 
     fn clone_box(&self) -> Box<dyn TableLike<Value = Self::Value, Id = Self::Id>> {

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -53,19 +53,19 @@ pub trait TableSource: DataSource + Clone + 'static {
         parameters: Vec<ExpressiveEnum<Self::Value>>,
     ) -> Expression<Self::Value>;
 
-    /// Create a search expression for a table (e.g., searches across searchable fields)
+    /// Create a search condition for a table (e.g., searches across searchable fields)
     ///
     /// Different vendors implement search differently:
-    /// - SQL: `field LIKE '%value%'`
-    /// - SurrealDB: `field CONTAINS 'value'` or `field ~ 'value'`
-    /// - MongoDB: `{ field: { $regex: 'value', $options: 'i' } }`
+    /// - SQL: `field LIKE '%value%'` (returns Expression)
+    /// - SurrealDB: `field CONTAINS 'value'` (returns Expression)
+    /// - MongoDB: `{ field: { $regex: 'value' } }` (returns MongoCondition)
     ///
     /// The implementation should search across appropriate fields in the table.
-    fn search_table_expr<E>(
+    fn search_table_condition<E>(
         &self,
         table: &Table<Self, E>,
         search_value: &str,
-    ) -> Expression<Self::Value>
+    ) -> Self::Condition
     where
         E: Entity<Self::Value>,
         Self: Sized;

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -217,6 +217,24 @@ pub trait TableSource: DataSource + Clone + 'static {
         })
     }
 
+    /// Build a condition for "target_field IN (values of source_column from source_table)".
+    ///
+    /// Used by the relationship traversal system (`get_ref_as`) to filter
+    /// a target table by foreign key values from a source table.
+    ///
+    /// Each backend implements this natively:
+    /// - SQL backends build a subquery: `"id" IN (SELECT "bakery_id" FROM "client" WHERE ...)`
+    /// - MongoDB builds a deferred `{ field: { "$in": [...] } }` document
+    /// - CSV fetches values in memory and builds an IN condition
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        target_field: &str,
+        source_table: &Table<Self, SourceE>,
+        source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized;
+
     /// Return an associated expression that, when resolved, yields all values
     /// of the given typed column from this table (respecting current conditions).
     ///

--- a/vantage-table/tests/column_type_system.rs
+++ b/vantage-table/tests/column_type_system.rs
@@ -468,6 +468,18 @@ impl TableSource for Type3TableSource {
         Err(vantage_core::error!("Insert operations not supported"))
     }
 
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        _target_field: &str,
+        _source_table: &Table<Self, SourceE>,
+        _source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized,
+    {
+        unimplemented!("Type3 does not support related_in_condition")
+    }
+
     fn column_table_values_expr<'a, E, Type: ColumnType>(
         &'a self,
         _table: &Table<Self, E>,

--- a/vantage-table/tests/column_type_system.rs
+++ b/vantage-table/tests/column_type_system.rs
@@ -285,7 +285,7 @@ impl TableSource for Type3TableSource {
         Expression::new(template, parameters)
     }
 
-    fn search_table_expr<E>(
+    fn search_table_condition<E>(
         &self,
         _table: &Table<Self, E>,
         search_value: &str,


### PR DESCRIPTION
`search_table_expr` is now `search_table_condition` and returns `Self::Condition` instead of `Expression<Self::Value>`. Custom `TableSource` implementations also need a new `related_in_condition` method that builds a "target_field IN (values from source)" filter natively for the backend.

The reason both changes happen together: `Table::get_ref_as` used to compose relationship traversal from `column_table_values_expr` + `in_()`, which forced every backend's `Condition` to be `Expression`-shaped. MongoDB can't satisfy that — its filters are `bson::Document`, not expression trees. Pushing `related_in_condition` into the trait lets each backend implement traversal in its own dialect: SQL emits a subquery, MongoDB queues a deferred `$in` document, CSV pulls values into memory.

### MongoDB reaches relationship parity

`with_one`/`with_many`/`get_ref_as` now work against MongoDB the same way they work against PostgreSQL. Mongo has no cross-collection joins, so traversal runs as two queries — fetch the source `_id` values, then filter the target collection with `{ field: { $in: [...] } }`. The `MongoCondition::Deferred` variant means resolution happens at query time, not at table setup.

`bakery_model3` gains a `mongo` source in its CLI alongside `csv`, `sqlite`, `postgres`, `surreal`. New `tests/5_references.rs` covers `has_many` and `has_one` end-to-end, and `vantage-mongodb` finally has a README walking through conditions-as-documents, ID handling, and aggregation.

### Tradeoff

`MongoCondition: From<Expression<AnyMongoType>>` is implemented as `unimplemented!()` — the bound is required by the JOIN-style `get_linked_table` path on `ReferenceOne`/`ReferenceMany`, which Mongo never uses. Calling it panics; the alternative was to fork the relationship traits, which would have leaked the SQL/no-SQL distinction into every consumer.