### PR TITLE
Store MySQL retrieved types in CBOR (instead of JsonValue) - better type preservation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3833,6 +3833,8 @@ version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "ciborium",
+ "hex",
  "indexmap",
  "paste",
  "rust_decimal",

--- a/NEW_PERSISTENCE_GUIDE.md
+++ b/NEW_PERSISTENCE_GUIDE.md
@@ -318,8 +318,8 @@ impl Expressive<AnyMysqlType> for Identifier {
 When you add a new SQL backend, add an `Expressive<YourAnyType>` impl with your quote character. The
 compiler picks the right impl based on the expression type context.
 
-In practice you use the `ident()` shorthand and pass it into the vendor macro with parentheses —
-the `(...)` syntax calls `.expr()` automatically, so quoting is handled by the type context:
+In practice you use the `ident()` shorthand and pass it into the vendor macro with parentheses — the
+`(...)` syntax calls `.expr()` automatically, so quoting is handled by the type context:
 
 ```rust
 use vantage_sql::primitives::identifier::{Identifier, ident};
@@ -995,6 +995,35 @@ let orders = clients.get_ref_as::<SqliteDB, ClientOrder>("orders").unwrap();
 //   WHERE client_id IN (SELECT "id" FROM "client" WHERE is_paying_client = 1)
 assert_eq!(orders.list().await.unwrap().len(), 3);
 ```
+
+## Step 5.1: Expression Fields (Correlated Subqueries)
+
+`with_expression` adds computed fields to a table using correlated subqueries. It pairs with
+`get_subquery_as` which produces `target.fk = source.id` conditions (vs `get_ref_as` which uses
+`IN (subquery)`).
+
+```rust
+.with_many("orders", "client_id", Order::sqlite_table)
+.with_expression("order_count", |t| {
+    t.get_subquery_as::<Order>("orders").unwrap().get_count_query()
+})
+// Generates: (SELECT COUNT(*) FROM "client_order"
+//   WHERE "client_order"."client_id" = "client"."id") AS "order_count"
+```
+
+**What to implement:** override `related_correlated_condition` in your `TableSource` to produce
+table-qualified equality. Default panics — backends without correlated subquery support (CSV) simply
+can't use this feature.
+
+```rust
+fn related_correlated_condition(&self, target_table: &str, target_field: &str,
+    source_table: &str, source_column: &str) -> Self::Condition {
+    sqlite_expr!("{} = {}", (ident(target_field).dot_of(target_table)),
+        (ident(source_column).dot_of(source_table)))
+}
+```
+
+Requires `SelectableDataSource` (Step 3) since aggregate query builders use `table.select()`.
 
 ## Step 6: Using tables in a multi-backend application
 

--- a/TODO.md
+++ b/TODO.md
@@ -18,10 +18,16 @@
       `get_ref_as::<PostgresDB, Order>("orders")`. Backend type inferred from self.
 - [x] **`get_ref()` returns `AnyTable`** — works for both same-backend and foreign refs via
       `Reference::resolve_as_any`.
-- [x] MongoDB relationship traversal working — `with_one`/`with_many` + `get_ref_as` tested
-      for has_many and has_one patterns.
+- [x] MongoDB relationship traversal working — `with_one`/`with_many` + `get_ref_as` tested for
+      has_many and has_one patterns.
 - [x] MongoDB search regex escaping — metacharacters escaped, empty columns return always-false.
 - [x] MongoDB `related_in_condition` uses projected query (only fetches needed column).
+- [x] **`with_expression` / `get_subquery_as` / `related_correlated_condition`** — Table supports
+      computed expression fields via closure-based lazy evaluation. `get_subquery_as` produces
+      correlated conditions (`target.fk = source.id`) for embedding subqueries in SELECT.
+      `related_correlated_condition` on `TableSource` (default `unimplemented!`). Implemented for
+      Postgres, MySQL, SQLite (`ident().dot_of()`), SurrealDB (`$parent` syntax). Tested via CLI
+      across Postgres, SQLite, SurrealDB with `order_count` expression on Client table.
 
 ## Trait boundary fixes needed
 
@@ -147,7 +153,7 @@
 Implement extensions:
 
 - [ ] Lazy table joins (read-only)
-- [ ] Implement add_field_lazy()
+- [x] Implement add_field_lazy() — implemented as `with_expression` on Table
 
 Minor Cases:
 

--- a/bakery_model3/src/client.rs
+++ b/bakery_model3/src/client.rs
@@ -41,6 +41,11 @@ impl Client {
             .with_column_of::<String>("contact_details")
             .with_column_of::<bool>("is_paying_client")
             .with_one("bakery", "bakery", Bakery::surreal_table)
+            .with_many("orders", "client", Order::surreal_table)
+            .with_expression("order_count", |t| {
+                let orders = t.get_subquery_as::<Order>("orders").unwrap();
+                orders.get_count_query()
+            })
     }
 
     pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Client> {
@@ -53,6 +58,10 @@ impl Client {
             .with_column_of::<String>("bakery_id")
             .with_one("bakery", "bakery_id", Bakery::sqlite_table)
             .with_many("orders", "client_id", Order::sqlite_table)
+            .with_expression("order_count", |t| {
+                let orders = t.get_subquery_as::<Order>("orders").unwrap();
+                orders.get_count_query()
+            })
     }
 
     pub fn postgres_table(db: PostgresDB) -> Table<PostgresDB, Client> {
@@ -65,6 +74,10 @@ impl Client {
             .with_column_of::<String>("bakery_id")
             .with_one("bakery", "bakery_id", Bakery::postgres_table)
             .with_many("orders", "client_id", Order::postgres_table)
+            .with_expression("order_count", |t| {
+                let orders = t.get_subquery_as::<Order>("orders").unwrap();
+                orders.get_count_query()
+            })
     }
 
     pub fn mongo_table(db: MongoDB) -> Table<MongoDB, Client> {

--- a/bakery_model3/src/order.rs
+++ b/bakery_model3/src/order.rs
@@ -5,6 +5,7 @@ use vantage_sql::postgres::AnyPostgresType;
 use vantage_sql::postgres::PostgresDB;
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_surrealdb::surrealdb::SurrealDB;
+use vantage_surrealdb::thing::Thing;
 use vantage_surrealdb::types::AnySurrealType;
 use vantage_table::table::Table;
 use vantage_types::entity;
@@ -33,7 +34,9 @@ impl Order {
     pub fn surreal_table(db: SurrealDB) -> Table<SurrealDB, Order> {
         Table::new("order", db)
             .with_id_column("id")
+            .with_column_of::<Thing>("client")
             .with_column_of::<bool>("is_deleted")
+            .with_one("client", "client", Client::surreal_table)
     }
 
     pub fn sqlite_table(db: SqliteDB) -> Table<SqliteDB, Order> {

--- a/history.txt
+++ b/history.txt
@@ -14,3 +14,6 @@ SELECT count() FROM product GROUP ALL; SELECT count() FROM client GROUP ALL; SEL
 SELECT count() FROM product GROUP ALL; SELECT count() FROM client GROUP ALL;
 SELECT name FROM bakery:hill_valley->owns->product WHERE is_deleted = false ORDER BY name;
 SELECT name FROM (SELECT * FROM bakery:hill_valley->owns->product WHERE is_deleted = false) ORDER BY name;
+SELECT * FROM order LIMIT 1;
+SELECT id, name, count(SELECT id FROM order WHERE order.client = client.id) AS order_count FROM client;
+SELECT id, name, count(SELECT id FROM order WHERE client = $parent.id) AS order_count FROM client;

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -32,6 +32,8 @@ uuid = "1"
 chrono = "0.4"
 serde_json = { version = "1", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
+ciborium = "0.2"
+hex = "0.4"
 indexmap = { version = "2.12.0", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/vantage-sql/src/mysql/expr_data_source.rs
+++ b/vantage-sql/src/mysql/expr_data_source.rs
@@ -1,4 +1,4 @@
-use serde_json::Value as JsonValue;
+use ciborium::Value as CborValue;
 use vantage_expressions::traits::expressive::DeferredFn;
 use vantage_expressions::{Expression, ExpressionFlattener, ExpressiveEnum, Flatten};
 
@@ -25,22 +25,22 @@ impl vantage_expressions::ExprDataSource<AnyMysqlType> for MysqlDB {
             .await
             .map_err(|e| vantage_core::error!("MySQL query failed", details = e.to_string()))?;
 
-        // 4. Convert rows to AnyMysqlType (untyped)
-        let arr: Vec<JsonValue> = rows
+        // 4. Convert rows to AnyMysqlType — each row becomes a CBOR Map
+        let arr: Vec<CborValue> = rows
             .iter()
             .map(|row| {
                 let record = row_to_record(row);
-                let json_map: serde_json::Map<String, JsonValue> = record
+                let map: Vec<(CborValue, CborValue)> = record
                     .into_iter()
-                    .map(|(k, v)| (k, v.into_value()))
+                    .map(|(k, v)| (CborValue::Text(k), v.into_value()))
                     .collect();
-                JsonValue::Object(json_map)
+                CborValue::Map(map)
             })
             .collect();
 
-        let json_arr = JsonValue::Array(arr);
-        Ok(AnyMysqlType::from_json(&json_arr)
-            .expect("JSON array should always convert to AnyMysqlType"))
+        let cbor_arr = CborValue::Array(arr);
+        Ok(AnyMysqlType::from_cbor(&cbor_arr)
+            .expect("CBOR array should always convert to AnyMysqlType"))
     }
 
     fn defer(&self, expr: Expression<AnyMysqlType>) -> DeferredFn<AnyMysqlType> {
@@ -50,16 +50,18 @@ impl vantage_expressions::ExprDataSource<AnyMysqlType> for MysqlDB {
             let expr = expr.clone();
             Box::pin(async move {
                 let result = vantage_expressions::ExprDataSource::execute(&db, &expr).await?;
-                let scalar = match result.value() {
-                    serde_json::Value::Array(arr) => arr
+                Ok(match result.value() {
+                    CborValue::Array(arr) => arr
                         .first()
-                        .and_then(|row| row.as_object())
-                        .and_then(|obj| obj.values().next())
-                        .map(|v| AnyMysqlType::untyped(v.clone()))
+                        .and_then(|row| match row {
+                            CborValue::Map(map) => {
+                                map.first().map(|(_, v)| AnyMysqlType::untyped(v.clone()))
+                            }
+                            _ => None,
+                        })
                         .unwrap_or(result),
                     _ => result,
-                };
-                Ok(scalar)
+                })
             })
         })
     }

--- a/vantage-sql/src/mysql/mod.rs
+++ b/vantage-sql/src/mysql/mod.rs
@@ -1,11 +1,12 @@
 #[macro_use]
 mod macros;
 pub mod operation;
-mod row;
+pub(crate) mod row;
 pub mod statements;
 mod table_source;
 pub mod types;
 
+use ciborium::Value as CborValue;
 use sqlx::mysql::MySqlPool;
 
 pub use types::{AnyMysqlType, MysqlType};
@@ -37,11 +38,14 @@ impl MysqlDB {
         let expr = select.as_aggregate(func, column);
         let result = self.execute(&expr).await?;
         Ok(match result.value() {
-            serde_json::Value::Array(arr) => arr
+            CborValue::Array(arr) => arr
                 .first()
-                .and_then(|row| row.as_object())
-                .and_then(|obj| obj.values().next())
-                .map(|v| AnyMysqlType::untyped(v.clone()))
+                .and_then(|row| match row {
+                    CborValue::Map(map) => {
+                        map.first().map(|(_, v)| AnyMysqlType::untyped(v.clone()))
+                    }
+                    _ => None,
+                })
                 .unwrap_or(result),
             _ => result,
         })

--- a/vantage-sql/src/mysql/row.rs
+++ b/vantage-sql/src/mysql/row.rs
@@ -1,11 +1,14 @@
 //! Helpers for converting between sqlx rows/values and vantage types.
 //!
-//! **Writing** (bind): Takes `AnyMysqlType` with variant tags -- the variant
+//! **Writing** (bind): Takes `AnyMysqlType` with variant tags — the variant
 //! tells us exactly how to bind each value to sqlx.
 //!
-//! **Reading** (row): Returns `Record<AnyMysqlType>` with `type_variant: None`.
+//! **Reading** (row): Returns `Record<AnyMysqlType>` with variant inferred from
+//! the MySQL column type. Values are stored as `ciborium::Value` (CBOR) for
+//! lossless type preservation — decimals stay as tagged strings, datetimes
+//! keep their type identity, booleans aren't confused with integers.
 
-use serde_json::Value as JsonValue;
+use ciborium::Value as CborValue;
 use sqlx::mysql::MySqlRow;
 use sqlx::{Column, Row, TypeInfo};
 use vantage_types::Record;
@@ -17,89 +20,172 @@ pub(crate) fn bind_mysql_value<'q>(
     query: sqlx::query::Query<'q, sqlx::MySql, sqlx::mysql::MySqlArguments>,
     value: &'q AnyMysqlType,
 ) -> sqlx::query::Query<'q, sqlx::MySql, sqlx::mysql::MySqlArguments> {
-    let json = value.value();
+    let cbor = value.value();
     match value.type_variant() {
         Some(MysqlTypeVariants::Null) => query.bind(None::<String>),
-        None => bind_by_json(query, json),
-        Some(MysqlTypeVariants::Bool) => match json {
-            JsonValue::Null => query.bind(None::<bool>),
-            JsonValue::Bool(b) => query.bind(*b),
-            JsonValue::Number(n) => match n.as_i64() {
-                Some(i) => query.bind(i != 0),
-                None => query.bind(None::<bool>),
+        None => bind_by_cbor(query, cbor),
+        Some(MysqlTypeVariants::Bool) => match cbor {
+            CborValue::Null => query.bind(None::<bool>),
+            CborValue::Bool(b) => query.bind(*b),
+            CborValue::Integer(i) => match i64::try_from(*i) {
+                Ok(n) => query.bind(n != 0),
+                Err(_) => query.bind(None::<bool>),
             },
             _ => query.bind(None::<bool>),
         },
-        Some(MysqlTypeVariants::Int2) => match json {
-            JsonValue::Null => query.bind(None::<i16>),
-            JsonValue::Number(n) => query.bind(n.as_i64().map(|i| i as i16)),
+        Some(MysqlTypeVariants::Int2) => match cbor {
+            CborValue::Null => query.bind(None::<i16>),
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as i16)),
             _ => query.bind(None::<i16>),
         },
-        Some(MysqlTypeVariants::Int4) => match json {
-            JsonValue::Null => query.bind(None::<i32>),
-            JsonValue::Number(n) => query.bind(n.as_i64().map(|i| i as i32)),
+        Some(MysqlTypeVariants::Int4) => match cbor {
+            CborValue::Null => query.bind(None::<i32>),
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as i32)),
             _ => query.bind(None::<i32>),
         },
-        Some(MysqlTypeVariants::Int8) => match json {
-            JsonValue::Null => query.bind(None::<i64>),
-            JsonValue::Number(n) => query.bind(n.as_i64()),
+        Some(MysqlTypeVariants::Int8) => match cbor {
+            CborValue::Null => query.bind(None::<i64>),
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok()),
             _ => query.bind(None::<i64>),
         },
-        Some(MysqlTypeVariants::Float4) => match json {
-            JsonValue::Null => query.bind(None::<f32>),
-            JsonValue::Number(n) => query.bind(n.as_f64().map(|f| f as f32)),
+        Some(MysqlTypeVariants::Float4) => match cbor {
+            CborValue::Null => query.bind(None::<f32>),
+            CborValue::Float(f) => query.bind(*f as f32),
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as f32)),
             _ => query.bind(None::<f32>),
         },
-        Some(MysqlTypeVariants::Float8) => match json {
-            JsonValue::Null => query.bind(None::<f64>),
-            JsonValue::Number(n) => query.bind(n.as_f64()),
+        Some(MysqlTypeVariants::Float8) => match cbor {
+            CborValue::Null => query.bind(None::<f64>),
+            CborValue::Float(f) => query.bind(*f),
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as f64)),
             _ => query.bind(None::<f64>),
         },
-        Some(MysqlTypeVariants::Text) => match json {
-            JsonValue::Null => query.bind(None::<String>),
-            JsonValue::String(s) => query.bind(s.as_str()),
+        Some(MysqlTypeVariants::Text) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Text(s) => query.bind(s.as_str()),
             _ => query.bind(None::<String>),
+        },
+        Some(MysqlTypeVariants::Decimal) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Tag(10, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    query.bind(s.as_str())
+                } else {
+                    query.bind(None::<String>)
+                }
+            }
+            CborValue::Text(s) => query.bind(s.as_str()),
+            _ => query.bind(None::<String>),
+        },
+        Some(MysqlTypeVariants::DateTime) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Tag(0, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    query.bind(s.as_str())
+                } else {
+                    query.bind(None::<String>)
+                }
+            }
+            CborValue::Text(s) => query.bind(s.as_str()),
+            _ => query.bind(None::<String>),
+        },
+        Some(MysqlTypeVariants::Date) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Tag(100, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    query.bind(s.as_str())
+                } else {
+                    query.bind(None::<String>)
+                }
+            }
+            CborValue::Text(s) => query.bind(s.as_str()),
+            _ => query.bind(None::<String>),
+        },
+        Some(MysqlTypeVariants::Time) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Tag(101, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    query.bind(s.as_str())
+                } else {
+                    query.bind(None::<String>)
+                }
+            }
+            CborValue::Text(s) => query.bind(s.as_str()),
+            _ => query.bind(None::<String>),
+        },
+        Some(MysqlTypeVariants::Blob) => match cbor {
+            CborValue::Null => query.bind(None::<Vec<u8>>),
+            CborValue::Bytes(b) => query.bind(b.as_slice()),
+            CborValue::Text(s) => query.bind(s.as_bytes()),
+            _ => query.bind(None::<Vec<u8>>),
         },
     }
 }
 
