### PR TITLE
refactor refs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,11 +4,24 @@
 
 - [x] Added `type Condition` associated type to `TableSource` — allows non-Expression condition
       types (e.g. `bson::Document` for MongoDB). SQL/SurrealDB backends use
-      `type Condition = Expression<Self::Value>` (no change). References (`with_one`/`with_many`)
-      require `T::Condition: From<Expression<T::Value>>` bound.
+      `type Condition = Expression<Self::Value>` (no change).
 - [x] MongoDB type system (`AnyMongoType`, `bson::Bson` value type, bson v2)
 - [x] MongoDB `TableSource` impl — full CRUD using mongodb driver directly, no Expression queries.
-      `type Condition = bson::Document` for native MongoDB filters.
+      `type Condition = MongoCondition` for native MongoDB filters with deferred support.
+- [x] **Refactored reference system** — replaced `RelatedTable` trait with `Reference` trait.
+      `HasOne`/`HasMany` describe relationships (field names + factory). Resolution happens in
+      `Table::get_ref_as` via `related_in_condition`. Factory takes `T` (data source) instead of
+      closures — enables `with_many("orders", "client_id", Order::postgres_table)`.
+- [x] **Added `HasForeign` for cross-persistence refs** — `with_foreign()` accepts a closure that
+      returns `AnyTable` with deferred conditions. Enables lazy cross-backend traversal.
+- [x] **`get_ref_as` takes one type param** — `get_ref_as::<Order>("orders")` instead of
+      `get_ref_as::<PostgresDB, Order>("orders")`. Backend type inferred from self.
+- [x] **`get_ref()` returns `AnyTable`** — works for both same-backend and foreign refs via
+      `Reference::resolve_as_any`.
+- [x] MongoDB relationship traversal working — `with_one`/`with_many` + `get_ref_as` tested
+      for has_many and has_one patterns.
+- [x] MongoDB search regex escaping — metacharacters escaped, empty columns return always-false.
+- [x] MongoDB `related_in_condition` uses projected query (only fetches needed column).
 
 ## Trait boundary fixes needed
 
@@ -20,22 +33,27 @@
       place for deletion (doesn't require entity type). Having both causes ambiguity when calling
       `table.delete()`. Keep only in `WritableValueSet`.
 - [ ] **Decouple `column_table_values_expr` from `ExprDataSource`** — the method returns
-      `AssociatedExpression` which forces `ExprDataSource` dependency. The actual work is "get
-      column values from table" which `TableSource` can already do via `list_table_values`. Explore
-      returning a `Condition`-based result instead, or refactor `AssociatedExpression` to not
-      require `ExprDataSource`.
+      `AssociatedExpression` which forces `ExprDataSource` dependency. Consider moving to a
+      sub-trait so non-SQL backends don't carry dead code. SQL backends use it internally in
+      `related_in_condition`; MongoDB never touches it.
 - [ ] **Explore `Selectable` parameterized on condition type** — currently `add_where_condition`
       takes `impl Expressive<T>`, hardcoding Expression-based conditions. MongoDB could implement
       its own `select()` if `Selectable` (or a parallel trait) accepted `Condition` type directly.
-      Investigate parameterizing `Selectable<T, C>` where `C` is the condition type, or creating
-      `DocumentSelectable` for document-oriented backends.
-- [ ] **Analyse `with_one`/`with_many` for non-Expression backends** — currently requires
-      `T::Condition: From<Expression<T::Value>>`. For MongoDB, need to either: (a) implement
-      `From<Expression<AnyMongoType>> for bson::Document` by parsing common Operation templates
-      (`"{} = {}"` → `doc!{field: value}`, `"{} IN ({})"` → `doc!{field: {"$in": [...]}}`), (b)
-      create MongoDB-native reference types that produce `bson::Document` conditions directly, or
-      (c) refactor the reference system to work with `Condition` generically. Goal: relationship
-      traversal (`ref products list`) working for MongoDB.
+- [x] ~~**Analyse `with_one`/`with_many` for non-Expression backends**~~ — **RESOLVED**: Refactored
+      reference system. `HasOne`/`HasMany` use `related_in_condition` (each backend builds its own
+      native condition). `From<Expression<T::Value>>` bound still exists on `with_one`/`with_many`
+      via `resolve_as_any` but MongoDB implements it as a no-op panic (never called for traversal —
+      `get_ref_as` uses `related_in_condition` directly). Could be cleaned up further by moving
+      `resolve_as_any` bounds into the impl block.
+
+## Cleanup (lower priority)
+
+- [ ] **Remove `From<Expression<AnyMongoType>> for MongoCondition` panic impl** — exists only to
+      satisfy trait bounds. Could be eliminated by separating the `resolve_as_any` bounds or
+      splitting `with_one`/`with_many` bounds from the `Reference` impl bounds.
+- [ ] **Consider removing `related_in_condition` from `TableSource`** — now only used by
+      `Table::get_ref_as` (same-backend resolution). Could be moved into the `HasOne`/`HasMany`
+      `resolve_as_any` implementations directly, removing it from the trait surface.
 
 # Query Builder Improvements (from MySQL work, 2026-04)
 

--- a/bakery_model3/examples/0-intro.rs
+++ b/bakery_model3/examples/0-intro.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
     }
 
     println!("\n-[ orders for paying clients (traversal) ]------------------------------------");
-    let orders_for_paying = paying_clients.get_ref_as::<Csv, Order>("orders")?;
+    let orders_for_paying = paying_clients.get_ref_as::<Order>("orders")?;
     for order in orders_for_paying
         .list()
         .await

