### PR TITLE
move postgres to cbor

### DIFF
--- a/vantage-sql/src/mysql/row.rs
+++ b/vantage-sql/src/mysql/row.rs
@@ -35,12 +35,16 @@ pub(crate) fn bind_mysql_value<'q>(
         },
         Some(MysqlTypeVariants::Int2) => match cbor {
             CborValue::Null => query.bind(None::<i16>),
-            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as i16)),
+            CborValue::Integer(i) => {
+                query.bind(i64::try_from(*i).ok().and_then(|n| i16::try_from(n).ok()))
+            }
             _ => query.bind(None::<i16>),
         },
         Some(MysqlTypeVariants::Int4) => match cbor {
             CborValue::Null => query.bind(None::<i32>),
-            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as i32)),
+            CborValue::Integer(i) => {
+                query.bind(i64::try_from(*i).ok().and_then(|n| i32::try_from(n).ok()))
+            }
             _ => query.bind(None::<i32>),
         },
         Some(MysqlTypeVariants::Int8) => match cbor {

--- a/vantage-sql/src/mysql/types/value.rs
+++ b/vantage-sql/src/mysql/types/value.rs
@@ -47,7 +47,13 @@ impl std::fmt::Display for AnyMysqlType {
             CborValue::Null => write!(f, "NULL"),
             CborValue::Bool(b) => write!(f, "{}", b),
             CborValue::Integer(i) => write!(f, "{}", i128::from(*i)),
-            CborValue::Float(v) => write!(f, "{}", v),
+            CborValue::Float(v) => {
+                if v.fract() == 0.0 {
+                    write!(f, "{:.1}", v)
+                } else {
+                    write!(f, "{}", v)
+                }
+            }
             CborValue::Text(s) => write!(f, "'{}'", s.replace('\'', "''")),
             CborValue::Bytes(b) => write!(f, "x'{}'", hex::encode(b)),
             CborValue::Tag(10, inner) => {
@@ -186,7 +192,10 @@ fn cbor_to_json(val: CborValue) -> JsonValue {
             .map(JsonValue::Number)
             .unwrap_or(JsonValue::Null),
         CborValue::Text(s) => JsonValue::String(s),
-        CborValue::Bytes(b) => JsonValue::String(hex::encode(b)),
+        CborValue::Bytes(b) => match String::from_utf8(b) {
+            Ok(s) => JsonValue::String(s),
+            Err(e) => JsonValue::String(hex::encode(e.as_bytes())),
+        },
         CborValue::Array(arr) => JsonValue::Array(arr.into_iter().map(cbor_to_json).collect()),
         CborValue::Map(map) => {
             let obj: serde_json::Map<String, JsonValue> = map
@@ -203,9 +212,17 @@ fn cbor_to_json(val: CborValue) -> JsonValue {
         }
         // Tagged values: extract the inner value for JSON (tags have no JSON equivalent)
         CborValue::Tag(10, inner) => {
-            // Decimal — preserve as string
+            // Decimal — try to parse as JSON number, fall back to string
             if let CborValue::Text(s) = *inner {
-                JsonValue::String(s)
+                if let Ok(i) = s.parse::<i64>() {
+                    JsonValue::Number(i.into())
+                } else if let Ok(f) = s.parse::<f64>() {
+                    serde_json::Number::from_f64(f)
+                        .map(JsonValue::Number)
+                        .unwrap_or(JsonValue::String(s))
+                } else {
+                    JsonValue::String(s)
+                }
             } else {
                 cbor_to_json(*inner)
             }

--- a/vantage-sql/src/postgres/impls/expr_data_source.rs
+++ b/vantage-sql/src/postgres/impls/expr_data_source.rs
@@ -1,4 +1,4 @@
-use serde_json::Value as JsonValue;
+use ciborium::Value as CborValue;
 use vantage_expressions::traits::expressive::DeferredFn;
 use vantage_expressions::{Expression, ExpressionFlattener, ExpressiveEnum, Flatten};
 
@@ -11,7 +11,7 @@ impl vantage_expressions::ExprDataSource<AnyPostgresType> for PostgresDB {
         &self,
         expr: &Expression<AnyPostgresType>,
     ) -> vantage_core::Result<AnyPostgresType> {
-        // 1. Resolve deferred parameters (async -- may call other databases)
+        // 1. Resolve deferred parameters (async — may call other databases)
         let resolved = resolve_deferred(expr).await?;
 
         // 2. Flatten nested expressions + convert {} to $N (PostgreSQL uses $1, $2, ...)
@@ -27,22 +27,22 @@ impl vantage_expressions::ExprDataSource<AnyPostgresType> for PostgresDB {
             vantage_core::error!("PostgreSQL query failed", details = e.to_string())
         })?;
 
-        // 4. Convert rows to AnyPostgresType (untyped -- type_variant: None)
-        let arr: Vec<JsonValue> = rows
+        // 4. Convert rows to AnyPostgresType — each row becomes a CBOR Map
+        let arr: Vec<CborValue> = rows
             .iter()
             .map(|row| {
                 let record = row_to_record(row);
-                let json_map: serde_json::Map<String, JsonValue> = record
+                let map: Vec<(CborValue, CborValue)> = record
                     .into_iter()
-                    .map(|(k, v)| (k, v.into_value()))
+                    .map(|(k, v)| (CborValue::Text(k), v.into_value()))
                     .collect();
-                JsonValue::Object(json_map)
+                CborValue::Map(map)
             })
             .collect();
 
-        let json_arr = JsonValue::Array(arr);
-        Ok(AnyPostgresType::from_json(&json_arr)
-            .expect("JSON array should always convert to AnyPostgresType"))
+        let cbor_arr = CborValue::Array(arr);
+        Ok(AnyPostgresType::from_cbor(&cbor_arr)
+            .expect("CBOR array should always convert to AnyPostgresType"))
     }
 
     fn defer(&self, expr: Expression<AnyPostgresType>) -> DeferredFn<AnyPostgresType> {
@@ -52,16 +52,18 @@ impl vantage_expressions::ExprDataSource<AnyPostgresType> for PostgresDB {
             let expr = expr.clone();
             Box::pin(async move {
                 let result = vantage_expressions::ExprDataSource::execute(&db, &expr).await?;
-                let scalar = match result.value() {
-                    serde_json::Value::Array(arr) => arr
+                Ok(match result.value() {
+                    CborValue::Array(arr) => arr
                         .first()
-                        .and_then(|row| row.as_object())
-                        .and_then(|obj| obj.values().next())
-                        .map(|v| AnyPostgresType::untyped(v.clone()))
+                        .and_then(|row| match row {
+                            CborValue::Map(map) => map
+                                .first()
+                                .map(|(_, v)| AnyPostgresType::untyped(v.clone())),
+                            _ => None,
+                        })
                         .unwrap_or(result),
                     _ => result,
-                };
-                Ok(scalar)
+                })
             })
         })
     }

--- a/vantage-sql/src/postgres/impls/selectable_data_source.rs
+++ b/vantage-sql/src/postgres/impls/selectable_data_source.rs
@@ -21,7 +21,7 @@ impl SelectableDataSource<AnyPostgresType> for PostgresDB {
         let result = self.execute(&select.expr()).await?;
 
         match result.value() {
-            serde_json::Value::Array(arr) => Ok(arr
+            ciborium::Value::Array(arr) => Ok(arr
                 .iter()
                 .map(|v| AnyPostgresType::untyped(v.clone()))
                 .collect()),

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use ciborium::Value as CborValue;
 use indexmap::IndexMap;
 use vantage_core::{Result, error};
 use vantage_expressions::traits::associated_expressions::AssociatedExpression;
@@ -26,37 +27,47 @@ fn id_value(id: &str) -> AnyPostgresType {
     }
 }
 
-/// Parse the JSON array result from execute() into an IndexMap of id -> Record.
+/// Parse the CBOR array result from execute() into an IndexMap of id -> Record.
 fn parse_rows(
     result: AnyPostgresType,
     id_field_name: &str,
 ) -> Result<IndexMap<String, Record<AnyPostgresType>>> {
     let arr = match result.into_value() {
-        serde_json::Value::Array(arr) => arr,
-        other => return Err(error!("expected array result", details = other.to_string())),
+        CborValue::Array(arr) => arr,
+        other => {
+            return Err(error!(
+                "expected array result",
+                details = format!("{:?}", other)
+            ));
+        }
     };
 
     let mut records = IndexMap::new();
     for item in arr {
-        let obj = match item {
-            serde_json::Value::Object(map) => map,
+        let map = match item {
+            CborValue::Map(map) => map,
             _ => continue,
         };
 
-        let id = obj
-            .get(id_field_name)
-            .and_then(|v| match v {
-                serde_json::Value::String(s) => Some(s.clone()),
-                serde_json::Value::Number(n) => Some(n.to_string()),
-                _ => None,
-            })
-            .ok_or_else(|| error!("row missing id field", field = id_field_name))?;
+        let mut id = None;
+        let mut record = Record::new();
+        for (k, v) in map {
+            let key = match k {
+                CborValue::Text(s) => s,
+                _ => continue,
+            };
+            if key == id_field_name {
+                id = Some(match &v {
+                    CborValue::Text(s) => s.clone(),
+                    CborValue::Integer(i) => i128::from(*i).to_string(),
+                    CborValue::Float(f) => f.to_string(),
+                    _ => format!("{:?}", v),
+                });
+            }
+            record.insert(key, AnyPostgresType::untyped(v));
+        }
 
-        let record: Record<AnyPostgresType> = obj
-            .into_iter()
-            .map(|(k, v)| (k, AnyPostgresType::untyped(v)))
-            .collect();
-
+        let id = id.ok_or_else(|| error!("row missing id field", field = id_field_name))?;
         records.insert(id, record);
     }
 

--- a/vantage-sql/src/postgres/mod.rs
+++ b/vantage-sql/src/postgres/mod.rs
@@ -2,10 +2,11 @@
 mod macros;
 pub mod impls;
 mod operation;
-mod row;
+pub(crate) mod row;
 pub mod statements;
 pub mod types;
 
+use ciborium::Value as CborValue;
 use sqlx::postgres::PgPool;
 
 pub use types::{AnyPostgresType, PostgresType};
@@ -37,11 +38,14 @@ impl PostgresDB {
         let expr = select.as_aggregate(func, column);
         let result = self.execute(&expr).await?;
         Ok(match result.value() {
-            serde_json::Value::Array(arr) => arr
+            CborValue::Array(arr) => arr
                 .first()
-                .and_then(|row| row.as_object())
-                .and_then(|obj| obj.values().next())
-                .map(|v| AnyPostgresType::untyped(v.clone()))
+                .and_then(|row| match row {
+                    CborValue::Map(map) => map
+                        .first()
+                        .map(|(_, v)| AnyPostgresType::untyped(v.clone())),
+                    _ => None,
+                })
                 .unwrap_or(result),
             _ => result,
         })

--- a/vantage-sql/src/postgres/row.rs
+++ b/vantage-sql/src/postgres/row.rs
@@ -1,13 +1,14 @@
 //! Helpers for converting between sqlx rows/values and vantage types.
 //!
-//! **Writing** (bind): Takes `AnyPostgresType` with variant tags -- the variant
+//! **Writing** (bind): Takes `AnyPostgresType` with variant tags — the variant
 //! tells us exactly how to bind each value to sqlx.
 //!
-//! **Reading** (row): Returns `Record<AnyPostgresType>` with `type_variant: None`.
-//! The values are marker-less -- `try_get` will attempt conversion without
-//! variant enforcement, and struct deserialization validates the actual types.
+//! **Reading** (row): Returns `Record<AnyPostgresType>` with variant inferred from
+//! the PostgreSQL column type. Values are stored as `ciborium::Value` (CBOR) for
+//! lossless type preservation — decimals stay as tagged strings, datetimes
+//! keep their type identity, booleans aren't confused with integers.
 
-use serde_json::Value as JsonValue;
+use ciborium::Value as CborValue;
 use sqlx::postgres::PgRow;
 use sqlx::{Column, Row, TypeInfo};
 use vantage_types::Record;
@@ -15,100 +16,197 @@ use vantage_types::Record;
 use super::types::{AnyPostgresType, PostgresTypeVariants};
 
 /// Bind an AnyPostgresType to a sqlx query. Uses the variant tag to pick
-/// the right sqlx bind type -- no guessing from the JSON number format.
+/// the right sqlx bind type — no guessing from the CBOR value format.
 pub(crate) fn bind_postgres_value<'q>(
     query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
     value: &'q AnyPostgresType,
 ) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
-    let json = value.value();
+    let cbor = value.value();
     match value.type_variant() {
         Some(PostgresTypeVariants::Null) => query.bind(None::<String>),
-        // Untyped values (from deferred results, database reads) -- infer from JSON
-        None => bind_by_json(query, json),
-        Some(PostgresTypeVariants::Bool) => match json {
-            JsonValue::Null => query.bind(None::<bool>),
-            JsonValue::Bool(b) => query.bind(*b),
-            JsonValue::Number(n) => match n.as_i64() {
-                Some(i) => query.bind(i != 0),
-                None => query.bind(None::<bool>),
+        None => bind_by_cbor(query, cbor),
+        Some(PostgresTypeVariants::Bool) => match cbor {
+            CborValue::Null => query.bind(None::<bool>),
+            CborValue::Bool(b) => query.bind(*b),
+            CborValue::Integer(i) => match i64::try_from(*i) {
+                Ok(n) => query.bind(n != 0),
+                Err(_) => query.bind(None::<bool>),
             },
             _ => query.bind(None::<bool>),
         },
-        Some(PostgresTypeVariants::Int2) => match json {
-            JsonValue::Null => query.bind(None::<i16>),
-            JsonValue::Number(n) => query.bind(n.as_i64().map(|i| i as i16)),
+        Some(PostgresTypeVariants::Int2) => match cbor {
+            CborValue::Null => query.bind(None::<i16>),
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as i16)),
             _ => query.bind(None::<i16>),
         },
-        Some(PostgresTypeVariants::Int4) => match json {
-            JsonValue::Null => query.bind(None::<i32>),
-            JsonValue::Number(n) => query.bind(n.as_i64().map(|i| i as i32)),
+        Some(PostgresTypeVariants::Int4) => match cbor {
+            CborValue::Null => query.bind(None::<i32>),
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as i32)),
             _ => query.bind(None::<i32>),
         },
-        Some(PostgresTypeVariants::Int8) => match json {
-            JsonValue::Null => query.bind(None::<i64>),
-            JsonValue::Number(n) => query.bind(n.as_i64()),
+        Some(PostgresTypeVariants::Int8) => match cbor {
+            CborValue::Null => query.bind(None::<i64>),
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok()),
             _ => query.bind(None::<i64>),
         },
-        Some(PostgresTypeVariants::Float4) => match json {
-            JsonValue::Null => query.bind(None::<f32>),
-            JsonValue::Number(n) => query.bind(n.as_f64().map(|f| f as f32)),
+        Some(PostgresTypeVariants::Float4) => match cbor {
+            CborValue::Null => query.bind(None::<f32>),
+            CborValue::Float(f) => query.bind(*f as f32),
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as f32)),
             _ => query.bind(None::<f32>),
         },
-        Some(PostgresTypeVariants::Float8) => match json {
-            JsonValue::Null => query.bind(None::<f64>),
-            JsonValue::Number(n) => query.bind(n.as_f64()),
+        Some(PostgresTypeVariants::Float8) => match cbor {
+            CborValue::Null => query.bind(None::<f64>),
+            CborValue::Float(f) => query.bind(*f),
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as f64)),
             _ => query.bind(None::<f64>),
         },
-        Some(PostgresTypeVariants::Text) => match json {
-            JsonValue::Null => query.bind(None::<String>),
-            JsonValue::String(s) => query.bind(s.as_str()),
+        Some(PostgresTypeVariants::Text) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Text(s) => query.bind(s.as_str()),
             _ => query.bind(None::<String>),
+        },
+        Some(PostgresTypeVariants::Decimal) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Tag(10, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    query.bind(s.as_str())
+                } else {
+                    query.bind(None::<String>)
+                }
+            }
+            CborValue::Text(s) => query.bind(s.as_str()),
+            _ => query.bind(None::<String>),
+        },
+        Some(PostgresTypeVariants::DateTime) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Tag(0, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    query.bind(s.as_str())
+                } else {
+                    query.bind(None::<String>)
+                }
+            }
+            CborValue::Text(s) => query.bind(s.as_str()),
+            _ => query.bind(None::<String>),
+        },
+        Some(PostgresTypeVariants::Date) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Tag(100, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    query.bind(s.as_str())
+                } else {
+                    query.bind(None::<String>)
+                }
+            }
+            CborValue::Text(s) => query.bind(s.as_str()),
+            _ => query.bind(None::<String>),
+        },
+        Some(PostgresTypeVariants::Time) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Tag(101, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    query.bind(s.as_str())
+                } else {
+                    query.bind(None::<String>)
+                }
+            }
+            CborValue::Text(s) => query.bind(s.as_str()),
+            _ => query.bind(None::<String>),
+        },
+        Some(PostgresTypeVariants::Uuid) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Tag(9, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    query.bind(s.as_str())
+                } else {
+                    query.bind(None::<String>)
+                }
+            }
+            CborValue::Text(s) => query.bind(s.as_str()),
+            _ => query.bind(None::<String>),
+        },
+        Some(PostgresTypeVariants::Blob) => match cbor {
+            CborValue::Null => query.bind(None::<Vec<u8>>),
+            CborValue::Bytes(b) => query.bind(b.as_slice()),
+            CborValue::Text(s) => query.bind(s.as_bytes()),
+            _ => query.bind(None::<Vec<u8>>),
         },
     }
 }
 