-/// Bind a JSON value without type variant -- infers from the value itself.
-fn bind_by_json<'q>(
+/// Bind a CBOR value without type variant — infers from the value itself.
+fn bind_by_cbor<'q>(
     query: sqlx::query::Query<'q, sqlx::MySql, sqlx::mysql::MySqlArguments>,
-    json: &'q JsonValue,
+    cbor: &'q CborValue,
 ) -> sqlx::query::Query<'q, sqlx::MySql, sqlx::mysql::MySqlArguments> {
-    match json {
-        JsonValue::Null => query.bind(None::<String>),
-        JsonValue::Bool(b) => query.bind(*b),
-        JsonValue::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                query.bind(i)
-            } else if let Some(f) = n.as_f64() {
-                query.bind(f)
+    match cbor {
+        CborValue::Null => query.bind(None::<String>),
+        CborValue::Bool(b) => query.bind(*b),
+        CborValue::Integer(i) => {
+            if let Ok(n) = i64::try_from(*i) {
+                query.bind(n)
             } else {
-                query.bind(n.to_string())
+                query.bind(i128::from(*i).to_string())
             }
         }
-        JsonValue::String(s) => query.bind(s.as_str()),
-        other => query.bind(other.to_string()),
+        CborValue::Float(f) => query.bind(*f),
+        CborValue::Text(s) => query.bind(s.as_str()),
+        CborValue::Bytes(b) => query.bind(b.as_slice()),
+        CborValue::Tag(10, inner) => {
+            // Decimal — bind as string, MySQL will coerce
+            if let CborValue::Text(s) = inner.as_ref() {
+                query.bind(s.as_str())
+            } else {
+                query.bind(None::<String>)
+            }
+        }
+        CborValue::Tag(0 | 100 | 101, inner) => {
+            // DateTime / Date / Time — bind as string
+            if let CborValue::Text(s) = inner.as_ref() {
+                query.bind(s.as_str())
+            } else {
+                query.bind(None::<String>)
+            }
+        }
+        _ => query.bind(None::<String>),
     }
 }
 
 /// Convert a MySqlRow to Record<AnyMysqlType>.
+///
+/// Each value is stored as CBOR with the type variant inferred from the
+/// MySQL column type, preserving full type fidelity.
 pub(crate) fn row_to_record(row: &MySqlRow) -> Record<AnyMysqlType> {
     let mut record = Record::new();
     for col in row.columns() {
         let name = col.name().to_string();
         let type_name = col.type_info().name();
-        let json = mysql_column_to_json(row, col.ordinal(), type_name);
-        let value = AnyMysqlType::untyped(json);
+        let (cbor, variant) = mysql_column_to_cbor(row, col.ordinal(), type_name);
+        let value = match variant {
+            Some(v) => AnyMysqlType::with_variant(cbor, v),
+            None => AnyMysqlType::untyped(cbor),
+        };
         record.insert(name, value);
     }
     record
 }
 