--- a/bakery_model3/src/bakery.rs
+++ b/bakery_model3/src/bakery.rs
@@ -24,14 +24,11 @@ impl Bakery {
     }
 
     pub fn surreal_table(db: SurrealDB) -> Table<SurrealDB, Bakery> {
-        let db2 = db.clone();
         Table::new("bakery", db)
             .with_id_column("id")
             .with_column_of::<String>("name")
             .with_column_of::<i64>("profit_margin")
-            .with_many("products", "bakery", move || {
-                crate::Product::surreal_table(db2.clone())
-            })
+            .with_many("products", "bakery", crate::Product::surreal_table)
     }
 
     pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Bakery> {

--- a/bakery_model3/src/client.rs
+++ b/bakery_model3/src/client.rs
@@ -23,38 +23,27 @@ pub struct Client {
 
 impl Client {
     pub fn csv_table(csv: Csv) -> Table<Csv, Client> {
-        let csv2 = csv.clone();
-        let csv3 = csv.clone();
         Table::new("client", csv)
             .with_column_of::<String>("name")
             .with_column_of::<String>("email")
             .with_column_of::<String>("contact_details")
             .with_column_of::<bool>("is_paying_client")
             .with_column_of::<String>("bakery_id")
-            .with_one("bakery", "bakery_id", move || {
-                Bakery::csv_table(csv2.clone())
-            })
-            .with_many("orders", "client_id", move || {
-                Order::csv_table(csv3.clone())
-            })
+            .with_one("bakery", "bakery_id", Bakery::csv_table)
+            .with_many("orders", "client_id", Order::csv_table)
     }
 
     pub fn surreal_table(db: SurrealDB) -> Table<SurrealDB, Client> {
-        let db2 = db.clone();
         Table::new("client", db)
             .with_id_column("id")
             .with_column_of::<String>("name")
             .with_column_of::<String>("email")
             .with_column_of::<String>("contact_details")
             .with_column_of::<bool>("is_paying_client")
-            .with_one("bakery", "bakery", move || {
-                Bakery::surreal_table(db2.clone())
-            })
+            .with_one("bakery", "bakery", Bakery::surreal_table)
     }
 
     pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Client> {
-        let db2 = db.clone();
-        let db3 = db.clone();
         Table::new("client", db)
             .with_id_column("id")
             .with_column_of::<String>("name")
@@ -62,17 +51,11 @@ impl Client {
             .with_column_of::<String>("contact_details")
             .with_column_of::<bool>("is_paying_client")
             .with_column_of::<String>("bakery_id")
-            .with_one("bakery", "bakery_id", move || {
-                Bakery::sqlite_table(db2.clone())
-            })
-            .with_many("orders", "client_id", move || {
-                Order::sqlite_table(db3.clone())
-            })
+            .with_one("bakery", "bakery_id", Bakery::sqlite_table)
+            .with_many("orders", "client_id", Order::sqlite_table)
     }
 
     pub fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Client> {
-        let db2 = db.clone();
-        let db3 = db.clone();
         Table::new("client", db)
             .with_id_column("id")
             .with_column_of::<String>("name")
@@ -80,17 +63,11 @@ impl Client {
             .with_column_of::<String>("contact_details")
             .with_column_of::<bool>("is_paying_client")
             .with_column_of::<String>("bakery_id")
-            .with_one("bakery", "bakery_id", move || {
-                Bakery::postgres_table(db2.clone())
-            })
-            .with_many("orders", "client_id", move || {
-                Order::postgres_table(db3.clone())
-            })
+            .with_one("bakery", "bakery_id", Bakery::postgres_table)
+            .with_many("orders", "client_id", Order::postgres_table)
     }
 
     pub fn mongo_table(db: MongoDB) -> Table<MongoDB, Client> {
-        let db2 = db.clone();
-        let db3 = db.clone();
         Table::new("client", db)
             .with_id_column("_id")
             .with_column_of::<String>("name")
@@ -98,11 +75,7 @@ impl Client {
             .with_column_of::<String>("contact_details")
             .with_column_of::<bool>("is_paying_client")
             .with_column_of::<String>("bakery_id")
-            .with_one("bakery", "bakery_id", move || {
-                Bakery::mongo_table(db2.clone())
-            })
-            .with_many("orders", "client_id", move || {
-                Order::mongo_table(db3.clone())
-            })
+            .with_one("bakery", "bakery_id", Bakery::mongo_table)
+            .with_many("orders", "client_id", Order::mongo_table)
     }
 }

--- a/bakery_model3/src/order.rs
+++ b/bakery_model3/src/order.rs
@@ -22,15 +22,12 @@ pub struct Order {
 
 impl Order {
     pub fn csv_table(csv: Csv) -> Table<Csv, Order> {
-        let csv2 = csv.clone();
         Table::new("order", csv)
             .with_column_of::<String>("client_id")
             .with_column_of::<bool>("is_deleted")
             .with_column_of::<String>("created_at")
             .with_column_of::<String>("lines")
-            .with_one("client", "client_id", move || {
-                Client::csv_table(csv2.clone())
-            })
+            .with_one("client", "client_id", Client::csv_table)
     }
 
     pub fn surreal_table(db: SurrealDB) -> Table<SurrealDB, Order> {
@@ -40,35 +37,26 @@ impl Order {
     }
 
     pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Order> {
-        let db2 = db.clone();
         Table::new("client_order", db)
             .with_id_column("id")
             .with_column_of::<String>("client_id")
             .with_column_of::<bool>("is_deleted")
-            .with_one("client", "client_id", move || {
-                Client::sqlite_table(db2.clone())
-            })
+            .with_one("client", "client_id", Client::sqlite_table)
     }
 
     pub fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Order> {
-        let db2 = db.clone();
         Table::new("client_order", db)
             .with_id_column("id")
             .with_column_of::<String>("client_id")
             .with_column_of::<bool>("is_deleted")
-            .with_one("client", "client_id", move || {
-                Client::postgres_table(db2.clone())
-            })
+            .with_one("client", "client_id", Client::postgres_table)
     }
 
     pub fn mongo_table(db: MongoDB) -> Table<MongoDB, Order> {
-        let db2 = db.clone();
         Table::new("client_order", db)
             .with_id_column("_id")
             .with_column_of::<String>("client_id")
             .with_column_of::<bool>("is_deleted")
-            .with_one("client", "client_id", move || {
-                Client::mongo_table(db2.clone())
-            })
+            .with_one("client", "client_id", Client::mongo_table)
     }
 }

--- a/bakery_model3/src/product.rs
+++ b/bakery_model3/src/product.rs
@@ -32,7 +32,6 @@ impl Product {
     }
 
     pub fn surreal_table(db: SurrealDB) -> Table<SurrealDB, Product> {
-        let db2 = db.clone();
         Table::new("product", db)
             .with_id_column("id")
             .with_column_of::<String>("name")
@@ -40,14 +39,11 @@ impl Product {
             .with_column_of::<i64>("price")
             .with_column_of::<bool>("is_deleted")
             .with_column_of::<Option<Animal>>("sticker")
-            .with_column_of::<String>("bakery") // record link, used for relationships
-            .with_one("bakery", "bakery", move || {
-                Bakery::surreal_table(db2.clone())
-            })
+            .with_column_of::<String>("bakery")
+            .with_one("bakery", "bakery", Bakery::surreal_table)
     }
 
     pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Product> {
-        let db2 = db.clone();
         Table::new("product", db)
             .with_id_column("id")
             .with_column_of::<String>("name")
@@ -55,13 +51,10 @@ impl Product {
             .with_column_of::<i64>("price")
             .with_column_of::<bool>("is_deleted")
             .with_column_of::<Option<Animal>>("sticker")
-            .with_one("bakery", "bakery_id", move || {
-                Bakery::sqlite_table(db2.clone())
-            })
+            .with_one("bakery", "bakery_id", Bakery::sqlite_table)
     }
 
     pub fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Product> {
-        let db2 = db.clone();
         Table::new("product", db)
             .with_id_column("id")
             .with_column_of::<String>("name")
@@ -69,9 +62,7 @@ impl Product {
             .with_column_of::<i64>("price")
             .with_column_of::<bool>("is_deleted")
             .with_column_of::<Option<Animal>>("sticker")
-            .with_one("bakery", "bakery_id", move || {
-                Bakery::postgres_table(db2.clone())
-            })
+            .with_one("bakery", "bakery_id", Bakery::postgres_table)
     }
 
     pub fn mongo_table(db: MongoDB) -> Table<MongoDB, Product> {

--- a/vantage-mongodb/src/condition.rs
+++ b/vantage-mongodb/src/condition.rs
@@ -70,15 +70,6 @@ impl From<Document> for MongoCondition {
     }
 }
 
-/// Required by `ReferenceOne`/`ReferenceMany` trait bounds for `get_linked_table`
-/// (JOIN-style queries). MongoDB does not support JOINs — this will never be called
-/// via `get_related_table` (which uses `related_in_condition` instead).
-impl From<vantage_expressions::Expression<AnyMongoType>> for MongoCondition {
-    fn from(_expr: vantage_expressions::Expression<AnyMongoType>) -> Self {
-        unimplemented!("MongoDB does not support Expression-based conditions (JOINs)")
-    }
-}
-
 impl std::fmt::Debug for MongoCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/vantage-mongodb/tests/5_references.rs
+++ b/vantage-mongodb/tests/5_references.rs
@@ -38,7 +38,6 @@ struct ClientOrder {
 }
 
 fn client_table(db: MongoDB) -> Table<MongoDB, Client> {
-    let db2 = db.clone();
     Table::new("client", db)
         .with_id_column("_id")
         .with_column_of::<String>("name")
@@ -46,16 +45,15 @@ fn client_table(db: MongoDB) -> Table<MongoDB, Client> {
         .with_column_of::<String>("contact_details")
         .with_column_of::<bool>("is_paying_client")
         .with_column_of::<String>("bakery_id")
-        .with_many("orders", "client_id", move || order_table(db2.clone()))
+        .with_many("orders", "client_id", order_table)
 }
 
 fn order_table(db: MongoDB) -> Table<MongoDB, ClientOrder> {
-    let db2 = db.clone();
     Table::new("client_order", db)
         .with_id_column("_id")
         .with_column_of::<String>("client_id")
         .with_column_of::<bool>("is_deleted")
-        .with_one("client", "client_id", move || client_table(db2.clone()))
+        .with_one("client", "client_id", client_table)
 }
 
 /// Traverse has_many: paying clients -> their orders
@@ -65,9 +63,7 @@ async fn test_has_many_orders_for_paying_clients() {
     let mut clients = client_table(db.clone());
     clients.add_condition(doc! { "is_paying_client": true });
 
-    let orders = clients
-        .get_ref_as::<MongoDB, ClientOrder>("orders")
-        .unwrap();
+    let orders = clients.get_ref_as::<ClientOrder>("orders").unwrap();
 
     let order_list = orders.list().await.unwrap();
     // Marty has 1 order, Doc has 2 orders -> 3 total
@@ -81,9 +77,7 @@ async fn test_has_many_orders_for_single_client() {
     let mut clients = client_table(db.clone());
     clients.add_condition(doc! { "name": "Doc Brown" });
 
-    let orders = clients
-        .get_ref_as::<MongoDB, ClientOrder>("orders")
-        .unwrap();
+    let orders = clients.get_ref_as::<ClientOrder>("orders").unwrap();
 
     let order_list = orders.list().await.unwrap();
     assert_eq!(order_list.len(), 2);
@@ -96,7 +90,7 @@ async fn test_has_one_client_for_order() {
     let mut orders = order_table(db.clone());
     orders.add_condition(doc! { "_id": "order1" });
 
-    let client = orders.get_ref_as::<MongoDB, Client>("client").unwrap();
+    let client = orders.get_ref_as::<Client>("client").unwrap();
 
     let client_list = client.list().await.unwrap();
     assert_eq!(client_list.len(), 1);

--- a/vantage-sql/tests/mysql/5_references.rs
+++ b/vantage-sql/tests/mysql/5_references.rs
@@ -36,7 +36,6 @@ struct ClientOrder {
 }
 
 fn client_table(db: MysqlDB) -> Table<MysqlDB, Client> {
-    let db2 = db.clone();
     Table::new("client", db)
         .with_id_column("id")
         .with_column_of::<String>("name")
@@ -44,17 +43,16 @@ fn client_table(db: MysqlDB) -> Table<MysqlDB, Client> {
         .with_column_of::<String>("contact_details")
         .with_column_of::<bool>("is_paying_client")
         .with_column_of::<String>("bakery_id")
-        .with_many("orders", "client_id", move || order_table(db2.clone()))
+        .with_many("orders", "client_id", order_table)
 }
 
 fn order_table(db: MysqlDB) -> Table<MysqlDB, ClientOrder> {
-    let db2 = db.clone();
     Table::new("client_order", db)
         .with_id_column("id")
         .with_column_of::<String>("bakery_id")
         .with_column_of::<String>("client_id")
         .with_column_of::<bool>("is_deleted")
-        .with_one("client", "client_id", move || client_table(db2.clone()))
+        .with_one("client", "client_id", client_table)
 }
 
 /// Traverse has_many: paying clients -> their orders
@@ -64,9 +62,7 @@ async fn test_has_many_orders_for_paying_clients() {
     let mut clients = client_table(db.clone());
     clients.add_condition(mysql_expr!("{} = {}", (clients["is_paying_client"]), true));
 
-    let orders = clients
-        .get_ref_as::<MysqlDB, ClientOrder>("orders")
-        .unwrap();
+    let orders = clients.get_ref_as::<ClientOrder>("orders").unwrap();
 
     let order_list = orders.list().await.unwrap();
     // Marty has 1 order, Doc has 2 orders -> 3 total
@@ -80,9 +76,7 @@ async fn test_has_many_orders_for_single_client() {
     let mut clients = client_table(db.clone());
     clients.add_condition(mysql_expr!("{} = {}", (clients["name"]), "Doc Brown"));
 
-    let orders = clients
-        .get_ref_as::<MysqlDB, ClientOrder>("orders")
-        .unwrap();
+    let orders = clients.get_ref_as::<ClientOrder>("orders").unwrap();
 
     let order_list = orders.list().await.unwrap();
     assert_eq!(order_list.len(), 2);
@@ -95,7 +89,7 @@ async fn test_has_one_client_for_order() {
     let mut orders = order_table(db.clone());
     orders.add_condition(mysql_expr!("{} = {}", (orders["id"]), "order1"));
 
-    let client = orders.get_ref_as::<MysqlDB, Client>("client").unwrap();
+    let client = orders.get_ref_as::<Client>("client").unwrap();
 
     let client_list = client.list().await.unwrap();
     assert_eq!(client_list.len(), 1);

--- a/vantage-sql/tests/postgres/5_references.rs
+++ b/vantage-sql/tests/postgres/5_references.rs
@@ -36,7 +36,6 @@ struct ClientOrder {
 }
 
 fn client_table(db: PostgresDB) -> Table<PostgresDB, Client> {
-    let db2 = db.clone();
     Table::new("client", db)
         .with_id_column("id")
         .with_column_of::<String>("name")
@@ -44,17 +43,16 @@ fn client_table(db: PostgresDB) -> Table<PostgresDB, Client> {
         .with_column_of::<String>("contact_details")
         .with_column_of::<bool>("is_paying_client")
         .with_column_of::<String>("bakery_id")
-        .with_many("orders", "client_id", move || order_table(db2.clone()))
+        .with_many("orders", "client_id", order_table)
 }
 
 fn order_table(db: PostgresDB) -> Table<PostgresDB, ClientOrder> {
-    let db2 = db.clone();
     Table::new("client_order", db)
         .with_id_column("id")
         .with_column_of::<String>("bakery_id")
         .with_column_of::<String>("client_id")
         .with_column_of::<bool>("is_deleted")
-        .with_one("client", "client_id", move || client_table(db2.clone()))
+        .with_one("client", "client_id", client_table)
 }
 
 /// Traverse has_many: paying clients -> their orders
@@ -68,9 +66,7 @@ async fn test_has_many_orders_for_paying_clients() {
         true
     ));
 
-    let orders = clients
-        .get_ref_as::<PostgresDB, ClientOrder>("orders")
-        .unwrap();
+    let orders = clients.get_ref_as::<ClientOrder>("orders").unwrap();
 
     let order_list = orders.list().await.unwrap();
     // Marty has 1 order, Doc has 2 orders -> 3 total
@@ -84,9 +80,7 @@ async fn test_has_many_orders_for_single_client() {
     let mut clients = client_table(db.clone());
     clients.add_condition(postgres_expr!("{} = {}", (clients["name"]), "Doc Brown"));
 
-    let orders = clients
-        .get_ref_as::<PostgresDB, ClientOrder>("orders")
-        .unwrap();
+    let orders = clients.get_ref_as::<ClientOrder>("orders").unwrap();
 
     let order_list = orders.list().await.unwrap();
     assert_eq!(order_list.len(), 2);
@@ -99,7 +93,7 @@ async fn test_has_one_client_for_order() {
     let mut orders = order_table(db.clone());
     orders.add_condition(postgres_expr!("{} = {}", (orders["id"]), "order1"));
 
-    let client = orders.get_ref_as::<PostgresDB, Client>("client").unwrap();
+    let client = orders.get_ref_as::<Client>("client").unwrap();
 
     let client_list = client.list().await.unwrap();
     assert_eq!(client_list.len(), 1);

--- a/vantage-sql/tests/sqlite/5_references.rs
+++ b/vantage-sql/tests/sqlite/5_references.rs
@@ -42,7 +42,6 @@ struct ClientOrder {
 // ── Table constructors with relationships ──────────────────────────────────
 
 fn client_table(db: SqliteDB) -> Table<SqliteDB, Client> {
-    let db2 = db.clone();
     Table::new("client", db)
         .with_id_column("id")
         .with_column_of::<String>("name")
@@ -50,17 +49,16 @@ fn client_table(db: SqliteDB) -> Table<SqliteDB, Client> {
         .with_column_of::<String>("contact_details")
         .with_column_of::<bool>("is_paying_client")
         .with_column_of::<String>("bakery_id")
-        .with_many("orders", "client_id", move || order_table(db2.clone()))
+        .with_many("orders", "client_id", order_table)
 }
 
 fn order_table(db: SqliteDB) -> Table<SqliteDB, ClientOrder> {
-    let db2 = db.clone();
     Table::new("client_order", db)
         .with_id_column("id")
         .with_column_of::<String>("bakery_id")
         .with_column_of::<String>("client_id")
         .with_column_of::<bool>("is_deleted")
-        .with_one("client", "client_id", move || client_table(db2.clone()))
+        .with_one("client", "client_id", client_table)
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -72,9 +70,7 @@ async fn test_has_many_orders_for_paying_clients() {
     let mut clients = client_table(db.clone());
     clients.add_condition(sqlite_expr!("{} = {}", (clients["is_paying_client"]), true));
 
-    let orders = clients
-        .get_ref_as::<SqliteDB, ClientOrder>("orders")
-        .unwrap();
+    let orders = clients.get_ref_as::<ClientOrder>("orders").unwrap();
 
     let preview = orders.select().preview();
     assert_eq!(
@@ -95,9 +91,7 @@ async fn test_has_many_orders_for_single_client() {
     let mut clients = client_table(db.clone());
     clients.add_condition(sqlite_expr!("{} = {}", (clients["name"]), "Doc Brown"));
 
-    let orders = clients
-        .get_ref_as::<SqliteDB, ClientOrder>("orders")
-        .unwrap();
+    let orders = clients.get_ref_as::<ClientOrder>("orders").unwrap();
 
     let preview = orders.select().preview();
     assert_eq!(
@@ -117,7 +111,7 @@ async fn test_has_one_client_for_order() {
     let mut orders = order_table(db.clone());
     orders.add_condition(sqlite_expr!("{} = {}", (orders["id"]), "order1"));
 
-    let client = orders.get_ref_as::<SqliteDB, Client>("client").unwrap();
+    let client = orders.get_ref_as::<Client>("client").unwrap();
 
     let preview = client.select().preview();
     assert_eq!(

--- a/vantage-surrealdb/tests/5_references.rs
+++ b/vantage-surrealdb/tests/5_references.rs
@@ -22,7 +22,7 @@ async fn test_has_many_products_for_bakery() {
     let db = get_db().await;
     let bakery = Bakery::surreal_table(db.clone());
 
-    let products = bakery.get_ref_as::<SurrealDB, Product>("products").unwrap();
+    let products = bakery.get_ref_as::<Product>("products").unwrap();
 
     let product_list = products.list().await.unwrap();
     // v2 has 5 products all belonging to hill_valley bakery
@@ -36,7 +36,7 @@ async fn test_has_one_bakery_for_product() {
     let mut products = Product::surreal_table(db.clone());
     products.add_condition(surreal_expr!("name = {}", "Flux Capacitor Cupcake"));
 
-    let bakery = products.get_ref_as::<SurrealDB, Bakery>("bakery").unwrap();
+    let bakery = products.get_ref_as::<Bakery>("bakery").unwrap();
 
     let bakery_list = bakery.list().await.unwrap();
     assert_eq!(bakery_list.len(), 1);
@@ -53,7 +53,7 @@ async fn test_has_one_bakery_for_paying_clients() {
     let mut clients = Client::surreal_table(db.clone());
     clients.add_condition(surreal_expr!("is_paying_client = {}", true));
 
-    let bakery = clients.get_ref_as::<SurrealDB, Bakery>("bakery").unwrap();
+    let bakery = clients.get_ref_as::<Bakery>("bakery").unwrap();
 
     let bakery_list = bakery.list().await.unwrap();
     // Both paying clients (Marty, Doc) belong to the same bakery

--- a/vantage-table/README.md
+++ b/vantage-table/README.md
@@ -19,8 +19,7 @@ struct User {
 let table = Table::new("users", data_source)
     .with_column_of::<String>("name")
     .with_column_of::<String>("email")
-    .with_column_of::<bool>("active")
-    .into_entity::<User>();
+    .with_column_of::<bool>("active");
 
 // Load and modify entities
 let mut user = table.get_entity(&"user123".to_string()).await?
@@ -41,23 +40,60 @@ user.save().await?;
 ## Features
 
 - **ActiveEntity Pattern**: Load entities, modify fields directly, and save changes automatically
-- **Database Agnostic**: Works with CSV, SurrealDB, and custom data sources
+- **Database Agnostic**: Works with CSV, PostgreSQL, MySQL, SQLite, SurrealDB, MongoDB, and custom
+  data sources
 - **Type Safety**: Full compile-time validation of entity structure and field access
 - **Flexible Queries**: Integration with vantage-expressions for complex query building
+- **Relationships**: Same-persistence traversal via `with_one`/`with_many`, cross-persistence via
+  `with_foreign`
 
 ## Core Operations
+
+### Data Source
+
+A `Table` is parameterized by its data source — the persistence that stores and retrieves records.
+You pass it when constructing the table, and it determines what condition syntax you use, how
+queries execute, and what types flow through:
+
+```rust
+// PostgreSQL — SQL expressions, connection pool
+let pg_db = PostgresDB::connect("postgres://localhost/mydb").await?;
+let users = Table::new("users", pg_db)
+    .with_id_column("id")
+    .with_column_of::<String>("name");
+
+// MongoDB — BSON documents, collection-based
+let mongo_db = MongoDB::connect("mongodb://localhost:27017", "mydb").await?;
+let users = Table::new("users", mongo_db)
+    .with_id_column("_id")
+    .with_column_of::<String>("name");
+
+// CSV — file-based, read-only
+let csv = Csv::new("data/");
+let users = Table::new("users", csv)
+    .with_column_of::<String>("name");
+```
+
+The same entity struct works with any persistence. Model crates typically provide a constructor per
+persistence:
+
+```rust
+impl User {
+    pub fn postgres_table(db: PostgresDB) -> Table<PostgresDB, User> { ... }
+    pub fn mongo_table(db: MongoDB) -> Table<MongoDB, User> { ... }
+    pub fn csv_table(csv: Csv) -> Table<Csv, User> { ... }
+}
+```
 
 ### Columns
 
 Define table structure with typed columns for precise querying:
 
 ```rust
-// Define columns with types
 let users_table = Table::new("users", data_source)
     .with_column_of::<String>("name")
     .with_column_of::<i64>("age")
-    .with_column_of::<bool>("active")
-    .into_entity::<User>();
+    .with_column_of::<bool>("active");
 
 // Add conditions to filter records
 let active_users = users_table
@@ -70,18 +106,242 @@ for mut user in active_users.list_entities().await? {
 }
 ```
 
-> **Note:** Comparison operators like `.gt()`, `.lt()` are planned but not yet implemented.
-> Currently `.eq()` is the primary condition operator.
+### Conditions
+
+Conditions can be added in two ways.
+
+**Using columns and operators** — persistence-agnostic, works the same everywhere. The `Operation`
+trait provides `.eq()`, `.gt()`, `.lt()`, `.gte()`, `.lte()`, `.ne()`, `.in_()` on any column:
+
+```rust
+// Works on PostgreSQL, SQLite, MongoDB, SurrealDB — any persistence
+products.add_condition(products["is_deleted"].eq(false));
+products.add_condition(products["price"].gt(100));
+```
+
+**Using persistence-specific syntax** — for queries that need native features beyond what the
+generic operators express:
+
+```rust
+// PostgreSQL — vendor-specific SQL function
+let mut products = Table::new("product", pg_db);
+products.add_condition(postgres_expr!(
+    "LENGTH({}) > {} AND {} = ANY({})",
+    (ident("name")),
+    10i64,
+    "cupcake",
+    (ident("tags"))
+));
+```
+
+```rust
+// MongoDB — native BSON operators
+let mut products = Table::new("product", mongo_db);
+products.add_condition(doc! {
+    "price": { "$gte": 100, "$lte": 500 },
+    "tags": { "$elemMatch": { "$eq": "seasonal" } }
+});
+```
+
+Either way, the effect is the same: the table now addresses a subset of your records. Every
+subsequent operation honours the conditions — `list()`, `get_count()`, `get_sum()`, `delete_all()`,
+relationship traversal, and any other operation on the table. A conditioned table isn't a query
+result — it's a narrowed view of your data set.
+
+### Data Modeling
+
+Entity-based modeling is a way to abstract persistence behind a unified interface. A single model
+file defines how an entity is stored — columns, relationships, business rules — for each persistence
+it needs to support. The rest of your application works with the model and doesn't know or care
+where the data lives:
+
+```rust
+// models/user.rs
+
+#[entity(PostgresType, SqliteType)]
+#[derive(Debug, Clone, Default)]
+pub struct User {
+    pub name: String,
+    pub email: String,
+    pub tier: String,
+}
+
+impl User {
+    /// Primary storage — PostgreSQL
+    pub fn from_db(db: PostgresDB) -> Table<PostgresDB, User> {
+        Table::new("user", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<String>("email")
+            .with_column_of::<String>("tier")
+            .with_many("orders", "user_id", Order::from_db)
+            .with_one("active_subscription", "id", |db| {
+                let mut t = Subscription::from_db(db);
+                t.add_condition(t["is_active"].eq(true));
+                t
+            })
+    }
+
+    /// Local cache — SQLite (same entity, different persistence)
+    pub fn from_cache(db: SqliteDB) -> Table<SqliteDB, User> {
+        Table::new("user_cache", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<String>("email")
+            .with_column_of::<String>("tier")
+            .with_column_of::<chrono::NaiveDateTime>("cache_expires")
+    }
+
+    /// In-memory mock — for tests
+    #[cfg(test)]
+    pub fn from_mock(data: Vec<User>) -> Table<MockTableSource, User> {
+        let ds = MockTableSource::from_data("user", data);
+        Table::new("user", ds)
+            .with_column_of::<String>("name")
+            .with_column_of::<String>("email")
+            .with_column_of::<String>("tier")
+    }
+}
+```
+
+`Table<PostgresDB, User>` retains full type information — you have access to PostgreSQL-specific
+expressions, typed columns, and relationship traversal. A trait on the typed table can expose domain
+methods that hide persistence details completely. The caller doesn't know table names, column
+layouts, or SQL syntax — and may not even be aware whether data comes from PostgreSQL or has been
+migrated to a REST API:
+
+When you need to pass a table into generic code that doesn't care about the persistence type (CLI
+rendering, admin panels, API handlers), wrap it with `AnyTable::from_table()` to erase the types —
+see the [AnyTable](#anytable) section below.
+
+```rust
+pub trait UserTable {
+    fn current_user(&self, id: &str) -> Self;
+    fn ref_orders(&self) -> Table<PostgresDB, Order>;
+    fn ref_active_subscription(&self) -> Table<PostgresDB, Subscription>;
+    fn discount_expr(&self) -> AssociatedExpression<'_, PostgresDB, AnyPostgresType, f64>;
+}
+
+impl UserTable for Table<PostgresDB, User> {
+    fn current_user(&self, id: &str) -> Self {
+        let mut t = self.clone();
+        t.add_condition(t["id"].eq(id));
+        t
+    }
+
+    fn ref_orders(&self) -> Table<PostgresDB, Order> {
+        self.get_ref_as::<Order>("orders").unwrap()
+    }
+
+    fn ref_active_subscription(&self) -> Table<PostgresDB, Subscription> {
+        self.get_ref_as::<Subscription>("active_subscription").unwrap()
+    }
+
+    /// Discount based on order history — returns a composable expression.
+    /// Uses CASE to tier the discount by order count.
+    fn discount_expr(&self) -> AssociatedExpression<'_, PostgresDB, AnyPostgresType, f64> {
+        let orders = self.ref_orders();
+        let order_count = Fx::new("count", [ident("id").expr()]);
+
+        let discount = Case::new()
+            .when(order_count.clone().gt(50), 20.0f64)
+            .when(order_count.clone().gt(10), 15.0f64)
+            .when(order_count.clone().gt(0), 10.0f64)
+            .otherwise(0.0f64);
+
+        let mut select = orders.select();
+        select.clear_fields();
+        select.add_expression(discount, Some("discount".into()));
+
+        self.data_source().associate::<f64>(select.expr())
+    }
+}
+```
+
+Rest of your business logic doesn't build raw SQL or reference column names. If the storage changes,
+only the model file changes. Rest of the code is unchanged or has minimal changes:
+
+```rust
+// Today — discount computed via PostgreSQL subquery
+let discount = users.discount_expr().get().await?;
+
+// Tomorrow — persistence switched to RestAPI, same caller code
+let discount = users.discount_expr().get().await?;  // unchanged
+```
+
+### Relationships
+
+Vantage has unique relationship traversal. References are defined through expressions, traversing
+them is almost zero-cost:
+
+```rust
+let active_subscription = current_user.ref_active_subscription();
+let orders = current_user.ref_orders();
+```
+
+You can decide when to execute queries and how:
+
+```rust
+if active_subscription.get_some_value().await?.is_some() {
+    let order_count = orders.get_count().await?;
+}
+```
+
+Vantage also supports foreign references via `with_foreign()` — relationships that cross
+persistence boundaries (e.g. PostgreSQL users → billing API subscriptions). The closure
+receives the source table and returns an `AnyTable` with deferred conditions. See the
+[vantage-expressions README](vantage-expressions/README.md) for details on `DeferredFn` and
+cross-persistence query building.
+
+### AnyTable
+
+`AnyTable` erases the persistence and entity types, exposing a uniform `serde_json::Value`-based
+interface. This is useful for generic code — CLI tools, API handlers, admin panels — that doesn't
+need to know which database is behind it:
+
+```rust
+// Wrap any typed table
+let any_table = AnyTable::from_table(Product::postgres_table(db));
+
+// Same interface regardless of persistence
+let records = any_table.list_values().await?;
+let count = any_table.get_count().await?;
+any_table.insert_value(&id, &record).await?;
+any_table.delete(&id).await?;
+```
+
+A CLI tool that works with multiple persistence sources at runtime:
+
+```rust
+let table: AnyTable = match source {
+    "postgres" => AnyTable::from_table(Product::postgres_table(pg_db)),
+    "mongo"    => AnyTable::from_table(Product::mongo_table(mongo_db)),
+    "csv"      => AnyTable::from_table(Product::csv_table(csv)),
+    _ => panic!("unknown source"),
+};
+
+// All commands work identically — list, count, insert, delete
+let records = table.list_values().await?;
+render_records(&records);
+```
+
+Values flow through as `serde_json::Value` — booleans render as `true`/`false`, numbers stay
+numeric, nulls render cleanly. Your persistence's type system (defined in Step 1 of the persistence
+guide) ensures values arrive with the right JSON type rather than everything being a string.
+
+Most application code works directly with `Table<T, E>` instead — this gives access to typed
+entities, persistence-specific conditions, and relationship traversal. `AnyTable` is for the layer
+above, where persistence choice is a runtime decision.
 
 ### Loading Records
 
 There are multiple ways to load records depending on your needs:
 
-- **`get_entity(id)`** - Load ActiveEntity by ID (returns `None` if not found)
-- **`get_value(id)`** - Load raw record data by ID
-- **`list()`** - Load all raw entities as `IndexMap<Id, Entity>`
-- **`list_entities()`** - Load all entities as `Vec<ActiveEntity>`
-- **`list_values()`** - Load all raw record data
+- **`get_entity(id)`** — Load ActiveEntity by ID (returns `None` if not found)
+- **`get_value(id)`** — Load raw record data by ID
+- **`list()`** — Load all raw entities as `IndexMap<Id, Entity>`
+- **`list_entities()`** — Load all entities as `Vec<ActiveEntity>`
+- **`list_values()`** — Load all raw record data
 
 ```rust
 // Load raw entities (no save functionality)
@@ -100,7 +360,6 @@ if let Ok(record) = table.get_value(&"user123".to_string()).await {
 ### Get-or-Create Pattern
 
 ```rust
-// Get existing or create new entity
 let mut user = table.get_entity(&"user123".to_string()).await?
     .unwrap_or_else(|| table.new_entity("user123".to_string(), User::default()));
 ```
@@ -110,20 +369,18 @@ let mut user = table.get_entity(&"user123".to_string()).await?
 Various ways to interact with table metadata and statistics:
 
 ```rust
-// Get record count immediately
+// Get record count
 let count: i64 = table.get_count().await?;
-println!("Total users: {}", count);
 
 // Get count as AssociatedExpression for use in other queries
 let count_expr = table.get_table_expr_count();
-let result = count_expr.get().await?; // Execute now
-// Or use in another expression: expr!("SELECT {} as user_count", count_expr)
+let result = count_expr.get().await?;
 
-// Get aggregated values like max, min, sum (returns AssociatedExpression)
+// Aggregated values
 let max_age = table.get_table_expr_max(&table["age"]);
 let max_value = max_age.get().await?;
 
-// Get select query builder implementing Selectable trait for complex operations
+// Select query builder
 let select = table.get_select_query();
 let results = select
     .with_field("name")
@@ -132,61 +389,53 @@ let results = select
     .execute().await?;
 ```
 
-See [`AssociatedExpression`] for deferred query execution and [`Selectable`] trait for query builder
-interface.
-
 ## Diverse Data Persistence Support
 
 Vantage Table works with a wide range of data sources through modular adapter crates:
 
-### Ready-to-Use Adapters
+### Available Adapters
 
-- **vantage-csv**: CSV file backend with type-safe column parsing
-- **vantage-surrealdb**: SurrealDB integration with native query building
+- **vantage-sql**: PostgreSQL, MySQL, SQLite via vendor-aware SQL generation
+- **vantage-mongodb**: MongoDB with native BSON conditions (no SQL)
+- **vantage-surrealdb**: SurrealDB with native SurrealQL
+- **vantage-csv**: CSV file persistence with type-safe column parsing
+- **vantage-api-client**: REST API persistence with pagination
 - **[`MockTableSource`]**: In-memory testing and development mock
-
-### Planned Adapters
-
-- **vantage-sql**: PostgreSQL, MySQL, SQLite support via SQL generation (TODO)
 
 ### Create Your Own Persistence Adapter
 
-A persistence backend plugs into the Vantage framework by implementing traits at two levels.
-Once implemented, `Table<T, E>` automatically bridges these into the full `ReadableValueSet`,
-`WritableValueSet`, `ReadableDataSet<E>`, and `WritableDataSet<E>` trait families — you do not
-need to implement those yourself.
+A persistence adapter plugs into the Vantage framework by implementing traits at two levels. Once
+implemented, `Table<T, E>` automatically bridges these into the full `ReadableValueSet`,
+`WritableValueSet`, `ReadableDataSet<E>`, and `WritableDataSet<E>` trait families — you do not need
+to implement those yourself.
 
 #### Required Traits
 
-| Trait | Crate | Purpose |
-|---|---|---|
-| **`TableSource`** | vantage-table | The core trait. Defines associated types (`Column`, `AnyType`, `Value`, `Id`) and all CRUD + aggregation methods: `list_table_values`, `get_table_value`, `insert_table_value`, `replace_table_value`, `patch_table_value`, `delete_table_value`, `get_count`, `get_sum`, column creation, and expression support. |
-| **`ColumnLike<AnyType>`** | vantage-table | Column metadata for your persistence's column type (`name`, `alias`, `flags`, `get_type`). You can use the built-in `Column<T>` which preserves original type info through type-erasure, or create a custom column type. |
+| Trait                     | Crate         | Purpose                                                                                                                                                                                                          |
+| ------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`TableSource`**         | vantage-table | The core trait. Defines associated types (`Column`, `AnyType`, `Value`, `Id`, `Condition`) and all CRUD + aggregation methods. Also provides `related_in_condition` for same-persistence relationship traversal. |
+| **`ColumnLike<AnyType>`** | vantage-table | Column metadata for your persistence's column type (`name`, `alias`, `flags`, `get_type`). You can use the built-in `Column<T>` or create a custom column type.                                                  |
 
-#### Required for Relationships
+#### Optional Traits
 
-| Trait | Crate | Purpose |
-|---|---|---|
-| **`ExprDataSource`** | vantage-expressions | Execute expressions and create deferred closures. Required for `with_one`/`with_many` relationship traversal. |
-| **`Operation`** | vantage-table | Provides `eq()` and `in_()` condition builders on columns. Each backend implements this for its column type. |
-
-#### Optional Traits (for query-language backends)
-
-| Trait | Crate | Purpose |
-|---|---|---|
-| **`TableExprSource`** | vantage-table | Expression-returning aggregations (`get_table_expr_count`, `get_table_expr_max`) for use in subqueries or deferred execution. |
-| **`TableQuerySource`** | vantage-table | SELECT query builder support (`get_table_select_query`) for backends that can compose structured queries. |
+| Trait                  | Crate               | Purpose                                                                                                                                                                            |
+| ---------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`ExprDataSource`**   | vantage-expressions | Execute expressions and create deferred closures. Required by SQL persistence for subquery-based relationship traversal. Not needed by document-oriented persistence like MongoDB. |
+| **`TableExprSource`**  | vantage-table       | Expression-returning aggregations (`get_table_expr_count`, `get_table_expr_max`) for use in subqueries or deferred execution.                                                      |
+| **`TableQuerySource`** | vantage-table       | SELECT query builder support for persistence that can compose structured queries.                                                                                                  |
 
 #### What You Get for Free
 
 Once `TableSource` is implemented, `Table<T, E>` provides:
 
 - **`ReadableValueSet`** / **`WritableValueSet`** — raw record CRUD (delegates to your TableSource)
-- **`ReadableDataSet<E>`** / **`WritableDataSet<E>`** — typed entity CRUD with automatic Record ↔ Entity conversion
+- **`ReadableDataSet<E>`** / **`WritableDataSet<E>`** — typed entity CRUD with automatic
+  Record-Entity conversion
 - **`ActiveEntitySet<E>`** — change-tracked entity wrappers with `.save()`
 - **`TableLike`** — dyn-safe interface with conditions, pagination, ordering, and search
 - **`AnyTable`** — type-erased wrapper for heterogeneous table collections
-- **Relationship traversal** — `with_one()`, `with_many()`, `get_ref_as()` for navigating between related tables
+- **Relationship traversal** — `with_one()`, `with_many()`, `with_foreign()`, `get_ref_as()`,
+  `get_ref()`
 
 #### Supporting Crates
 
@@ -196,18 +445,13 @@ Once `TableSource` is implemented, `Table<T, E>` provides:
 
 #### Simple Alternative: Direct DataSet Implementation
 
-For backends that don't need table/column abstractions (e.g. in-memory stores), you can
+For persistence that doesn't need table/column abstractions (e.g. in-memory stores), you can
 implement the vantage-dataset traits directly:
 
 - `ReadableValueSet` + `WritableValueSet` + `InsertableValueSet` (raw record layer)
 - `ReadableDataSet<E>` + `WritableDataSet<E>` + `InsertableDataSet<E>` (typed entity layer)
 
 See `ImTable` in vantage-dataset for a reference implementation of this approach.
-
-## Upcoming Features
-
-- **Pagination**: Limit/offset support in Table operations (TODO)
-- **Comparison operators**: `.gt()`, `.lt()`, `.gte()`, `.lte()` for conditions (TODO)
 
 ## Integration
 
@@ -218,18 +462,7 @@ Part of the Vantage framework:
 - **vantage-dataset**: CRUD operation traits
 - **vantage-core**: Error handling and utilities
 - **vantage-csv**: CSV file data source
+- **vantage-sql**: SQL persistence (PostgreSQL, MySQL, SQLite)
+- **vantage-mongodb**: MongoDB persistence
+- **vantage-surrealdb**: SurrealDB persistence
 - **vantage-cli-util**: Terminal table rendering utilities
-
-## Migration from 0.2
-
-```rust
-// Old (0.2): Manual record management
-let record = table.get_record(id).await?;
-record.set_field("name", "New Name");
-table.save_record(record).await?;
-
-// New (0.3): Direct entity modification
-let mut entity = table.get_entity(&id).await?.unwrap();
-entity.name = "New Name".to_string();
-entity.save().await?;
-```

--- a/vantage-table/examples/ref_example.rs
+++ b/vantage-table/examples/ref_example.rs
@@ -40,21 +40,18 @@ impl Bakery {
 
 impl Client {
     pub fn table(ds: MockTableSource) -> Table<MockTableSource, Client> {
-        let ds2 = ds.clone();
-        let ds3 = ds.clone();
         Table::new("client", ds)
             .into_entity::<Client>()
-            // Define relationships using with_one and with_many
-            .with_one("bakery", "bakery_id", move || Bakery::table(ds2.clone()))
-            .with_many("orders", "client_id", move || Order::table(ds3.clone()))
+            .with_one("bakery", "bakery_id", Bakery::table)
+            .with_many("orders", "client_id", Order::table)
     }
 }
 
 impl Order {
     pub fn table(ds: MockTableSource) -> Table<MockTableSource, Order> {
-        Table::new("order", ds.clone())
+        Table::new("order", ds)
             .into_entity::<Order>()
-            .with_one("client", "client_id", move || Client::table(ds.clone()))
+            .with_one("client", "client_id", Client::table)
     }
 }
 

--- a/vantage-table/src/mocks/mock_column.rs
+++ b/vantage-table/src/mocks/mock_column.rs
@@ -8,6 +8,7 @@ use crate::traits::column_like::ColumnLike;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::marker::PhantomData;
+use vantage_expressions::{Expression, Expressive, expr_any};
 
 /// Simple column implementation for testing mocks
 #[derive(Debug, Clone)]
@@ -39,6 +40,12 @@ impl<T: ColumnType> MockColumn<T> {
             flags: self.flags,
             _phantom: PhantomData,
         }
+    }
+}
+
+impl<T: ColumnType> Expressive<T> for MockColumn<T> {
+    fn expr(&self) -> Expression<T> {
+        expr_any!(self.name.clone())
     }
 }
 

--- a/vantage-table/src/mocks/mock_table_source.rs
+++ b/vantage-table/src/mocks/mock_table_source.rs
@@ -358,14 +358,33 @@ impl TableSource for MockTableSource {
 
     fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
         &self,
-        _target_field: &str,
-        _source_table: &Table<Self, SourceE>,
-        _source_column: &str,
+        target_field: &str,
+        source_table: &Table<Self, SourceE>,
+        source_column: &str,
     ) -> Self::Condition
     where
         Self: Sized,
     {
-        unimplemented!("related_in_condition not yet supported for MockTableSource")
+        use vantage_expressions::{Expressive, Selectable, SelectableDataSource};
+
+        // Build a subquery for source column values
+        let mut select = self.select();
+        select.add_source(source_table.table_name(), None);
+        select.clear_fields();
+        select.add_field(source_column);
+        for condition in source_table.conditions() {
+            select.add_where_condition(condition.clone());
+        }
+
+        // target_field IN (subquery)
+        let tgt_col: Expression<Value> = Expression::new(target_field, vec![]);
+        Expression::new(
+            "{} IN ({})",
+            vec![
+                ExpressiveEnum::Nested(tgt_col),
+                ExpressiveEnum::Nested(select.expr()),
+            ],
+        )
     }
 
     fn column_table_values_expr<'a, E, Type: ColumnType>(

--- a/vantage-table/src/references.rs
+++ b/vantage-table/src/references.rs
@@ -1,55 +1,46 @@
-//! Table reference implementations for one-to-one and one-to-many relationships
+//! Table reference system for relationships between tables.
 //!
-//! This module provides relationship management between tables, using
-//! `column_table_values_expr` and `Operation::in_()` for universal backend support.
+//! The `Reference` trait describes a relationship (field names, target factory).
+//! Resolution (building conditions) happens in `Table::get_ref_as`.
+//!
+//! Three concrete types:
+//! - `HasOne` — foreign key on source table (e.g. Client.bakery_id → Bakery)
+//! - `HasMany` — foreign key on target table (e.g. Bakery → Client.bakery_id)
+//! - `HasForeign` — cross-persistence reference with user-provided resolution
 
 use std::any::Any;
 
-use vantage_core::{Result, error};
-use vantage_types::Entity;
+use vantage_core::Result;
 
-use crate::{table::Table, traits::table_source::TableSource};
+use crate::any::AnyTable;
 
+pub mod foreign;
 pub mod many;
 pub mod one;
 
-pub use many::ReferenceMany;
-pub use one::ReferenceOne;
+pub use foreign::HasForeign;
+pub use many::HasMany;
+pub use one::HasOne;
 
-/// Trait that references between Tables must implement.
-pub trait RelatedTable: Send + Sync {
-    /// For a source_table return related table having necessary conditions applied
-    fn get_related_table(&self, source_table: &dyn Any) -> Result<Box<dyn Any>>;
+/// Describes a relationship between two tables.
+pub trait Reference: Send + Sync {
+    /// Given source and target id field names, return (source_column, target_column).
+    fn columns(&self, source_id: &str, target_id: &str) -> (String, String);
 
-    /// Link table to current selection, making it appropriate to join both tables
-    fn get_linked_table(&self, source_table: &dyn Any) -> Result<Box<dyn Any>>;
+    /// Produce a fresh target table (no conditions applied).
+    fn build_target(&self, data_source: &dyn Any) -> Box<dyn Any>;
 
-    /// Get the type name of the table this reference creates
-    fn target_type_name(&self) -> &'static str;
-}
-
-/// Extension trait for RelatedTable with generic methods
-pub trait RelatedTableExt {
-    fn as_table<T: TableSource + 'static, E: Entity<T::Value> + 'static>(
-        &self,
-        source_table: &dyn Any,
-    ) -> Result<Table<T, E>>;
-}
-
-impl<R: RelatedTable + ?Sized> RelatedTableExt for R {
-    fn as_table<T: TableSource + 'static, E: Entity<T::Value> + 'static>(
-        &self,
-        source_table: &dyn Any,
-    ) -> Result<Table<T, E>> {
-        let any = self.get_related_table(source_table)?;
-        any.downcast::<Table<T, E>>()
-            .map(|boxed| *boxed)
-            .map_err(|_| {
-                error!(
-                    "Cannot downcast to Table",
-                    target_type = std::any::type_name::<T>(),
-                    entity_type = std::any::type_name::<E>()
-                )
-            })
+    /// Whether this is a cross-persistence reference.
+    fn is_foreign(&self) -> bool {
+        false
     }
+
+    /// Resolve this reference and return an AnyTable.
+    ///
+    /// For same-backend: builds target, applies condition, wraps in AnyTable.
+    /// For foreign: returns the AnyTable from the user's closure.
+    fn resolve_as_any(&self, source_table: &dyn Any) -> Result<AnyTable>;
+
+    /// Type name of the target table (for error messages).
+    fn target_type_name(&self) -> &'static str;
 }

--- a/vantage-table/src/references/foreign.rs
+++ b/vantage-table/src/references/foreign.rs
@@ -1,0 +1,85 @@
+//! HasForeign — cross-persistence reference with user-provided resolution.
+//!
+//! The user supplies a sync closure that receives the source table and returns
+//! an AnyTable with deferred conditions attached. The actual async work
+//! (fetching IDs, querying the foreign backend) happens lazily at query time
+//! via DeferredFn inside the target's condition system.
+
+use std::{any::Any, marker::PhantomData, sync::Arc};
+
+use vantage_core::Result;
+use vantage_types::Entity;
+
+use crate::{
+    any::AnyTable, references::Reference, table::Table, traits::table_source::TableSource,
+};
+
+type ResolveFn<T, E> = dyn Fn(&Table<T, E>) -> Result<AnyTable> + Send + Sync;
+
+pub struct HasForeign<T: TableSource, SourceE: Entity<T::Value>> {
+    /// Sync closure: receives source table, returns AnyTable with deferred conditions
+    resolve: Arc<ResolveFn<T, SourceE>>,
+    /// Type name for error messages
+    target_type: &'static str,
+    _phantom: PhantomData<(T, SourceE)>,
+}
+
+impl<T: TableSource + 'static, SourceE: Entity<T::Value> + 'static> HasForeign<T, SourceE> {
+    pub fn new(
+        target_type: &'static str,
+        resolve: impl Fn(&Table<T, SourceE>) -> Result<AnyTable> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            resolve: Arc::new(resolve),
+            target_type,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: TableSource, SourceE: Entity<T::Value>> Clone for HasForeign<T, SourceE> {
+    fn clone(&self) -> Self {
+        Self {
+            resolve: self.resolve.clone(),
+            target_type: self.target_type,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: TableSource, SourceE: Entity<T::Value>> std::fmt::Debug for HasForeign<T, SourceE> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HasForeign")
+            .field("target_type", &self.target_type)
+            .finish()
+    }
+}
+
+impl<T: TableSource + 'static, SourceE: Entity<T::Value> + 'static> Reference
+    for HasForeign<T, SourceE>
+{
+    fn columns(&self, _source_id: &str, _target_id: &str) -> (String, String) {
+        unreachable!("columns() should not be called on foreign references")
+    }
+
+    fn build_target(&self, _data_source: &dyn Any) -> Box<dyn Any> {
+        unreachable!("build_target() should not be called on foreign references")
+    }
+
+    fn is_foreign(&self) -> bool {
+        true
+    }
+
+    fn resolve_as_any(&self, source_table: &dyn Any) -> Result<AnyTable> {
+        let source = source_table
+            .downcast_ref::<Table<T, SourceE>>()
+            .ok_or_else(|| {
+                vantage_core::error!("Source table type mismatch in HasForeign::resolve_as_any")
+            })?;
+        (self.resolve)(source)
+    }
+
+    fn target_type_name(&self) -> &'static str {
+        self.target_type
+    }
+}

--- a/vantage-table/src/references/many.rs
+++ b/vantage-table/src/references/many.rs
@@ -1,108 +1,111 @@
+//! HasMany — one-to-many relationship where the foreign key is on the target table.
+//!
+//! Example: Bakery has many Clients (via client.bakery_id)
+
+use std::fmt::Display;
 use std::{any::Any, marker::PhantomData, sync::Arc};
 
-use vantage_core::{Result, error};
-use vantage_expressions::Expression;
-use vantage_expressions::traits::datasource::ExprDataSource;
+use vantage_core::Result;
 use vantage_types::Entity;
 
 use crate::{
-    references::RelatedTable, table::Table, traits::column_like::ColumnLike,
-    traits::table_source::TableSource,
+    any::AnyTable,
+    references::Reference,
+    table::Table,
+    traits::{column_like::ColumnLike, table_source::TableSource},
 };
 
-/// One-to-many relationship reference
-///
-/// Example: Bakery has many Clients (via client.bakery_id)
-/// - foreign_key: "bakery_id" (column on Client table pointing to Bakery)
-/// - get_table: returns Table<SurrealDB, Client>
-pub struct ReferenceMany<T: TableSource, SourceE: Entity<T::Value>, TargetE: Entity<T::Value>> {
-    /// Foreign key column name on the target table
+pub struct HasMany<T: TableSource, SourceE: Entity<T::Value>, TargetE: Entity<T::Value>> {
+    /// Foreign key column on the target table (e.g. "bakery_id" on client)
     target_foreign_key: String,
-    /// Factory function that creates the target table
-    get_table: Arc<dyn Fn() -> Table<T, TargetE> + Send + Sync>,
-    _phantom: PhantomData<(T, SourceE, TargetE)>,
+    /// Factory: given a data source, produce the target table
+    build_target: Arc<dyn Fn(T) -> Table<T, TargetE> + Send + Sync>,
+    _phantom: PhantomData<SourceE>,
 }
 
 impl<T: TableSource, SourceE: Entity<T::Value>, TargetE: Entity<T::Value>>
-    ReferenceMany<T, SourceE, TargetE>
+    HasMany<T, SourceE, TargetE>
 {
     pub fn new(
         target_foreign_key: impl Into<String>,
-        get_table: impl Fn() -> Table<T, TargetE> + Send + Sync + 'static,
+        build_target: impl Fn(T) -> Table<T, TargetE> + Send + Sync + 'static,
     ) -> Self {
         Self {
             target_foreign_key: target_foreign_key.into(),
-            get_table: Arc::new(get_table),
+            build_target: Arc::new(build_target),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: TableSource, SourceE: Entity<T::Value>, TargetE: Entity<T::Value>> Clone
+    for HasMany<T, SourceE, TargetE>
+{
+    fn clone(&self) -> Self {
+        Self {
+            target_foreign_key: self.target_foreign_key.clone(),
+            build_target: self.build_target.clone(),
             _phantom: PhantomData,
         }
     }
 }
 
 impl<T: TableSource, SourceE: Entity<T::Value>, TargetE: Entity<T::Value>> std::fmt::Debug
-    for ReferenceMany<T, SourceE, TargetE>
+    for HasMany<T, SourceE, TargetE>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ReferenceMany")
+        f.debug_struct("HasMany")
             .field("target_foreign_key", &self.target_foreign_key)
             .finish()
     }
 }
 
-impl<T: TableSource, SourceE: Entity<T::Value>, TargetE: Entity<T::Value>> Clone
-    for ReferenceMany<T, SourceE, TargetE>
-{
-    fn clone(&self) -> Self {
-        Self {
-            target_foreign_key: self.target_foreign_key.clone(),
-            get_table: self.get_table.clone(),
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl<T: TableSource, SourceE: Entity<T::Value> + 'static, TargetE: Entity<T::Value> + 'static>
-    RelatedTable for ReferenceMany<T, SourceE, TargetE>
+impl<
+    T: TableSource + 'static,
+    SourceE: Entity<T::Value> + 'static,
+    TargetE: Entity<T::Value> + 'static,
+> Reference for HasMany<T, SourceE, TargetE>
 where
-    T: ExprDataSource<T::Value>,
-    T::Value: Clone + Send + Sync + 'static,
-    T::Condition: From<Expression<T::Value>>,
+    T::Value: Into<serde_json::Value> + From<serde_json::Value>,
+    T::Id: Display + From<String>,
 {
-    fn get_related_table(&self, source_table: &dyn Any) -> Result<Box<dyn Any>> {
+    fn columns(&self, source_id: &str, _target_id: &str) -> (String, String) {
+        (source_id.to_string(), self.target_foreign_key.clone())
+    }
+
+    fn build_target(&self, data_source: &dyn Any) -> Box<dyn Any> {
+        let ds = data_source
+            .downcast_ref::<T>()
+            .expect("data source type mismatch in HasMany::build_target");
+        Box::new((self.build_target)(ds.clone()))
+    }
+
+    fn resolve_as_any(&self, source_table: &dyn Any) -> Result<AnyTable> {
         let source = source_table
             .downcast_ref::<Table<T, SourceE>>()
-            .ok_or_else(|| error!("Source table type mismatch in ReferenceMany"))?;
-        let mut target = (self.get_table)();
+            .ok_or_else(|| {
+                vantage_core::error!("Source table type mismatch in HasMany::resolve_as_any")
+            })?;
 
         let source_id = source
             .id_field()
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let condition =
-            target
-                .data_source()
-                .related_in_condition(&self.target_foreign_key, source, &source_id);
-        target.add_condition(condition);
-        Ok(Box::new(target))
-    }
+        let mut target = (self.build_target)(source.data_source().clone());
 
-    fn get_linked_table(&self, source_table: &dyn Any) -> Result<Box<dyn Any>> {
-        let source = source_table
-            .downcast_ref::<Table<T, SourceE>>()
-            .ok_or_else(|| error!("Source table type mismatch in ReferenceMany"))?;
-        let mut target = (self.get_table)();
+        let target_id = target
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
 
-        let condition = target.data_source().expr(
-            format!(
-                "{}.{} = {}.id",
-                target.table_name(),
-                self.target_foreign_key,
-                source.table_name()
-            ),
-            vec![],
-        );
+        let (src_col, tgt_col) = self.columns(&source_id, &target_id);
+        let condition = source
+            .data_source()
+            .related_in_condition(&tgt_col, source, &src_col);
         target.add_condition(condition);
-        Ok(Box::new(target))
+
+        Ok(AnyTable::from_table(target))
     }
 
     fn target_type_name(&self) -> &'static str {

--- a/vantage-table/src/references/one.rs
+++ b/vantage-table/src/references/one.rs
@@ -1,115 +1,111 @@
+//! HasOne — one-to-one relationship where the foreign key is on the source table.
+//!
+//! Example: Client has one Bakery (via client.bakery_id)
+
+use std::fmt::Display;
 use std::{any::Any, marker::PhantomData, sync::Arc};
 
-use vantage_core::{Result, error};
-use vantage_expressions::Expression;
-use vantage_expressions::traits::datasource::ExprDataSource;
+use vantage_core::Result;
 use vantage_types::Entity;
 
 use crate::{
-    references::RelatedTable,
+    any::AnyTable,
+    references::Reference,
     table::Table,
     traits::{column_like::ColumnLike, table_source::TableSource},
 };
 
-/// One-to-one relationship reference
-///
-/// Example: Client has one Bakery (via bakery_id)
-/// - foreign_key: "bakery_id" (column on Client table)
-/// - get_table: returns Table<SurrealDB, Bakery>
-pub struct ReferenceOne<T: TableSource, SourceE: Entity<T::Value>, TargetE: Entity<T::Value>> {
-    /// Foreign key column name on the source table
-    our_foreign_key: String,
-    /// Factory function that creates the target table
-    get_table: Arc<dyn Fn() -> Table<T, TargetE> + Send + Sync>,
-    _phantom: PhantomData<(T, SourceE, TargetE)>,
+pub struct HasOne<T: TableSource, SourceE: Entity<T::Value>, TargetE: Entity<T::Value>> {
+    /// Foreign key column on the source table (e.g. "bakery_id")
+    foreign_key: String,
+    /// Factory: given a data source, produce the target table
+    build_target: Arc<dyn Fn(T) -> Table<T, TargetE> + Send + Sync>,
+    _phantom: PhantomData<SourceE>,
 }
 
 impl<T: TableSource, SourceE: Entity<T::Value>, TargetE: Entity<T::Value>>
-    ReferenceOne<T, SourceE, TargetE>
+    HasOne<T, SourceE, TargetE>
 {
     pub fn new(
-        our_foreign_key: impl Into<String>,
-        get_table: impl Fn() -> Table<T, TargetE> + Send + Sync + 'static,
+        foreign_key: impl Into<String>,
+        build_target: impl Fn(T) -> Table<T, TargetE> + Send + Sync + 'static,
     ) -> Self {
         Self {
-            our_foreign_key: our_foreign_key.into(),
-            get_table: Arc::new(get_table),
+            foreign_key: foreign_key.into(),
+            build_target: Arc::new(build_target),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T: TableSource, SourceE: Entity<T::Value>, TargetE: Entity<T::Value>> Clone
+    for HasOne<T, SourceE, TargetE>
+{
+    fn clone(&self) -> Self {
+        Self {
+            foreign_key: self.foreign_key.clone(),
+            build_target: self.build_target.clone(),
             _phantom: PhantomData,
         }
     }
 }
 
 impl<T: TableSource, SourceE: Entity<T::Value>, TargetE: Entity<T::Value>> std::fmt::Debug
-    for ReferenceOne<T, SourceE, TargetE>
+    for HasOne<T, SourceE, TargetE>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ReferenceOne")
-            .field("our_foreign_key", &self.our_foreign_key)
+        f.debug_struct("HasOne")
+            .field("foreign_key", &self.foreign_key)
             .finish()
     }
 }
 
-impl<T: TableSource, SourceE: Entity<T::Value>, TargetE: Entity<T::Value>> Clone
-    for ReferenceOne<T, SourceE, TargetE>
-{
-    fn clone(&self) -> Self {
-        Self {
-            our_foreign_key: self.our_foreign_key.clone(),
-            get_table: self.get_table.clone(),
-            _phantom: PhantomData,
-        }
-    }
-}
-
-impl<T: TableSource, SourceE: Entity<T::Value> + 'static, TargetE: Entity<T::Value> + 'static>
-    RelatedTable for ReferenceOne<T, SourceE, TargetE>
+impl<
+    T: TableSource + 'static,
+    SourceE: Entity<T::Value> + 'static,
+    TargetE: Entity<T::Value> + 'static,
+> Reference for HasOne<T, SourceE, TargetE>
 where
-    T: ExprDataSource<T::Value>,
-    T::Value: Clone + Send + Sync + 'static,
-    T::Condition: From<Expression<T::Value>>,
+    T::Value: Into<serde_json::Value> + From<serde_json::Value>,
+    T::Id: Display + From<String>,
 {
-    fn get_related_table(&self, source_table: &dyn Any) -> Result<Box<dyn Any>> {
-        let source = source_table
-            .downcast_ref::<Table<T, SourceE>>()
-            .ok_or_else(|| error!("Source table type mismatch in ReferenceOne"))?;
-        let mut target = (self.get_table)();
-
-        let id_field = target
-            .id_field()
-            .map(|c| c.name().to_string())
-            .unwrap_or_else(|| "id".to_string());
-
-        let condition =
-            target
-                .data_source()
-                .related_in_condition(&id_field, source, &self.our_foreign_key);
-        target.add_condition(condition);
-        Ok(Box::new(target))
+    fn columns(&self, _source_id: &str, target_id: &str) -> (String, String) {
+        (self.foreign_key.clone(), target_id.to_string())
     }
 
-    fn get_linked_table(&self, source_table: &dyn Any) -> Result<Box<dyn Any>> {
+    fn build_target(&self, data_source: &dyn Any) -> Box<dyn Any> {
+        let ds = data_source
+            .downcast_ref::<T>()
+            .expect("data source type mismatch in HasOne::build_target");
+        Box::new((self.build_target)(ds.clone()))
+    }
+
+    fn resolve_as_any(&self, source_table: &dyn Any) -> Result<AnyTable> {
         let source = source_table
             .downcast_ref::<Table<T, SourceE>>()
-            .ok_or_else(|| error!("Source table type mismatch in ReferenceOne"))?;
-        let mut target = (self.get_table)();
+            .ok_or_else(|| {
+                vantage_core::error!("Source table type mismatch in HasOne::resolve_as_any")
+            })?;
 
-        let id_field = target
+        let source_id = source
             .id_field()
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
 
-        let condition = target.data_source().expr(
-            format!(
-                "{}.{} = {}.{}",
-                target.table_name(),
-                id_field,
-                source.table_name(),
-                self.our_foreign_key
-            ),
-            vec![],
-        );
+        let mut target = (self.build_target)(source.data_source().clone());
+
+        let target_id = target
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let (src_col, tgt_col) = self.columns(&source_id, &target_id);
+        let condition = source
+            .data_source()
+            .related_in_condition(&tgt_col, source, &src_col);
         target.add_condition(condition);
-        Ok(Box::new(target))
+
+        Ok(AnyTable::from_table(target))
     }
 
     fn target_type_name(&self) -> &'static str {

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use vantage_types::Entity;
 
 use crate::{
-    pagination::Pagination, references::RelatedTable, sorting::SortDirection,
+    pagination::Pagination, references::Reference, sorting::SortDirection,
     traits::table_source::TableSource,
 };
 
@@ -23,7 +23,7 @@ where
     pub(super) next_condition_id: i64,
     pub(super) order_by: IndexMap<i64, (T::Condition, SortDirection)>,
     pub(super) next_order_id: i64,
-    pub(super) refs: Option<IndexMap<String, Arc<dyn RelatedTable>>>,
+    pub(super) refs: Option<IndexMap<String, Arc<dyn Reference>>>,
     pub(super) pagination: Option<Pagination>,
     pub(super) title_field: Option<String>,
     pub(super) id_field: Option<String>,

--- a/vantage-table/src/table/impls/refereces.rs
+++ b/vantage-table/src/table/impls/refereces.rs
@@ -1,82 +1,83 @@
-//! Table relationship methods for defining and traversing one-to-one and one-to-many relationships
-//!
-//! This module provides methods for adding and accessing table relationships in the 0.3 architecture.
+//! Table relationship methods for defining and traversing references.
 
 use indexmap::IndexMap;
 use std::sync::Arc;
 
 use vantage_core::{Result, error};
-use vantage_expressions::Expression;
-use vantage_expressions::traits::datasource::ExprDataSource;
 use vantage_types::Entity;
 
 use crate::{
-    references::{ReferenceMany, ReferenceOne, RelatedTable, RelatedTableExt},
+    any::AnyTable,
+    references::{HasForeign, HasMany, HasOne, Reference},
     table::Table,
-    traits::table_source::TableSource,
+    traits::{column_like::ColumnLike, table_source::TableSource},
 };
 
 impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
-    /// Define a one-to-one relationship
+    /// Define a one-to-one relationship.
     ///
-    /// # Arguments
-    /// * `relation` - Name for this relationship (e.g., "bakery")
-    /// * `foreign_key` - Column name on this table (e.g., "bakery_id")
-    /// * `get_table` - Closure that returns the related table
-    ///
-    /// # Example
     /// ```rust,ignore
-    /// let clients = Table::new("client", db)
-    ///     .with_one("bakery", "bakery_id", || Bakery::table(db.clone()));
+    /// .with_one("bakery", "bakery_id", Bakery::postgres_table)
     /// ```
     pub fn with_one<E2: Entity<T::Value> + 'static>(
         mut self,
         relation: &str,
         foreign_key: &str,
-        get_table: impl Fn() -> Table<T, E2> + Send + Sync + 'static,
+        build_target: impl Fn(T) -> Table<T, E2> + Send + Sync + 'static,
     ) -> Self
     where
-        T: ExprDataSource<T::Value>,
-        T::Value: Clone + Send + Sync + 'static,
-        T::Column<T::AnyType>: crate::operation::Operation<T::Value>,
-        T::Condition: From<Expression<T::Value>>,
+        T::Value: Into<serde_json::Value> + From<serde_json::Value>,
+        T::Id: std::fmt::Display + From<String>,
     {
-        let reference = ReferenceOne::<T, E, E2>::new(foreign_key, get_table);
+        let reference = HasOne::<T, E, E2>::new(foreign_key, build_target);
         self.add_ref(relation, Box::new(reference));
         self
     }
 
-    /// Define a one-to-many relationship
+    /// Define a one-to-many relationship.
     ///
-    /// # Arguments
-    /// * `relation` - Name for this relationship (e.g., "orders")
-    /// * `foreign_key` - Column name on target table (e.g., "client_id")
-    /// * `get_table` - Closure that returns the related table
-    ///
-    /// # Example
     /// ```rust,ignore
-    /// let clients = Table::new("client", db)
-    ///     .with_many("orders", "client_id", || Order::table(db.clone()));
+    /// .with_many("orders", "client_id", Order::postgres_table)
     /// ```
     pub fn with_many<E2: Entity<T::Value> + 'static>(
         mut self,
         relation: &str,
         foreign_key: &str,
-        get_table: impl Fn() -> Table<T, E2> + Send + Sync + 'static,
+        build_target: impl Fn(T) -> Table<T, E2> + Send + Sync + 'static,
     ) -> Self
     where
-        T: ExprDataSource<T::Value>,
-        T::Value: Clone + Send + Sync + 'static,
-        T::Column<T::AnyType>: crate::operation::Operation<T::Value>,
-        T::Condition: From<Expression<T::Value>>,
+        T::Value: Into<serde_json::Value> + From<serde_json::Value>,
+        T::Id: std::fmt::Display + From<String>,
     {
-        let reference = ReferenceMany::<T, E, E2>::new(foreign_key, get_table);
+        let reference = HasMany::<T, E, E2>::new(foreign_key, build_target);
         self.add_ref(relation, Box::new(reference));
         self
     }
 
-    /// Add a reference manually (internal use)
-    pub(crate) fn add_ref(&mut self, relation: &str, reference: Box<dyn RelatedTable>) {
+    /// Define a cross-persistence reference.
+    ///
+    /// The closure receives this table and returns an `AnyTable` from any backend
+    /// with deferred conditions attached.
+    ///
+    /// ```rust,ignore
+    /// .with_foreign("mongo_orders", "Table<MongoDB, Order>", |clients| {
+    ///     let mut orders = Order::mongo_table(mongo_db.clone());
+    ///     // attach deferred condition ...
+    ///     Ok(AnyTable::from_table(orders))
+    /// })
+    /// ```
+    pub fn with_foreign(
+        mut self,
+        relation: &str,
+        target_type: &'static str,
+        resolve: impl Fn(&Table<T, E>) -> Result<AnyTable> + Send + Sync + 'static,
+    ) -> Self {
+        let reference = HasForeign::<T, E>::new(target_type, resolve);
+        self.add_ref(relation, Box::new(reference));
+        self
+    }
+
+    pub(crate) fn add_ref(&mut self, relation: &str, reference: Box<dyn Reference>) {
         if self.refs.is_none() {
             self.refs = Some(IndexMap::new());
         }
@@ -86,7 +87,6 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
             .insert(relation.to_string(), Arc::from(reference));
     }
 
-    /// Get list of available reference names
     pub fn references(&self) -> Vec<String> {
         self.refs
             .as_ref()
@@ -94,82 +94,68 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
             .unwrap_or_default()
     }
 
-    /// Get a related table as `Box<dyn Any>`
-    pub fn get_ref(&self, relation: &str) -> Result<Box<dyn std::any::Any>> {
-        let table_name = self.table_name().to_string();
-        let refs = self.refs.as_ref().ok_or_else(|| {
-            error!(
-                "No references defined on table",
-                table = table_name.as_str()
-            )
-        })?;
-
-        let relation_str = relation.to_string();
-        let reference = refs.get(relation).ok_or_else(|| {
-            error!(
-                "Reference not found on table",
-                relation = relation_str.as_str(),
-                table = table_name.as_str()
-            )
-        })?;
-
-        reference.get_related_table(self as &dyn std::any::Any)
+    /// Check if a reference is cross-persistence (foreign).
+    pub fn is_foreign_ref(&self, relation: &str) -> Result<bool> {
+        let (reference, _) = self.lookup_ref(relation)?;
+        Ok(reference.is_foreign())
     }
 
-    /// Get a related table with automatic downcasting
-    pub fn get_ref_as<T2: TableSource + 'static, E2: Entity<T2::Value> + 'static>(
+    /// Get a same-backend related table with automatic downcasting.
+    ///
+    /// For foreign references, use `get_ref()` instead.
+    pub fn get_ref_as<E2: Entity<T::Value> + 'static>(
         &self,
         relation: &str,
-    ) -> Result<Table<T2, E2>> {
-        let table_name = self.table_name().to_string();
-        let refs = self.refs.as_ref().ok_or_else(|| {
-            error!(
-                "No references defined on table",
-                table = table_name.as_str()
-            )
-        })?;
+    ) -> Result<Table<T, E2>> {
+        let (reference, relation_str) = self.lookup_ref(relation)?;
 
-        let relation_str = relation.to_string();
-        let reference = refs.get(relation).ok_or_else(|| {
-            error!(
-                "Reference not found on table",
-                relation = relation_str.as_str(),
-                table = table_name.as_str()
-            )
-        })?;
+        if reference.is_foreign() {
+            return Err(error!(
+                "Cannot use get_ref_as for foreign references, use get_ref instead",
+                relation = relation_str.as_str()
+            ));
+        }
 
-        reference
-            .as_ref()
-            .as_table::<T2, E2>(self as &dyn std::any::Any)
+        // 1. Build target
+        let source_id = self
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let mut target: Table<T, E2> = *reference
+            .build_target(self.data_source() as &dyn std::any::Any)
+            .downcast::<Table<T, E2>>()
+            .map_err(|_| {
+                error!(
+                    "Failed to downcast related table",
+                    relation = relation_str.as_str()
+                )
+            })?;
+
+        // 2. Get columns
+        let target_id = target
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let (src_col, tgt_col) = reference.columns(&source_id, &target_id);
+
+        // 3. Build and apply condition
+        let condition = self
+            .data_source()
+            .related_in_condition(&tgt_col, self, &src_col);
+        target.add_condition(condition);
+
+        Ok(target)
     }
 
-    /// Get a linked table (for subqueries/JOINs)
-    pub fn get_subquery(&self, relation: &str) -> Result<Box<dyn std::any::Any>> {
-        let table_name = self.table_name().to_string();
-        let refs = self.refs.as_ref().ok_or_else(|| {
-            error!(
-                "No references defined on table",
-                table = table_name.as_str()
-            )
-        })?;
-
-        let relation_str = relation.to_string();
-        let reference = refs.get(relation).ok_or_else(|| {
-            error!(
-                "Reference not found on table",
-                relation = relation_str.as_str(),
-                table = table_name.as_str()
-            )
-        })?;
-
-        reference.get_linked_table(self as &dyn std::any::Any)
+    /// Get a related table as AnyTable — works for both same-backend and foreign refs.
+    pub fn get_ref(&self, relation: &str) -> Result<AnyTable> {
+        let (reference, _) = self.lookup_ref(relation)?;
+        reference.resolve_as_any(self as &dyn std::any::Any)
     }
 
-    /// Get a linked table with automatic downcasting
-    pub fn get_subquery_as<T2: TableSource + 'static, E2: Entity<T2::Value> + 'static>(
-        &self,
-        relation: &str,
-    ) -> Result<Table<T2, E2>> {
+    fn lookup_ref(&self, relation: &str) -> Result<(&dyn Reference, String)> {
         let table_name = self.table_name().to_string();
         let refs = self.refs.as_ref().ok_or_else(|| {
             error!(
@@ -187,10 +173,6 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
             )
         })?;
 
-        let boxed_table = reference.get_linked_table(self as &dyn std::any::Any)?;
-        boxed_table
-            .downcast::<Table<T2, E2>>()
-            .map(|boxed| *boxed)
-            .map_err(|_| error!("Failed to downcast linked table"))
+        Ok((reference.as_ref(), relation_str))
     }
 }


### PR DESCRIPTION
Reference setup loses its closure boilerplate. The factory now takes the data source, so you can pass a method reference directly:

```rust
// Before
let db2 = db.clone();
.with_many("orders", "client_id", move || Order::postgres_table(db2.clone()))

// After
.with_many("orders", "client_id", Order::postgres_table)
```

Same for `with_one`. Every `Order::table` constructor in `bakery_model3` shed its `let db2 = db.clone()` lines.

`get_ref_as` drops its first type parameter — the backend is inferred from `self`:

```rust
// Before
clients.get_ref_as::<PostgresDB, Order>("orders")
// After
clients.get_ref_as::<Order>("orders")
```

### New: cross-persistence references

`with_foreign(name, target_type, |source| -> Result<AnyTable>)` registers a reference whose target lives in a different backend. The closure is sync and returns an `AnyTable` with deferred conditions; the actual cross-backend work happens at query time via `DeferredFn`. Resolve it with `get_ref()`, which now returns `AnyTable` (not `Box<dyn Any>`).

### Internal

`RelatedTable` / `ReferenceOne` / `ReferenceMany` are gone — replaced by a single `Reference` trait with `HasOne` / `HasMany` / `HasForeign`. MongoDB no longer needs the panic-stub `From<Expression<AnyMongoType>> for MongoCondition` to satisfy reference bounds. `get_subquery` / `get_subquery_as` and `get_linked_table` (JOIN-style) removed.

A small bound-leak still exists: `with_one`/`with_many` carry `T::Value: Into<serde_json::Value> + From<serde_json::Value>` and `T::Id: Display + From<String>` so they compile against the `Reference` trait — could move into the impl block in a follow-up.