-/// Bind a JSON value without type variant -- infers the bind type from the value itself.
-fn bind_by_json<'q>(
+/// Bind a CBOR value without type variant — infers from the value itself.
+fn bind_by_cbor<'q>(
     query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
-    json: &'q JsonValue,
+    cbor: &'q CborValue,
 ) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
-    match json {
-        JsonValue::Null => query.bind(None::<String>),
-        JsonValue::Bool(b) => query.bind(*b),
-        JsonValue::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                query.bind(i)
-            } else if let Some(f) = n.as_f64() {
-                query.bind(f)
+    match cbor {
+        CborValue::Null => query.bind(None::<String>),
+        CborValue::Bool(b) => query.bind(*b),
+        CborValue::Integer(i) => {
+            if let Ok(n) = i64::try_from(*i) {
+                query.bind(n)
             } else {
-                query.bind(n.to_string())
+                query.bind(i128::from(*i).to_string())
             }
         }
-        JsonValue::String(s) => query.bind(s.as_str()),
-        other => query.bind(other.to_string()),
+        CborValue::Float(f) => query.bind(*f),
+        CborValue::Text(s) => query.bind(s.as_str()),
+        CborValue::Bytes(b) => query.bind(b.as_slice()),
+        CborValue::Tag(10, inner) => {
+            // Decimal — bind as string, PostgreSQL will coerce
+            if let CborValue::Text(s) = inner.as_ref() {
+                query.bind(s.as_str())
+            } else {
+                query.bind(None::<String>)
+            }
+        }
+        CborValue::Tag(0 | 100 | 101, inner) => {
+            // DateTime / Date / Time — bind as string
+            if let CborValue::Text(s) = inner.as_ref() {
+                query.bind(s.as_str())
+            } else {
+                query.bind(None::<String>)
+            }
+        }
+        CborValue::Tag(9, inner) => {
+            // UUID — bind as string
+            if let CborValue::Text(s) = inner.as_ref() {
+                query.bind(s.as_str())
+            } else {
+                query.bind(None::<String>)
+            }
+        }
+        _ => query.bind(None::<String>),
     }
 }
 
 /// Convert a PgRow to Record<AnyPostgresType>.
 ///
-/// Each value has `type_variant: None` -- the database doesn't preserve our
-/// type markers. This means `try_get` on these values bypasses variant
-/// checking and just attempts the conversion.
+/// Each value is stored as CBOR with the type variant inferred from the
+/// PostgreSQL column type, preserving full type fidelity.
 pub(crate) fn row_to_record(row: &PgRow) -> Record<AnyPostgresType> {
     let mut record = Record::new();
     for col in row.columns() {
         let name = col.name().to_string();
         let type_name = col.type_info().name();
-        let json = pg_column_to_json(row, col.ordinal(), type_name);
-        let value = AnyPostgresType::untyped(json);
+        let (cbor, variant) = pg_column_to_cbor(row, col.ordinal(), type_name);
+        let value = match variant {
+            Some(v) => AnyPostgresType::with_variant(cbor, v),
+            None => AnyPostgresType::untyped(cbor),
+        };
         record.insert(name, value);
     }
     record
 }
 