-/// Read a single column from a MySQL row as JsonValue.
-fn mysql_column_to_json(row: &MySqlRow, ordinal: usize, type_name: &str) -> JsonValue {
+/// Read a single column from a MySQL row as CborValue, returning both the
+/// value and the detected type variant.
+fn mysql_column_to_cbor(
+    row: &MySqlRow,
+    ordinal: usize,
+    type_name: &str,
+) -> (CborValue, Option<MysqlTypeVariants>) {
     use sqlx::ValueRef;
 
     if row
@@ -107,156 +193,188 @@ fn mysql_column_to_json(row: &MySqlRow, ordinal: usize, type_name: &str) -> Json
         .map(|v| v.is_null())
         .unwrap_or(true)
     {
-        return JsonValue::Null;
+        return (CborValue::Null, Some(MysqlTypeVariants::Null));
     }
 
     match type_name {
         "BOOLEAN" | "BOOL" => {
             // MySQL BOOLEAN is TINYINT(1). sqlx decodes as i8.
             if let Ok(v) = row.try_get::<i8, _>(ordinal) {
-                return JsonValue::Bool(v != 0);
+                return (CborValue::Bool(v != 0), Some(MysqlTypeVariants::Bool));
             }
             if let Ok(v) = row.try_get::<bool, _>(ordinal) {
-                return JsonValue::Bool(v);
+                return (CborValue::Bool(v), Some(MysqlTypeVariants::Bool));
             }
         }
         "TINYINT" => {
             if let Ok(v) = row.try_get::<i8, _>(ordinal) {
-                return JsonValue::Number((v as i64).into());
-            }
-        }
-        "SMALLINT" => {
-            if let Ok(v) = row.try_get::<i16, _>(ordinal) {
-                return JsonValue::Number((v as i64).into());
-            }
-        }
-        "INT" | "INTEGER" | "MEDIUMINT" => {
-            if let Ok(v) = row.try_get::<i32, _>(ordinal) {
-                return JsonValue::Number((v as i64).into());
-            }
-        }
-        "BIGINT" => {
-            if let Ok(v) = row.try_get::<i64, _>(ordinal) {
-                return JsonValue::Number(v.into());
-            }
-        }
-        "BIGINT UNSIGNED" => {
-            if let Ok(v) = row.try_get::<u64, _>(ordinal) {
-                return JsonValue::Number(v.into());
-            }
-        }
-        "INT UNSIGNED" | "MEDIUMINT UNSIGNED" => {
-            if let Ok(v) = row.try_get::<u32, _>(ordinal) {
-                return JsonValue::Number((v as i64).into());
-            }
-        }
-        "SMALLINT UNSIGNED" => {
-            if let Ok(v) = row.try_get::<u16, _>(ordinal) {
-                return JsonValue::Number((v as i64).into());
+                return (
+                    CborValue::Integer((v as i64).into()),
+                    Some(MysqlTypeVariants::Int2),
+                );
             }
         }
         "TINYINT UNSIGNED" => {
             if let Ok(v) = row.try_get::<u8, _>(ordinal) {
-                return JsonValue::Number((v as i64).into());
+                return (
+                    CborValue::Integer((v as i64).into()),
+                    Some(MysqlTypeVariants::Int2),
+                );
+            }
+        }
+        "SMALLINT" => {
+            if let Ok(v) = row.try_get::<i16, _>(ordinal) {
+                return (
+                    CborValue::Integer((v as i64).into()),
+                    Some(MysqlTypeVariants::Int2),
+                );
+            }
+        }
+        "SMALLINT UNSIGNED" => {
+            if let Ok(v) = row.try_get::<u16, _>(ordinal) {
+                return (
+                    CborValue::Integer((v as i64).into()),
+                    Some(MysqlTypeVariants::Int2),
+                );
+            }
+        }
+        "INT" | "INTEGER" | "MEDIUMINT" => {
+            if let Ok(v) = row.try_get::<i32, _>(ordinal) {
+                return (
+                    CborValue::Integer((v as i64).into()),
+                    Some(MysqlTypeVariants::Int4),
+                );
+            }
+        }
+        "INT UNSIGNED" | "MEDIUMINT UNSIGNED" => {
+            if let Ok(v) = row.try_get::<u32, _>(ordinal) {
+                return (
+                    CborValue::Integer((v as i64).into()),
+                    Some(MysqlTypeVariants::Int4),
+                );
+            }
+        }
+        "BIGINT" => {
+            if let Ok(v) = row.try_get::<i64, _>(ordinal) {
+                return (CborValue::Integer(v.into()), Some(MysqlTypeVariants::Int8));
+            }
+        }
+        "BIGINT UNSIGNED" => {
+            if let Ok(v) = row.try_get::<u64, _>(ordinal) {
+                return (CborValue::Integer(v.into()), Some(MysqlTypeVariants::Int8));
+            }
+        }
+        "FLOAT" => {
+            if let Ok(v) = row.try_get::<f32, _>(ordinal) {
+                return (CborValue::Float(v as f64), Some(MysqlTypeVariants::Float4));
+            }
+        }
+        "DOUBLE" => {
+            if let Ok(v) = row.try_get::<f64, _>(ordinal) {
+                return (CborValue::Float(v), Some(MysqlTypeVariants::Float8));
+            }
+        }
+        "DECIMAL" | "NUMERIC" | "NEWDECIMAL" => {
+            // Lossless: store decimal as Tag(10, Text("..."))
+            if let Ok(v) = row.try_get::<rust_decimal::Decimal, _>(ordinal) {
+                return (
+                    CborValue::Tag(10, Box::new(CborValue::Text(v.to_string()))),
+                    Some(MysqlTypeVariants::Decimal),
+                );
+            }
+            // Fallback: try as string
+            if let Ok(v) = row.try_get::<String, _>(ordinal) {
+                return (
+                    CborValue::Tag(10, Box::new(CborValue::Text(v))),
+                    Some(MysqlTypeVariants::Decimal),
+                );
             }
         }
         "JSON" => {
             if let Ok(v) = row.try_get::<serde_json::Value, _>(ordinal) {
-                return v;
-            }
-        }
-        "FLOAT" => {
-            if let Ok(v) = row.try_get::<f32, _>(ordinal)
-                && let Some(n) = serde_json::Number::from_f64(v as f64)
-            {
-                return JsonValue::Number(n);
-            }
-        }
-        "DOUBLE" => {
-            if let Ok(v) = row.try_get::<f64, _>(ordinal)
-                && let Some(n) = serde_json::Number::from_f64(v)
-            {
-                return JsonValue::Number(n);
-            }
-        }
-        "DECIMAL" | "NUMERIC" | "NEWDECIMAL" => {
-            if let Ok(v) = row.try_get::<rust_decimal::Decimal, _>(ordinal) {
-                use rust_decimal::prelude::ToPrimitive;
-                if v.scale() == 0
-                    && let Some(i) = v.to_i64()
-                {
-                    return JsonValue::Number(i.into());
-                }
-                if let Some(f) = v.to_f64()
-                    && let Some(n) = serde_json::Number::from_f64(f)
-                {
-                    return JsonValue::Number(n);
-                }
-            }
-            // Fallback: try as string and parse
-            if let Ok(v) = row.try_get::<String, _>(ordinal) {
-                if let Ok(i) = v.parse::<i64>() {
-                    return JsonValue::Number(i.into());
-                }
-                if let Ok(f) = v.parse::<f64>()
-                    && let Some(n) = serde_json::Number::from_f64(f)
-                {
-                    return JsonValue::Number(n);
-                }
-                return JsonValue::String(v);
+                // JSON columns: convert the serde_json::Value to CBOR
+                let cbor = json_value_to_cbor(v);
+                return (cbor, Some(MysqlTypeVariants::Text));
             }
         }
         "TEXT" | "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT" | "VARCHAR" | "CHAR" | "ENUM" | "SET" => {
             if let Ok(v) = row.try_get::<String, _>(ordinal) {
-                return JsonValue::String(v);
+                return (CborValue::Text(v), Some(MysqlTypeVariants::Text));
             }
         }
-        "BLOB" | "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" => {
-            // sqlx decodes BLOB types as Vec<u8>; try String first, then bytes
-            if let Ok(v) = row.try_get::<String, _>(ordinal) {
-                return JsonValue::String(v);
-            }
+        "BLOB" | "TINYBLOB" | "MEDIUMBLOB" | "LONGBLOB" | "BINARY" | "VARBINARY" => {
             if let Ok(v) = row.try_get::<Vec<u8>, _>(ordinal) {
-                return JsonValue::String(String::from_utf8_lossy(&v).into_owned());
+                return (CborValue::Bytes(v), Some(MysqlTypeVariants::Blob));
             }
         }
         "TIME" => {
             if let Ok(v) = row.try_get::<chrono::NaiveTime, _>(ordinal) {
-                return JsonValue::String(v.format("%H:%M:%S").to_string());
+                return (
+                    CborValue::Tag(
+                        101,
+                        Box::new(CborValue::Text(v.format("%H:%M:%S").to_string())),
+                    ),
+                    Some(MysqlTypeVariants::Time),
+                );
             }
         }
         "DATE" => {
             if let Ok(v) = row.try_get::<chrono::NaiveDate, _>(ordinal) {
-                return JsonValue::String(v.format("%Y-%m-%d").to_string());
+                return (
+                    CborValue::Tag(
+                        100,
+                        Box::new(CborValue::Text(v.format("%Y-%m-%d").to_string())),
+                    ),
+                    Some(MysqlTypeVariants::Date),
+                );
             }
         }
         "DATETIME" => {
             if let Ok(v) = row.try_get::<chrono::NaiveDateTime, _>(ordinal) {
-                return JsonValue::String(v.format("%Y-%m-%d %H:%M:%S%.f").to_string());
+                return (
+                    CborValue::Tag(
+                        0,
+                        Box::new(CborValue::Text(
+                            v.format("%Y-%m-%d %H:%M:%S%.f").to_string(),
+                        )),
+                    ),
+                    Some(MysqlTypeVariants::DateTime),
+                );
             }
         }
         "TIMESTAMP" | "TIMESTAMP(6)" => {
             if let Ok(v) = row.try_get::<chrono::DateTime<chrono::Utc>, _>(ordinal) {
-                return JsonValue::String(v.format("%Y-%m-%d %H:%M:%S%.f").to_string());
+                return (
+                    CborValue::Tag(
+                        0,
+                        Box::new(CborValue::Text(
+                            v.format("%Y-%m-%d %H:%M:%S%.f").to_string(),
+                        )),
+                    ),
+                    Some(MysqlTypeVariants::DateTime),
+                );
             }
         }
         "YEAR" => {
             if let Ok(v) = row.try_get::<u16, _>(ordinal) {
-                return JsonValue::Number((v as i64).into());
+                return (
+                    CborValue::Integer((v as i64).into()),
+                    Some(MysqlTypeVariants::Int4),
+                );
             }
         }
         "BIT" => {
             if let Ok(v) = row.try_get::<bool, _>(ordinal) {
-                return JsonValue::Number((if v { 1u64 } else { 0u64 }).into());
+                return (CborValue::Bool(v), Some(MysqlTypeVariants::Bool));
             }
             if let Ok(v) = row.try_get::<u64, _>(ordinal) {
-                return JsonValue::Number(v.into());
+                return (CborValue::Integer(v.into()), Some(MysqlTypeVariants::Int8));
             }
             if let Ok(bytes) = row.try_get::<Vec<u8>, _>(ordinal) {
                 let v = bytes
                     .into_iter()
                     .fold(0u64, |acc, byte| (acc << 8) | u64::from(byte));
-                return JsonValue::Number(v.into());
+                return (CborValue::Integer(v.into()), Some(MysqlTypeVariants::Int8));
             }
         }
         _ => {}
@@ -264,18 +382,19 @@ fn mysql_column_to_json(row: &MySqlRow, ordinal: usize, type_name: &str) -> Json
 
     // Fallback: try common types in order
     if let Ok(v) = row.try_get::<i64, _>(ordinal) {
-        return JsonValue::Number(v.into());
+        return (CborValue::Integer(v.into()), Some(MysqlTypeVariants::Int8));
     }
     if let Ok(v) = row.try_get::<i32, _>(ordinal) {
-        return JsonValue::Number((v as i64).into());
+        return (
+            CborValue::Integer((v as i64).into()),
+            Some(MysqlTypeVariants::Int4),
+        );
     }
-    if let Ok(v) = row.try_get::<f64, _>(ordinal)
-        && let Some(n) = serde_json::Number::from_f64(v)
-    {
-        return JsonValue::Number(n);
+    if let Ok(v) = row.try_get::<f64, _>(ordinal) {
+        return (CborValue::Float(v), Some(MysqlTypeVariants::Float8));
     }
     if let Ok(v) = row.try_get::<String, _>(ordinal) {
-        return JsonValue::String(v);
+        return (CborValue::Text(v), Some(MysqlTypeVariants::Text));
     }
 
     // Intentional: surface decode failures so missing type handlers are noticed early.
@@ -284,5 +403,33 @@ fn mysql_column_to_json(row: &MySqlRow, ordinal: usize, type_name: &str) -> Json
         row.columns()[ordinal].name(),
         type_name,
     );
-    JsonValue::Null
+    (CborValue::Null, Some(MysqlTypeVariants::Null))
+}
+
+/// Convert a serde_json::Value to CborValue (used for JSON columns).
+fn json_value_to_cbor(val: serde_json::Value) -> CborValue {
+    match val {
+        serde_json::Value::Null => CborValue::Null,
+        serde_json::Value::Bool(b) => CborValue::Bool(b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                CborValue::Integer(i.into())
+            } else if let Some(u) = n.as_u64() {
+                CborValue::Integer(u.into())
+            } else if let Some(f) = n.as_f64() {
+                CborValue::Float(f)
+            } else {
+                CborValue::Text(n.to_string())
+            }
+        }
+        serde_json::Value::String(s) => CborValue::Text(s),
+        serde_json::Value::Array(arr) => {
+            CborValue::Array(arr.into_iter().map(json_value_to_cbor).collect())
+        }
+        serde_json::Value::Object(map) => CborValue::Map(
+            map.into_iter()
+                .map(|(k, v)| (CborValue::Text(k), json_value_to_cbor(v)))
+                .collect(),
+        ),
+    }
 }

--- a/vantage-sql/src/mysql/selectable_data_source.rs
+++ b/vantage-sql/src/mysql/selectable_data_source.rs
@@ -21,7 +21,7 @@ impl SelectableDataSource<AnyMysqlType> for MysqlDB {
         let result = self.execute(&select.expr()).await?;
 
         match result.value() {
-            serde_json::Value::Array(arr) => Ok(arr
+            ciborium::Value::Array(arr) => Ok(arr
                 .iter()
                 .map(|v| AnyMysqlType::untyped(v.clone()))
                 .collect()),

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use ciborium::Value as CborValue;
 use indexmap::IndexMap;
 use vantage_core::{Result, error};
 use vantage_expressions::traits::associated_expressions::AssociatedExpression;
@@ -23,37 +24,47 @@ fn id_value(id: &str) -> AnyMysqlType {
     AnyMysqlType::from(id.to_string())
 }
 
-/// Parse the JSON array result from execute() into an IndexMap of id -> Record.
+/// Parse the CBOR array result from execute() into an IndexMap of id -> Record.
 fn parse_rows(
     result: AnyMysqlType,
     id_field_name: &str,
 ) -> Result<IndexMap<String, Record<AnyMysqlType>>> {
     let arr = match result.into_value() {
-        serde_json::Value::Array(arr) => arr,
-        other => return Err(error!("expected array result", details = other.to_string())),
+        CborValue::Array(arr) => arr,
+        other => {
+            return Err(error!(
+                "expected array result",
+                details = format!("{:?}", other)
+            ));
+        }
     };
 
     let mut records = IndexMap::new();
     for item in arr {
-        let obj = match item {
-            serde_json::Value::Object(map) => map,
+        let map = match item {
+            CborValue::Map(map) => map,
             _ => continue,
         };
 
-        let id = obj
-            .get(id_field_name)
-            .and_then(|v| match v {
-                serde_json::Value::String(s) => Some(s.clone()),
-                serde_json::Value::Number(n) => Some(n.to_string()),
-                _ => None,
-            })
-            .ok_or_else(|| error!("row missing id field", field = id_field_name))?;
+        let mut id = None;
+        let mut record = Record::new();
+        for (k, v) in map {
+            let key = match k {
+                CborValue::Text(s) => s,
+                _ => continue,
+            };
+            if key == id_field_name {
+                id = Some(match &v {
+                    CborValue::Text(s) => s.clone(),
+                    CborValue::Integer(i) => i128::from(*i).to_string(),
+                    CborValue::Float(f) => f.to_string(),
+                    _ => format!("{:?}", v),
+                });
+            }
+            record.insert(key, AnyMysqlType::untyped(v));
+        }
 
-        let record: Record<AnyMysqlType> = obj
-            .into_iter()
-            .map(|(k, v)| (k, AnyMysqlType::untyped(v)))
-            .collect();
-
+        let id = id.ok_or_else(|| error!("row missing id field", field = id_field_name))?;
         records.insert(id, record);
     }
 
@@ -442,6 +453,20 @@ impl TableSource for MysqlDB {
         let fk_values = self.column_table_values_expr(source_table, &src_col);
         let tgt_col = self.create_column::<Self::AnyType>(target_field);
         tgt_col.in_(fk_values.expr())
+    }
+
+    fn related_correlated_condition(
+        &self,
+        target_table: &str,
+        target_field: &str,
+        source_table: &str,
+        source_column: &str,
+    ) -> Self::Condition {
+        mysql_expr!(
+            "{} = {}",
+            (ident(target_field).dot_of(target_table)),
+            (ident(source_column).dot_of(source_table))
+        )
     }
 
     fn column_table_values_expr<'a, E, Type: ColumnType>(

--- a/vantage-sql/src/mysql/types/bool.rs
+++ b/vantage-sql/src/mysql/types/bool.rs
@@ -2,19 +2,19 @@
 //! MySQL has BOOLEAN type (alias for TINYINT(1)).
 
 use super::{MysqlType, MysqlTypeBoolMarker};
-use serde_json::Value;
+use ciborium::Value;
 
 impl MysqlType for bool {
     type Target = MysqlTypeBoolMarker;
 
-    fn to_json(&self) -> Value {
+    fn to_cbor(&self) -> Value {
         Value::Bool(*self)
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
             Value::Bool(b) => Some(b),
-            Value::Number(n) => n.as_i64().map(|i| i != 0),
+            Value::Integer(i) => i64::try_from(i).ok().map(|n| n != 0),
             _ => None,
         }
     }

--- a/vantage-sql/src/mysql/types/mod.rs
+++ b/vantage-sql/src/mysql/types/mod.rs
@@ -1,51 +1,55 @@
 //! MySQL Type System
 //!
-//! Defines type variants aligned with MySQL's type system:
+//! Uses `ciborium::Value` as the underlying value type for lossless storage.
+//! CBOR tags follow SurrealDB conventions where they overlap:
+//!   Tag(0)  = DateTime (RFC 3339)
+//!   Tag(10) = Decimal (string representation)
+//!   Tag(100) = Date (YYYY-MM-DD string)
+//!   Tag(101) = Time (HH:MM:SS string)
 //!
-//! - Bool       : BOOLEAN / TINYINT(1)
-//! - Int2       : SMALLINT
-//! - Int4       : INT, INTEGER
-//! - Int8       : BIGINT
-//! - Float4     : FLOAT
-//! - Float8     : DOUBLE
-//! - Text       : TEXT, VARCHAR(N), CHAR(N)
-//!
-//! Uses `serde_json::Value` as the underlying value type with type variant
-//! tracking to prevent silent type confusion.
+//! Type variants track the original MySQL column type so that bind and
+//! entity deserialization can reconstruct the correct Rust type.
 
-use serde_json::Value;
 use vantage_types::vantage_type_system;
 
 vantage_type_system! {
     type_trait: MysqlType,
-    method_name: json,
-    value_type: serde_json::Value,
+    method_name: cbor,
+    value_type: ciborium::Value,
     type_variants: [
         Null,
-        Bool,       // bool
-        Int2,       // i16
-        Int4,       // i32
-        Int8,       // i64
-        Float4,     // f32
-        Float8,     // f64
-        Text        // String, &str
+        Bool,       // BOOLEAN / TINYINT(1)
+        Int2,       // SMALLINT, TINYINT
+        Int4,       // INT, INTEGER, MEDIUMINT
+        Int8,       // BIGINT
+        Float4,     // FLOAT
+        Float8,     // DOUBLE
+        Text,       // TEXT, VARCHAR, CHAR, ENUM, SET
+        Decimal,    // DECIMAL, NUMERIC
+        DateTime,   // DATETIME, TIMESTAMP
+        Date,       // DATE
+        Time,       // TIME
+        Blob        // BLOB, BINARY, VARBINARY
     ]
 }
 
 impl MysqlTypeVariants {
-    /// Detect the type variant from a JSON value.
-    pub fn from_json(value: &Value) -> Option<Self> {
+    /// Detect the type variant from a CBOR value.
+    pub fn from_cbor(value: &ciborium::Value) -> Option<Self> {
+        use ciborium::Value::*;
+
         match value {
-            Value::Null => Some(Self::Null),
-            Value::Bool(_) => Some(Self::Bool),
-            Value::Number(n) => {
-                if n.is_i64() || n.is_u64() {
-                    Some(Self::Int8)
-                } else {
-                    Some(Self::Float8)
-                }
-            }
-            Value::String(_) => Some(Self::Text),
+            Null => Some(Self::Null),
+            Bool(_) => Some(Self::Bool),
+            Integer(_) => Some(Self::Int8),
+            Float(_) => Some(Self::Float8),
+            Text(_) => Some(Self::Text),
+            Bytes(_) => Some(Self::Blob),
+            Tag(0, _) => Some(Self::DateTime),
+            Tag(10, _) => Some(Self::Decimal),
+            Tag(100, _) => Some(Self::Date),
+            Tag(101, _) => Some(Self::Time),
+            Tag(_, inner) => Self::from_cbor(inner),
             _ => None,
         }
     }
@@ -86,17 +90,16 @@ mod tests {
         let val = AnyMysqlType::new(true);
         assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Bool));
         assert_eq!(val.try_get::<bool>(), Some(true));
-        // Bool is a distinct variant -- i64 extraction blocked by type boundary
         assert_eq!(val.try_get::<i64>(), None);
     }
 
     #[test]
     fn test_null_round_trip() {
         let val = AnyMysqlType::new(None::<i64>);
-        assert_eq!(*val.value(), serde_json::Value::Null);
+        assert_eq!(*val.value(), ciborium::Value::Null);
         assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Int8));
 
-        let direct = <Option<i64> as MysqlType>::from_json(serde_json::Value::Null);
+        let direct = <Option<i64> as MysqlType>::from_cbor(ciborium::Value::Null);
         assert_eq!(direct, Some(None));
 
         assert_eq!(val.try_get::<Option<i64>>(), Some(None));
@@ -132,5 +135,44 @@ mod tests {
         let val = AnyMysqlType::new(42i16);
         assert_eq!(val.type_variant(), Some(MysqlTypeVariants::Int2));
         assert_eq!(val.try_get::<i16>(), Some(42));
+    }
+
+    #[test]
+    fn test_untyped_integer_try_get() {
+        // Values from database come back untyped — try_get should still work
+        let val = AnyMysqlType::untyped(ciborium::Value::Integer(42.into()));
+        assert_eq!(val.try_get::<i64>(), Some(42));
+        assert_eq!(val.try_get::<i32>(), Some(42));
+    }
+
+    #[test]
+    fn test_untyped_text_try_get() {
+        let val = AnyMysqlType::untyped(ciborium::Value::Text("world".into()));
+        assert_eq!(val.try_get::<String>(), Some("world".to_string()));
+    }
+
+    #[test]
+    fn test_untyped_decimal_tag() {
+        let val = AnyMysqlType::untyped(ciborium::Value::Tag(
+            10,
+            Box::new(ciborium::Value::Text("123.456".into())),
+        ));
+        // Variant detection should identify it as Decimal
+        assert_eq!(
+            MysqlTypeVariants::from_cbor(val.value()),
+            Some(MysqlTypeVariants::Decimal)
+        );
+    }
+
+    #[test]
+    fn test_untyped_datetime_tag() {
+        let val = AnyMysqlType::untyped(ciborium::Value::Tag(
+            0,
+            Box::new(ciborium::Value::Text("2024-01-15T10:30:00".into())),
+        ));
+        assert_eq!(
+            MysqlTypeVariants::from_cbor(val.value()),
+            Some(MysqlTypeVariants::DateTime)
+        );
     }
 }

--- a/vantage-sql/src/mysql/types/numbers.rs
+++ b/vantage-sql/src/mysql/types/numbers.rs
@@ -1,31 +1,28 @@
 //! Numeric type implementations for MySQL.
 //!
-//! - i16 -> Int2 (SMALLINT)
-//! - i32 -> Int4 (INT)
-//! - i64 -> Int8 (BIGINT)
-//! - f32 -> Float4 (FLOAT)
-//! - f64 -> Float8 (DOUBLE)
-//! - i8, u8, u16, u32 -> mapped to appropriate integer variants
+//! Uses ciborium::Value (CBOR) as the underlying storage:
+//! - Integers → CborValue::Integer
+//! - Floats → CborValue::Float
 //! - Option<T> delegates to T, with Null for None
 
 use super::{
     MysqlType, MysqlTypeFloat4Marker, MysqlTypeFloat8Marker, MysqlTypeInt2Marker,
     MysqlTypeInt4Marker, MysqlTypeInt8Marker,
 };
-use serde_json::Value;
+use ciborium::Value;
 
 // -- i16 -> Int2 (SMALLINT) ---------------------------------------------------
 
 impl MysqlType for i16 {
     type Target = MysqlTypeInt2Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| i16::try_from(i).ok()),
+            Value::Integer(i) => i16::try_from(i).ok(),
             _ => None,
         }
     }
@@ -36,13 +33,13 @@ impl MysqlType for i16 {
 impl MysqlType for i32 {
     type Target = MysqlTypeInt4Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| i32::try_from(i).ok()),
+            Value::Integer(i) => i32::try_from(i).ok(),
             _ => None,
         }
     }
@@ -53,30 +50,30 @@ impl MysqlType for i32 {
 impl MysqlType for i64 {
     type Target = MysqlTypeInt8Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64(),
+            Value::Integer(i) => i64::try_from(i).ok(),
             _ => None,
         }
     }
 }
 
-// -- Smaller unsigned integers mapped to appropriate MySQL types ---------------
+// -- Smaller integer types mapped to appropriate MySQL variants ---------------
 
 impl MysqlType for i8 {
     type Target = MysqlTypeInt2Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| i8::try_from(i).ok()),
+            Value::Integer(i) => i8::try_from(i).ok(),
             _ => None,
         }
     }
@@ -85,13 +82,13 @@ impl MysqlType for i8 {
 impl MysqlType for u8 {
     type Target = MysqlTypeInt2Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| u8::try_from(i).ok()),
+            Value::Integer(i) => u8::try_from(i).ok(),
             _ => None,
         }
     }
@@ -100,13 +97,13 @@ impl MysqlType for u8 {
 impl MysqlType for u16 {
     type Target = MysqlTypeInt4Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| u16::try_from(i).ok()),
+            Value::Integer(i) => u16::try_from(i).ok(),
             _ => None,
         }
     }
@@ -115,13 +112,13 @@ impl MysqlType for u16 {
 impl MysqlType for u32 {
     type Target = MysqlTypeInt8Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| u32::try_from(i).ok()),
+            Value::Integer(i) => u32::try_from(i).ok(),
             _ => None,
         }
     }
@@ -132,15 +129,14 @@ impl MysqlType for u32 {
 impl MysqlType for f32 {
     type Target = MysqlTypeFloat4Marker;
 
-    fn to_json(&self) -> Value {
-        serde_json::Number::from_f64(*self as f64)
-            .map(Value::Number)
-            .unwrap_or(Value::Null)
+    fn to_cbor(&self) -> Value {
+        Value::Float((*self) as f64)
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_f64().map(|f| f as f32),
+            Value::Float(f) => Some(f as f32),
+            Value::Integer(i) => i64::try_from(i).ok().map(|n| n as f32),
             _ => None,
         }
     }
@@ -149,15 +145,14 @@ impl MysqlType for f32 {
 impl MysqlType for f64 {
     type Target = MysqlTypeFloat8Marker;
 
-    fn to_json(&self) -> Value {
-        serde_json::Number::from_f64(*self)
-            .map(Value::Number)
-            .unwrap_or(Value::Null)
+    fn to_cbor(&self) -> Value {
+        Value::Float(*self)
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_f64(),
+            Value::Float(f) => Some(f),
+            Value::Integer(i) => i64::try_from(i).ok().map(|n| n as f64),
             _ => None,
         }
     }
@@ -168,17 +163,17 @@ impl MysqlType for f64 {
 impl<T: MysqlType> MysqlType for Option<T> {
     type Target = T::Target;
 
-    fn to_json(&self) -> Value {
+    fn to_cbor(&self) -> Value {
         match self {
-            Some(v) => v.to_json(),
+            Some(v) => v.to_cbor(),
             None => Value::Null,
         }
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
             Value::Null => Some(None),
-            other => T::from_json(other).map(Some),
+            other => T::from_cbor(other).map(Some),
         }
     }
 }

--- a/vantage-sql/src/mysql/types/string.rs
+++ b/vantage-sql/src/mysql/types/string.rs
@@ -1,18 +1,18 @@
 //! String types -> MySQL TEXT
 
 use super::{MysqlType, MysqlTypeTextMarker};
-use serde_json::Value;
+use ciborium::Value;
 
 impl MysqlType for String {
     type Target = MysqlTypeTextMarker;
 
-    fn to_json(&self) -> Value {
-        Value::String(self.clone())
+    fn to_cbor(&self) -> Value {
+        Value::Text(self.clone())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::String(s) => Some(s),
+            Value::Text(s) => Some(s),
             _ => None,
         }
     }
@@ -21,11 +21,11 @@ impl MysqlType for String {
 impl MysqlType for &'static str {
     type Target = MysqlTypeTextMarker;
 
-    fn to_json(&self) -> Value {
-        Value::String(self.to_string())
+    fn to_cbor(&self) -> Value {
+        Value::Text(self.to_string())
     }
 
-    fn from_json(_value: Value) -> Option<Self> {
+    fn from_cbor(_value: Value) -> Option<Self> {
         None // cannot produce &'static str from arbitrary data
     }
 }

--- a/vantage-sql/src/mysql/types/value.rs
+++ b/vantage-sql/src/mysql/types/value.rs
@@ -1,17 +1,29 @@
-//! AnyMysqlType extras: From conversions, Display, Expressive.
+//! AnyMysqlType extras: From conversions, Display, Expressive, TryFrom.
+//!
+//! Uses ciborium::Value (CBOR) as the underlying value type.
 
-use super::{AnyMysqlType, MysqlType, MysqlTypeNullMarker};
-use serde_json::Value;
+use super::{AnyMysqlType, MysqlType, MysqlTypeNullMarker, MysqlTypeVariants};
+use ciborium::Value as CborValue;
+use serde_json::Value as JsonValue;
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
 impl AnyMysqlType {
     /// Create an AnyMysqlType with no type marker. Used for values coming
     /// back from the database where we don't know the original type.
     /// `try_get` on these values bypasses variant checking.
-    pub fn untyped(value: serde_json::Value) -> Self {
+    pub fn untyped(value: CborValue) -> Self {
         Self {
             value,
             type_variant: None,
+        }
+    }
+
+    /// Create an AnyMysqlType with an explicit type variant.
+    /// Used by row_to_record where the MySQL column type is known.
+    pub fn with_variant(value: CborValue, variant: MysqlTypeVariants) -> Self {
+        Self {
+            value,
+            type_variant: Some(variant),
         }
     }
 }
@@ -20,28 +32,79 @@ impl AnyMysqlType {
 impl MysqlType for AnyMysqlType {
     type Target = MysqlTypeNullMarker;
 
-    fn to_json(&self) -> Value {
+    fn to_cbor(&self) -> CborValue {
         self.value().clone()
     }
 
-    fn from_json(value: Value) -> Option<Self> {
-        AnyMysqlType::from_json(&value)
+    fn from_cbor(value: CborValue) -> Option<Self> {
+        AnyMysqlType::from_cbor(&value)
     }
 }
 
 impl std::fmt::Display for AnyMysqlType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.value() {
-            Value::Null => write!(f, "NULL"),
-            Value::Bool(b) => write!(f, "{}", b),
-            Value::Number(n) => write!(f, "{}", n),
-            Value::String(s) => write!(f, "'{}'", s.replace('\'', "''")),
-            other => write!(f, "{}", other),
+            CborValue::Null => write!(f, "NULL"),
+            CborValue::Bool(b) => write!(f, "{}", b),
+            CborValue::Integer(i) => write!(f, "{}", i128::from(*i)),
+            CborValue::Float(v) => write!(f, "{}", v),
+            CborValue::Text(s) => write!(f, "'{}'", s.replace('\'', "''")),
+            CborValue::Bytes(b) => write!(f, "x'{}'", hex::encode(b)),
+            CborValue::Tag(10, inner) => {
+                // Decimal
+                if let CborValue::Text(s) = inner.as_ref() {
+                    write!(f, "{}", s)
+                } else {
+                    write!(f, "{:?}", inner)
+                }
+            }
+            CborValue::Tag(0, inner) | CborValue::Tag(100, inner) | CborValue::Tag(101, inner) => {
+                // DateTime / Date / Time
+                if let CborValue::Text(s) = inner.as_ref() {
+                    write!(f, "'{}'", s)
+                } else {
+                    write!(f, "{:?}", inner)
+                }
+            }
+            CborValue::Array(arr) => {
+                write!(f, "[")?;
+                for (i, item) in arr.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    if let Some(any) = AnyMysqlType::from_cbor(item) {
+                        write!(f, "{}", any)?;
+                    } else {
+                        write!(f, "{:?}", item)?;
+                    }
+                }
+                write!(f, "]")
+            }
+            CborValue::Map(map) => {
+                write!(f, "{{")?;
+                for (i, (k, v)) in map.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    let key_str = match k {
+                        CborValue::Text(s) => s.clone(),
+                        _ => format!("{:?}", k),
+                    };
+                    if let Some(any) = AnyMysqlType::from_cbor(v) {
+                        write!(f, "{}: {}", key_str, any)?;
+                    } else {
+                        write!(f, "{}: {:?}", key_str, v)?;
+                    }
+                }
+                write!(f, "}}")
+            }
+            other => write!(f, "{:?}", other),
         }
     }
 }
 
-// From impls for common types
+// -- From impls for common types ----------------------------------------------
+
 macro_rules! impl_from_for_any_mysql {
     ($($ty:ty),*) => {
         $(
@@ -62,7 +125,98 @@ impl From<&str> for AnyMysqlType {
     }
 }
 
-// Expressive impls -- allows passing scalars directly into mysql_expr!
+// -- JSON <-> CBOR bridge (for AnyTable interop) ------------------------------
+
+impl From<JsonValue> for AnyMysqlType {
+    fn from(val: JsonValue) -> Self {
+        if val.is_null() {
+            return AnyMysqlType::untyped(CborValue::Null);
+        }
+        let cbor = json_to_cbor(val);
+        AnyMysqlType::from_cbor(&cbor).expect("json_to_cbor produced unconvertible CBOR")
+    }
+}
+
+impl From<AnyMysqlType> for JsonValue {
+    fn from(val: AnyMysqlType) -> Self {
+        cbor_to_json(val.into_value())
+    }
+}
+
+fn json_to_cbor(val: JsonValue) -> CborValue {
+    match val {
+        JsonValue::Null => CborValue::Null,
+        JsonValue::Bool(b) => CborValue::Bool(b),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                CborValue::Integer(i.into())
+            } else if let Some(u) = n.as_u64() {
+                CborValue::Integer(u.into())
+            } else if let Some(f) = n.as_f64() {
+                CborValue::Float(f)
+            } else {
+                CborValue::Text(n.to_string())
+            }
+        }
+        JsonValue::String(s) => CborValue::Text(s),
+        JsonValue::Array(arr) => CborValue::Array(arr.into_iter().map(json_to_cbor).collect()),
+        JsonValue::Object(map) => CborValue::Map(
+            map.into_iter()
+                .map(|(k, v)| (CborValue::Text(k), json_to_cbor(v)))
+                .collect(),
+        ),
+    }
+}
+
+fn cbor_to_json(val: CborValue) -> JsonValue {
+    match val {
+        CborValue::Null => JsonValue::Null,
+        CborValue::Bool(b) => JsonValue::Bool(b),
+        CborValue::Integer(i) => {
+            let n = i128::from(i);
+            if let Ok(v) = i64::try_from(n) {
+                JsonValue::Number(v.into())
+            } else if let Ok(v) = u64::try_from(n) {
+                JsonValue::Number(v.into())
+            } else {
+                JsonValue::String(n.to_string())
+            }
+        }
+        CborValue::Float(f) => serde_json::Number::from_f64(f)
+            .map(JsonValue::Number)
+            .unwrap_or(JsonValue::Null),
+        CborValue::Text(s) => JsonValue::String(s),
+        CborValue::Bytes(b) => JsonValue::String(hex::encode(b)),
+        CborValue::Array(arr) => JsonValue::Array(arr.into_iter().map(cbor_to_json).collect()),
+        CborValue::Map(map) => {
+            let obj: serde_json::Map<String, JsonValue> = map
+                .into_iter()
+                .map(|(k, v)| {
+                    let key = match k {
+                        CborValue::Text(s) => s,
+                        other => format!("{:?}", other),
+                    };
+                    (key, cbor_to_json(v))
+                })
+                .collect();
+            JsonValue::Object(obj)
+        }
+        // Tagged values: extract the inner value for JSON (tags have no JSON equivalent)
+        CborValue::Tag(10, inner) => {
+            // Decimal — preserve as string
+            if let CborValue::Text(s) = *inner {
+                JsonValue::String(s)
+            } else {
+                cbor_to_json(*inner)
+            }
+        }
+        CborValue::Tag(_, inner) => cbor_to_json(*inner),
+        _ => JsonValue::Null,
+    }
+}
+
+// -- Expressive impls ---------------------------------------------------------
+
 macro_rules! impl_expressive_for_mysql_scalar {
     ($($ty:ty),*) => {
         $(
@@ -89,7 +243,14 @@ impl Expressive<AnyMysqlType> for &str {
     }
 }
 
-// TryFrom<AnyMysqlType> impls -- enables AssociatedExpression::get()
+impl Expressive<AnyMysqlType> for AnyMysqlType {
+    fn expr(&self) -> Expression<AnyMysqlType> {
+        Expression::new("{}", vec![ExpressiveEnum::Scalar(self.clone())])
+    }
+}
+
+// -- TryFrom impls (for AssociatedExpression::get()) --------------------------
+
 macro_rules! impl_try_from_mysql {
     ($($ty:ty),*) => {
         $(
@@ -101,13 +262,12 @@ macro_rules! impl_try_from_mysql {
                         return Ok(v);
                     }
                     // If result is [{col: value}], extract the scalar
-                    if let serde_json::Value::Array(arr) = val.value() {
+                    if let CborValue::Array(ref arr) = *val.value() {
                         if arr.len() == 1 {
-                            if let Some(obj) = arr[0].as_object() {
-                                if obj.len() == 1 {
-                                    let inner = AnyMysqlType::untyped(
-                                        obj.values().next().unwrap().clone()
-                                    );
+                            if let CborValue::Map(ref map) = arr[0] {
+                                if map.len() == 1 {
+                                    let (_, v) = &map[0];
+                                    let inner = AnyMysqlType::untyped(v.clone());
                                     if let Some(v) = inner.try_get::<$ty>() {
                                         return Ok(v);
                                     }
@@ -128,22 +288,12 @@ macro_rules! impl_try_from_mysql {
 
 impl_try_from_mysql!(i64, i32, f64, bool, String);
 
-/// Extract first row from a result array as a JSON object.
-fn extract_first_row(val: &AnyMysqlType) -> Option<serde_json::Value> {
+/// Extract first row from a CBOR result array as a map.
+fn extract_first_row(val: &AnyMysqlType) -> Option<CborValue> {
     match val.value() {
-        serde_json::Value::Array(arr) => arr.first().cloned(),
-        obj @ serde_json::Value::Object(_) => Some(obj.clone()),
+        CborValue::Array(arr) => arr.first().cloned(),
+        obj @ CborValue::Map(_) => Some(obj.clone()),
         _ => None,
-    }
-}
-
-impl TryFrom<AnyMysqlType> for vantage_types::Record<serde_json::Value> {
-    type Error = vantage_core::VantageError;
-    fn try_from(val: AnyMysqlType) -> Result<Self, Self::Error> {
-        let row = extract_first_row(&val).ok_or_else(|| {
-            vantage_core::error!("Expected row result", value = format!("{}", val))
-        })?;
-        Ok(row.into())
     }
 }
 
@@ -154,20 +304,92 @@ impl TryFrom<AnyMysqlType> for vantage_types::Record<AnyMysqlType> {
             vantage_core::error!("Expected row result", value = format!("{}", val))
         })?;
         match row {
-            serde_json::Value::Object(map) => Ok(map
-                .into_iter()
-                .map(|(k, v)| (k, AnyMysqlType::untyped(v)))
-                .collect()),
+            CborValue::Map(map) => Ok(cbor_map_to_record(map)),
             _ => Err(vantage_core::error!(
-                "Expected object row",
+                "Expected map row",
                 value = format!("{:?}", row)
             )),
         }
     }
 }
 
-impl Expressive<AnyMysqlType> for AnyMysqlType {
-    fn expr(&self) -> Expression<AnyMysqlType> {
-        Expression::new("{}", vec![ExpressiveEnum::Scalar(self.clone())])
+/// Convert a CBOR Map into a Record<AnyMysqlType>.
+fn cbor_map_to_record(map: Vec<(CborValue, CborValue)>) -> vantage_types::Record<AnyMysqlType> {
+    map.into_iter()
+        .map(|(k, v)| {
+            let key = match k {
+                CborValue::Text(s) => s,
+                other => format!("{:?}", other),
+            };
+            (key, AnyMysqlType::untyped(v))
+        })
+        .collect()
+}
+
+impl TryFrom<AnyMysqlType> for Vec<vantage_types::Record<AnyMysqlType>> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnyMysqlType) -> Result<Self, Self::Error> {
+        match val.into_value() {
+            CborValue::Array(arr) => arr
+                .into_iter()
+                .map(|item| match item {
+                    CborValue::Map(map) => Ok(cbor_map_to_record(map)),
+                    other => Err(vantage_core::error!(
+                        "Expected map row",
+                        value = format!("{:?}", other)
+                    )),
+                })
+                .collect(),
+            CborValue::Map(map) => Ok(vec![cbor_map_to_record(map)]),
+            other => Err(vantage_core::error!(
+                "Expected array or map result",
+                value = format!("{:?}", other)
+            )),
+        }
+    }
+}
+
+impl TryFrom<AnyMysqlType> for vantage_types::Record<serde_json::Value> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnyMysqlType) -> Result<Self, Self::Error> {
+        let record: vantage_types::Record<AnyMysqlType> = val.try_into()?;
+        Ok(record
+            .into_iter()
+            .map(|(k, v)| (k, cbor_to_json(v.into_value())))
+            .collect())
+    }
+}
+
+impl vantage_types::TerminalRender for AnyMysqlType {
+    fn render(&self) -> String {
+        match self.value() {
+            CborValue::Null => "-".to_string(),
+            CborValue::Text(s) => s.clone(),
+            CborValue::Bool(b) => b.to_string(),
+            CborValue::Tag(10, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    s.clone()
+                } else {
+                    format!("{}", self)
+                }
+            }
+            CborValue::Tag(0, inner) | CborValue::Tag(100, inner) | CborValue::Tag(101, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    s.clone()
+                } else {
+                    format!("{}", self)
+                }
+            }
+            _ => format!("{}", self),
+        }
+    }
+
+    fn color_hint(&self) -> Option<&'static str> {
+        match self.value() {
+            CborValue::Bool(true) => Some("green"),
+            CborValue::Bool(false) => Some("red"),
+            CborValue::Null => Some("dim"),
+            _ => None,
+        }
     }
 }

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -402,6 +402,20 @@ impl TableSource for PostgresDB {
         tgt_col.in_(fk_values.expr())
     }
 
+    fn related_correlated_condition(
+        &self,
+        target_table: &str,
+        target_field: &str,
+        source_table: &str,
+        source_column: &str,
+    ) -> Self::Condition {
+        postgres_expr!(
+            "{} = {}",
+            (ident(target_field).dot_of(target_table)),
+            (ident(source_column).dot_of(source_table))
+        )
+    }
+
     fn column_table_values_expr<'a, E, Type: ColumnType>(
         &'a self,
         table: &Table<Self, E>,

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -369,6 +369,20 @@ impl TableSource for SqliteDB {
         tgt_col.in_(fk_values.expr())
     }
 
+    fn related_correlated_condition(
+        &self,
+        target_table: &str,
+        target_field: &str,
+        source_table: &str,
+        source_column: &str,
+    ) -> Self::Condition {
+        sqlite_expr!(
+            "{} = {}",
+            (ident(target_field).dot_of(target_table)),
+            (ident(source_column).dot_of(source_table))
+        )
+    }
+
     fn column_table_values_expr<'a, E, Type: ColumnType>(
         &'a self,
         table: &Table<Self, E>,

--- a/vantage-sql/tests/mysql/1_types_record.rs
+++ b/vantage-sql/tests/mysql/1_types_record.rs
@@ -1,6 +1,10 @@
 //! Test 1b: Record<AnyMysqlType> conversions — typed (write path) and
 //! untyped (read path) round-trips, error cases.
+//!
+//! Uses native CborValue for untyped values (simulating database reads)
+//! instead of the JSON bridge.
 
+use ciborium::Value as CborValue;
 use vantage_sql::mysql::AnyMysqlType;
 use vantage_types::Record;
 
@@ -14,7 +18,6 @@ fn test_typed_record_creation() {
     record.insert("price".into(), AnyMysqlType::new(120i64));
     record.insert("is_deleted".into(), AnyMysqlType::new(false));
 
-    // Values carry their type markers
     assert_eq!(
         record["name"].try_get::<String>(),
         Some("Cupcake".to_string())
@@ -52,18 +55,17 @@ fn test_untyped_record_creation() {
     let mut record: Record<AnyMysqlType> = Record::new();
     record.insert(
         "name".into(),
-        AnyMysqlType::untyped(serde_json::json!("Cupcake")),
+        AnyMysqlType::untyped(CborValue::Text("Cupcake".into())),
     );
     record.insert(
         "price".into(),
-        AnyMysqlType::untyped(serde_json::json!(120)),
+        AnyMysqlType::untyped(CborValue::Integer(120.into())),
     );
     record.insert(
         "active".into(),
-        AnyMysqlType::untyped(serde_json::json!(true)),
+        AnyMysqlType::untyped(CborValue::Bool(true)),
     );
 
-    // Untyped values — try_get just attempts the conversion
     assert_eq!(
         record["name"].try_get::<String>(),
         Some("Cupcake".to_string())
@@ -72,19 +74,15 @@ fn test_untyped_record_creation() {
     assert_eq!(record["active"].try_get::<bool>(), Some(true));
 
     // Still fails when the underlying value can't convert
-    assert_eq!(record["name"].try_get::<i64>(), None); // "Cupcake" isn't a number
-    assert_eq!(record["price"].try_get::<String>(), None); // 120 isn't a string
+    assert_eq!(record["name"].try_get::<i64>(), None);
+    assert_eq!(record["price"].try_get::<String>(), None);
 }
 
 #[test]
 fn test_untyped_null() {
     let mut record: Record<AnyMysqlType> = Record::new();
-    record.insert(
-        "note".into(),
-        AnyMysqlType::untyped(serde_json::json!(null)),
-    );
+    record.insert("note".into(), AnyMysqlType::untyped(CborValue::Null));
 
-    // Untyped null → Option<String> works (no variant blocking it)
     assert_eq!(record["note"].try_get::<Option<String>>(), Some(None));
     assert_eq!(record["note"].try_get::<Option<i64>>(), Some(None));
 }
@@ -98,35 +96,89 @@ fn test_typed_blocks_cross_variant() {
     assert_eq!(typed.try_get::<i64>(), Some(42));
     assert_eq!(typed.try_get::<f64>(), None); // Int8 ≠ Float8 → blocked
 
-    // Untyped: same JSON value but no variant
-    let untyped = AnyMysqlType::untyped(serde_json::json!(42));
+    // Untyped: same CBOR value but no variant — permissive
+    let untyped = AnyMysqlType::untyped(CborValue::Integer(42.into()));
     assert_eq!(untyped.try_get::<i64>(), Some(42));
 }
 
 #[test]
-fn test_untyped_is_permissive_across_numeric() {
-    // Untyped integer: try_get as f64 works because json Number can be read as f64
-    let untyped = AnyMysqlType::untyped(serde_json::json!(42));
-    assert_eq!(untyped.try_get::<i64>(), Some(42));
-    assert_eq!(untyped.try_get::<f64>(), Some(42.0));
-
-    // Typed integer: f64 blocked by variant
-    let typed = AnyMysqlType::new(42i64);
-    assert_eq!(typed.try_get::<f64>(), None); // Int8 ≠ Float8
+fn test_untyped_integer_narrowing() {
+    let val = AnyMysqlType::untyped(CborValue::Integer(42.into()));
+    assert_eq!(val.try_get::<i64>(), Some(42));
+    assert_eq!(val.try_get::<i32>(), Some(42));
+    assert_eq!(val.try_get::<i16>(), Some(42));
 }
 
-// ── MySQL-specific: bool stored natively ──────────────────────────────────
+// ── CBOR tag preservation ─────────────────────────────────────────────────
+
+#[test]
+fn test_decimal_tag_preserved() {
+    let val = AnyMysqlType::untyped(CborValue::Tag(
+        10,
+        Box::new(CborValue::Text("123.456".into())),
+    ));
+    // Decimal tag should be detectable
+    assert_eq!(
+        *val.value(),
+        CborValue::Tag(10, Box::new(CborValue::Text("123.456".into())))
+    );
+}
+
+#[test]
+fn test_datetime_tag_preserved() {
+    let val = AnyMysqlType::untyped(CborValue::Tag(
+        0,
+        Box::new(CborValue::Text("2024-01-15T10:30:00".into())),
+    ));
+    assert_eq!(
+        *val.value(),
+        CborValue::Tag(0, Box::new(CborValue::Text("2024-01-15T10:30:00".into())))
+    );
+}
+
+// ── Bool stored natively ──────────────────────────────────────────────────
 
 #[test]
 fn test_typed_bool_in_record() {
     let mut record: Record<AnyMysqlType> = Record::new();
     record.insert("active".into(), AnyMysqlType::new(true));
 
-    // MySQL stores bool as native JSON bool
-    assert_eq!(*record["active"].value(), serde_json::json!(true));
+    assert_eq!(*record["active"].value(), CborValue::Bool(true));
     assert_eq!(record["active"].try_get::<bool>(), Some(true));
     // Bool ≠ Int8 → blocked
     assert_eq!(record["active"].try_get::<i64>(), None);
+}
+
+// ── JSON bridge round-trip ────────────────────────────────────────────────
+
+#[test]
+fn test_json_round_trip_integer() {
+    let original = AnyMysqlType::new(42i64);
+    let json: serde_json::Value = original.clone().into();
+    assert_eq!(json, serde_json::json!(42));
+
+    let restored = AnyMysqlType::from(json);
+    assert_eq!(restored.try_get::<i64>(), Some(42));
+}
+
+#[test]
+fn test_json_round_trip_string() {
+    let original = AnyMysqlType::new("hello".to_string());
+    let json: serde_json::Value = original.into();
+    assert_eq!(json, serde_json::json!("hello"));
+
+    let restored = AnyMysqlType::from(json);
+    assert_eq!(restored.try_get::<String>(), Some("hello".to_string()));
+}
+
+#[test]
+fn test_json_round_trip_bool() {
+    let original = AnyMysqlType::new(true);
+    let json: serde_json::Value = original.into();
+    assert_eq!(json, serde_json::json!(true));
+
+    let restored = AnyMysqlType::from(json);
+    assert_eq!(restored.try_get::<bool>(), Some(true));
 }
 
 // ── Error cases ────────────────────────────────────────────────────────────

--- a/vantage-sql/tests/mysql/2_defer.rs
+++ b/vantage-sql/tests/mysql/2_defer.rs
@@ -3,18 +3,15 @@
 //! A deferred expression runs a query on one database at execution time,
 //! and the resulting value gets placed as a parameter in another database's query.
 
-use serde_json::Value as JsonValue;
 use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
 use vantage_sql::mysql::{AnyMysqlType, MysqlDB};
 use vantage_sql::mysql_expr;
+use vantage_types::Record;
 
 const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
 
-fn rows(result: AnyMysqlType) -> Vec<JsonValue> {
-    match result.into_value() {
-        JsonValue::Array(arr) => arr,
-        other => panic!("expected array, got: {:?}", other),
-    }
+fn records(result: AnyMysqlType) -> Vec<Record<AnyMysqlType>> {
+    Vec::<Record<AnyMysqlType>>::try_from(result).unwrap()
 }
 
 async fn setup(prefix: &str) -> (MysqlDB, MysqlDB) {
@@ -84,11 +81,17 @@ async fn test_cross_database_deferred() {
         vec![ExpressiveEnum::Deferred(deferred_threshold)],
     );
 
-    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+    let result = records(shop_db.execute(&shop_query).await.unwrap());
 
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0]["name"], "Mid Thing");
-    assert_eq!(result[1]["name"], "Expensive Thing");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Mid Thing".to_string())
+    );
+    assert_eq!(
+        result[1]["name"].try_get::<String>(),
+        Some("Expensive Thing".to_string())
+    );
 }
 
 // ── Deferred mixed with regular scalar parameters ──────────────────────────
@@ -111,10 +114,13 @@ async fn test_deferred_mixed_with_scalars() {
         ],
     );
 
-    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+    let result = records(shop_db.execute(&shop_query).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "Expensive Thing");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Expensive Thing".to_string())
+    );
 }
 
 // ── Deferred inside a nested expression ───────────────────────────────────
@@ -139,9 +145,15 @@ async fn test_nested_deferred() {
         (inner)
     );
 
-    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+    let result = records(shop_db.execute(&shop_query).await.unwrap());
 
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0]["name"], "Mid Thing");
-    assert_eq!(result[1]["name"], "Expensive Thing");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Mid Thing".to_string())
+    );
+    assert_eq!(
+        result[1]["name"].try_get::<String>(),
+        Some("Expensive Thing".to_string())
+    );
 }

--- a/vantage-sql/tests/mysql/2_expressions.rs
+++ b/vantage-sql/tests/mysql/2_expressions.rs
@@ -1,8 +1,8 @@
 //! Test 2: ExprDataSource — execute Expression<AnyMysqlType> against live MySQL.
 
-use serde_json::Value as JsonValue;
 use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
 use vantage_sql::mysql::{AnyMysqlType, MysqlDB};
+use vantage_types::Record;
 
 const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
 
@@ -39,12 +39,9 @@ async fn setup(table: &str) -> MysqlDB {
     db
 }
 
-/// Helper: unwrap result into JSON array of row objects.
-fn rows(result: AnyMysqlType) -> Vec<JsonValue> {
-    match result.into_value() {
-        JsonValue::Array(arr) => arr,
-        other => panic!("expected array, got: {:?}", other),
-    }
+/// Helper: unwrap result into Vec of Record<AnyMysqlType>.
+fn records(result: AnyMysqlType) -> Vec<Record<AnyMysqlType>> {
+    Vec::<Record<AnyMysqlType>>::try_from(result).unwrap()
 }
 
 // ── Basic select via ExprDataSource ────────────────────────────────────────
@@ -54,11 +51,17 @@ async fn test_select_all() {
     let db = setup("expr_select_all").await;
     let expr =
         Expression::<AnyMysqlType>::new("SELECT * FROM `expr_select_all` ORDER BY id", vec![]);
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 3);
-    assert_eq!(result[0]["name"], "Apple");
-    assert_eq!(result[2]["name"], "Cherry");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Apple".to_string())
+    );
+    assert_eq!(
+        result[2]["name"].try_get::<String>(),
+        Some("Cherry".to_string())
+    );
 }
 
 // ── Parameterized query ────────────────────────────────────────────────────
@@ -70,10 +73,13 @@ async fn test_parameterized_integer() {
         "SELECT name FROM `expr_param_int` WHERE id = {}",
         vec![ExpressiveEnum::Scalar(AnyMysqlType::new(2i64))],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "Banana");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Banana".to_string())
+    );
 }
 
 #[tokio::test]
@@ -85,10 +91,10 @@ async fn test_parameterized_text() {
             "Cherry".to_string(),
         ))],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["price"], 200);
+    assert_eq!(result[0]["price"].try_get::<i64>(), Some(200));
 }
 
 #[tokio::test]
@@ -98,11 +104,17 @@ async fn test_parameterized_bool() {
         "SELECT name FROM `expr_param_bool` WHERE active = {} ORDER BY name",
         vec![ExpressiveEnum::Scalar(AnyMysqlType::new(true))],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0]["name"], "Apple");
-    assert_eq!(result[1]["name"], "Banana");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Apple".to_string())
+    );
+    assert_eq!(
+        result[1]["name"].try_get::<String>(),
+        Some("Banana".to_string())
+    );
 }
 
 // ── Multiple parameters ───────────────────────────────────────────────────