-/// Read a single column from a PostgreSQL row as JsonValue.
-/// Uses the declared column type to pick the right extraction method.
-fn pg_column_to_json(row: &PgRow, ordinal: usize, type_name: &str) -> JsonValue {
+/// Read a single column from a PostgreSQL row as CborValue, returning both the
+/// value and the detected type variant.
+fn pg_column_to_cbor(
+    row: &PgRow,
+    ordinal: usize,
+    type_name: &str,
+) -> (CborValue, Option<PostgresTypeVariants>) {
     use sqlx::ValueRef;
 
     if row
@@ -116,100 +214,129 @@ fn pg_column_to_json(row: &PgRow, ordinal: usize, type_name: &str) -> JsonValue 
         .map(|v| v.is_null())
         .unwrap_or(true)
     {
-        return JsonValue::Null;
+        return (CborValue::Null, Some(PostgresTypeVariants::Null));
     }
 
     match type_name {
         "BOOL" => {
             if let Ok(v) = row.try_get::<bool, _>(ordinal) {
-                return JsonValue::Bool(v);
+                return (CborValue::Bool(v), Some(PostgresTypeVariants::Bool));
             }
         }
         "INT2" | "SMALLINT" | "SMALLSERIAL" => {
             if let Ok(v) = row.try_get::<i16, _>(ordinal) {
-                return JsonValue::Number((v as i64).into());
+                return (
+                    CborValue::Integer((v as i64).into()),
+                    Some(PostgresTypeVariants::Int2),
+                );
             }
         }
         "INT4" | "INT" | "INTEGER" | "SERIAL" => {
             if let Ok(v) = row.try_get::<i32, _>(ordinal) {
-                return JsonValue::Number((v as i64).into());
+                return (
+                    CborValue::Integer((v as i64).into()),
+                    Some(PostgresTypeVariants::Int4),
+                );
             }
         }
         "INT8" | "BIGINT" | "BIGSERIAL" => {
             if let Ok(v) = row.try_get::<i64, _>(ordinal) {
-                return JsonValue::Number(v.into());
+                return (
+                    CborValue::Integer(v.into()),
+                    Some(PostgresTypeVariants::Int8),
+                );
             }
         }
         "FLOAT4" | "REAL" => {
-            if let Ok(v) = row.try_get::<f32, _>(ordinal)
-                && let Some(n) = serde_json::Number::from_f64(v as f64)
-            {
-                return JsonValue::Number(n);
+            if let Ok(v) = row.try_get::<f32, _>(ordinal) {
+                return (
+                    CborValue::Float(v as f64),
+                    Some(PostgresTypeVariants::Float4),
+                );
             }
         }
         "FLOAT8" | "DOUBLE PRECISION" => {
-            if let Ok(v) = row.try_get::<f64, _>(ordinal)
-                && let Some(n) = serde_json::Number::from_f64(v)
-            {
-                return JsonValue::Number(n);
+            if let Ok(v) = row.try_get::<f64, _>(ordinal) {
+                return (CborValue::Float(v), Some(PostgresTypeVariants::Float8));
             }
         }
         "NUMERIC" | "DECIMAL" => {
-            // PostgreSQL NUMERIC: decode via rust_decimal, then convert
-            // to JSON number. Integer values are exact; decimals go through
-            // f64 which may lose precision for very large or high-scale values.
+            // Lossless: store decimal as Tag(10, Text("..."))
             if let Ok(v) = row.try_get::<rust_decimal::Decimal, _>(ordinal) {
-                use rust_decimal::prelude::ToPrimitive;
-                if v.scale() == 0
-                    && let Some(i) = v.to_i64()
-                {
-                    return JsonValue::Number(i.into());
-                }
-                if let Some(f) = v.to_f64()
-                    && let Some(n) = serde_json::Number::from_f64(f)
-                {
-                    return JsonValue::Number(n);
-                }
+                return (
+                    CborValue::Tag(10, Box::new(CborValue::Text(v.to_string()))),
+                    Some(PostgresTypeVariants::Decimal),
+                );
             }
         }
-        // -- PostgreSQL-specific types --
+        // -- PostgreSQL array types --
         "_TEXT" | "TEXT[]" => {
             if let Ok(v) = row.try_get::<Vec<String>, _>(ordinal) {
-                return JsonValue::Array(v.into_iter().map(JsonValue::String).collect());
+                return (
+                    CborValue::Array(v.into_iter().map(CborValue::Text).collect()),
+                    Some(PostgresTypeVariants::Text),
+                );
             }
         }
         "_INT4" | "INT4[]" | "INTEGER[]" => {
             if let Ok(v) = row.try_get::<Vec<i32>, _>(ordinal) {
-                return JsonValue::Array(
-                    v.into_iter()
-                        .map(|i| JsonValue::Number((i as i64).into()))
-                        .collect(),
+                return (
+                    CborValue::Array(
+                        v.into_iter()
+                            .map(|i| CborValue::Integer((i as i64).into()))
+                            .collect(),
+                    ),
+                    Some(PostgresTypeVariants::Int4),
                 );
             }
         }
         "UUID" => {
             if let Ok(v) = row.try_get::<uuid::Uuid, _>(ordinal) {
-                return JsonValue::String(v.to_string());
+                return (
+                    CborValue::Tag(9, Box::new(CborValue::Text(v.to_string()))),
+                    Some(PostgresTypeVariants::Uuid),
+                );
             }
         }
         "DATE" => {
             if let Ok(v) = row.try_get::<chrono::NaiveDate, _>(ordinal) {
-                return JsonValue::String(v.format("%Y-%m-%d").to_string());
+                return (
+                    CborValue::Tag(
+                        100,
+                        Box::new(CborValue::Text(v.format("%Y-%m-%d").to_string())),
+                    ),
+                    Some(PostgresTypeVariants::Date),
+                );
             }
         }
         "TIMESTAMPTZ" | "TIMESTAMP WITH TIME ZONE" => {
             if let Ok(v) = row.try_get::<chrono::DateTime<chrono::Utc>, _>(ordinal) {
-                return JsonValue::String(v.to_rfc3339());
+                return (
+                    CborValue::Tag(0, Box::new(CborValue::Text(v.to_rfc3339()))),
+                    Some(PostgresTypeVariants::DateTime),
+                );
             }
         }
         "TIMESTAMP" | "TIMESTAMP WITHOUT TIME ZONE" => {
             if let Ok(v) = row.try_get::<chrono::NaiveDateTime, _>(ordinal) {
-                return JsonValue::String(v.format("%Y-%m-%dT%H:%M:%S").to_string());
+                return (
+                    CborValue::Tag(
+                        0,
+                        Box::new(CborValue::Text(v.format("%Y-%m-%dT%H:%M:%S").to_string())),
+                    ),
+                    Some(PostgresTypeVariants::DateTime),
+                );
             }
         }
         "JSONB" | "JSON" => {
             if let Ok(v) = row.try_get::<serde_json::Value, _>(ordinal) {
-                return v;
+                let cbor = json_value_to_cbor(v);
+                return (cbor, Some(PostgresTypeVariants::Text));
+            }
+        }
+        "BYTEA" => {
+            if let Ok(v) = row.try_get::<Vec<u8>, _>(ordinal) {
+                return (CborValue::Bytes(v), Some(PostgresTypeVariants::Blob));
             }
         }
         _ => {}
@@ -217,22 +344,60 @@ fn pg_column_to_json(row: &PgRow, ordinal: usize, type_name: &str) -> JsonValue 
 
     // Fallback: try common types in order
     if let Ok(v) = row.try_get::<bool, _>(ordinal) {
-        return JsonValue::Bool(v);
+        return (CborValue::Bool(v), Some(PostgresTypeVariants::Bool));
     }
     if let Ok(v) = row.try_get::<i64, _>(ordinal) {
-        return JsonValue::Number(v.into());
+        return (
+            CborValue::Integer(v.into()),
+            Some(PostgresTypeVariants::Int8),
+        );
     }
     if let Ok(v) = row.try_get::<i32, _>(ordinal) {
-        return JsonValue::Number((v as i64).into());
+        return (
+            CborValue::Integer((v as i64).into()),
+            Some(PostgresTypeVariants::Int4),
+        );
     }
-    if let Ok(v) = row.try_get::<f64, _>(ordinal)
-        && let Some(n) = serde_json::Number::from_f64(v)
-    {
-        return JsonValue::Number(n);
+    if let Ok(v) = row.try_get::<f64, _>(ordinal) {
+        return (CborValue::Float(v), Some(PostgresTypeVariants::Float8));
     }
     if let Ok(v) = row.try_get::<String, _>(ordinal) {
-        return JsonValue::String(v);
+        return (CborValue::Text(v), Some(PostgresTypeVariants::Text));
     }
 
-    JsonValue::Null
+    // Intentional: surface decode failures so missing type handlers are noticed early.
+    eprintln!(
+        "vantage: failed to decode PostgreSQL column '{}' (type '{}') — returning NULL",
+        row.columns()[ordinal].name(),
+        type_name,
+    );
+    (CborValue::Null, Some(PostgresTypeVariants::Null))
+}
+
+/// Convert a serde_json::Value to CborValue (used for JSON/JSONB columns).
+fn json_value_to_cbor(val: serde_json::Value) -> CborValue {
+    match val {
+        serde_json::Value::Null => CborValue::Null,
+        serde_json::Value::Bool(b) => CborValue::Bool(b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                CborValue::Integer(i.into())
+            } else if let Some(u) = n.as_u64() {
+                CborValue::Integer(u.into())
+            } else if let Some(f) = n.as_f64() {
+                CborValue::Float(f)
+            } else {
+                CborValue::Text(n.to_string())
+            }
+        }
+        serde_json::Value::String(s) => CborValue::Text(s),
+        serde_json::Value::Array(arr) => {
+            CborValue::Array(arr.into_iter().map(json_value_to_cbor).collect())
+        }
+        serde_json::Value::Object(map) => CborValue::Map(
+            map.into_iter()
+                .map(|(k, v)| (CborValue::Text(k), json_value_to_cbor(v)))
+                .collect(),
+        ),
+    }
 }

--- a/vantage-sql/src/postgres/row.rs
+++ b/vantage-sql/src/postgres/row.rs
@@ -36,12 +36,16 @@ pub(crate) fn bind_postgres_value<'q>(
         },
         Some(PostgresTypeVariants::Int2) => match cbor {
             CborValue::Null => query.bind(None::<i16>),
-            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as i16)),
+            CborValue::Integer(i) => {
+                query.bind(i64::try_from(*i).ok().and_then(|n| i16::try_from(n).ok()))
+            }
             _ => query.bind(None::<i16>),
         },
         Some(PostgresTypeVariants::Int4) => match cbor {
             CborValue::Null => query.bind(None::<i32>),
-            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as i32)),
+            CborValue::Integer(i) => {
+                query.bind(i64::try_from(*i).ok().and_then(|n| i32::try_from(n).ok()))
+            }
             _ => query.bind(None::<i32>),
         },
         Some(PostgresTypeVariants::Int8) => match cbor {

--- a/vantage-sql/src/postgres/types/bool.rs
+++ b/vantage-sql/src/postgres/types/bool.rs
@@ -2,19 +2,19 @@
 //! PostgreSQL has native BOOLEAN type (unlike SQLite's 0/1).
 
 use super::{PostgresType, PostgresTypeBoolMarker};
-use serde_json::Value;
+use ciborium::Value;
 
 impl PostgresType for bool {
     type Target = PostgresTypeBoolMarker;
 
-    fn to_json(&self) -> Value {
+    fn to_cbor(&self) -> Value {
         Value::Bool(*self)
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
             Value::Bool(b) => Some(b),
-            Value::Number(n) => n.as_i64().map(|i| i != 0),
+            Value::Integer(i) => i64::try_from(i).ok().map(|n| n != 0),
             _ => None,
         }
     }

--- a/vantage-sql/src/postgres/types/mod.rs
+++ b/vantage-sql/src/postgres/types/mod.rs
@@ -1,51 +1,58 @@
 //! PostgreSQL Type System
 //!
-//! Defines type variants aligned with PostgreSQL's type system:
+//! Uses `ciborium::Value` as the underlying value type for lossless storage.
+//! CBOR tags follow SurrealDB conventions where they overlap:
+//!   Tag(0)   = DateTime (RFC 3339)
+//!   Tag(10)  = Decimal (string representation)
+//!   Tag(100) = Date (YYYY-MM-DD string)
+//!   Tag(101) = Time (HH:MM:SS string)
+//!   Tag(9)   = UUID (string representation)
 //!
-//! - Bool       : BOOLEAN
-//! - Int2       : SMALLINT, INT2
-//! - Int4       : INTEGER, INT, INT4
-//! - Int8       : BIGINT, INT8
-//! - Float4     : REAL, FLOAT4
-//! - Float8     : DOUBLE PRECISION, FLOAT8
-//! - Text       : TEXT, VARCHAR(N), CHAR(N), NAME
-//!
-//! Uses `serde_json::Value` as the underlying value type with type variant
-//! tracking to prevent silent type confusion.
+//! Type variants track the original PostgreSQL column type so that bind and
+//! entity deserialization can reconstruct the correct Rust type.
 
-use serde_json::Value;
 use vantage_types::vantage_type_system;
 
 vantage_type_system! {
     type_trait: PostgresType,
-    method_name: json,
-    value_type: serde_json::Value,
+    method_name: cbor,
+    value_type: ciborium::Value,
     type_variants: [
         Null,
-        Bool,       // bool
-        Int2,       // i16
-        Int4,       // i32
-        Int8,       // i64
-        Float4,     // f32
-        Float8,     // f64
-        Text        // String, &str
+        Bool,       // BOOLEAN
+        Int2,       // SMALLINT, INT2
+        Int4,       // INTEGER, INT, INT4, SERIAL
+        Int8,       // BIGINT, INT8, BIGSERIAL
+        Float4,     // REAL, FLOAT4
+        Float8,     // DOUBLE PRECISION, FLOAT8
+        Text,       // TEXT, VARCHAR, CHAR, NAME
+        Decimal,    // NUMERIC, DECIMAL
+        DateTime,   // TIMESTAMPTZ, TIMESTAMP
+        Date,       // DATE
+        Time,       // TIME
+        Uuid,       // UUID
+        Blob        // BYTEA
     ]
 }
 
 impl PostgresTypeVariants {
-    /// Detect the type variant from a JSON value.
-    pub fn from_json(value: &Value) -> Option<Self> {
+    /// Detect the type variant from a CBOR value.
+    pub fn from_cbor(value: &ciborium::Value) -> Option<Self> {
+        use ciborium::Value::*;
+
         match value {
-            Value::Null => Some(Self::Null),
-            Value::Bool(_) => Some(Self::Bool),
-            Value::Number(n) => {
-                if n.is_i64() || n.is_u64() {
-                    Some(Self::Int8)
-                } else {
-                    Some(Self::Float8)
-                }
-            }
-            Value::String(_) => Some(Self::Text),
+            Null => Some(Self::Null),
+            Bool(_) => Some(Self::Bool),
+            Integer(_) => Some(Self::Int8),
+            Float(_) => Some(Self::Float8),
+            Text(_) => Some(Self::Text),
+            Bytes(_) => Some(Self::Blob),
+            Tag(0, _) => Some(Self::DateTime),
+            Tag(9, _) => Some(Self::Uuid),
+            Tag(10, _) => Some(Self::Decimal),
+            Tag(100, _) => Some(Self::Date),
+            Tag(101, _) => Some(Self::Time),
+            Tag(_, inner) => Self::from_cbor(inner),
             _ => None,
         }
     }
@@ -86,17 +93,16 @@ mod tests {
         let val = AnyPostgresType::new(true);
         assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Bool));
         assert_eq!(val.try_get::<bool>(), Some(true));
-        // Bool is a distinct variant — i64 extraction blocked by type boundary
         assert_eq!(val.try_get::<i64>(), None);
     }
 
     #[test]
     fn test_null_round_trip() {
         let val = AnyPostgresType::new(None::<i64>);
-        assert_eq!(*val.value(), serde_json::Value::Null);
+        assert_eq!(*val.value(), ciborium::Value::Null);
         assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Int8));
 
-        let direct = <Option<i64> as PostgresType>::from_json(serde_json::Value::Null);
+        let direct = <Option<i64> as PostgresType>::from_cbor(ciborium::Value::Null);
         assert_eq!(direct, Some(None));
 
         assert_eq!(val.try_get::<Option<i64>>(), Some(None));
@@ -132,5 +138,56 @@ mod tests {
         let val = AnyPostgresType::new(42i16);
         assert_eq!(val.type_variant(), Some(PostgresTypeVariants::Int2));
         assert_eq!(val.try_get::<i16>(), Some(42));
+    }
+
+    #[test]
+    fn test_untyped_integer_try_get() {
+        let val = AnyPostgresType::untyped(ciborium::Value::Integer(42.into()));
+        assert_eq!(val.try_get::<i64>(), Some(42));
+        assert_eq!(val.try_get::<i32>(), Some(42));
+    }
+
+    #[test]
+    fn test_untyped_text_try_get() {
+        let val = AnyPostgresType::untyped(ciborium::Value::Text("world".into()));
+        assert_eq!(val.try_get::<String>(), Some("world".to_string()));
+    }
+
+    #[test]
+    fn test_untyped_decimal_tag() {
+        let val = AnyPostgresType::untyped(ciborium::Value::Tag(
+            10,
+            Box::new(ciborium::Value::Text("123.456".into())),
+        ));
+        assert_eq!(
+            PostgresTypeVariants::from_cbor(val.value()),
+            Some(PostgresTypeVariants::Decimal)
+        );
+    }
+
+    #[test]
+    fn test_untyped_datetime_tag() {
+        let val = AnyPostgresType::untyped(ciborium::Value::Tag(
+            0,
+            Box::new(ciborium::Value::Text("2024-01-15T10:30:00".into())),
+        ));
+        assert_eq!(
+            PostgresTypeVariants::from_cbor(val.value()),
+            Some(PostgresTypeVariants::DateTime)
+        );
+    }
+
+    #[test]
+    fn test_untyped_uuid_tag() {
+        let val = AnyPostgresType::untyped(ciborium::Value::Tag(
+            9,
+            Box::new(ciborium::Value::Text(
+                "550e8400-e29b-41d4-a716-446655440000".into(),
+            )),
+        ));
+        assert_eq!(
+            PostgresTypeVariants::from_cbor(val.value()),
+            Some(PostgresTypeVariants::Uuid)
+        );
     }
 }