@@ -117,10 +129,13 @@ async fn test_multiple_params() {
             ExpressiveEnum::Scalar(AnyMysqlType::new(true)),
         ],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "Apple");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Apple".to_string())
+    );
 }
 
 // ── Nested expressions ────────────────────────────────────────────────────
@@ -138,10 +153,16 @@ async fn test_nested_expression() {
         vec![ExpressiveEnum::Nested(where_clause)],
     );
 
-    let result = rows(db.execute(&full_query).await.unwrap());
+    let result = records(db.execute(&full_query).await.unwrap());
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0]["name"], "Apple");
-    assert_eq!(result[1]["name"], "Cherry");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Apple".to_string())
+    );
+    assert_eq!(
+        result[1]["name"].try_get::<String>(),
+        Some("Cherry".to_string())
+    );
 }
 
 // ── Empty result ──────────────────────────────────────────────────────────
@@ -153,7 +174,7 @@ async fn test_empty_result() {
         "SELECT name FROM `expr_empty` WHERE id = {}",
         vec![ExpressiveEnum::Scalar(AnyMysqlType::new(999i64))],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert!(result.is_empty());
 }

--- a/vantage-sql/tests/mysql/2_insert.rs
+++ b/vantage-sql/tests/mysql/2_insert.rs
@@ -4,7 +4,6 @@
 //! Focuses on the Product table to exercise multiple types (text, integer, bool).
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
 #[allow(unused_imports)]
 use vantage_expressions::Expressive;
 use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
@@ -49,12 +48,9 @@ async fn setup(table: &str) -> MysqlDB {
     db
 }
 
-/// Helper: execute expression, unwrap result into JSON rows.
-fn rows(result: AnyMysqlType) -> Vec<JsonValue> {
-    match result.into_value() {
-        JsonValue::Array(arr) => arr,
-        other => panic!("expected array, got: {:?}", other),
-    }
+/// Helper: unwrap result into Vec of Record<AnyMysqlType>.
+fn records(result: AnyMysqlType) -> Vec<Record<AnyMysqlType>> {
+    Vec::<Record<AnyMysqlType>>::try_from(result).unwrap()
 }
 
 // ── Insert with typed parameters ───────────────────────────────────────────
@@ -79,18 +75,19 @@ async fn test_insert_product() {
         "SELECT name, price, calories, is_deleted, inventory_stock FROM `ins_product` WHERE id = {}",
         "cupcake"
     );
-    let result = rows(db.execute(&select).await.unwrap());
+    let result = records(db.execute(&select).await.unwrap());
 
     assert_eq!(result.len(), 1);
 
-    let record: Record<JsonValue> = result[0].clone().into();
-    let product: Product = Product::from_record(record).unwrap();
-
-    assert_eq!(product.name, "Flux Cupcake");
-    assert_eq!(product.price, 120);
-    assert_eq!(product.calories, 300);
-    assert!(!product.is_deleted);
-    assert_eq!(product.inventory_stock, 50);
+    let row = &result[0];
+    assert_eq!(
+        row["name"].try_get::<String>(),
+        Some("Flux Cupcake".to_string())
+    );
+    assert_eq!(row["price"].try_get::<i64>(), Some(120));
+    assert_eq!(row["calories"].try_get::<i64>(), Some(300));
+    assert_eq!(row["is_deleted"].try_get::<bool>(), Some(false));
+    assert_eq!(row["inventory_stock"].try_get::<i64>(), Some(50));
 }
 
 // ── Insert multiple rows via nested expressions ───────────────────────────