--- a/vantage-sql/src/postgres/types/numbers.rs
+++ b/vantage-sql/src/postgres/types/numbers.rs
@@ -1,31 +1,28 @@
 //! Numeric type implementations for PostgreSQL.
 //!
-//! - i16 -> Int2 (SMALLINT)
-//! - i32 -> Int4 (INTEGER)
-//! - i64 -> Int8 (BIGINT)
-//! - f32 -> Float4 (REAL)
-//! - f64 -> Float8 (DOUBLE PRECISION)
-//! - i8, u8, u16, u32 -> mapped to appropriate integer variants
+//! Uses ciborium::Value (CBOR) as the underlying storage:
+//! - Integers → CborValue::Integer
+//! - Floats → CborValue::Float
 //! - Option<T> delegates to T, with Null for None
 
 use super::{
     PostgresType, PostgresTypeFloat4Marker, PostgresTypeFloat8Marker, PostgresTypeInt2Marker,
     PostgresTypeInt4Marker, PostgresTypeInt8Marker,
 };
-use serde_json::Value;
+use ciborium::Value;
 
 // -- i16 -> Int2 (SMALLINT) ---------------------------------------------------
 
 impl PostgresType for i16 {
     type Target = PostgresTypeInt2Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| i16::try_from(i).ok()),
+            Value::Integer(i) => i16::try_from(i).ok(),
             _ => None,
         }
     }
@@ -36,13 +33,13 @@ impl PostgresType for i16 {
 impl PostgresType for i32 {
     type Target = PostgresTypeInt4Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| i32::try_from(i).ok()),
+            Value::Integer(i) => i32::try_from(i).ok(),
             _ => None,
         }
     }
@@ -53,30 +50,30 @@ impl PostgresType for i32 {
 impl PostgresType for i64 {
     type Target = PostgresTypeInt8Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64(),
+            Value::Integer(i) => i64::try_from(i).ok(),
             _ => None,
         }
     }
 }
 
-// -- Smaller unsigned integers mapped to appropriate Postgres types -----------
+// -- Smaller integer types mapped to appropriate PostgreSQL variants -----------
 
 impl PostgresType for i8 {
     type Target = PostgresTypeInt2Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| i8::try_from(i).ok()),
+            Value::Integer(i) => i8::try_from(i).ok(),
             _ => None,
         }
     }
@@ -85,13 +82,13 @@ impl PostgresType for i8 {
 impl PostgresType for u8 {
     type Target = PostgresTypeInt2Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| u8::try_from(i).ok()),
+            Value::Integer(i) => u8::try_from(i).ok(),
             _ => None,
         }
     }
@@ -100,13 +97,13 @@ impl PostgresType for u8 {
 impl PostgresType for u16 {
     type Target = PostgresTypeInt4Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| u16::try_from(i).ok()),
+            Value::Integer(i) => u16::try_from(i).ok(),
             _ => None,
         }
     }
@@ -115,13 +112,13 @@ impl PostgresType for u16 {
 impl PostgresType for u32 {
     type Target = PostgresTypeInt8Marker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| u32::try_from(i).ok()),
+            Value::Integer(i) => u32::try_from(i).ok(),
             _ => None,
         }
     }