@@ -138,23 +135,59 @@ async fn test_insert_multiple_products() {
     let select = mysql_expr!(
         "SELECT name, price, calories, is_deleted, inventory_stock FROM `ins_multi` ORDER BY price"
     );
-    let result = rows(db.execute(&select).await.unwrap());
+    let result = records(db.execute(&select).await.unwrap());
 
     assert_eq!(result.len(), 3);
 
-    let parsed: Vec<Product> = result
-        .into_iter()
-        .map(|r| Product::from_record(r.into()).unwrap())
-        .collect();
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("DeLorean Doughnut".to_string())
+    );
+    assert_eq!(result[0]["price"].try_get::<i64>(), Some(135));
+    assert_eq!(result[0]["is_deleted"].try_get::<bool>(), Some(false));
 
-    assert_eq!(parsed[0].name, "DeLorean Doughnut");
-    assert_eq!(parsed[0].price, 135);
-    assert!(!parsed[0].is_deleted);
+    assert_eq!(
+        result[2]["name"].try_get::<String>(),
+        Some("Sea Pie".to_string())
+    );
+    assert_eq!(result[2]["price"].try_get::<i64>(), Some(299));
+    assert_eq!(result[2]["is_deleted"].try_get::<bool>(), Some(true));
+    assert_eq!(result[2]["inventory_stock"].try_get::<i64>(), Some(0));
+}
 
-    assert_eq!(parsed[2].name, "Sea Pie");
-    assert_eq!(parsed[2].price, 299);
-    assert!(parsed[2].is_deleted);
-    assert_eq!(parsed[2].inventory_stock, 0);
+// ── Insert + round-trip via serde deserialization ──────────────────────────
+
+#[tokio::test]
+async fn test_insert_and_deserialize_product() {
+    let db = setup("ins_serde").await;
+
+    let insert = mysql_expr!(
+        "INSERT INTO `ins_serde` (`id`, `name`, `price`, `calories`, `is_deleted`, `inventory_stock`) VALUES ({}, {}, {}, {}, {}, {})",
+        "cupcake",
+        "Flux Cupcake",
+        120i64,
+        300i64,
+        false,
+        50i64
+    );
+    db.execute(&insert).await.unwrap();
+
+    let select = mysql_expr!(
+        "SELECT name, price, calories, is_deleted, inventory_stock FROM `ins_serde` WHERE id = {}",
+        "cupcake"
+    );
+
+    // Serde path: AnyMysqlType → JsonValue → Record<JsonValue> → Product
+    let json: serde_json::Value = db.execute(&select).await.unwrap().into();
+    let arr = json.as_array().unwrap();
+    let record: Record<serde_json::Value> = arr[0].clone().into();
+    let product: Product = Product::from_record(record).unwrap();
+
+    assert_eq!(product.name, "Flux Cupcake");
+    assert_eq!(product.price, 120);
+    assert_eq!(product.calories, 300);
+    assert!(!product.is_deleted);
+    assert_eq!(product.inventory_stock, 50);
 }
 
 // ── Type marker verification ────────────────────────────────────────────────
@@ -176,10 +209,13 @@ async fn test_bool_binds_correctly() {
 
     // Query with bool parameter — MySQL BOOLEAN is TINYINT(1)
     let select = mysql_expr!("SELECT name FROM `ins_bool` WHERE is_deleted = {}", true);
-    let result = rows(db.execute(&select).await.unwrap());
+    let result = records(db.execute(&select).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "Gone");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Gone".to_string())
+    );
 }
 
 #[tokio::test]
@@ -198,10 +234,10 @@ async fn test_integer_vs_text_binding() {
     db.execute(&insert).await.unwrap();
 
     let by_price = mysql_expr!("SELECT id FROM `ins_int_text` WHERE price = {}", 100i64);
-    let result = rows(db.execute(&by_price).await.unwrap());
+    let result = records(db.execute(&by_price).await.unwrap());
     assert_eq!(result.len(), 1);
 
     let by_name = mysql_expr!("SELECT id FROM `ins_int_text` WHERE name = {}", "Test");
-    let result = rows(db.execute(&by_name).await.unwrap());
+    let result = records(db.execute(&by_name).await.unwrap());
     assert_eq!(result.len(), 1);
 }

--- a/vantage-sql/tests/mysql/3_complex_queries.rs
+++ b/vantage-sql/tests/mysql/3_complex_queries.rs
@@ -32,8 +32,8 @@ async fn check_and_run<T: for<'de> Deserialize<'de>>(
 
     let db = get_db().await;
     let result = db.execute(&select.expr()).await.unwrap();
-    let rows = result.into_value();
-    let arr = rows.as_array().unwrap();
+    let json: serde_json::Value = result.into();
+    let arr = json.as_array().unwrap();
 
     let records: Vec<Record<serde_json::Value>> = arr.iter().map(|v| v.clone().into()).collect();
     records
@@ -606,8 +606,8 @@ async fn test_q8() {
 
     let db = get_db().await;
     let result = db.execute(&compound.expr()).await.unwrap();
-    let rows = result.into_value();
-    let arr = rows.as_array().unwrap();
+    let json: serde_json::Value = result.into();
+    let arr = json.as_array().unwrap();
 
     assert_eq!(
         compound.preview(),

--- a/vantage-sql/tests/mysql/3_complex_queries_my.rs
+++ b/vantage-sql/tests/mysql/3_complex_queries_my.rs
@@ -37,8 +37,8 @@ async fn check_and_run<T: for<'de> Deserialize<'de>>(
 
     let db = get_db().await;
     let result = db.execute(&select.expr()).await.unwrap();
-    let rows = result.into_value();
-    let arr = rows.as_array().unwrap();
+    let json: serde_json::Value = result.into();
+    let arr = json.as_array().unwrap();
 
     let records: Vec<Record<serde_json::Value>> = arr.iter().map(|v| v.clone().into()).collect();
     records

--- a/vantage-surrealdb/scripts/db/v2.surql
+++ b/vantage-surrealdb/scripts/db/v2.surql
@@ -38,6 +38,7 @@ DEFINE FIELD inventory.stock ON product TYPE int DEFAULT 0;
 
 -- Order table (schema-full with embedded line items)
 DEFINE TABLE order SCHEMAFULL;
+DEFINE FIELD client ON order TYPE record<client>; -- Direct link to client
 DEFINE FIELD bakery ON order TYPE record<bakery>; -- Direct link to bakery
 DEFINE FIELD is_deleted ON order TYPE bool DEFAULT false;
 DEFINE FIELD created_at ON order TYPE datetime DEFAULT time::now();
@@ -132,6 +133,7 @@ CREATE product:hover_cookies SET
 -- Create orders with embedded line items
 -- Order 1: Marty's order
 CREATE order:order1 SET
+    client = client:marty,
     bakery = bakery:hill_valley,
     lines = [
         {
@@ -153,6 +155,7 @@ CREATE order:order1 SET
 
 -- Order 2: Doc's order
 CREATE order:order2 SET
+    client = client:doc,
     bakery = bakery:hill_valley,
     lines = [
         {
@@ -164,6 +167,7 @@ CREATE order:order2 SET
 
 -- Order 3: Doc's second order
 CREATE order:order3 SET
+    client = client:doc,
     bakery = bakery:hill_valley,
     lines = [
         {

--- a/vantage-surrealdb/src/statements/select/impls/selectable.rs
+++ b/vantage-surrealdb/src/statements/select/impls/selectable.rs
@@ -1,6 +1,6 @@
 use crate::identifier::Identifier;
 use crate::sum::{Fx, Sum};
-use crate::{AnySurrealType, Expr, surreal_expr};
+use crate::{AnySurrealType, Expr};
 use vantage_expressions::result::QueryResult;
 use vantage_expressions::traits::expressive::Expressive;
 use vantage_expressions::traits::selectable::{Order, Selectable, SourceRef};
@@ -95,8 +95,14 @@ impl<T: QueryResult> Selectable<AnySurrealType> for SurrealSelect<T> {
     }
 
     fn as_count(&self) -> Expr {
-        let id_expr = surreal_expr!("id");
-        Fx::new("count", vec![id_expr]).into()
+        let mut count_select = self.clone();
+        count_select.fields.clear();
+        count_select
+            .fields
+            .push(SelectField::new(Identifier::new("id")));
+        count_select.order_by.clear();
+        let subquery = count_select.render();
+        Fx::new("count", vec![subquery]).into()
     }
 
     fn as_sum(&self, column: impl Expressive<AnySurrealType>) -> Expr {

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -398,6 +398,21 @@ impl TableSource for SurrealDB {
         tgt_col.in_(fk_values.expr())
     }
 
+    fn related_correlated_condition(
+        &self,
+        _target_table: &str,
+        target_field: &str,
+        _source_table: &str,
+        source_column: &str,
+    ) -> Self::Condition {
+        use crate::identifier::Parent;
+        crate::surreal_expr!(
+            "{} = {}",
+            (Identifier::new(target_field)),
+            (Parent::identifier().dot(source_column))
+        )
+    }
+
     fn column_table_values_expr<'a, E, Type: ColumnType>(
         &'a self,
         table: &Table<Self, E>,

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -2,12 +2,17 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use indexmap::IndexMap;
+use vantage_expressions::Expression;
 use vantage_types::Entity;
 
 use crate::{
     pagination::Pagination, references::Reference, sorting::SortDirection,
     traits::table_source::TableSource,
 };
+
+/// Type alias for expression closures stored on Table.
+pub type ExpressionFn<T, E> =
+    Arc<dyn Fn(&Table<T, E>) -> Expression<<T as TableSource>::Value> + Send + Sync>;
 
 #[derive(Clone)]
 pub struct Table<T, E>
@@ -24,6 +29,7 @@ where
     pub(super) order_by: IndexMap<i64, (T::Condition, SortDirection)>,
     pub(super) next_order_id: i64,
     pub(super) refs: Option<IndexMap<String, Arc<dyn Reference>>>,
+    pub(super) expressions: IndexMap<String, ExpressionFn<T, E>>,
     pub(super) pagination: Option<Pagination>,
     pub(super) title_field: Option<String>,
     pub(super) id_field: Option<String>,
@@ -42,6 +48,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             order_by: IndexMap::new(),
             next_order_id: 1,
             refs: None,
+            expressions: IndexMap::new(),
             pagination: None,
             title_field: None,
             id_field: None,
@@ -60,6 +67,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             order_by: self.order_by,
             next_order_id: self.next_order_id,
             refs: self.refs,
+            expressions: IndexMap::new(),
             pagination: self.pagination,
             title_field: self.title_field,
             id_field: self.id_field,
@@ -133,6 +141,7 @@ impl<T: TableSource, E: Entity<T::Value>> std::fmt::Debug for Table<T, E> {
                 "refs_count",
                 &self.refs.as_ref().map(|r| r.len()).unwrap_or(0),
             )
+            .field("expressions_count", &self.expressions.len())
             .finish()
     }
 }

--- a/vantage-table/src/table/impls/refereces.rs
+++ b/vantage-table/src/table/impls/refereces.rs
@@ -4,6 +4,7 @@ use indexmap::IndexMap;
 use std::sync::Arc;
 
 use vantage_core::{Result, error};
+use vantage_expressions::Expression;
 use vantage_types::Entity;
 
 use crate::{
@@ -153,6 +154,79 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
     pub fn get_ref(&self, relation: &str) -> Result<AnyTable> {
         let (reference, _) = self.lookup_ref(relation)?;
         reference.resolve_as_any(self as &dyn std::any::Any)
+    }
+
+    /// Get a correlated related table for use inside SELECT expressions.
+    ///
+    /// Unlike `get_ref_as` (which uses `IN (subquery)`), this produces a
+    /// correlated condition like `order.client_id = client.id`, suitable
+    /// for embedding as a subquery in a SELECT clause.
+    pub fn get_subquery_as<E2: Entity<T::Value> + 'static>(
+        &self,
+        relation: &str,
+    ) -> Result<Table<T, E2>> {
+        let (reference, relation_str) = self.lookup_ref(relation)?;
+
+        if reference.is_foreign() {
+            return Err(error!(
+                "Cannot use get_subquery_as for foreign references",
+                relation = relation_str.as_str()
+            ));
+        }
+
+        // 1. Build target
+        let source_id = self
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let mut target: Table<T, E2> = *reference
+            .build_target(self.data_source() as &dyn std::any::Any)
+            .downcast::<Table<T, E2>>()
+            .map_err(|_| {
+                error!(
+                    "Failed to downcast related table",
+                    relation = relation_str.as_str()
+                )
+            })?;
+
+        // 2. Get columns
+        let target_id = target
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let (src_col, tgt_col) = reference.columns(&source_id, &target_id);
+
+        // 3. Build correlated condition: target_table.tgt_col = source_table.src_col
+        let condition = self.data_source().related_correlated_condition(
+            target.table_name(),
+            &tgt_col,
+            self.table_name(),
+            &src_col,
+        );
+        target.add_condition(condition);
+
+        Ok(target)
+    }
+
+    /// Add a computed expression field using builder pattern.
+    ///
+    /// The closure receives `&Table<T, E>` and returns an `Expression<T::Value>`.
+    /// It is evaluated lazily when `select()` builds the query.
+    ///
+    /// ```rust,ignore
+    /// .with_expression("order_count", |t| {
+    ///     t.get_subquery_as::<Order>("orders").unwrap().get_count_query()
+    /// })
+    /// ```
+    pub fn with_expression(
+        mut self,
+        name: &str,
+        expr_fn: impl Fn(&Table<T, E>) -> Expression<T::Value> + Send + Sync + 'static,
+    ) -> Self {
+        self.expressions.insert(name.to_string(), Arc::new(expr_fn));
+        self
     }
 
     fn lookup_ref(&self, relation: &str) -> Result<(&dyn Reference, String)> {

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -1,6 +1,6 @@
 use vantage_core::Result;
 use vantage_expressions::traits::selectable::Selectable;
-use vantage_expressions::{Expression, Expressive, SelectableDataSource};
+use vantage_expressions::{Expression, Expressive, SelectableDataSource, expr_any};
 use vantage_types::Entity;
 
 use crate::{
@@ -21,14 +21,27 @@ where
         // Set the table as source
         select.add_source(self.table_name(), None);
 
-        // Add all columns as fields
+        // Add all columns as fields (or expressions if defined)
         for column in self.columns.values() {
-            match column.alias() {
-                Some(alias) => select.add_expression(
-                    self.data_source.expr(column.name(), vec![]),
-                    Some(alias.to_string()),
-                ),
-                None => select.add_field(column.name()),
+            if let Some(expr_fn) = self.expressions.get(column.name()) {
+                let expr = expr_fn(self);
+                select.add_expression(expr_any!("({})", (expr)), Some(column.name().to_string()));
+            } else {
+                match column.alias() {
+                    Some(alias) => select.add_expression(
+                        self.data_source.expr(column.name(), vec![]),
+                        Some(alias.to_string()),
+                    ),
+                    None => select.add_field(column.name()),
+                }
+            }
+        }
+
+        // Add expressions that don't correspond to any column
+        for (name, expr_fn) in &self.expressions {
+            if !self.columns.contains_key(name) {
+                let expr = expr_fn(self);
+                select.add_expression(expr_any!("({})", (expr)), Some(name.clone()));
             }
         }
 

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -235,6 +235,24 @@ pub trait TableSource: DataSource + Clone + 'static {
     where
         Self: Sized;
 
+    /// Build a correlated condition: `target_table.target_field = source_table.source_column`.
+    ///
+    /// Used by `get_subquery_as` for embedding correlated subqueries inside SELECT
+    /// expressions (e.g. `(SELECT COUNT(*) FROM order WHERE order.client_id = client.id)`).
+    ///
+    /// SQL backends produce table-qualified equality; non-SQL backends may not support
+    /// correlated subqueries and should leave the default (which panics).
+    fn related_correlated_condition(
+        &self,
+        target_table: &str,
+        target_field: &str,
+        source_table: &str,
+        source_column: &str,
+    ) -> Self::Condition {
+        let _ = (target_table, target_field, source_table, source_column);
+        unimplemented!("correlated subqueries not supported by this backend")
+    }
+
     /// Return an associated expression that, when resolved, yields all values
     /// of the given typed column from this table (respecting current conditions).
     ///


### PR DESCRIPTION
MySQL rows used to come back through `serde_json::Value`. That meant `DECIMAL` columns silently became `f64` (precision loss past 15 significant digits), `DATETIME` became an indistinguishable string, `BOOLEAN` was a number, and `BLOB` had to survive as base64-shaped text. If you were reading money or timestamps out of MySQL, you were already working around this.

Read-path values are now `ciborium::Value`. Type identity survives the round-trip from sqlx into `AnyMysqlType`:

```rust
match val.value() {
    CborValue::Tag(10, inner) => /* DECIMAL, original string preserved */,
    CborValue::Tag(0, inner)  => /* DATETIME / TIMESTAMP */,
    CborValue::Bytes(b)       => /* BLOB / VARBINARY */,
    CborValue::Bool(b)        => /* BOOLEAN — no longer aliased as TINYINT(1) */,
    ..
}
```

### What's preserved end-to-end

- `DECIMAL` / `NUMERIC` — `Tag(10, Text)`, original string representation, no `f64` narrowing.
- `DATETIME` / `TIMESTAMP` — `Tag(0, Text)`, distinct from a TEXT column.
- `DATE` — `Tag(100, Text)`. `TIME` — `Tag(101, Text)`.
- `BLOB` / `BINARY` / `VARBINARY` — native `CborValue::Bytes`.
- Unsigned integers (`BIGINT UNSIGNED` etc.) — full range via CBOR's integer model.

The tag numbers match SurrealDB's CBOR conventions where they overlap, so the two backends now speak the same dialect for the types they share.

### Why CBOR rather than sqlx-native types

The obvious alternative is to surface `rust_decimal::Decimal` / `chrono::NaiveDateTime` directly. That would force every value crossing the `AnyMysqlType` boundary to know about those concrete types, which breaks the universal value contract that `AnyType3`, `AnySurrealType` and friends already settle on. CBOR keeps `AnyMysqlType` a single carrier type with type identity preserved via tags — same shape as the SurrealDB backend.

### What changes for callers

If you read MySQL results via `AnyMysqlType::value()`, the inner type is now `ciborium::Value` rather than `serde_json::Value`. `try_get::<T>()` is unchanged. `From<JsonValue>` and `Into<JsonValue>` are still implemented for `AnyTable` interop — but tagged values lose their tag identity when crossing into JSON (a `DECIMAL` becomes a string, a `DATETIME` becomes a string), so prefer staying on the CBOR side when precision matters.

The JSON bridge stays in `types/value.rs` for now — it's load-bearing for code that builds `Record<serde_json::Value>` from a MySQL result. Removing it is a follow-up once the schemaless path is fully CBOR-aware.

First step in moving every SQL backend off `serde_json::Value` for reads. Postgres and SQLite follow in #186; the JSON bridge gets cleaned up after that.