@@ -132,15 +129,14 @@ impl PostgresType for u32 {
 impl PostgresType for f32 {
     type Target = PostgresTypeFloat4Marker;
 
-    fn to_json(&self) -> Value {
-        serde_json::Number::from_f64(*self as f64)
-            .map(Value::Number)
-            .unwrap_or(Value::Null)
+    fn to_cbor(&self) -> Value {
+        Value::Float((*self) as f64)
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_f64().map(|f| f as f32),
+            Value::Float(f) => Some(f as f32),
+            Value::Integer(i) => i64::try_from(i).ok().map(|n| n as f32),
             _ => None,
         }
     }
@@ -149,15 +145,14 @@ impl PostgresType for f32 {
 impl PostgresType for f64 {
     type Target = PostgresTypeFloat8Marker;
 
-    fn to_json(&self) -> Value {
-        serde_json::Number::from_f64(*self)
-            .map(Value::Number)
-            .unwrap_or(Value::Null)
+    fn to_cbor(&self) -> Value {
+        Value::Float(*self)
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_f64(),
+            Value::Float(f) => Some(f),
+            Value::Integer(i) => i64::try_from(i).ok().map(|n| n as f64),
             _ => None,
         }
     }
@@ -168,17 +163,17 @@ impl PostgresType for f64 {
 impl<T: PostgresType> PostgresType for Option<T> {
     type Target = T::Target;
 
-    fn to_json(&self) -> Value {
+    fn to_cbor(&self) -> Value {
         match self {
-            Some(v) => v.to_json(),
+            Some(v) => v.to_cbor(),
             None => Value::Null,
         }
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
             Value::Null => Some(None),
-            other => T::from_json(other).map(Some),
+            other => T::from_cbor(other).map(Some),
         }
     }
 }

--- a/vantage-sql/src/postgres/types/string.rs
+++ b/vantage-sql/src/postgres/types/string.rs
@@ -1,18 +1,18 @@
 //! String types -> PostgreSQL TEXT
 
 use super::{PostgresType, PostgresTypeTextMarker};
-use serde_json::Value;
+use ciborium::Value;
 
 impl PostgresType for String {
     type Target = PostgresTypeTextMarker;
 
-    fn to_json(&self) -> Value {
-        Value::String(self.clone())
+    fn to_cbor(&self) -> Value {
+        Value::Text(self.clone())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::String(s) => Some(s),
+            Value::Text(s) => Some(s),
             _ => None,
         }
     }
@@ -21,11 +21,11 @@ impl PostgresType for String {
 impl PostgresType for &'static str {
     type Target = PostgresTypeTextMarker;
 
-    fn to_json(&self) -> Value {
-        Value::String(self.to_string())
+    fn to_cbor(&self) -> Value {
+        Value::Text(self.to_string())
     }
 
-    fn from_json(_value: Value) -> Option<Self> {
+    fn from_cbor(_value: Value) -> Option<Self> {
         None // cannot produce &'static str from arbitrary data
     }
 }

--- a/vantage-sql/src/postgres/types/value.rs
+++ b/vantage-sql/src/postgres/types/value.rs
@@ -1,17 +1,29 @@
-//! AnyPostgresType extras: From conversions, Display, Expressive.
+//! AnyPostgresType extras: From conversions, Display, Expressive, TryFrom.
+//!
+//! Uses ciborium::Value (CBOR) as the underlying value type.
 
-use super::{AnyPostgresType, PostgresType, PostgresTypeNullMarker};
-use serde_json::Value;
+use super::{AnyPostgresType, PostgresType, PostgresTypeNullMarker, PostgresTypeVariants};
+use ciborium::Value as CborValue;
+use serde_json::Value as JsonValue;
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
 impl AnyPostgresType {
     /// Create an AnyPostgresType with no type marker. Used for values coming
     /// back from the database where we don't know the original type.
     /// `try_get` on these values bypasses variant checking.
-    pub fn untyped(value: serde_json::Value) -> Self {
+    pub fn untyped(value: CborValue) -> Self {
         Self {
             value,
             type_variant: None,
+        }
+    }
+
+    /// Create an AnyPostgresType with an explicit type variant.
+    /// Used by row_to_record where the PostgreSQL column type is known.
+    pub fn with_variant(value: CborValue, variant: PostgresTypeVariants) -> Self {
+        Self {
+            value,
+            type_variant: Some(variant),
         }
     }
 }
@@ -20,28 +32,91 @@ impl AnyPostgresType {
 impl PostgresType for AnyPostgresType {
     type Target = PostgresTypeNullMarker;
 
-    fn to_json(&self) -> Value {
+    fn to_cbor(&self) -> CborValue {
         self.value().clone()
     }
 
-    fn from_json(value: Value) -> Option<Self> {
-        AnyPostgresType::from_json(&value)
+    fn from_cbor(value: CborValue) -> Option<Self> {
+        AnyPostgresType::from_cbor(&value)
     }
 }
 
 impl std::fmt::Display for AnyPostgresType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.value() {
-            Value::Null => write!(f, "NULL"),
-            Value::Bool(b) => write!(f, "{}", b),
-            Value::Number(n) => write!(f, "{}", n),
-            Value::String(s) => write!(f, "'{}'", s.replace('\'', "''")),
-            other => write!(f, "{}", other),
+            CborValue::Null => write!(f, "NULL"),
+            CborValue::Bool(b) => write!(f, "{}", b),
+            CborValue::Integer(i) => write!(f, "{}", i128::from(*i)),
+            CborValue::Float(v) => {
+                if v.fract() == 0.0 {
+                    write!(f, "{:.1}", v)
+                } else {
+                    write!(f, "{}", v)
+                }
+            }
+            CborValue::Text(s) => write!(f, "'{}'", s.replace('\'', "''")),
+            CborValue::Bytes(b) => write!(f, "\\x{}", hex::encode(b)),
+            CborValue::Tag(10, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    write!(f, "{}", s)
+                } else {
+                    write!(f, "{:?}", inner)
+                }
+            }
+            CborValue::Tag(9, inner) => {
+                // UUID
+                if let CborValue::Text(s) = inner.as_ref() {
+                    write!(f, "'{}'", s)
+                } else {
+                    write!(f, "{:?}", inner)
+                }
+            }
+            CborValue::Tag(0, inner) | CborValue::Tag(100, inner) | CborValue::Tag(101, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    write!(f, "'{}'", s)
+                } else {
+                    write!(f, "{:?}", inner)
+                }
+            }
+            CborValue::Array(arr) => {
+                write!(f, "[")?;
+                for (i, item) in arr.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    if let Some(any) = AnyPostgresType::from_cbor(item) {
+                        write!(f, "{}", any)?;
+                    } else {
+                        write!(f, "{:?}", item)?;
+                    }
+                }
+                write!(f, "]")
+            }
+            CborValue::Map(map) => {
+                write!(f, "{{")?;
+                for (i, (k, v)) in map.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    let key_str = match k {
+                        CborValue::Text(s) => s.clone(),
+                        _ => format!("{:?}", k),
+                    };
+                    if let Some(any) = AnyPostgresType::from_cbor(v) {
+                        write!(f, "{}: {}", key_str, any)?;
+                    } else {
+                        write!(f, "{}: {:?}", key_str, v)?;
+                    }
+                }
+                write!(f, "}}")
+            }
+            other => write!(f, "{:?}", other),
         }
     }
 }
 
-// From impls for common types
+// -- From impls for common types ----------------------------------------------
+
 macro_rules! impl_from_for_any_postgres {
     ($($ty:ty),*) => {
         $(
@@ -62,7 +137,108 @@ impl From<&str> for AnyPostgresType {
     }
 }
 
-// Expressive impls -- allows passing scalars directly into postgres_expr!
+// -- JSON <-> CBOR bridge (for AnyTable interop) ------------------------------
+
+impl From<JsonValue> for AnyPostgresType {
+    fn from(val: JsonValue) -> Self {
+        if val.is_null() {
+            return AnyPostgresType::untyped(CborValue::Null);
+        }
+        let cbor = json_to_cbor(val);
+        AnyPostgresType::from_cbor(&cbor).expect("json_to_cbor produced unconvertible CBOR")
+    }
+}
+
+impl From<AnyPostgresType> for JsonValue {
+    fn from(val: AnyPostgresType) -> Self {
+        cbor_to_json(val.into_value())
+    }
+}
+
+fn json_to_cbor(val: JsonValue) -> CborValue {
+    match val {
+        JsonValue::Null => CborValue::Null,
+        JsonValue::Bool(b) => CborValue::Bool(b),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                CborValue::Integer(i.into())
+            } else if let Some(u) = n.as_u64() {
+                CborValue::Integer(u.into())
+            } else if let Some(f) = n.as_f64() {
+                CborValue::Float(f)
+            } else {
+                CborValue::Text(n.to_string())
+            }
+        }
+        JsonValue::String(s) => CborValue::Text(s),
+        JsonValue::Array(arr) => CborValue::Array(arr.into_iter().map(json_to_cbor).collect()),
+        JsonValue::Object(map) => CborValue::Map(
+            map.into_iter()
+                .map(|(k, v)| (CborValue::Text(k), json_to_cbor(v)))
+                .collect(),
+        ),
+    }
+}
+
+fn cbor_to_json(val: CborValue) -> JsonValue {
+    match val {
+        CborValue::Null => JsonValue::Null,
+        CborValue::Bool(b) => JsonValue::Bool(b),
+        CborValue::Integer(i) => {
+            let n = i128::from(i);
+            if let Ok(v) = i64::try_from(n) {
+                JsonValue::Number(v.into())
+            } else if let Ok(v) = u64::try_from(n) {
+                JsonValue::Number(v.into())
+            } else {
+                JsonValue::String(n.to_string())
+            }
+        }
+        CborValue::Float(f) => serde_json::Number::from_f64(f)
+            .map(JsonValue::Number)
+            .unwrap_or(JsonValue::Null),
+        CborValue::Text(s) => JsonValue::String(s),
+        CborValue::Bytes(b) => match String::from_utf8(b) {
+            Ok(s) => JsonValue::String(s),
+            Err(e) => JsonValue::String(hex::encode(e.as_bytes())),
+        },
+        CborValue::Array(arr) => JsonValue::Array(arr.into_iter().map(cbor_to_json).collect()),
+        CborValue::Map(map) => {
+            let obj: serde_json::Map<String, JsonValue> = map
+                .into_iter()
+                .map(|(k, v)| {
+                    let key = match k {
+                        CborValue::Text(s) => s,
+                        other => format!("{:?}", other),
+                    };
+                    (key, cbor_to_json(v))
+                })
+                .collect();
+            JsonValue::Object(obj)
+        }
+        CborValue::Tag(10, inner) => {
+            // Decimal — try to parse as JSON number, fall back to string
+            if let CborValue::Text(s) = *inner {
+                if let Ok(i) = s.parse::<i64>() {
+                    JsonValue::Number(i.into())
+                } else if let Ok(f) = s.parse::<f64>() {
+                    serde_json::Number::from_f64(f)
+                        .map(JsonValue::Number)
+                        .unwrap_or(JsonValue::String(s))
+                } else {
+                    JsonValue::String(s)
+                }
+            } else {
+                cbor_to_json(*inner)
+            }
+        }
+        CborValue::Tag(_, inner) => cbor_to_json(*inner),
+        _ => JsonValue::Null,
+    }
+}
+
+// -- Expressive impls ---------------------------------------------------------
+
 macro_rules! impl_expressive_for_postgres_scalar {
     ($($ty:ty),*) => {
         $(
@@ -91,25 +267,30 @@ impl Expressive<AnyPostgresType> for &str {
     }
 }
 
-// TryFrom<AnyPostgresType> impls -- enables AssociatedExpression::get()
+impl Expressive<AnyPostgresType> for AnyPostgresType {
+    fn expr(&self) -> Expression<AnyPostgresType> {
+        Expression::new("{}", vec![ExpressiveEnum::Scalar(self.clone())])
+    }
+}
+
+// -- TryFrom impls (for AssociatedExpression::get()) --------------------------
+
 macro_rules! impl_try_from_postgres {
     ($($ty:ty),*) => {
         $(
             impl TryFrom<AnyPostgresType> for $ty {
                 type Error = vantage_core::VantageError;
                 fn try_from(val: AnyPostgresType) -> Result<Self, Self::Error> {
-                    // Try direct extraction first
                     if let Some(v) = val.try_get::<$ty>() {
                         return Ok(v);
                     }
                     // If result is [{col: value}], extract the scalar
-                    if let serde_json::Value::Array(arr) = val.value() {
+                    if let CborValue::Array(ref arr) = *val.value() {
                         if arr.len() == 1 {
-                            if let Some(obj) = arr[0].as_object() {
-                                if obj.len() == 1 {
-                                    let inner = AnyPostgresType::untyped(
-                                        obj.values().next().unwrap().clone()
-                                    );
+                            if let CborValue::Map(ref map) = arr[0] {
+                                if map.len() == 1 {
+                                    let (_, v) = &map[0];
+                                    let inner = AnyPostgresType::untyped(v.clone());
                                     if let Some(v) = inner.try_get::<$ty>() {
                                         return Ok(v);
                                     }
@@ -130,23 +311,26 @@ macro_rules! impl_try_from_postgres {
 
 impl_try_from_postgres!(i64, i32, f64, bool, String);
 
-/// Extract first row from a result array as a JSON object.
-fn extract_first_row(val: &AnyPostgresType) -> Option<serde_json::Value> {
+/// Extract first row from a CBOR result array as a map.
+fn extract_first_row(val: &AnyPostgresType) -> Option<CborValue> {
     match val.value() {
-        serde_json::Value::Array(arr) => arr.first().cloned(),
-        obj @ serde_json::Value::Object(_) => Some(obj.clone()),
+        CborValue::Array(arr) => arr.first().cloned(),
+        obj @ CborValue::Map(_) => Some(obj.clone()),
         _ => None,
     }
 }
 
-impl TryFrom<AnyPostgresType> for vantage_types::Record<serde_json::Value> {
-    type Error = vantage_core::VantageError;
-    fn try_from(val: AnyPostgresType) -> Result<Self, Self::Error> {
-        let row = extract_first_row(&val).ok_or_else(|| {
-            vantage_core::error!("Expected row result", value = format!("{}", val))
-        })?;
-        Ok(row.into())
-    }
+/// Convert a CBOR Map into a Record<AnyPostgresType>.
+fn cbor_map_to_record(map: Vec<(CborValue, CborValue)>) -> vantage_types::Record<AnyPostgresType> {
+    map.into_iter()
+        .map(|(k, v)| {
+            let key = match k {
+                CborValue::Text(s) => s,
+                other => format!("{:?}", other),
+            };
+            (key, AnyPostgresType::untyped(v))
+        })
+        .collect()
 }
 
 impl TryFrom<AnyPostgresType> for vantage_types::Record<AnyPostgresType> {
@@ -156,20 +340,86 @@ impl TryFrom<AnyPostgresType> for vantage_types::Record<AnyPostgresType> {
             vantage_core::error!("Expected row result", value = format!("{}", val))
         })?;
         match row {
-            serde_json::Value::Object(map) => Ok(map
-                .into_iter()
-                .map(|(k, v)| (k, AnyPostgresType::untyped(v)))
-                .collect()),
+            CborValue::Map(map) => Ok(cbor_map_to_record(map)),
             _ => Err(vantage_core::error!(
-                "Expected object row",
+                "Expected map row",
                 value = format!("{:?}", row)
             )),
         }
     }
 }
 
-impl Expressive<AnyPostgresType> for AnyPostgresType {
-    fn expr(&self) -> Expression<AnyPostgresType> {
-        Expression::new("{}", vec![ExpressiveEnum::Scalar(self.clone())])
+impl TryFrom<AnyPostgresType> for Vec<vantage_types::Record<AnyPostgresType>> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnyPostgresType) -> Result<Self, Self::Error> {
+        match val.into_value() {
+            CborValue::Array(arr) => arr
+                .into_iter()
+                .map(|item| match item {
+                    CborValue::Map(map) => Ok(cbor_map_to_record(map)),
+                    other => Err(vantage_core::error!(
+                        "Expected map row",
+                        value = format!("{:?}", other)
+                    )),
+                })
+                .collect(),
+            CborValue::Map(map) => Ok(vec![cbor_map_to_record(map)]),
+            other => Err(vantage_core::error!(
+                "Expected array or map result",
+                value = format!("{:?}", other)
+            )),
+        }
+    }
+}
+
+impl TryFrom<AnyPostgresType> for vantage_types::Record<serde_json::Value> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnyPostgresType) -> Result<Self, Self::Error> {
+        let record: vantage_types::Record<AnyPostgresType> = val.try_into()?;
+        Ok(record
+            .into_iter()
+            .map(|(k, v)| (k, cbor_to_json(v.into_value())))
+            .collect())
+    }
+}
+
+impl vantage_types::TerminalRender for AnyPostgresType {
+    fn render(&self) -> String {
+        match self.value() {
+            CborValue::Null => "-".to_string(),
+            CborValue::Text(s) => s.clone(),
+            CborValue::Bool(b) => b.to_string(),
+            CborValue::Tag(10, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    s.clone()
+                } else {
+                    format!("{}", self)
+                }
+            }
+            CborValue::Tag(0, inner) | CborValue::Tag(100, inner) | CborValue::Tag(101, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    s.clone()
+                } else {
+                    format!("{}", self)
+                }
+            }
+            CborValue::Tag(9, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    s.clone()
+                } else {
+                    format!("{}", self)
+                }
+            }
+            _ => format!("{}", self),
+        }
+    }
+
+    fn color_hint(&self) -> Option<&'static str> {
+        match self.value() {
+            CborValue::Bool(true) => Some("green"),
+            CborValue::Bool(false) => Some("red"),
+            CborValue::Null => Some("dim"),
+            _ => None,
+        }
     }
 }

--- a/vantage-sql/tests/postgres/1_types_record.rs
+++ b/vantage-sql/tests/postgres/1_types_record.rs
@@ -1,6 +1,10 @@
 //! Test 1b: Record<AnyPostgresType> conversions — typed (write path) and
 //! untyped (read path) round-trips, error cases.
+//!
+//! Uses native CborValue for untyped values (simulating database reads)
+//! instead of the JSON bridge.
 
+use ciborium::Value as CborValue;
 use vantage_sql::postgres::AnyPostgresType;
 use vantage_types::Record;
 
@@ -14,7 +18,6 @@ fn test_typed_record_creation() {
     record.insert("price".into(), AnyPostgresType::new(120i64));
     record.insert("is_deleted".into(), AnyPostgresType::new(false));
 
-    // Values carry their type markers
     assert_eq!(
         record["name"].try_get::<String>(),
         Some("Cupcake".to_string())
@@ -52,18 +55,17 @@ fn test_untyped_record_creation() {
     let mut record: Record<AnyPostgresType> = Record::new();
     record.insert(
         "name".into(),
-        AnyPostgresType::untyped(serde_json::json!("Cupcake")),
+        AnyPostgresType::untyped(CborValue::Text("Cupcake".into())),
     );
     record.insert(
         "price".into(),
-        AnyPostgresType::untyped(serde_json::json!(120)),
+        AnyPostgresType::untyped(CborValue::Integer(120.into())),
     );
     record.insert(
         "active".into(),
-        AnyPostgresType::untyped(serde_json::json!(true)),
+        AnyPostgresType::untyped(CborValue::Bool(true)),
     );
 
-    // Untyped values — try_get just attempts the conversion
     assert_eq!(
         record["name"].try_get::<String>(),
         Some("Cupcake".to_string())
@@ -72,19 +74,15 @@ fn test_untyped_record_creation() {
     assert_eq!(record["active"].try_get::<bool>(), Some(true));
 
     // Still fails when the underlying value can't convert
-    assert_eq!(record["name"].try_get::<i64>(), None); // "Cupcake" isn't a number
-    assert_eq!(record["price"].try_get::<String>(), None); // 120 isn't a string
+    assert_eq!(record["name"].try_get::<i64>(), None);
+    assert_eq!(record["price"].try_get::<String>(), None);
 }
 
 #[test]
 fn test_untyped_null() {
     let mut record: Record<AnyPostgresType> = Record::new();
-    record.insert(
-        "note".into(),
-        AnyPostgresType::untyped(serde_json::json!(null)),
-    );
+    record.insert("note".into(), AnyPostgresType::untyped(CborValue::Null));
 
-    // Untyped null → Option<String> works (no variant blocking it)
     assert_eq!(record["note"].try_get::<Option<String>>(), Some(None));
     assert_eq!(record["note"].try_get::<Option<i64>>(), Some(None));
 }
@@ -98,35 +96,89 @@ fn test_typed_blocks_cross_variant() {
     assert_eq!(typed.try_get::<i64>(), Some(42));
     assert_eq!(typed.try_get::<f64>(), None); // Int8 ≠ Float8 → blocked
 
-    // Untyped: same JSON value but no variant
-    let untyped = AnyPostgresType::untyped(serde_json::json!(42));
+    // Untyped: same CBOR value but no variant — permissive
+    let untyped = AnyPostgresType::untyped(CborValue::Integer(42.into()));
     assert_eq!(untyped.try_get::<i64>(), Some(42));
 }
 
 #[test]
-fn test_untyped_is_permissive_across_numeric() {
-    // Untyped integer: try_get as f64 works because json Number can be read as f64
-    let untyped = AnyPostgresType::untyped(serde_json::json!(42));
-    assert_eq!(untyped.try_get::<i64>(), Some(42));
-    assert_eq!(untyped.try_get::<f64>(), Some(42.0));
-
-    // Typed integer: f64 blocked by variant
-    let typed = AnyPostgresType::new(42i64);
-    assert_eq!(typed.try_get::<f64>(), None); // Int8 ≠ Float8
+fn test_untyped_integer_narrowing() {
+    let val = AnyPostgresType::untyped(CborValue::Integer(42.into()));
+    assert_eq!(val.try_get::<i64>(), Some(42));
+    assert_eq!(val.try_get::<i32>(), Some(42));
+    assert_eq!(val.try_get::<i16>(), Some(42));
 }
 
-// ── PostgreSQL-specific: bool stored natively ──────────────────────────────
+// ── CBOR tag preservation ─────────────────────────────────────────────────
+
+#[test]
+fn test_decimal_tag_preserved() {
+    let val = AnyPostgresType::untyped(CborValue::Tag(
+        10,
+        Box::new(CborValue::Text("123.456".into())),
+    ));
+    // Decimal tag should be detectable
+    assert_eq!(
+        *val.value(),
+        CborValue::Tag(10, Box::new(CborValue::Text("123.456".into())))
+    );
+}
+
+#[test]
+fn test_datetime_tag_preserved() {
+    let val = AnyPostgresType::untyped(CborValue::Tag(
+        0,
+        Box::new(CborValue::Text("2024-01-15T10:30:00".into())),
+    ));
+    assert_eq!(
+        *val.value(),
+        CborValue::Tag(0, Box::new(CborValue::Text("2024-01-15T10:30:00".into())))
+    );
+}
+
+// ── Bool stored natively ──────────────────────────────────────────────────
 
 #[test]
 fn test_typed_bool_in_record() {
     let mut record: Record<AnyPostgresType> = Record::new();
     record.insert("active".into(), AnyPostgresType::new(true));
 
-    // PostgreSQL stores bool as native JSON bool, not as 0/1
-    assert_eq!(*record["active"].value(), serde_json::json!(true));
+    assert_eq!(*record["active"].value(), CborValue::Bool(true));
     assert_eq!(record["active"].try_get::<bool>(), Some(true));
     // Bool ≠ Int8 → blocked
     assert_eq!(record["active"].try_get::<i64>(), None);
+}
+
+// ── JSON bridge round-trip ────────────────────────────────────────────────
+
+#[test]
+fn test_json_round_trip_integer() {
+    let original = AnyPostgresType::new(42i64);
+    let json: serde_json::Value = original.clone().into();
+    assert_eq!(json, serde_json::json!(42));
+
+    let restored = AnyPostgresType::from(json);
+    assert_eq!(restored.try_get::<i64>(), Some(42));
+}
+
+#[test]
+fn test_json_round_trip_string() {
+    let original = AnyPostgresType::new("hello".to_string());
+    let json: serde_json::Value = original.into();
+    assert_eq!(json, serde_json::json!("hello"));
+
+    let restored = AnyPostgresType::from(json);
+    assert_eq!(restored.try_get::<String>(), Some("hello".to_string()));
+}
+
+#[test]
+fn test_json_round_trip_bool() {
+    let original = AnyPostgresType::new(true);
+    let json: serde_json::Value = original.into();
+    assert_eq!(json, serde_json::json!(true));
+
+    let restored = AnyPostgresType::from(json);
+    assert_eq!(restored.try_get::<bool>(), Some(true));
 }
 
 // ── Error cases ────────────────────────────────────────────────────────────

--- a/vantage-sql/tests/postgres/2_defer.rs
+++ b/vantage-sql/tests/postgres/2_defer.rs
@@ -3,18 +3,15 @@
 //! A deferred expression runs a query on one database at execution time,
 //! and the resulting value gets placed as a parameter in another database's query.
 
-use serde_json::Value as JsonValue;
 use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
 use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_sql::postgres_expr;
+use vantage_types::Record;
 
-const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5432/vantage";
 
-fn rows(result: AnyPostgresType) -> Vec<JsonValue> {
-    match result.into_value() {
-        JsonValue::Array(arr) => arr,
-        other => panic!("expected array, got: {:?}", other),
-    }
+fn records(result: AnyPostgresType) -> Vec<Record<AnyPostgresType>> {
+    Vec::<Record<AnyPostgresType>>::try_from(result).unwrap()
 }
 
 async fn setup(prefix: &str) -> (PostgresDB, PostgresDB) {
@@ -24,24 +21,24 @@ async fn setup(prefix: &str) -> (PostgresDB, PostgresDB) {
     let config_table = format!("{}_config", prefix);
     let product_table = format!("{}_product", prefix);
 
-    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", config_table))
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", config_table))
         .execute(db.pool())
         .await
         .unwrap();
-    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", product_table))
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", product_table))
         .execute(db.pool())
         .await
         .unwrap();
 
     sqlx::query(&format!(
-        "CREATE TABLE \"{}\" (key TEXT PRIMARY KEY, value BIGINT NOT NULL)",
+        "CREATE TABLE `{}` (`key` VARCHAR(255) PRIMARY KEY, value BIGINT NOT NULL)",
         config_table
     ))
     .execute(db.pool())
     .await
     .unwrap();
     sqlx::query(&format!(
-        "INSERT INTO \"{}\" VALUES ('min_price', 150)",
+        "INSERT INTO `{}` VALUES ('min_price', 150)",
         config_table
     ))
     .execute(db.pool())
@@ -49,14 +46,14 @@ async fn setup(prefix: &str) -> (PostgresDB, PostgresDB) {
     .unwrap();
 
     sqlx::query(&format!(
-        "CREATE TABLE \"{}\" (id TEXT PRIMARY KEY, name TEXT NOT NULL, price BIGINT NOT NULL)",
+        "CREATE TABLE `{}` (id VARCHAR(255) PRIMARY KEY, name TEXT NOT NULL, price BIGINT NOT NULL)",
         product_table
     ))
     .execute(db.pool())
     .await
     .unwrap();
     sqlx::query(&format!(
-        "INSERT INTO \"{}\" VALUES ('a', 'Cheap Thing', 50), ('b', 'Mid Thing', 150), ('c', 'Expensive Thing', 300)",
+        "INSERT INTO `{}` VALUES ('a', 'Cheap Thing', 50), ('b', 'Mid Thing', 150), ('c', 'Expensive Thing', 300)",
         product_table
     ))
     .execute(db.pool())
@@ -74,21 +71,27 @@ async fn test_cross_database_deferred() {
     let (config_db, shop_db) = setup("defer1").await;
 
     let threshold_query = postgres_expr!(
-        "SELECT value FROM \"defer1_config\" WHERE key = {}",
+        "SELECT value FROM `defer1_config` WHERE `key` = {}",
         "min_price"
     );
     let deferred_threshold = config_db.defer(threshold_query);
 
     let shop_query = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM \"defer1_product\" WHERE price >= {} ORDER BY price",
+        "SELECT name FROM `defer1_product` WHERE price >= {} ORDER BY price",
         vec![ExpressiveEnum::Deferred(deferred_threshold)],
     );
 
-    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+    let result = records(shop_db.execute(&shop_query).await.unwrap());
 
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0]["name"], "Mid Thing");
-    assert_eq!(result[1]["name"], "Expensive Thing");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Mid Thing".to_string())
+    );
+    assert_eq!(
+        result[1]["name"].try_get::<String>(),
+        Some("Expensive Thing".to_string())
+    );
 }
 
 // ── Deferred mixed with regular scalar parameters ──────────────────────────
@@ -98,23 +101,26 @@ async fn test_deferred_mixed_with_scalars() {
     let (config_db, shop_db) = setup("defer2").await;
 
     let threshold_query = postgres_expr!(
-        "SELECT value FROM \"defer2_config\" WHERE key = {}",
+        "SELECT value FROM `defer2_config` WHERE `key` = {}",
         "min_price"
     );
     let deferred_threshold = config_db.defer(threshold_query);
 
     let shop_query = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM \"defer2_product\" WHERE price >= {} AND name != {} ORDER BY price",
+        "SELECT name FROM `defer2_product` WHERE price >= {} AND name != {} ORDER BY price",
         vec![
             ExpressiveEnum::Deferred(deferred_threshold),
             ExpressiveEnum::Scalar(AnyPostgresType::new("Mid Thing".to_string())),
         ],
     );
 
-    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+    let result = records(shop_db.execute(&shop_query).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "Expensive Thing");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Expensive Thing".to_string())
+    );
 }
 
 // ── Deferred inside a nested expression ───────────────────────────────────
@@ -124,7 +130,7 @@ async fn test_nested_deferred() {
     let (config_db, shop_db) = setup("defer3").await;
 
     let threshold_query = postgres_expr!(
-        "SELECT value FROM \"defer3_config\" WHERE key = {}",
+        "SELECT value FROM `defer3_config` WHERE `key` = {}",
         "min_price"
     );
     let deferred_threshold = config_db.defer(threshold_query);
@@ -135,13 +141,19 @@ async fn test_nested_deferred() {
     );
 
     let shop_query = postgres_expr!(
-        "SELECT name FROM \"defer3_product\" WHERE {} ORDER BY price",
+        "SELECT name FROM `defer3_product` WHERE {} ORDER BY price",
         (inner)
     );
 
-    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+    let result = records(shop_db.execute(&shop_query).await.unwrap());
 
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0]["name"], "Mid Thing");
-    assert_eq!(result[1]["name"], "Expensive Thing");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Mid Thing".to_string())
+    );
+    assert_eq!(
+        result[1]["name"].try_get::<String>(),
+        Some("Expensive Thing".to_string())
+    );
 }

--- a/vantage-sql/tests/postgres/2_expressions.rs
+++ b/vantage-sql/tests/postgres/2_expressions.rs
@@ -1,25 +1,25 @@
 //! Test 2: ExprDataSource — execute Expression<AnyPostgresType> against live PostgreSQL.
 
-use serde_json::Value as JsonValue;
 use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
 use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
+use vantage_types::Record;
 
-const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5432/vantage";
 
 async fn setup(table: &str) -> PostgresDB {
     let db = PostgresDB::connect(PG_URL).await.unwrap();
 
-    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", table))
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", table))
         .execute(db.pool())
         .await
         .unwrap();
 
     sqlx::query(&format!(
-        "CREATE TABLE \"{}\" (
+        "CREATE TABLE `{}` (
             id INTEGER PRIMARY KEY,
             name TEXT NOT NULL,
             price BIGINT NOT NULL,
-            weight DOUBLE PRECISION NOT NULL,
+            weight DOUBLE NOT NULL,
             active BOOLEAN NOT NULL
         )",
         table
@@ -29,7 +29,7 @@ async fn setup(table: &str) -> PostgresDB {
     .unwrap();
 
     sqlx::query(&format!(
-        "INSERT INTO \"{}\" VALUES (1, 'Apple', 100, 0.2, true), (2, 'Banana', 50, 0.15, true), (3, 'Cherry', 200, 0.01, false)",
+        "INSERT INTO `{}` VALUES (1, 'Apple', 100, 0.2, true), (2, 'Banana', 50, 0.15, true), (3, 'Cherry', 200, 0.01, false)",
         table
     ))
     .execute(db.pool())
@@ -39,12 +39,9 @@ async fn setup(table: &str) -> PostgresDB {
     db
 }
 
-/// Helper: unwrap result into JSON array of row objects.
-fn rows(result: AnyPostgresType) -> Vec<JsonValue> {
-    match result.into_value() {
-        JsonValue::Array(arr) => arr,
-        other => panic!("expected array, got: {:?}", other),
-    }
+/// Helper: unwrap result into Vec of Record<AnyPostgresType>.
+fn records(result: AnyPostgresType) -> Vec<Record<AnyPostgresType>> {
+    Vec::<Record<AnyPostgresType>>::try_from(result).unwrap()
 }
 
 // ── Basic select via ExprDataSource ────────────────────────────────────────
@@ -53,12 +50,18 @@ fn rows(result: AnyPostgresType) -> Vec<JsonValue> {
 async fn test_select_all() {
     let db = setup("expr_select_all").await;
     let expr =
-        Expression::<AnyPostgresType>::new("SELECT * FROM \"expr_select_all\" ORDER BY id", vec![]);
-    let result = rows(db.execute(&expr).await.unwrap());
+        Expression::<AnyPostgresType>::new("SELECT * FROM `expr_select_all` ORDER BY id", vec![]);
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 3);
-    assert_eq!(result[0]["name"], "Apple");
-    assert_eq!(result[2]["name"], "Cherry");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Apple".to_string())
+    );
+    assert_eq!(
+        result[2]["name"].try_get::<String>(),
+        Some("Cherry".to_string())
+    );
 }
 
 // ── Parameterized query ────────────────────────────────────────────────────
@@ -67,42 +70,51 @@ async fn test_select_all() {
 async fn test_parameterized_integer() {
     let db = setup("expr_param_int").await;
     let expr = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM \"expr_param_int\" WHERE id = {}",
+        "SELECT name FROM `expr_param_int` WHERE id = {}",
         vec![ExpressiveEnum::Scalar(AnyPostgresType::new(2i64))],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "Banana");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Banana".to_string())
+    );
 }
 
 #[tokio::test]
 async fn test_parameterized_text() {
     let db = setup("expr_param_text").await;
     let expr = Expression::<AnyPostgresType>::new(
-        "SELECT price FROM \"expr_param_text\" WHERE name = {}",
+        "SELECT price FROM `expr_param_text` WHERE name = {}",
         vec![ExpressiveEnum::Scalar(AnyPostgresType::new(
             "Cherry".to_string(),
         ))],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["price"], 200);
+    assert_eq!(result[0]["price"].try_get::<i64>(), Some(200));
 }
 
 #[tokio::test]
 async fn test_parameterized_bool() {
     let db = setup("expr_param_bool").await;
     let expr = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM \"expr_param_bool\" WHERE active = {} ORDER BY name",
+        "SELECT name FROM `expr_param_bool` WHERE active = {} ORDER BY name",
         vec![ExpressiveEnum::Scalar(AnyPostgresType::new(true))],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0]["name"], "Apple");
-    assert_eq!(result[1]["name"], "Banana");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Apple".to_string())
+    );
+    assert_eq!(
+        result[1]["name"].try_get::<String>(),
+        Some("Banana".to_string())
+    );
 }
 
 // ── Multiple parameters ───────────────────────────────────────────────────
@@ -111,16 +123,19 @@ async fn test_parameterized_bool() {
 async fn test_multiple_params() {
     let db = setup("expr_multi_params").await;
     let expr = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM \"expr_multi_params\" WHERE price >= {} AND active = {}",
+        "SELECT name FROM `expr_multi_params` WHERE price >= {} AND active = {}",
         vec![
             ExpressiveEnum::Scalar(AnyPostgresType::new(100i64)),
             ExpressiveEnum::Scalar(AnyPostgresType::new(true)),
         ],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "Apple");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Apple".to_string())
+    );
 }
 
 // ── Nested expressions ────────────────────────────────────────────────────
@@ -134,14 +149,20 @@ async fn test_nested_expression() {
         vec![ExpressiveEnum::Scalar(AnyPostgresType::new(75i64))],
     );
     let full_query = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM \"expr_nested\" WHERE {} ORDER BY name",
+        "SELECT name FROM `expr_nested` WHERE {} ORDER BY name",
         vec![ExpressiveEnum::Nested(where_clause)],
     );
 
-    let result = rows(db.execute(&full_query).await.unwrap());
+    let result = records(db.execute(&full_query).await.unwrap());
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0]["name"], "Apple");
-    assert_eq!(result[1]["name"], "Cherry");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Apple".to_string())
+    );
+    assert_eq!(
+        result[1]["name"].try_get::<String>(),
+        Some("Cherry".to_string())
+    );
 }
 
 // ── Empty result ──────────────────────────────────────────────────────────
@@ -150,10 +171,10 @@ async fn test_nested_expression() {
 async fn test_empty_result() {
     let db = setup("expr_empty").await;
     let expr = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM \"expr_empty\" WHERE id = {}",
+        "SELECT name FROM `expr_empty` WHERE id = {}",
         vec![ExpressiveEnum::Scalar(AnyPostgresType::new(999i64))],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert!(result.is_empty());
 }

--- a/vantage-sql/tests/postgres/2_insert.rs
+++ b/vantage-sql/tests/postgres/2_insert.rs
@@ -4,7 +4,6 @@
 //! Focuses on the Product table to exercise multiple types (text, integer, bool).
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
 #[allow(unused_imports)]
 use vantage_expressions::Expressive;
 use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
@@ -49,12 +48,9 @@ async fn setup(table: &str) -> PostgresDB {
     db
 }
 
-/// Helper: execute expression, unwrap result into JSON rows.
-fn rows(result: AnyPostgresType) -> Vec<JsonValue> {
-    match result.into_value() {
-        JsonValue::Array(arr) => arr,
-        other => panic!("expected array, got: {:?}", other),
-    }
+/// Helper: unwrap result into Vec of Record<AnyPostgresType>.
+fn records(result: AnyPostgresType) -> Vec<Record<AnyPostgresType>> {
+    Vec::<Record<AnyPostgresType>>::try_from(result).unwrap()
 }
 
 // ── Insert with typed parameters ───────────────────────────────────────────
@@ -79,18 +75,19 @@ async fn test_insert_product() {
         "SELECT name, price, calories, is_deleted, inventory_stock FROM \"ins_product\" WHERE id = {}",
         "cupcake"
     );
-    let result = rows(db.execute(&select).await.unwrap());
+    let result = records(db.execute(&select).await.unwrap());
 
     assert_eq!(result.len(), 1);
 
-    let record: Record<JsonValue> = result[0].clone().into();
-    let product: Product = Product::from_record(record).unwrap();
-
-    assert_eq!(product.name, "Flux Cupcake");
-    assert_eq!(product.price, 120);
-    assert_eq!(product.calories, 300);
-    assert!(!product.is_deleted);
-    assert_eq!(product.inventory_stock, 50);
+    let row = &result[0];
+    assert_eq!(
+        row["name"].try_get::<String>(),
+        Some("Flux Cupcake".to_string())
+    );
+    assert_eq!(row["price"].try_get::<i64>(), Some(120));
+    assert_eq!(row["calories"].try_get::<i64>(), Some(300));
+    assert_eq!(row["is_deleted"].try_get::<bool>(), Some(false));
+    assert_eq!(row["inventory_stock"].try_get::<i64>(), Some(50));
 }
 
 // ── Insert multiple rows via nested expressions ───────────────────────────
@@ -138,23 +135,59 @@ async fn test_insert_multiple_products() {
     let select = postgres_expr!(
         "SELECT name, price, calories, is_deleted, inventory_stock FROM \"ins_multi\" ORDER BY price"
     );
-    let result = rows(db.execute(&select).await.unwrap());
+    let result = records(db.execute(&select).await.unwrap());
 
     assert_eq!(result.len(), 3);
 
-    let parsed: Vec<Product> = result
-        .into_iter()
-        .map(|r| Product::from_record(r.into()).unwrap())
-        .collect();
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("DeLorean Doughnut".to_string())
+    );
+    assert_eq!(result[0]["price"].try_get::<i64>(), Some(135));
+    assert_eq!(result[0]["is_deleted"].try_get::<bool>(), Some(false));
 
-    assert_eq!(parsed[0].name, "DeLorean Doughnut");
-    assert_eq!(parsed[0].price, 135);
-    assert!(!parsed[0].is_deleted);
+    assert_eq!(
+        result[2]["name"].try_get::<String>(),
+        Some("Sea Pie".to_string())
+    );
+    assert_eq!(result[2]["price"].try_get::<i64>(), Some(299));
+    assert_eq!(result[2]["is_deleted"].try_get::<bool>(), Some(true));
+    assert_eq!(result[2]["inventory_stock"].try_get::<i64>(), Some(0));
+}
 
-    assert_eq!(parsed[2].name, "Sea Pie");
-    assert_eq!(parsed[2].price, 299);
-    assert!(parsed[2].is_deleted);
-    assert_eq!(parsed[2].inventory_stock, 0);
+// ── Insert + round-trip via serde deserialization ──────────────────────────
+
+#[tokio::test]
+async fn test_insert_and_deserialize_product() {
+    let db = setup("ins_serde").await;
+
+    let insert = postgres_expr!(
+        "INSERT INTO \"ins_serde\" (\"id\", \"name\", \"price\", \"calories\", \"is_deleted\", \"inventory_stock\") VALUES ({}, {}, {}, {}, {}, {})",
+        "cupcake",
+        "Flux Cupcake",
+        120i64,
+        300i64,
+        false,
+        50i64
+    );
+    db.execute(&insert).await.unwrap();
+
+    let select = postgres_expr!(
+        "SELECT name, price, calories, is_deleted, inventory_stock FROM \"ins_serde\" WHERE id = {}",
+        "cupcake"
+    );
+
+    // Serde path: AnyPostgresType → JsonValue → Record<JsonValue> → Product
+    let json: serde_json::Value = db.execute(&select).await.unwrap().into();
+    let arr = json.as_array().unwrap();
+    let record: Record<serde_json::Value> = arr[0].clone().into();
+    let product: Product = Product::from_record(record).unwrap();
+
+    assert_eq!(product.name, "Flux Cupcake");
+    assert_eq!(product.price, 120);
+    assert_eq!(product.calories, 300);
+    assert!(!product.is_deleted);
+    assert_eq!(product.inventory_stock, 50);
 }
 
 // ── Type marker verification ────────────────────────────────────────────────
@@ -176,10 +209,13 @@ async fn test_bool_binds_correctly() {
 
     // Query with bool parameter — PostgreSQL has native BOOLEAN
     let select = postgres_expr!("SELECT name FROM \"ins_bool\" WHERE is_deleted = {}", true);
-    let result = rows(db.execute(&select).await.unwrap());
+    let result = records(db.execute(&select).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "Gone");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Gone".to_string())
+    );
 }
 
 #[tokio::test]
@@ -198,10 +234,10 @@ async fn test_integer_vs_text_binding() {
     db.execute(&insert).await.unwrap();
 
     let by_price = postgres_expr!("SELECT id FROM \"ins_int_text\" WHERE price = {}", 100i64);
-    let result = rows(db.execute(&by_price).await.unwrap());
+    let result = records(db.execute(&by_price).await.unwrap());
     assert_eq!(result.len(), 1);
 
     let by_name = postgres_expr!("SELECT id FROM \"ins_int_text\" WHERE name = {}", "Test");
-    let result = rows(db.execute(&by_name).await.unwrap());
+    let result = records(db.execute(&by_name).await.unwrap());
     assert_eq!(result.len(), 1);
 }

--- a/vantage-sql/tests/postgres/3_complex_queries.rs
+++ b/vantage-sql/tests/postgres/3_complex_queries.rs
@@ -31,8 +31,8 @@ async fn check_and_run<T: for<'de> Deserialize<'de>>(
 
     let db = get_db().await;
     let result = db.execute(&select.expr()).await.unwrap();
-    let rows = result.into_value();
-    let arr = rows.as_array().unwrap();
+    let json: serde_json::Value = result.into();
+    let arr = json.as_array().unwrap();
 
     let records: Vec<Record<serde_json::Value>> = arr.iter().map(|v| v.clone().into()).collect();
     records
@@ -605,8 +605,8 @@ async fn test_q8() {
 
     let db = get_db().await;
     let result = db.execute(&compound.expr()).await.unwrap();
-    let rows = result.into_value();
-    let arr = rows.as_array().unwrap();
+    let json: serde_json::Value = result.into();
+    let arr = json.as_array().unwrap();
 
     assert_eq!(
         compound.preview(),

--- a/vantage-sql/tests/postgres/3_complex_queries_pg.rs
+++ b/vantage-sql/tests/postgres/3_complex_queries_pg.rs
@@ -32,8 +32,8 @@ async fn check_and_run<T: for<'de> Deserialize<'de>>(
 
     let db = get_db().await;
     let result = db.execute(&select.expr()).await.unwrap();
-    let rows = result.into_value();
-    let arr = rows.as_array().unwrap();
+    let json: serde_json::Value = result.into();
+    let arr = json.as_array().unwrap();
 
     let records: Vec<Record<serde_json::Value>> = arr.iter().map(|v| v.clone().into()).collect();
     records


### PR DESCRIPTION
PostgreSQL row reads now preserve native column types instead of collapsing to JSON. `NUMERIC` stays exact (no f64 rounding), `TIMESTAMPTZ` stays distinguishable from `TEXT`, `UUID` keeps its identity, and `BYTEA` survives as bytes instead of getting hex-encoded into a string. The `try_get::<T>()` API is unchanged — same calls, fewer surprises.

Same migration as `vantage-mysql` (#185): swap `serde_json::Value` for `ciborium::Value` as the underlying storage, tag values that have no native CBOR slot. Postgres uses Tag(0) for DateTime, Tag(9) for UUID, Tag(10) for Decimal, Tag(100) for Date, Tag(101) for Time. Variants are inferred from column metadata on read and from the Rust type on write, so binds pick the right sqlx target without guessing from value shape.

A few mysql cleanups rode along: `bind` for `Int2`/`Int4` now uses checked `try_from` instead of silent `as`-truncation, float `Display` no longer drops trailing `.0`, the JSON bridge tries UTF-8 before falling back to hex for `Bytes`, and tagged decimals downgrade to JSON numbers when they fit.