### PR TITLE
Sqlite to also use CBOR for type storage

### DIFF
--- a/bakery_model3/src/animal.rs
+++ b/bakery_model3/src/animal.rs
@@ -1,5 +1,4 @@
 use bson::Bson;
-use serde_json::Value as JsonValue;
 use vantage_csv::{CsvType, type_system::CsvTypeAnimalMarker};
 use vantage_mongodb::MongoType;
 use vantage_mongodb::types::MongoTypeStringMarker;
@@ -73,13 +72,13 @@ impl CsvType for Animal {
 impl SqliteType for Animal {
     type Target = SqliteTypeTextMarker;
 
-    fn to_json(&self) -> JsonValue {
-        JsonValue::String(self.as_str().to_string())
+    fn to_cbor(&self) -> CborValue {
+        CborValue::Text(self.as_str().to_string())
     }
 
-    fn from_json(value: JsonValue) -> Option<Self> {
+    fn from_cbor(value: CborValue) -> Option<Self> {
         match value {
-            JsonValue::String(s) => s.parse().ok(),
+            CborValue::Text(s) => s.parse().ok(),
             _ => None,
         }
     }
@@ -88,13 +87,13 @@ impl SqliteType for Animal {
 impl PostgresType for Animal {
     type Target = PostgresTypeTextMarker;
 
-    fn to_json(&self) -> JsonValue {
-        JsonValue::String(self.as_str().to_string())
+    fn to_cbor(&self) -> CborValue {
+        CborValue::Text(self.as_str().to_string())
     }
 
-    fn from_json(value: JsonValue) -> Option<Self> {
+    fn from_cbor(value: CborValue) -> Option<Self> {
         match value {
-            JsonValue::String(s) => s.parse().ok(),
+            CborValue::Text(s) => s.parse().ok(),
             _ => None,
         }
     }

--- a/vantage-sql/src/mysql/row.rs
+++ b/vantage-sql/src/mysql/row.rs
@@ -197,7 +197,7 @@ fn mysql_column_to_cbor(
         .map(|v| v.is_null())
         .unwrap_or(true)
     {
-        return (CborValue::Null, Some(MysqlTypeVariants::Null));
+        return (CborValue::Null, None);
     }
 
     match type_name {
@@ -407,7 +407,7 @@ fn mysql_column_to_cbor(
         row.columns()[ordinal].name(),
         type_name,
     );
-    (CborValue::Null, Some(MysqlTypeVariants::Null))
+    (CborValue::Null, None)
 }
 
 /// Convert a serde_json::Value to CborValue (used for JSON columns).

--- a/vantage-sql/src/postgres/row.rs
+++ b/vantage-sql/src/postgres/row.rs
@@ -335,7 +335,7 @@ fn pg_column_to_cbor(
         "JSONB" | "JSON" => {
             if let Ok(v) = row.try_get::<serde_json::Value, _>(ordinal) {
                 let cbor = json_value_to_cbor(v);
-                return (cbor, Some(PostgresTypeVariants::Text));
+                return (cbor, None);
             }
         }
         "BYTEA" => {

--- a/vantage-sql/src/postgres/row.rs
+++ b/vantage-sql/src/postgres/row.rs
@@ -218,7 +218,7 @@ fn pg_column_to_cbor(
         .map(|v| v.is_null())
         .unwrap_or(true)
     {
-        return (CborValue::Null, Some(PostgresTypeVariants::Null));
+        return (CborValue::Null, None);
     }
 
     match type_name {

--- a/vantage-sql/src/sqlite/impls/expr_data_source.rs
+++ b/vantage-sql/src/sqlite/impls/expr_data_source.rs
@@ -1,4 +1,4 @@
-use serde_json::Value as JsonValue;
+use ciborium::Value as CborValue;
 use vantage_expressions::traits::expressive::DeferredFn;
 use vantage_expressions::{Expression, ExpressionFlattener, ExpressiveEnum, Flatten};
 
@@ -28,22 +28,22 @@ impl vantage_expressions::ExprDataSource<AnySqliteType> for SqliteDB {
             .await
             .map_err(|e| vantage_core::error!("SQLite query failed", details = e.to_string()))?;
 
-        // 4. Convert rows to AnySqliteType (untyped — type_variant: None)
-        let arr: Vec<JsonValue> = rows
+        // 4. Convert rows to AnySqliteType — each row becomes a CBOR Map
+        let arr: Vec<CborValue> = rows
             .iter()
             .map(|row| {
                 let record = row_to_record(row);
-                let json_map: serde_json::Map<String, JsonValue> = record
+                let map: Vec<(CborValue, CborValue)> = record
                     .into_iter()
-                    .map(|(k, v)| (k, v.into_value()))
+                    .map(|(k, v)| (CborValue::Text(k), v.into_value()))
                     .collect();
-                JsonValue::Object(json_map)
+                CborValue::Map(map)
             })
             .collect();
 
-        let json_arr = JsonValue::Array(arr);
-        Ok(AnySqliteType::from_json(&json_arr)
-            .expect("JSON array should always convert to AnySqliteType"))
+        let cbor_arr = CborValue::Array(arr);
+        Ok(AnySqliteType::from_cbor(&cbor_arr)
+            .expect("CBOR array should always convert to AnySqliteType"))
     }
 
     fn defer(&self, expr: Expression<AnySqliteType>) -> DeferredFn<AnySqliteType> {
@@ -53,19 +53,18 @@ impl vantage_expressions::ExprDataSource<AnySqliteType> for SqliteDB {
             let expr = expr.clone();
             Box::pin(async move {
                 let result = vantage_expressions::ExprDataSource::execute(&db, &expr).await?;
-                // execute() returns rows as a JSON array. For use as a deferred
-                // parameter (scalar subquery), extract the first column of the
-                // first row. If the result is empty or not an array, return as-is.
-                let scalar = match result.value() {
-                    serde_json::Value::Array(arr) => arr
+                Ok(match result.value() {
+                    CborValue::Array(arr) => arr
                         .first()
-                        .and_then(|row| row.as_object())
-                        .and_then(|obj| obj.values().next())
-                        .map(|v| AnySqliteType::untyped(v.clone()))
+                        .and_then(|row| match row {
+                            CborValue::Map(map) => {
+                                map.first().map(|(_, v)| AnySqliteType::untyped(v.clone()))
+                            }
+                            _ => None,
+                        })
                         .unwrap_or(result),
                     _ => result,
-                };
-                Ok(scalar)
+                })
             })
         })
     }

--- a/vantage-sql/src/sqlite/impls/expr_data_source.rs
+++ b/vantage-sql/src/sqlite/impls/expr_data_source.rs
@@ -53,18 +53,7 @@ impl vantage_expressions::ExprDataSource<AnySqliteType> for SqliteDB {
             let expr = expr.clone();
             Box::pin(async move {
                 let result = vantage_expressions::ExprDataSource::execute(&db, &expr).await?;
-                Ok(match result.value() {
-                    CborValue::Array(arr) => arr
-                        .first()
-                        .and_then(|row| match row {
-                            CborValue::Map(map) => {
-                                map.first().map(|(_, v)| AnySqliteType::untyped(v.clone()))
-                            }
-                            _ => None,
-                        })
-                        .unwrap_or(result),
-                    _ => result,
-                })
+                Ok(result.unwrap_scalar())
             })
         })
     }

--- a/vantage-sql/src/sqlite/impls/selectable_data_source.rs
+++ b/vantage-sql/src/sqlite/impls/selectable_data_source.rs
@@ -22,7 +22,7 @@ impl SelectableDataSource<AnySqliteType> for SqliteDB {
 
         // Result is an array of row objects — unwrap into individual AnySqliteType values
         match result.value() {
-            serde_json::Value::Array(arr) => Ok(arr
+            ciborium::Value::Array(arr) => Ok(arr
                 .iter()
                 .map(|v| AnySqliteType::untyped(v.clone()))
                 .collect()),

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use ciborium::Value as CborValue;
 use indexmap::IndexMap;
 use vantage_core::{Result, error};
 use vantage_expressions::traits::associated_expressions::AssociatedExpression;
@@ -16,37 +17,47 @@ use crate::sqlite::SqliteDB;
 use crate::sqlite::types::AnySqliteType;
 use vantage_expressions::expr_any;
 
-/// Parse the JSON array result from execute() into an IndexMap of id → Record.
+/// Parse the CBOR array result from execute() into an IndexMap of id → Record.
 fn parse_rows(
     result: AnySqliteType,
     id_field_name: &str,
 ) -> Result<IndexMap<String, Record<AnySqliteType>>> {
     let arr = match result.into_value() {
-        serde_json::Value::Array(arr) => arr,
-        other => return Err(error!("expected array result", details = other.to_string())),
+        CborValue::Array(arr) => arr,
+        other => {
+            return Err(error!(
+                "expected array result",
+                details = format!("{:?}", other)
+            ));
+        }
     };
 
     let mut records = IndexMap::new();
     for item in arr {
-        let obj = match item {
-            serde_json::Value::Object(map) => map,
+        let map = match item {
+            CborValue::Map(map) => map,
             _ => continue,
         };
 
-        let id = obj
-            .get(id_field_name)
-            .and_then(|v| match v {
-                serde_json::Value::String(s) => Some(s.clone()),
-                serde_json::Value::Number(n) => Some(n.to_string()),
-                _ => None,
-            })
-            .ok_or_else(|| error!("row missing id field", field = id_field_name))?;
+        let mut id = None;
+        let mut record = Record::new();
+        for (k, v) in map {
+            let key = match k {
+                CborValue::Text(s) => s,
+                _ => continue,
+            };
+            if key == id_field_name {
+                id = Some(match &v {
+                    CborValue::Text(s) => s.clone(),
+                    CborValue::Integer(i) => i128::from(*i).to_string(),
+                    CborValue::Float(f) => f.to_string(),
+                    _ => format!("{:?}", v),
+                });
+            }
+            record.insert(key, AnySqliteType::untyped(v));
+        }
 
-        let record: Record<AnySqliteType> = obj
-            .into_iter()
-            .map(|(k, v)| (k, AnySqliteType::untyped(v)))
-            .collect();
-
+        let id = id.ok_or_else(|| error!("row missing id field", field = id_field_name))?;
         records.insert(id, record);
     }
 

--- a/vantage-sql/src/sqlite/mod.rs
+++ b/vantage-sql/src/sqlite/mod.rs
@@ -6,7 +6,6 @@ pub(crate) mod row;
 pub mod statements;
 pub mod types;
 
-use ciborium::Value as CborValue;
 use sqlx::sqlite::SqlitePool;
 
 pub use types::{AnySqliteType, SqliteType};
@@ -37,17 +36,6 @@ impl SqliteDB {
         use vantage_expressions::ExprDataSource;
         let expr = select.as_aggregate(func, column);
         let result = self.execute(&expr).await?;
-        Ok(match result.value() {
-            CborValue::Array(arr) => arr
-                .first()
-                .and_then(|row| match row {
-                    CborValue::Map(map) => {
-                        map.first().map(|(_, v)| AnySqliteType::untyped(v.clone()))
-                    }
-                    _ => None,
-                })
-                .unwrap_or(result),
-            _ => result,
-        })
+        Ok(result.unwrap_scalar())
     }
 }

--- a/vantage-sql/src/sqlite/mod.rs
+++ b/vantage-sql/src/sqlite/mod.rs
@@ -2,10 +2,11 @@
 mod macros;
 pub mod impls;
 mod operation;
-mod row;
+pub(crate) mod row;
 pub mod statements;
 pub mod types;
 
+use ciborium::Value as CborValue;
 use sqlx::sqlite::SqlitePool;
 
 pub use types::{AnySqliteType, SqliteType};
@@ -37,11 +38,14 @@ impl SqliteDB {
         let expr = select.as_aggregate(func, column);
         let result = self.execute(&expr).await?;
         Ok(match result.value() {
-            serde_json::Value::Array(arr) => arr
+            CborValue::Array(arr) => arr
                 .first()
-                .and_then(|row| row.as_object())
-                .and_then(|obj| obj.values().next())
-                .map(|v| AnySqliteType::untyped(v.clone()))
+                .and_then(|row| match row {
+                    CborValue::Map(map) => {
+                        map.first().map(|(_, v)| AnySqliteType::untyped(v.clone()))
+                    }
+                    _ => None,
+                })
                 .unwrap_or(result),
             _ => result,
         })

--- a/vantage-sql/src/sqlite/row.rs
+++ b/vantage-sql/src/sqlite/row.rs
@@ -102,7 +102,10 @@ fn bind_by_cbor<'q>(
                 query.bind(None::<String>)
             }
         }
-        _ => query.bind(None::<String>),
+        other => panic!(
+            "bind_by_cbor: unexpected CBOR value type {:?} — this is a bug upstream",
+            other
+        ),
     }
 }
 
@@ -177,7 +180,7 @@ fn sqlite_column_to_cbor(
         row.columns()[ordinal].name(),
         declared_type,
     );
-    (CborValue::Null, Some(SqliteTypeVariants::Null))
+    (CborValue::Null, None)
 }
 
 #[cfg(test)]

--- a/vantage-sql/src/sqlite/row.rs
+++ b/vantage-sql/src/sqlite/row.rs
@@ -3,11 +3,11 @@
 //! **Writing** (bind): Takes `AnySqliteType` with variant tags — the variant
 //! tells us exactly how to bind each value to sqlx.
 //!
-//! **Reading** (row): Returns `Record<AnySqliteType>` with `type_variant: None`.
-//! The values are marker-less — `try_get` will attempt conversion without
-//! variant enforcement, and struct deserialization validates the actual types.
+//! **Reading** (row): Returns `Record<AnySqliteType>` with variant inferred from
+//! the SQLite column type. Values are stored as `ciborium::Value` (CBOR) for
+//! lossless type preservation.
 
-use serde_json::Value as JsonValue;
+use ciborium::Value as CborValue;
 use sqlx::sqlite::SqliteRow;
 use sqlx::{Column, Row, TypeInfo};
 use vantage_types::Record;
@@ -15,106 +15,123 @@ use vantage_types::Record;
 use super::types::{AnySqliteType, SqliteTypeVariants};
 
 /// Bind an AnySqliteType to a sqlx query. Uses the variant tag to pick
-/// the right sqlx bind type — no guessing from the JSON number format.
+/// the right sqlx bind type — no guessing from the CBOR value format.
 pub(crate) fn bind_sqlite_value<'q>(
     query: sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>>,
     value: &'q AnySqliteType,
 ) -> sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
-    let json = value.value();
+    let cbor = value.value();
     match value.type_variant() {
         Some(SqliteTypeVariants::Null) => query.bind(None::<String>),
-        // Untyped values (from deferred results, database reads) — infer from JSON
-        None => bind_by_json(query, json),
-        Some(SqliteTypeVariants::Bool) => match json {
-            JsonValue::Null => query.bind(None::<bool>),
-            JsonValue::Number(n) => match n.as_i64() {
-                Some(i) => query.bind(i != 0),
-                None => query.bind(None::<bool>),
+        None => bind_by_cbor(query, cbor),
+        Some(SqliteTypeVariants::Bool) => match cbor {
+            CborValue::Null => query.bind(None::<bool>),
+            CborValue::Integer(i) => match i64::try_from(*i) {
+                Ok(n) => query.bind(n != 0),
+                Err(_) => query.bind(None::<bool>),
             },
-            JsonValue::Bool(b) => query.bind(*b),
+            CborValue::Bool(b) => query.bind(*b),
             _ => query.bind(None::<bool>),
         },
-        Some(SqliteTypeVariants::Integer) => match json {
-            JsonValue::Null => query.bind(None::<i64>),
-            JsonValue::Number(n) => query.bind(n.as_i64()),
+        Some(SqliteTypeVariants::Integer) => match cbor {
+            CborValue::Null => query.bind(None::<i64>),
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok()),
             _ => query.bind(None::<i64>),
         },
-        Some(SqliteTypeVariants::Real) => match json {
-            JsonValue::Null => query.bind(None::<f64>),
-            JsonValue::Number(n) => query.bind(n.as_f64()),
+        Some(SqliteTypeVariants::Real) => match cbor {
+            CborValue::Null => query.bind(None::<f64>),
+            CborValue::Float(f) => query.bind(*f),
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok().map(|n| n as f64)),
             _ => query.bind(None::<f64>),
         },
-        Some(SqliteTypeVariants::Text) => match json {
-            JsonValue::Null => query.bind(None::<String>),
-            JsonValue::String(s) => query.bind(s.as_str()),
+        Some(SqliteTypeVariants::Text) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Text(s) => query.bind(s.as_str()),
             _ => query.bind(None::<String>),
         },
-        Some(SqliteTypeVariants::Numeric) => match json {
-            JsonValue::Null => query.bind(None::<String>),
-            JsonValue::Object(o) => {
-                let s = o.get("numeric").and_then(|v| v.as_str()).unwrap_or("0");
-                query.bind(s)
+        Some(SqliteTypeVariants::Numeric) => match cbor {
+            CborValue::Null => query.bind(None::<String>),
+            CborValue::Tag(10, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    query.bind(s.as_str())
+                } else {
+                    query.bind(None::<String>)
+                }
             }
+            CborValue::Text(s) => query.bind(s.as_str()),
             _ => query.bind(None::<String>),
         },
-        Some(SqliteTypeVariants::Blob) => match json {
-            JsonValue::Null => query.bind(None::<String>),
-            JsonValue::Object(o) => {
-                let s = o.get("blob").and_then(|v| v.as_str()).unwrap_or("");
-                query.bind(s)
-            }
-            _ => query.bind(None::<String>),
+        Some(SqliteTypeVariants::Blob) => match cbor {
+            CborValue::Null => query.bind(None::<Vec<u8>>),
+            CborValue::Bytes(b) => query.bind(b.as_slice()),
+            CborValue::Text(s) => query.bind(s.as_bytes()),
+            _ => query.bind(None::<Vec<u8>>),
         },
     }
 }
 
-/// Bind a JSON value without type variant — infers the bind type from the value itself.
-/// Used for untyped values (deferred results, database reads).
-fn bind_by_json<'q>(
+/// Bind a CBOR value without type variant — infers from the value itself.
+fn bind_by_cbor<'q>(
     query: sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>>,
-    json: &'q JsonValue,
+    cbor: &'q CborValue,
 ) -> sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
-    match json {
-        JsonValue::Null => query.bind(None::<String>),
-        JsonValue::Bool(b) => query.bind(*b),
-        JsonValue::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                query.bind(i)
-            } else if let Some(f) = n.as_f64() {
-                query.bind(f)
+    match cbor {
+        CborValue::Null => query.bind(None::<String>),
+        CborValue::Bool(b) => query.bind(*b),
+        CborValue::Integer(i) => {
+            if let Ok(n) = i64::try_from(*i) {
+                query.bind(n)
             } else {
-                query.bind(n.to_string())
+                query.bind(i128::from(*i).to_string())
             }
         }
-        JsonValue::String(s) => query.bind(s.as_str()),
-        other => query.bind(other.to_string()),
+        CborValue::Float(f) => query.bind(*f),
+        CborValue::Text(s) => query.bind(s.as_str()),
+        CborValue::Bytes(b) => query.bind(b.as_slice()),
+        CborValue::Tag(10, inner) => {
+            if let CborValue::Text(s) = inner.as_ref() {
+                query.bind(s.as_str())
+            } else {
+                query.bind(None::<String>)
+            }
+        }
+        CborValue::Tag(0 | 100 | 101, inner) => {
+            if let CborValue::Text(s) = inner.as_ref() {
+                query.bind(s.as_str())
+            } else {
+                query.bind(None::<String>)
+            }
+        }
+        _ => query.bind(None::<String>),
     }
 }
 
 /// Convert a SqliteRow to Record<AnySqliteType>.
 ///
-/// Each value has `type_variant: None` — the database doesn't preserve our
-/// type markers. This means `try_get` on these values bypasses variant
-/// checking and just attempts the conversion, which is the right behavior
-/// for data coming back from the database.
+/// Each value is stored as CBOR with the type variant inferred from the
+/// SQLite column type, preserving full type fidelity.
 pub(crate) fn row_to_record(row: &SqliteRow) -> Record<AnySqliteType> {
     let mut record = Record::new();
     for col in row.columns() {
         let name = col.name().to_string();
         let declared_type = col.type_info().name();
-        let json = sqlite_column_to_json(row, col.ordinal(), declared_type);
-        // Wrap as AnySqliteType with type_variant: None — we intentionally
-        // don't assign variants to values coming from the database, so that
-        // try_get is permissive and attempts any conversion.
-        let value = AnySqliteType::untyped(json);
+        let (cbor, variant) = sqlite_column_to_cbor(row, col.ordinal(), declared_type);
+        let value = match variant {
+            Some(v) => AnySqliteType::with_variant(cbor, v),
+            None => AnySqliteType::untyped(cbor),
+        };
         record.insert(name, value);
     }
     record
 }
 
-/// Read a single column from a SQLite row as JsonValue.
-/// Uses the declared column type to disambiguate (e.g., INTEGER vs BOOLEAN).
-fn sqlite_column_to_json(row: &SqliteRow, ordinal: usize, declared_type: &str) -> JsonValue {
+/// Read a single column from a SQLite row as CborValue, returning both the
+/// value and the detected type variant.
+fn sqlite_column_to_cbor(
+    row: &SqliteRow,
+    ordinal: usize,
+    declared_type: &str,
+) -> (CborValue, Option<SqliteTypeVariants>) {
     use sqlx::ValueRef;
 
     if row
@@ -122,29 +139,45 @@ fn sqlite_column_to_json(row: &SqliteRow, ordinal: usize, declared_type: &str) -
         .map(|v| v.is_null())
         .unwrap_or(true)
     {
-        return JsonValue::Null;
+        return (CborValue::Null, None);
     }
 
     let dt = declared_type.to_uppercase();
+
+    // Boolean — SQLite stores as 0/1 INTEGER
     if (dt == "BOOLEAN" || dt == "BOOL")
         && let Ok(v) = row.try_get::<bool, _>(ordinal)
     {
-        return JsonValue::Bool(v);
+        return (CborValue::Bool(v), Some(SqliteTypeVariants::Bool));
     }
 
-    if let Ok(v) = row.try_get::<i64, _>(ordinal) {
-        return JsonValue::Number(v.into());
-    }
-    if let Ok(v) = row.try_get::<f64, _>(ordinal)
-        && let Some(n) = serde_json::Number::from_f64(v)
+    // BLOB
+    if dt == "BLOB"
+        && let Ok(v) = row.try_get::<Vec<u8>, _>(ordinal)
     {
-        return JsonValue::Number(n);
+        return (CborValue::Bytes(v), Some(SqliteTypeVariants::Blob));
+    }
+
+    // Fallback: try common types in order
+    if let Ok(v) = row.try_get::<i64, _>(ordinal) {
+        return (
+            CborValue::Integer(v.into()),
+            Some(SqliteTypeVariants::Integer),
+        );
+    }
+    if let Ok(v) = row.try_get::<f64, _>(ordinal) {
+        return (CborValue::Float(v), Some(SqliteTypeVariants::Real));
     }
     if let Ok(v) = row.try_get::<String, _>(ordinal) {
-        return JsonValue::String(v);
+        return (CborValue::Text(v), Some(SqliteTypeVariants::Text));
     }
 
-    JsonValue::Null
+    eprintln!(
+        "vantage: failed to decode SQLite column '{}' (type '{}') — returning NULL",
+        row.columns()[ordinal].name(),
+        declared_type,
+    );
+    (CborValue::Null, Some(SqliteTypeVariants::Null))
 }
 
 #[cfg(test)]
@@ -152,6 +185,7 @@ mod tests {
     use super::*;
     use crate::sqlite::SqliteDB;
     use serde::{Deserialize, Serialize};
+    use serde_json::Value as JsonValue;
     use vantage_types::TryFromRecord;
 
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -190,8 +224,6 @@ mod tests {
 
         let record = row_to_record(&rows[0]);
 
-        // Values have type_variant from from_json detection, but try_get
-        // is permissive — it attempts conversion regardless
         assert_eq!(
             record["name"].try_get::<String>(),
             Some("Alice".to_string())
@@ -233,14 +265,14 @@ mod tests {
             .await
             .unwrap();
 
-        // Record<AnySqliteType> → Record<JsonValue> → struct via serde
+        // Record<AnySqliteType> → Record<JsonValue> via JSON bridge → struct via serde
         let products: Vec<Product> = rows
             .iter()
             .map(|row| {
                 let record = row_to_record(row);
                 let json_record: Record<JsonValue> = record
                     .into_iter()
-                    .map(|(k, v)| (k, v.into_value()))
+                    .map(|(k, v)| (k, JsonValue::from(v)))
                     .collect();
                 Product::from_record(json_record).unwrap()
             })

--- a/vantage-sql/src/sqlite/types/bool.rs
+++ b/vantage-sql/src/sqlite/types/bool.rs
@@ -2,19 +2,19 @@
 //! Stored as INTEGER 0/1 on disk, but a distinct type at the vantage level.
 
 use super::{SqliteType, SqliteTypeBoolMarker};
-use serde_json::Value;
+use ciborium::Value;
 
 impl SqliteType for bool {
     type Target = SqliteTypeBoolMarker;
 
-    fn to_json(&self) -> Value {
+    fn to_cbor(&self) -> Value {
         // Store as integer 0/1 matching SQLite's convention
-        Value::Number(if *self { 1.into() } else { 0.into() })
+        Value::Integer(if *self { 1.into() } else { 0.into() })
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().map(|i| i != 0),
+            Value::Integer(i) => i64::try_from(i).ok().map(|n| n != 0),
             Value::Bool(b) => Some(b),
             _ => None,
         }

--- a/vantage-sql/src/sqlite/types/mod.rs
+++ b/vantage-sql/src/sqlite/types/mod.rs
@@ -1,58 +1,51 @@
 //! SQLite Type System
 //!
-//! Defines type variants aligned with SQLite's affinity system:
+//! Uses `ciborium::Value` as the underlying value type for lossless storage.
+//! CBOR tags follow the same conventions as MySQL/Postgres backends:
+//!   Tag(0)   = DateTime (RFC 3339)
+//!   Tag(10)  = Decimal/Numeric (string representation)
+//!   Tag(100) = Date (YYYY-MM-DD string)
+//!   Tag(101) = Time (HH:MM:SS string)
 //!
+//! SQLite type variants map to SQLite's affinity system:
 //! - INTEGER affinity: INTEGER, INT, TINYINT, SMALLINT, MEDIUMINT, BIGINT
 //! - TEXT    affinity: TEXT, VARCHAR(N), CHAR(N), CLOB, NVARCHAR(N)
 //! - REAL    affinity: REAL, FLOAT, DOUBLE, DOUBLE PRECISION
 //! - NUMERIC affinity: NUMERIC, DECIMAL(P,S), BOOLEAN, DATE, DATETIME
 //! - BLOB    affinity: BLOB
-//! - ANY     (STRICT): ANY
-//!
-//! Uses `serde_json::Value` as the underlying value type with type variant
-//! tracking to prevent silent type confusion.
 
-use serde_json::Value;
 use vantage_types::vantage_type_system;
 
 vantage_type_system! {
     type_trait: SqliteType,
-    method_name: json,
-    value_type: serde_json::Value,
+    method_name: cbor,
+    value_type: ciborium::Value,
     type_variants: [
         Null,
-        Bool,       // bool — stored as 0/1 on disk, but distinct from Integer at type level
-        Integer,    // i8, i16, i32, i64
+        Bool,       // BOOLEAN — stored as 0/1 on disk, distinct from Integer
+        Integer,    // i8..i64, u8..u32
         Text,       // String, &str
         Real,       // f32, f64
-        Numeric,    // Decimal — stored as {"numeric": "string"} to preserve precision
-        Blob        // Vec<u8> — stored as base64 string
+        Numeric,    // DECIMAL — Tag(10, Text("..."))
+        Blob        // Vec<u8> — CborValue::Bytes
     ]
 }
 
 impl SqliteTypeVariants {
-    /// Detect the type variant from a JSON value.
-    pub fn from_json(value: &Value) -> Option<Self> {
+    /// Detect the type variant from a CBOR value.
+    pub fn from_cbor(value: &ciborium::Value) -> Option<Self> {
+        use ciborium::Value::*;
+
         match value {
-            Value::Null => Some(Self::Null),
-            Value::Bool(_) => Some(Self::Bool),
-            Value::Number(n) => {
-                if n.is_i64() || n.is_u64() {
-                    Some(Self::Integer)
-                } else {
-                    Some(Self::Real)
-                }
-            }
-            Value::String(_) => Some(Self::Text),
-            Value::Object(obj) => {
-                if obj.contains_key("numeric") {
-                    Some(Self::Numeric)
-                } else if obj.contains_key("blob") {
-                    Some(Self::Blob)
-                } else {
-                    None
-                }
-            }
+            Null => Some(Self::Null),
+            Bool(_) => Some(Self::Bool),
+            Integer(_) => Some(Self::Integer),
+            Float(_) => Some(Self::Real),
+            Text(_) => Some(Self::Text),
+            Bytes(_) => Some(Self::Blob),
+            Tag(10, _) => Some(Self::Numeric),
+            Tag(0 | 100 | 101, _) => Some(Self::Text),
+            Tag(_, inner) => Self::from_cbor(inner),
             _ => None,
         }
     }
@@ -93,43 +86,61 @@ mod tests {
         let val = AnySqliteType::new(true);
         assert_eq!(val.type_variant(), Some(SqliteTypeVariants::Bool));
         assert_eq!(val.try_get::<bool>(), Some(true));
-        // Bool is a distinct variant — i64 extraction blocked by type boundary
         assert_eq!(val.try_get::<i64>(), None);
     }
 
     #[test]
     fn test_null_round_trip() {
         let val = AnySqliteType::new(None::<i64>);
-        // Value is Null, variant is Integer (from Option<i64>::Target)
-        assert_eq!(*val.value(), serde_json::Value::Null);
+        assert_eq!(*val.value(), ciborium::Value::Null);
         assert_eq!(val.type_variant(), Some(SqliteTypeVariants::Integer));
 
-        // from_json on the value directly should work
-        let direct = <Option<i64> as SqliteType>::from_json(serde_json::Value::Null);
+        let direct = <Option<i64> as SqliteType>::from_cbor(ciborium::Value::Null);
         assert_eq!(direct, Some(None));
 
-        // try_get: variant matches (Integer == Integer), then from_json(Null) → Some(None)
         assert_eq!(val.try_get::<Option<i64>>(), Some(None));
     }
 
     #[test]
     fn test_type_mismatch_text_as_integer() {
         let val = AnySqliteType::new("hello".to_string());
-        // Text variant should not convert to i64
         assert_eq!(val.try_get::<i64>(), None);
     }
 
     #[test]
     fn test_type_mismatch_integer_as_text() {
         let val = AnySqliteType::new(42i64);
-        // Integer variant should not convert to String
         assert_eq!(val.try_get::<String>(), None);
     }
 
     #[test]
     fn test_type_mismatch_real_as_integer() {
         let val = AnySqliteType::new(3.15f64);
-        // Real variant should not convert to i64
         assert_eq!(val.try_get::<i64>(), None);
+    }
+
+    #[test]
+    fn test_untyped_integer_try_get() {
+        let val = AnySqliteType::untyped(ciborium::Value::Integer(42.into()));
+        assert_eq!(val.try_get::<i64>(), Some(42));
+        assert_eq!(val.try_get::<i32>(), Some(42));
+    }
+
+    #[test]
+    fn test_untyped_text_try_get() {
+        let val = AnySqliteType::untyped(ciborium::Value::Text("world".into()));
+        assert_eq!(val.try_get::<String>(), Some("world".to_string()));
+    }
+
+    #[test]
+    fn test_untyped_numeric_tag() {
+        let val = AnySqliteType::untyped(ciborium::Value::Tag(
+            10,
+            Box::new(ciborium::Value::Text("123.456".into())),
+        ));
+        assert_eq!(
+            SqliteTypeVariants::from_cbor(val.value()),
+            Some(SqliteTypeVariants::Numeric)
+        );
     }
 }

--- a/vantage-sql/src/sqlite/types/numbers.rs
+++ b/vantage-sql/src/sqlite/types/numbers.rs
@@ -1,24 +1,25 @@
 //! Numeric type implementations for SQLite.
 //!
-//! - Integer types (i8..i64, u8..u32) → SqliteType::Integer
-//! - Float types (f32, f64) → SqliteType::Real
+//! Uses ciborium::Value (CBOR) as the underlying storage:
+//! - Integer types (i8..i64, u8..u32) → CborValue::Integer
+//! - Float types (f32, f64) → CborValue::Float
 //! - Option<T> delegates to T, with Null for None
 
 use super::{SqliteType, SqliteTypeIntegerMarker, SqliteTypeRealMarker};
-use serde_json::Value;
+use ciborium::Value;
 
 // -- Signed integers → Integer affinity ------------------------------------
 
 impl SqliteType for i64 {
     type Target = SqliteTypeIntegerMarker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64(),
+            Value::Integer(i) => i64::try_from(i).ok(),
             _ => None,
         }
     }
@@ -27,13 +28,13 @@ impl SqliteType for i64 {
 impl SqliteType for i32 {
     type Target = SqliteTypeIntegerMarker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| i32::try_from(i).ok()),
+            Value::Integer(i) => i32::try_from(i).ok(),
             _ => None,
         }
     }
@@ -42,13 +43,13 @@ impl SqliteType for i32 {
 impl SqliteType for i16 {
     type Target = SqliteTypeIntegerMarker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| i16::try_from(i).ok()),
+            Value::Integer(i) => i16::try_from(i).ok(),
             _ => None,
         }
     }
@@ -57,13 +58,13 @@ impl SqliteType for i16 {
 impl SqliteType for i8 {
     type Target = SqliteTypeIntegerMarker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| i8::try_from(i).ok()),
+            Value::Integer(i) => i8::try_from(i).ok(),
             _ => None,
         }
     }
@@ -74,13 +75,13 @@ impl SqliteType for i8 {
 impl SqliteType for u32 {
     type Target = SqliteTypeIntegerMarker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| u32::try_from(i).ok()),
+            Value::Integer(i) => u32::try_from(i).ok(),
             _ => None,
         }
     }
@@ -89,13 +90,13 @@ impl SqliteType for u32 {
 impl SqliteType for u16 {
     type Target = SqliteTypeIntegerMarker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| u16::try_from(i).ok()),
+            Value::Integer(i) => u16::try_from(i).ok(),
             _ => None,
         }
     }
@@ -104,13 +105,13 @@ impl SqliteType for u16 {
 impl SqliteType for u8 {
     type Target = SqliteTypeIntegerMarker;
 
-    fn to_json(&self) -> Value {
-        Value::Number((*self as i64).into())
+    fn to_cbor(&self) -> Value {
+        Value::Integer((*self).into())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_i64().and_then(|i| u8::try_from(i).ok()),
+            Value::Integer(i) => u8::try_from(i).ok(),
             _ => None,
         }
     }
@@ -121,15 +122,14 @@ impl SqliteType for u8 {
 impl SqliteType for f64 {
     type Target = SqliteTypeRealMarker;
 
-    fn to_json(&self) -> Value {
-        serde_json::Number::from_f64(*self)
-            .map(Value::Number)
-            .unwrap_or(Value::Null)
+    fn to_cbor(&self) -> Value {
+        Value::Float(*self)
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_f64(),
+            Value::Float(f) => Some(f),
+            Value::Integer(i) => i64::try_from(i).ok().map(|n| n as f64),
             _ => None,
         }
     }
@@ -138,15 +138,14 @@ impl SqliteType for f64 {
 impl SqliteType for f32 {
     type Target = SqliteTypeRealMarker;
 
-    fn to_json(&self) -> Value {
-        serde_json::Number::from_f64(*self as f64)
-            .map(Value::Number)
-            .unwrap_or(Value::Null)
+    fn to_cbor(&self) -> Value {
+        Value::Float((*self) as f64)
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::Number(n) => n.as_f64().map(|f| f as f32),
+            Value::Float(f) => Some(f as f32),
+            Value::Integer(i) => i64::try_from(i).ok().map(|n| n as f32),
             _ => None,
         }
     }
@@ -157,17 +156,17 @@ impl SqliteType for f32 {
 impl<T: SqliteType> SqliteType for Option<T> {
     type Target = T::Target;
 
-    fn to_json(&self) -> Value {
+    fn to_cbor(&self) -> Value {
         match self {
-            Some(v) => v.to_json(),
+            Some(v) => v.to_cbor(),
             None => Value::Null,
         }
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
             Value::Null => Some(None),
-            other => T::from_json(other).map(Some),
+            other => T::from_cbor(other).map(Some),
         }
     }
 }

--- a/vantage-sql/src/sqlite/types/string.rs
+++ b/vantage-sql/src/sqlite/types/string.rs
@@ -1,18 +1,18 @@
 //! String types → SQLite TEXT affinity
 
 use super::{SqliteType, SqliteTypeTextMarker};
-use serde_json::Value;
+use ciborium::Value;
 
 impl SqliteType for String {
     type Target = SqliteTypeTextMarker;
 
-    fn to_json(&self) -> Value {
-        Value::String(self.clone())
+    fn to_cbor(&self) -> Value {
+        Value::Text(self.clone())
     }
 
-    fn from_json(value: Value) -> Option<Self> {
+    fn from_cbor(value: Value) -> Option<Self> {
         match value {
-            Value::String(s) => Some(s),
+            Value::Text(s) => Some(s),
             _ => None,
         }
     }
@@ -21,11 +21,11 @@ impl SqliteType for String {
 impl SqliteType for &'static str {
     type Target = SqliteTypeTextMarker;
 
-    fn to_json(&self) -> Value {
-        Value::String(self.to_string())
+    fn to_cbor(&self) -> Value {
+        Value::Text(self.to_string())
     }
 
-    fn from_json(_value: Value) -> Option<Self> {
+    fn from_cbor(_value: Value) -> Option<Self> {
         None // cannot produce &'static str from arbitrary data
     }
 }

--- a/vantage-sql/src/sqlite/types/value.rs
+++ b/vantage-sql/src/sqlite/types/value.rs
@@ -1,17 +1,29 @@
-//! AnySqliteType extras: From conversions, Display, Expressive.
+//! AnySqliteType extras: From conversions, Display, Expressive, TryFrom.
+//!
+//! Uses ciborium::Value (CBOR) as the underlying value type.
 
-use super::{AnySqliteType, SqliteType, SqliteTypeNullMarker};
-use serde_json::Value;
+use super::{AnySqliteType, SqliteType, SqliteTypeNullMarker, SqliteTypeVariants};
+use ciborium::Value as CborValue;
+use serde_json::Value as JsonValue;
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
 impl AnySqliteType {
     /// Create an AnySqliteType with no type marker. Used for values coming
     /// back from the database where we don't know the original type.
     /// `try_get` on these values bypasses variant checking.
-    pub fn untyped(value: serde_json::Value) -> Self {
+    pub fn untyped(value: CborValue) -> Self {
         Self {
             value,
             type_variant: None,
+        }
+    }
+
+    /// Create an AnySqliteType with an explicit type variant.
+    /// Used by row_to_record where the SQLite column type is known.
+    pub fn with_variant(value: CborValue, variant: SqliteTypeVariants) -> Self {
+        Self {
+            value,
+            type_variant: Some(variant),
         }
     }
 }
@@ -20,28 +32,83 @@ impl AnySqliteType {
 impl SqliteType for AnySqliteType {
     type Target = SqliteTypeNullMarker;
 
-    fn to_json(&self) -> Value {
+    fn to_cbor(&self) -> CborValue {
         self.value().clone()
     }
 
-    fn from_json(value: Value) -> Option<Self> {
-        AnySqliteType::from_json(&value)
+    fn from_cbor(value: CborValue) -> Option<Self> {
+        AnySqliteType::from_cbor(&value)
     }
 }
 
 impl std::fmt::Display for AnySqliteType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.value() {
-            Value::Null => write!(f, "NULL"),
-            Value::Bool(b) => write!(f, "{}", b),
-            Value::Number(n) => write!(f, "{}", n),
-            Value::String(s) => write!(f, "'{}'", s.replace('\'', "''")),
-            other => write!(f, "{}", other),
+            CborValue::Null => write!(f, "NULL"),
+            CborValue::Bool(b) => write!(f, "{}", b),
+            CborValue::Integer(i) => write!(f, "{}", i128::from(*i)),
+            CborValue::Float(v) => {
+                if v.fract() == 0.0 {
+                    write!(f, "{:.1}", v)
+                } else {
+                    write!(f, "{}", v)
+                }
+            }
+            CborValue::Text(s) => write!(f, "'{}'", s.replace('\'', "''")),
+            CborValue::Bytes(b) => write!(f, "x'{}'", hex::encode(b)),
+            CborValue::Tag(10, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    write!(f, "{}", s)
+                } else {
+                    write!(f, "{:?}", inner)
+                }
+            }
+            CborValue::Tag(0, inner) | CborValue::Tag(100, inner) | CborValue::Tag(101, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    write!(f, "'{}'", s)
+                } else {
+                    write!(f, "{:?}", inner)
+                }
+            }
+            CborValue::Array(arr) => {
+                write!(f, "[")?;
+                for (i, item) in arr.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    if let Some(any) = AnySqliteType::from_cbor(item) {
+                        write!(f, "{}", any)?;
+                    } else {
+                        write!(f, "{:?}", item)?;
+                    }
+                }
+                write!(f, "]")
+            }
+            CborValue::Map(map) => {
+                write!(f, "{{")?;
+                for (i, (k, v)) in map.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    let key_str = match k {
+                        CborValue::Text(s) => s.clone(),
+                        _ => format!("{:?}", k),
+                    };
+                    if let Some(any) = AnySqliteType::from_cbor(v) {
+                        write!(f, "{}: {}", key_str, any)?;
+                    } else {
+                        write!(f, "{}: {:?}", key_str, v)?;
+                    }
+                }
+                write!(f, "}}")
+            }
+            other => write!(f, "{:?}", other),
         }
     }
 }
 
-// From impls for common types
+// -- From impls for common types ----------------------------------------------
+
 macro_rules! impl_from_for_any_sqlite {
     ($($ty:ty),*) => {
         $(
@@ -62,7 +129,108 @@ impl From<&str> for AnySqliteType {
     }
 }
 
-// Expressive impls — allows passing scalars directly into sql_expr!
+// -- JSON <-> CBOR bridge (for AnyTable interop) ------------------------------
+
+impl From<JsonValue> for AnySqliteType {
+    fn from(val: JsonValue) -> Self {
+        if val.is_null() {
+            return AnySqliteType::untyped(CborValue::Null);
+        }
+        let cbor = json_to_cbor(val);
+        AnySqliteType::from_cbor(&cbor).expect("json_to_cbor produced unconvertible CBOR")
+    }
+}
+
+impl From<AnySqliteType> for JsonValue {
+    fn from(val: AnySqliteType) -> Self {
+        cbor_to_json(val.into_value())
+    }
+}
+
+fn json_to_cbor(val: JsonValue) -> CborValue {
+    match val {
+        JsonValue::Null => CborValue::Null,
+        JsonValue::Bool(b) => CborValue::Bool(b),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                CborValue::Integer(i.into())
+            } else if let Some(u) = n.as_u64() {
+                CborValue::Integer(u.into())
+            } else if let Some(f) = n.as_f64() {
+                CborValue::Float(f)
+            } else {
+                CborValue::Text(n.to_string())
+            }
+        }
+        JsonValue::String(s) => CborValue::Text(s),
+        JsonValue::Array(arr) => CborValue::Array(arr.into_iter().map(json_to_cbor).collect()),
+        JsonValue::Object(map) => CborValue::Map(
+            map.into_iter()
+                .map(|(k, v)| (CborValue::Text(k), json_to_cbor(v)))
+                .collect(),
+        ),
+    }
+}
+
+fn cbor_to_json(val: CborValue) -> JsonValue {
+    match val {
+        CborValue::Null => JsonValue::Null,
+        CborValue::Bool(b) => JsonValue::Bool(b),
+        CborValue::Integer(i) => {
+            let n = i128::from(i);
+            if let Ok(v) = i64::try_from(n) {
+                JsonValue::Number(v.into())
+            } else if let Ok(v) = u64::try_from(n) {
+                JsonValue::Number(v.into())
+            } else {
+                JsonValue::String(n.to_string())
+            }
+        }
+        CborValue::Float(f) => serde_json::Number::from_f64(f)
+            .map(JsonValue::Number)
+            .unwrap_or(JsonValue::Null),
+        CborValue::Text(s) => JsonValue::String(s),
+        CborValue::Bytes(b) => match String::from_utf8(b) {
+            Ok(s) => JsonValue::String(s),
+            Err(e) => JsonValue::String(hex::encode(e.as_bytes())),
+        },
+        CborValue::Array(arr) => JsonValue::Array(arr.into_iter().map(cbor_to_json).collect()),
+        CborValue::Map(map) => {
+            let obj: serde_json::Map<String, JsonValue> = map
+                .into_iter()
+                .map(|(k, v)| {
+                    let key = match k {
+                        CborValue::Text(s) => s,
+                        other => format!("{:?}", other),
+                    };
+                    (key, cbor_to_json(v))
+                })
+                .collect();
+            JsonValue::Object(obj)
+        }
+        CborValue::Tag(10, inner) => {
+            // Decimal — try to parse as JSON number, fall back to string
+            if let CborValue::Text(s) = *inner {
+                if let Ok(i) = s.parse::<i64>() {
+                    JsonValue::Number(i.into())
+                } else if let Ok(f) = s.parse::<f64>() {
+                    serde_json::Number::from_f64(f)
+                        .map(JsonValue::Number)
+                        .unwrap_or(JsonValue::String(s))
+                } else {
+                    JsonValue::String(s)
+                }
+            } else {
+                cbor_to_json(*inner)
+            }
+        }
+        CborValue::Tag(_, inner) => cbor_to_json(*inner),
+        _ => JsonValue::Null,
+    }
+}
+
+// -- Expressive impls ---------------------------------------------------------
+
 macro_rules! impl_expressive_for_sqlite_scalar {
     ($($ty:ty),*) => {
         $(
@@ -91,28 +259,30 @@ impl Expressive<AnySqliteType> for &str {
     }
 }
 
-// TryFrom<AnySqliteType> impls — enables AssociatedExpression::get()
-//
-// If the value is a single-row, single-column result (common for COUNT, MAX, etc.),
-// extracts the scalar automatically. Otherwise falls back to try_get.
+impl Expressive<AnySqliteType> for AnySqliteType {
+    fn expr(&self) -> Expression<AnySqliteType> {
+        Expression::new("{}", vec![ExpressiveEnum::Scalar(self.clone())])
+    }
+}
+
+// -- TryFrom impls (for AssociatedExpression::get()) --------------------------
+
 macro_rules! impl_try_from_sqlite {
     ($($ty:ty),*) => {
         $(
             impl TryFrom<AnySqliteType> for $ty {
                 type Error = vantage_core::VantageError;
                 fn try_from(val: AnySqliteType) -> Result<Self, Self::Error> {
-                    // Try direct extraction first
                     if let Some(v) = val.try_get::<$ty>() {
                         return Ok(v);
                     }
                     // If result is [{col: value}], extract the scalar
-                    if let serde_json::Value::Array(arr) = val.value() {
+                    if let CborValue::Array(ref arr) = *val.value() {
                         if arr.len() == 1 {
-                            if let Some(obj) = arr[0].as_object() {
-                                if obj.len() == 1 {
-                                    let inner = AnySqliteType::untyped(
-                                        obj.values().next().unwrap().clone()
-                                    );
+                            if let CborValue::Map(ref map) = arr[0] {
+                                if map.len() == 1 {
+                                    let (_, v) = &map[0];
+                                    let inner = AnySqliteType::untyped(v.clone());
                                     if let Some(v) = inner.try_get::<$ty>() {
                                         return Ok(v);
                                     }
@@ -133,25 +303,26 @@ macro_rules! impl_try_from_sqlite {
 
 impl_try_from_sqlite!(i64, i32, f64, bool, String);
 
-/// Extract first row from a result array as a JSON object.
-/// Used by TryFrom impls for Record and serde structs.
-fn extract_first_row(val: &AnySqliteType) -> Option<serde_json::Value> {
+/// Extract first row from a CBOR result array as a map.
+fn extract_first_row(val: &AnySqliteType) -> Option<CborValue> {
     match val.value() {
-        serde_json::Value::Array(arr) => arr.first().cloned(),
-        // Already a single object (shouldn't happen from execute, but handle it)
-        obj @ serde_json::Value::Object(_) => Some(obj.clone()),
+        CborValue::Array(arr) => arr.first().cloned(),
+        obj @ CborValue::Map(_) => Some(obj.clone()),
         _ => None,
     }
 }
 
-impl TryFrom<AnySqliteType> for vantage_types::Record<serde_json::Value> {
-    type Error = vantage_core::VantageError;
-    fn try_from(val: AnySqliteType) -> Result<Self, Self::Error> {
-        let row = extract_first_row(&val).ok_or_else(|| {
-            vantage_core::error!("Expected row result", value = format!("{}", val))
-        })?;
-        Ok(row.into())
-    }
+/// Convert a CBOR Map into a Record<AnySqliteType>.
+fn cbor_map_to_record(map: Vec<(CborValue, CborValue)>) -> vantage_types::Record<AnySqliteType> {
+    map.into_iter()
+        .map(|(k, v)| {
+            let key = match k {
+                CborValue::Text(s) => s,
+                other => format!("{:?}", other),
+            };
+            (key, AnySqliteType::untyped(v))
+        })
+        .collect()
 }
 
 impl TryFrom<AnySqliteType> for vantage_types::Record<AnySqliteType> {
@@ -160,22 +331,80 @@ impl TryFrom<AnySqliteType> for vantage_types::Record<AnySqliteType> {
         let row = extract_first_row(&val).ok_or_else(|| {
             vantage_core::error!("Expected row result", value = format!("{}", val))
         })?;
-        // Convert JSON object → Record<AnySqliteType> with untyped values
         match row {
-            serde_json::Value::Object(map) => Ok(map
-                .into_iter()
-                .map(|(k, v)| (k, AnySqliteType::untyped(v)))
-                .collect()),
+            CborValue::Map(map) => Ok(cbor_map_to_record(map)),
             _ => Err(vantage_core::error!(
-                "Expected object row",
+                "Expected map row",
                 value = format!("{:?}", row)
             )),
         }
     }
 }
 
-impl Expressive<AnySqliteType> for AnySqliteType {
-    fn expr(&self) -> Expression<AnySqliteType> {
-        Expression::new("{}", vec![ExpressiveEnum::Scalar(self.clone())])
+impl TryFrom<AnySqliteType> for Vec<vantage_types::Record<AnySqliteType>> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnySqliteType) -> Result<Self, Self::Error> {
+        match val.into_value() {
+            CborValue::Array(arr) => arr
+                .into_iter()
+                .map(|item| match item {
+                    CborValue::Map(map) => Ok(cbor_map_to_record(map)),
+                    other => Err(vantage_core::error!(
+                        "Expected map row",
+                        value = format!("{:?}", other)
+                    )),
+                })
+                .collect(),
+            CborValue::Map(map) => Ok(vec![cbor_map_to_record(map)]),
+            other => Err(vantage_core::error!(
+                "Expected array or map result",
+                value = format!("{:?}", other)
+            )),
+        }
+    }
+}
+
+impl TryFrom<AnySqliteType> for vantage_types::Record<serde_json::Value> {
+    type Error = vantage_core::VantageError;
+    fn try_from(val: AnySqliteType) -> Result<Self, Self::Error> {
+        let record: vantage_types::Record<AnySqliteType> = val.try_into()?;
+        Ok(record
+            .into_iter()
+            .map(|(k, v)| (k, cbor_to_json(v.into_value())))
+            .collect())
+    }
+}
+
+impl vantage_types::TerminalRender for AnySqliteType {
+    fn render(&self) -> String {
+        match self.value() {
+            CborValue::Null => "-".to_string(),
+            CborValue::Text(s) => s.clone(),
+            CborValue::Bool(b) => b.to_string(),
+            CborValue::Tag(10, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    s.clone()
+                } else {
+                    format!("{}", self)
+                }
+            }
+            CborValue::Tag(0, inner) | CborValue::Tag(100, inner) | CborValue::Tag(101, inner) => {
+                if let CborValue::Text(s) = inner.as_ref() {
+                    s.clone()
+                } else {
+                    format!("{}", self)
+                }
+            }
+            _ => format!("{}", self),
+        }
+    }
+
+    fn color_hint(&self) -> Option<&'static str> {
+        match self.value() {
+            CborValue::Bool(true) => Some("green"),
+            CborValue::Bool(false) => Some("red"),
+            CborValue::Null => Some("dim"),
+            _ => None,
+        }
     }
 }

--- a/vantage-sql/src/sqlite/types/value.rs
+++ b/vantage-sql/src/sqlite/types/value.rs
@@ -26,6 +26,23 @@ impl AnySqliteType {
             type_variant: Some(variant),
         }
     }
+
+    /// If this is a single-row, single-column result `[{col: value}]`,
+    /// extract the scalar value. Otherwise return self unchanged.
+    pub fn unwrap_scalar(self) -> Self {
+        match self.value() {
+            CborValue::Array(arr) if arr.len() == 1 => {
+                if let CborValue::Map(map) = &arr[0] {
+                    if map.len() == 1 {
+                        let (_, v) = &map[0];
+                        return AnySqliteType::untyped(v.clone());
+                    }
+                }
+                self
+            }
+            _ => self,
+        }
+    }
 }
 
 /// AnySqliteType is itself a SqliteType — passthrough for type-erased values.
@@ -209,17 +226,9 @@ fn cbor_to_json(val: CborValue) -> JsonValue {
             JsonValue::Object(obj)
         }
         CborValue::Tag(10, inner) => {
-            // Decimal — try to parse as JSON number, fall back to string
+            // Decimal — preserve as string to avoid precision loss
             if let CborValue::Text(s) = *inner {
-                if let Ok(i) = s.parse::<i64>() {
-                    JsonValue::Number(i.into())
-                } else if let Ok(f) = s.parse::<f64>() {
-                    serde_json::Number::from_f64(f)
-                        .map(JsonValue::Number)
-                        .unwrap_or(JsonValue::String(s))
-                } else {
-                    JsonValue::String(s)
-                }
+                JsonValue::String(s)
             } else {
                 cbor_to_json(*inner)
             }
@@ -277,18 +286,9 @@ macro_rules! impl_try_from_sqlite {
                         return Ok(v);
                     }
                     // If result is [{col: value}], extract the scalar
-                    if let CborValue::Array(ref arr) = *val.value() {
-                        if arr.len() == 1 {
-                            if let CborValue::Map(ref map) = arr[0] {
-                                if map.len() == 1 {
-                                    let (_, v) = &map[0];
-                                    let inner = AnySqliteType::untyped(v.clone());
-                                    if let Some(v) = inner.try_get::<$ty>() {
-                                        return Ok(v);
-                                    }
-                                }
-                            }
-                        }
+                    let val = val.unwrap_scalar();
+                    if let Some(v) = val.try_get::<$ty>() {
+                        return Ok(v);
                     }
                     Err(vantage_core::error!(
                         "Cannot convert AnySqliteType to target type",

--- a/vantage-sql/tests/postgres/2_defer.rs
+++ b/vantage-sql/tests/postgres/2_defer.rs
@@ -8,7 +8,7 @@ use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_sql::postgres_expr;
 use vantage_types::Record;
 
-const PG_URL: &str = "postgres://vantage:vantage@localhost:5432/vantage";
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
 
 fn records(result: AnyPostgresType) -> Vec<Record<AnyPostgresType>> {
     Vec::<Record<AnyPostgresType>>::try_from(result).unwrap()
@@ -21,24 +21,24 @@ async fn setup(prefix: &str) -> (PostgresDB, PostgresDB) {
     let config_table = format!("{}_config", prefix);
     let product_table = format!("{}_product", prefix);
 
-    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", config_table))
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", config_table))
         .execute(db.pool())
         .await
         .unwrap();
-    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", product_table))
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", product_table))
         .execute(db.pool())
         .await
         .unwrap();
 
     sqlx::query(&format!(
-        "CREATE TABLE `{}` (`key` VARCHAR(255) PRIMARY KEY, value BIGINT NOT NULL)",
+        "CREATE TABLE \"{}\" (key TEXT PRIMARY KEY, value BIGINT NOT NULL)",
         config_table
     ))
     .execute(db.pool())
     .await
     .unwrap();
     sqlx::query(&format!(
-        "INSERT INTO `{}` VALUES ('min_price', 150)",
+        "INSERT INTO \"{}\" VALUES ('min_price', 150)",
         config_table
     ))
     .execute(db.pool())
@@ -46,14 +46,14 @@ async fn setup(prefix: &str) -> (PostgresDB, PostgresDB) {
     .unwrap();
 
     sqlx::query(&format!(
-        "CREATE TABLE `{}` (id VARCHAR(255) PRIMARY KEY, name TEXT NOT NULL, price BIGINT NOT NULL)",
+        "CREATE TABLE \"{}\" (id TEXT PRIMARY KEY, name TEXT NOT NULL, price BIGINT NOT NULL)",
         product_table
     ))
     .execute(db.pool())
     .await
     .unwrap();
     sqlx::query(&format!(
-        "INSERT INTO `{}` VALUES ('a', 'Cheap Thing', 50), ('b', 'Mid Thing', 150), ('c', 'Expensive Thing', 300)",
+        "INSERT INTO \"{}\" VALUES ('a', 'Cheap Thing', 50), ('b', 'Mid Thing', 150), ('c', 'Expensive Thing', 300)",
         product_table
     ))
     .execute(db.pool())
@@ -71,13 +71,13 @@ async fn test_cross_database_deferred() {
     let (config_db, shop_db) = setup("defer1").await;
 
     let threshold_query = postgres_expr!(
-        "SELECT value FROM `defer1_config` WHERE `key` = {}",
+        "SELECT value FROM \"defer1_config\" WHERE key = {}",
         "min_price"
     );
     let deferred_threshold = config_db.defer(threshold_query);
 
     let shop_query = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM `defer1_product` WHERE price >= {} ORDER BY price",
+        "SELECT name FROM \"defer1_product\" WHERE price >= {} ORDER BY price",
         vec![ExpressiveEnum::Deferred(deferred_threshold)],
     );
 
@@ -101,13 +101,13 @@ async fn test_deferred_mixed_with_scalars() {
     let (config_db, shop_db) = setup("defer2").await;
 
     let threshold_query = postgres_expr!(
-        "SELECT value FROM `defer2_config` WHERE `key` = {}",
+        "SELECT value FROM \"defer2_config\" WHERE key = {}",
         "min_price"
     );
     let deferred_threshold = config_db.defer(threshold_query);
 
     let shop_query = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM `defer2_product` WHERE price >= {} AND name != {} ORDER BY price",
+        "SELECT name FROM \"defer2_product\" WHERE price >= {} AND name != {} ORDER BY price",
         vec![
             ExpressiveEnum::Deferred(deferred_threshold),
             ExpressiveEnum::Scalar(AnyPostgresType::new("Mid Thing".to_string())),
@@ -130,7 +130,7 @@ async fn test_nested_deferred() {
     let (config_db, shop_db) = setup("defer3").await;
 
     let threshold_query = postgres_expr!(
-        "SELECT value FROM `defer3_config` WHERE `key` = {}",
+        "SELECT value FROM \"defer3_config\" WHERE key = {}",
         "min_price"
     );
     let deferred_threshold = config_db.defer(threshold_query);
@@ -141,7 +141,7 @@ async fn test_nested_deferred() {
     );
 
     let shop_query = postgres_expr!(
-        "SELECT name FROM `defer3_product` WHERE {} ORDER BY price",
+        "SELECT name FROM \"defer3_product\" WHERE {} ORDER BY price",
         (inner)
     );
 

--- a/vantage-sql/tests/postgres/2_expressions.rs
+++ b/vantage-sql/tests/postgres/2_expressions.rs
@@ -4,22 +4,22 @@ use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
 use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_types::Record;
 
-const PG_URL: &str = "postgres://vantage:vantage@localhost:5432/vantage";
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
 
 async fn setup(table: &str) -> PostgresDB {
     let db = PostgresDB::connect(PG_URL).await.unwrap();
 
-    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", table))
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", table))
         .execute(db.pool())
         .await
         .unwrap();
 
     sqlx::query(&format!(
-        "CREATE TABLE `{}` (
+        "CREATE TABLE \"{}\" (
             id INTEGER PRIMARY KEY,
             name TEXT NOT NULL,
             price BIGINT NOT NULL,
-            weight DOUBLE NOT NULL,
+            weight DOUBLE PRECISION NOT NULL,
             active BOOLEAN NOT NULL
         )",
         table
@@ -29,7 +29,7 @@ async fn setup(table: &str) -> PostgresDB {
     .unwrap();
 
     sqlx::query(&format!(
-        "INSERT INTO `{}` VALUES (1, 'Apple', 100, 0.2, true), (2, 'Banana', 50, 0.15, true), (3, 'Cherry', 200, 0.01, false)",
+        "INSERT INTO \"{}\" VALUES (1, 'Apple', 100, 0.2, true), (2, 'Banana', 50, 0.15, true), (3, 'Cherry', 200, 0.01, false)",
         table
     ))
     .execute(db.pool())
@@ -50,7 +50,7 @@ fn records(result: AnyPostgresType) -> Vec<Record<AnyPostgresType>> {
 async fn test_select_all() {
     let db = setup("expr_select_all").await;
     let expr =
-        Expression::<AnyPostgresType>::new("SELECT * FROM `expr_select_all` ORDER BY id", vec![]);
+        Expression::<AnyPostgresType>::new("SELECT * FROM \"expr_select_all\" ORDER BY id", vec![]);
     let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 3);
@@ -70,7 +70,7 @@ async fn test_select_all() {
 async fn test_parameterized_integer() {
     let db = setup("expr_param_int").await;
     let expr = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM `expr_param_int` WHERE id = {}",
+        "SELECT name FROM \"expr_param_int\" WHERE id = {}",
         vec![ExpressiveEnum::Scalar(AnyPostgresType::new(2i64))],
     );
     let result = records(db.execute(&expr).await.unwrap());
@@ -86,7 +86,7 @@ async fn test_parameterized_integer() {
 async fn test_parameterized_text() {
     let db = setup("expr_param_text").await;
     let expr = Expression::<AnyPostgresType>::new(
-        "SELECT price FROM `expr_param_text` WHERE name = {}",
+        "SELECT price FROM \"expr_param_text\" WHERE name = {}",
         vec![ExpressiveEnum::Scalar(AnyPostgresType::new(
             "Cherry".to_string(),
         ))],
@@ -101,7 +101,7 @@ async fn test_parameterized_text() {
 async fn test_parameterized_bool() {
     let db = setup("expr_param_bool").await;
     let expr = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM `expr_param_bool` WHERE active = {} ORDER BY name",
+        "SELECT name FROM \"expr_param_bool\" WHERE active = {} ORDER BY name",
         vec![ExpressiveEnum::Scalar(AnyPostgresType::new(true))],
     );
     let result = records(db.execute(&expr).await.unwrap());
@@ -123,7 +123,7 @@ async fn test_parameterized_bool() {
 async fn test_multiple_params() {
     let db = setup("expr_multi_params").await;
     let expr = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM `expr_multi_params` WHERE price >= {} AND active = {}",
+        "SELECT name FROM \"expr_multi_params\" WHERE price >= {} AND active = {}",
         vec![
             ExpressiveEnum::Scalar(AnyPostgresType::new(100i64)),
             ExpressiveEnum::Scalar(AnyPostgresType::new(true)),
@@ -149,7 +149,7 @@ async fn test_nested_expression() {
         vec![ExpressiveEnum::Scalar(AnyPostgresType::new(75i64))],
     );
     let full_query = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM `expr_nested` WHERE {} ORDER BY name",
+        "SELECT name FROM \"expr_nested\" WHERE {} ORDER BY name",
         vec![ExpressiveEnum::Nested(where_clause)],
     );
 
@@ -171,7 +171,7 @@ async fn test_nested_expression() {
 async fn test_empty_result() {
     let db = setup("expr_empty").await;
     let expr = Expression::<AnyPostgresType>::new(
-        "SELECT name FROM `expr_empty` WHERE id = {}",
+        "SELECT name FROM \"expr_empty\" WHERE id = {}",
         vec![ExpressiveEnum::Scalar(AnyPostgresType::new(999i64))],
     );
     let result = records(db.execute(&expr).await.unwrap());

--- a/vantage-sql/tests/sqlite/1_types_record.rs
+++ b/vantage-sql/tests/sqlite/1_types_record.rs
@@ -1,6 +1,10 @@
 //! Test 1b: Record<AnySqliteType> conversions — typed (write path) and
 //! untyped (read path) round-trips, error cases.
+//!
+//! Uses native CborValue for untyped values (simulating database reads)
+//! instead of the JSON bridge.
 
+use ciborium::Value as CborValue;
 use vantage_sql::sqlite::AnySqliteType;
 use vantage_types::Record;
 
@@ -14,7 +18,6 @@ fn test_typed_record_creation() {
     record.insert("price".into(), AnySqliteType::new(120i64));
     record.insert("is_deleted".into(), AnySqliteType::new(false));
 
-    // Values carry their type markers
     assert_eq!(
         record["name"].try_get::<String>(),
         Some("Cupcake".to_string())
@@ -52,18 +55,17 @@ fn test_untyped_record_creation() {
     let mut record: Record<AnySqliteType> = Record::new();
     record.insert(
         "name".into(),
-        AnySqliteType::untyped(serde_json::json!("Cupcake")),
+        AnySqliteType::untyped(CborValue::Text("Cupcake".into())),
     );
     record.insert(
         "price".into(),
-        AnySqliteType::untyped(serde_json::json!(120)),
+        AnySqliteType::untyped(CborValue::Integer(120.into())),
     );
     record.insert(
         "active".into(),
-        AnySqliteType::untyped(serde_json::json!(true)),
+        AnySqliteType::untyped(CborValue::Bool(true)),
     );
 
-    // Untyped values — try_get just attempts the conversion
     assert_eq!(
         record["name"].try_get::<String>(),
         Some("Cupcake".to_string())
@@ -72,19 +74,15 @@ fn test_untyped_record_creation() {
     assert_eq!(record["active"].try_get::<bool>(), Some(true));
 
     // Still fails when the underlying value can't convert
-    assert_eq!(record["name"].try_get::<i64>(), None); // "Cupcake" isn't a number
-    assert_eq!(record["price"].try_get::<String>(), None); // 120 isn't a string
+    assert_eq!(record["name"].try_get::<i64>(), None);
+    assert_eq!(record["price"].try_get::<String>(), None);
 }
 
 #[test]
 fn test_untyped_null() {
     let mut record: Record<AnySqliteType> = Record::new();
-    record.insert(
-        "note".into(),
-        AnySqliteType::untyped(serde_json::json!(null)),
-    );
+    record.insert("note".into(), AnySqliteType::untyped(CborValue::Null));
 
-    // Untyped null → Option<String> works (no variant blocking it)
     assert_eq!(record["note"].try_get::<Option<String>>(), Some(None));
     assert_eq!(record["note"].try_get::<Option<i64>>(), Some(None));
 }
@@ -98,25 +96,80 @@ fn test_typed_blocks_cross_variant() {
     assert_eq!(typed.try_get::<i64>(), Some(42));
     assert_eq!(typed.try_get::<f64>(), None); // Integer ≠ Real → blocked
 
-    // Untyped: same JSON value but no variant
-    let untyped = AnySqliteType::untyped(serde_json::json!(42));
+    // Untyped: same CBOR value but no variant — permissive
+    let untyped = AnySqliteType::untyped(CborValue::Integer(42.into()));
     assert_eq!(untyped.try_get::<i64>(), Some(42));
-    // Still None — not because of variant, but because json 42 doesn't parse as f64
-    // (serde_json::Number::as_f64 works on integers though, so this actually succeeds
-    // for untyped... let's verify)
 }
 
 #[test]
-fn test_untyped_is_permissive_across_numeric() {
-    // Untyped integer: try_get as f64 works because json Number can be read as f64
-    let untyped = AnySqliteType::untyped(serde_json::json!(42));
-    assert_eq!(untyped.try_get::<i64>(), Some(42));
-    // f64::from_json checks Value::Number → as_f64() which works for integer numbers
-    assert_eq!(untyped.try_get::<f64>(), Some(42.0));
+fn test_untyped_integer_narrowing() {
+    let val = AnySqliteType::untyped(CborValue::Integer(42.into()));
+    assert_eq!(val.try_get::<i64>(), Some(42));
+    assert_eq!(val.try_get::<i32>(), Some(42));
+    assert_eq!(val.try_get::<i16>(), Some(42));
+}
 
-    // Typed integer: f64 blocked by variant
-    let typed = AnySqliteType::new(42i64);
-    assert_eq!(typed.try_get::<f64>(), None); // Integer ≠ Real
+// ── CBOR tag preservation ─────────────────────────────────────────────────
+
+#[test]
+fn test_numeric_tag_preserved() {
+    let val = AnySqliteType::untyped(CborValue::Tag(
+        10,
+        Box::new(CborValue::Text("123.456".into())),
+    ));
+    assert_eq!(
+        *val.value(),
+        CborValue::Tag(10, Box::new(CborValue::Text("123.456".into())))
+    );
+}
+
+// ── Bool stored as integer ────────────────────────────────────────────────
+
+#[test]
+fn test_typed_bool_in_record() {
+    let mut record: Record<AnySqliteType> = Record::new();
+    record.insert("active".into(), AnySqliteType::new(true));
+
+    // SQLite stores bool as Integer 0/1
+    assert_eq!(*record["active"].value(), CborValue::Integer(1.into()));
+    assert_eq!(record["active"].try_get::<bool>(), Some(true));
+    // Bool ≠ Integer → blocked
+    assert_eq!(record["active"].try_get::<i64>(), None);
+}
+
+// ── JSON bridge round-trip ────────────────────────────────────────────────
+
+#[test]
+fn test_json_round_trip_integer() {
+    let original = AnySqliteType::new(42i64);
+    let json: serde_json::Value = original.clone().into();
+    assert_eq!(json, serde_json::json!(42));
+
+    let restored = AnySqliteType::from(json);
+    assert_eq!(restored.try_get::<i64>(), Some(42));
+}
+
+#[test]
+fn test_json_round_trip_string() {
+    let original = AnySqliteType::new("hello".to_string());
+    let json: serde_json::Value = original.into();
+    assert_eq!(json, serde_json::json!("hello"));
+
+    let restored = AnySqliteType::from(json);
+    assert_eq!(restored.try_get::<String>(), Some("hello".to_string()));
+}
+
+#[test]
+fn test_json_round_trip_bool() {
+    let original = AnySqliteType::new(true);
+    let json: serde_json::Value = original.into();
+    // SQLite bool is stored as integer 1 in CBOR, so JSON bridge produces number
+    assert_eq!(json, serde_json::json!(1));
+
+    // Roundtrip: JSON integer 1 → CBOR Integer(1) — variant is Integer, not Bool.
+    // Direct bool try_get won't work (variant mismatch), but i64 does.
+    let restored = AnySqliteType::from(json);
+    assert_eq!(restored.try_get::<i64>(), Some(1));
 }
 
 // ── Error cases ────────────────────────────────────────────────────────────
@@ -124,14 +177,13 @@ fn test_untyped_is_permissive_across_numeric() {
 #[test]
 fn test_missing_field_in_record() {
     let record: Record<AnySqliteType> = Record::new();
-    // Empty record — accessing a missing field
     assert!(record.get("name").is_none());
 }
 
 #[test]
 fn test_typed_wrong_extraction() {
     let mut record: Record<AnySqliteType> = Record::new();
-    record.insert("name".into(), AnySqliteType::new(42i64)); // stored as Integer
+    record.insert("name".into(), AnySqliteType::new(42i64));
 
     // Trying to get String from an Integer-tagged value fails
     assert_eq!(record["name"].try_get::<String>(), None);

--- a/vantage-sql/tests/sqlite/2_defer.rs
+++ b/vantage-sql/tests/sqlite/2_defer.rs
@@ -1,20 +1,15 @@
 //! Test 2b: Deferred expressions — cross-database value resolution.
 //!
 //! A deferred expression runs a query on one database at execution time,
-//! and the resulting value gets placed as a parameter in another database's
-//! query. This is NOT a subquery — the deferred query executes first,
-//! produces a concrete value, and that value gets bound into the outer query.
+//! and the resulting value gets placed as a parameter in another database's query.
 
-use serde_json::Value as JsonValue;
 use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_sql::sqlite_expr;
+use vantage_types::Record;
 
-fn rows(result: AnySqliteType) -> Vec<JsonValue> {
-    match result.into_value() {
-        JsonValue::Array(arr) => arr,
-        other => panic!("expected array, got: {:?}", other),
-    }
+fn records(result: AnySqliteType) -> Vec<Record<AnySqliteType>> {
+    Vec::<Record<AnySqliteType>>::try_from(result).unwrap()
 }
 
 async fn setup() -> (SqliteDB, SqliteDB) {
@@ -74,11 +69,17 @@ async fn test_cross_database_deferred() {
 
     // shop_db.execute() resolves the deferred first (calls config_db),
     // gets 150, then runs: SELECT name FROM product WHERE price >= 150
-    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+    let result = records(shop_db.execute(&shop_query).await.unwrap());
 
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0]["name"], "Mid Thing");
-    assert_eq!(result[1]["name"], "Expensive Thing");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Mid Thing".to_string())
+    );
+    assert_eq!(
+        result[1]["name"].try_get::<String>(),
+        Some("Expensive Thing".to_string())
+    );
 }
 
 // ── Deferred mixed with regular scalar parameters ──────────────────────────
@@ -98,11 +99,14 @@ async fn test_deferred_mixed_with_scalars() {
         ],
     );
 
-    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+    let result = records(shop_db.execute(&shop_query).await.unwrap());
 
     // 150 threshold, excluding "Mid Thing" → only "Expensive Thing"
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "Expensive Thing");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Expensive Thing".to_string())
+    );
 }
 
 // ── Deferred inside a nested expression ───────────────────────────────────
@@ -123,9 +127,15 @@ async fn test_nested_deferred() {
 
     let shop_query = sqlite_expr!("SELECT name FROM product WHERE {} ORDER BY price", (inner));
 
-    let result = rows(shop_db.execute(&shop_query).await.unwrap());
+    let result = records(shop_db.execute(&shop_query).await.unwrap());
 
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0]["name"], "Mid Thing");
-    assert_eq!(result[1]["name"], "Expensive Thing");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Mid Thing".to_string())
+    );
+    assert_eq!(
+        result[1]["name"].try_get::<String>(),
+        Some("Expensive Thing".to_string())
+    );
 }

--- a/vantage-sql/tests/sqlite/2_expressions.rs
+++ b/vantage-sql/tests/sqlite/2_expressions.rs
@@ -1,155 +1,175 @@
 //! Test 2: ExprDataSource — execute Expression<AnySqliteType> against live SQLite.
 
-use serde_json::Value as JsonValue;
 use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_types::Record;
 
-async fn setup() -> SqliteDB {
-    let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+const SQLITE_URL: &str = "sqlite::memory:";
 
-    sqlx::query(
-        "CREATE TABLE items (
+async fn setup(table: &str) -> SqliteDB {
+    let db = SqliteDB::connect(SQLITE_URL).await.unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE \"{}\" (
             id INTEGER PRIMARY KEY,
             name TEXT NOT NULL,
             price INTEGER NOT NULL,
             weight REAL NOT NULL,
             active BOOLEAN NOT NULL
         )",
-    )
+        table
+    ))
     .execute(db.pool())
     .await
     .unwrap();
 
-    sqlx::query("INSERT INTO items VALUES (1, 'Apple', 100, 0.2, 1)")
-        .execute(db.pool())
-        .await
-        .unwrap();
-    sqlx::query("INSERT INTO items VALUES (2, 'Banana', 50, 0.15, 1)")
-        .execute(db.pool())
-        .await
-        .unwrap();
-    sqlx::query("INSERT INTO items VALUES (3, 'Cherry', 200, 0.01, 0)")
-        .execute(db.pool())
-        .await
-        .unwrap();
+    sqlx::query(&format!(
+        "INSERT INTO \"{}\" VALUES (1, 'Apple', 100, 0.2, 1), (2, 'Banana', 50, 0.15, 1), (3, 'Cherry', 200, 0.01, 0)",
+        table
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
 
     db
 }
 
-/// Helper: unwrap result into JSON array of row objects.
-fn rows(result: AnySqliteType) -> Vec<JsonValue> {
-    match result.into_value() {
-        JsonValue::Array(arr) => arr,
-        other => panic!("expected array, got: {:?}", other),
-    }
+/// Helper: unwrap result into Vec of Record<AnySqliteType>.
+fn records(result: AnySqliteType) -> Vec<Record<AnySqliteType>> {
+    Vec::<Record<AnySqliteType>>::try_from(result).unwrap()
 }
 
 // ── Basic select via ExprDataSource ────────────────────────────────────────
 
 #[tokio::test]
 async fn test_select_all() {
-    let db = setup().await;
-    let expr = Expression::<AnySqliteType>::new("SELECT * FROM items ORDER BY id", vec![]);
-    let result = rows(db.execute(&expr).await.unwrap());
+    let db = setup("expr_select_all").await;
+    let expr =
+        Expression::<AnySqliteType>::new("SELECT * FROM \"expr_select_all\" ORDER BY id", vec![]);
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 3);
-    assert_eq!(result[0]["name"], "Apple");
-    assert_eq!(result[2]["name"], "Cherry");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Apple".to_string())
+    );
+    assert_eq!(
+        result[2]["name"].try_get::<String>(),
+        Some("Cherry".to_string())
+    );
 }
 
 // ── Parameterized query ────────────────────────────────────────────────────
 
 #[tokio::test]
 async fn test_parameterized_integer() {
-    let db = setup().await;
+    let db = setup("expr_param_int").await;
     let expr = Expression::<AnySqliteType>::new(
-        "SELECT name FROM items WHERE id = {}",
+        "SELECT name FROM \"expr_param_int\" WHERE id = {}",
         vec![ExpressiveEnum::Scalar(AnySqliteType::new(2i64))],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "Banana");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Banana".to_string())
+    );
 }
 
 #[tokio::test]
 async fn test_parameterized_text() {
-    let db = setup().await;
+    let db = setup("expr_param_text").await;
     let expr = Expression::<AnySqliteType>::new(
-        "SELECT price FROM items WHERE name = {}",
+        "SELECT price FROM \"expr_param_text\" WHERE name = {}",
         vec![ExpressiveEnum::Scalar(AnySqliteType::new(
             "Cherry".to_string(),
         ))],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["price"], 200);
+    assert_eq!(result[0]["price"].try_get::<i64>(), Some(200));
 }
 
 #[tokio::test]
 async fn test_parameterized_bool() {
-    let db = setup().await;
+    let db = setup("expr_param_bool").await;
     let expr = Expression::<AnySqliteType>::new(
-        "SELECT name FROM items WHERE active = {} ORDER BY name",
+        "SELECT name FROM \"expr_param_bool\" WHERE active = {} ORDER BY name",
         vec![ExpressiveEnum::Scalar(AnySqliteType::new(true))],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0]["name"], "Apple");
-    assert_eq!(result[1]["name"], "Banana");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Apple".to_string())
+    );
+    assert_eq!(
+        result[1]["name"].try_get::<String>(),
+        Some("Banana".to_string())
+    );
 }
 
 // ── Multiple parameters ───────────────────────────────────────────────────
 
 #[tokio::test]
 async fn test_multiple_params() {
-    let db = setup().await;
+    let db = setup("expr_multi_params").await;
     let expr = Expression::<AnySqliteType>::new(
-        "SELECT name FROM items WHERE price >= {} AND active = {}",
+        "SELECT name FROM \"expr_multi_params\" WHERE price >= {} AND active = {}",
         vec![
             ExpressiveEnum::Scalar(AnySqliteType::new(100i64)),
             ExpressiveEnum::Scalar(AnySqliteType::new(true)),
         ],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "Apple");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Apple".to_string())
+    );
 }
 
 // ── Nested expressions ────────────────────────────────────────────────────
 
 #[tokio::test]
 async fn test_nested_expression() {
-    let db = setup().await;
+    let db = setup("expr_nested").await;
 
     let where_clause = Expression::<AnySqliteType>::new(
         "price > {}",
         vec![ExpressiveEnum::Scalar(AnySqliteType::new(75i64))],
     );
     let full_query = Expression::<AnySqliteType>::new(
-        "SELECT name FROM items WHERE {} ORDER BY name",
+        "SELECT name FROM \"expr_nested\" WHERE {} ORDER BY name",
         vec![ExpressiveEnum::Nested(where_clause)],
     );
 
-    let result = rows(db.execute(&full_query).await.unwrap());
+    let result = records(db.execute(&full_query).await.unwrap());
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0]["name"], "Apple");
-    assert_eq!(result[1]["name"], "Cherry");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Apple".to_string())
+    );
+    assert_eq!(
+        result[1]["name"].try_get::<String>(),
+        Some("Cherry".to_string())
+    );
 }
 
 // ── Empty result ──────────────────────────────────────────────────────────
 
 #[tokio::test]
 async fn test_empty_result() {
-    let db = setup().await;
+    let db = setup("expr_empty").await;
     let expr = Expression::<AnySqliteType>::new(
-        "SELECT name FROM items WHERE id = {}",
+        "SELECT name FROM \"expr_empty\" WHERE id = {}",
         vec![ExpressiveEnum::Scalar(AnySqliteType::new(999i64))],
     );
-    let result = rows(db.execute(&expr).await.unwrap());
+    let result = records(db.execute(&expr).await.unwrap());
 
     assert!(result.is_empty());
 }

--- a/vantage-sql/tests/sqlite/2_insert.rs
+++ b/vantage-sql/tests/sqlite/2_insert.rs
@@ -30,7 +30,6 @@ async fn setup() -> SqliteDB {
     db
 }
 
-/// Helper: execute expression, unwrap result into JSON rows.
 /// Helper: unwrap result into Vec of Record<AnySqliteType>.
 fn records(result: AnySqliteType) -> Vec<Record<AnySqliteType>> {
     Vec::<Record<AnySqliteType>>::try_from(result).unwrap()

--- a/vantage-sql/tests/sqlite/2_insert.rs
+++ b/vantage-sql/tests/sqlite/2_insert.rs
@@ -3,23 +3,12 @@
 //! No statement builders — raw expressions with typed parameters.
 //! Focuses on the Product table to exercise multiple types (text, integer, bool).
 
-use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
 #[allow(unused_imports)]
 use vantage_expressions::Expressive;
 use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_sql::sqlite_expr;
-use vantage_types::{Record, TryFromRecord};
-
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-struct Product {
-    name: String,
-    price: i64,
-    calories: i64,
-    is_deleted: bool,
-    inventory_stock: i64,
-}
+use vantage_types::Record;
 
 async fn setup() -> SqliteDB {
     let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
@@ -42,11 +31,9 @@ async fn setup() -> SqliteDB {
 }
 
 /// Helper: execute expression, unwrap result into JSON rows.
-fn rows(result: AnySqliteType) -> Vec<JsonValue> {
-    match result.into_value() {
-        JsonValue::Array(arr) => arr,
-        other => panic!("expected array, got: {:?}", other),
-    }
+/// Helper: unwrap result into Vec of Record<AnySqliteType>.
+fn records(result: AnySqliteType) -> Vec<Record<AnySqliteType>> {
+    Vec::<Record<AnySqliteType>>::try_from(result).unwrap()
 }
 
 // ── Insert with typed parameters ───────────────────────────────────────────
@@ -73,18 +60,19 @@ async fn test_insert_product() {
         "SELECT name, price, calories, is_deleted, inventory_stock FROM product WHERE id = {}",
         "cupcake"
     );
-    let result = rows(db.execute(&select).await.unwrap());
+    let result = records(db.execute(&select).await.unwrap());
 
     assert_eq!(result.len(), 1);
 
-    let record: Record<JsonValue> = result[0].clone().into();
-    let product: Product = Product::from_record(record).unwrap();
-
-    assert_eq!(product.name, "Flux Cupcake");
-    assert_eq!(product.price, 120);
-    assert_eq!(product.calories, 300);
-    assert!(!product.is_deleted);
-    assert_eq!(product.inventory_stock, 50);
+    let row = &result[0];
+    assert_eq!(
+        row["name"].try_get::<String>(),
+        Some("Flux Cupcake".to_string())
+    );
+    assert_eq!(row["price"].try_get::<i64>(), Some(120));
+    assert_eq!(row["calories"].try_get::<i64>(), Some(300));
+    assert_eq!(row["is_deleted"].try_get::<bool>(), Some(false));
+    assert_eq!(row["inventory_stock"].try_get::<i64>(), Some(50));
 }
 
 // ── Insert multiple rows via nested expressions in a single VALUES ─────────
@@ -135,28 +123,29 @@ async fn test_insert_multiple_products() {
     let select = sqlite_expr!(
         "SELECT name, price, calories, is_deleted, inventory_stock FROM product ORDER BY price"
     );
-    let result = rows(db.execute(&select).await.unwrap());
+    let result = records(db.execute(&select).await.unwrap());
 
     assert_eq!(result.len(), 3);
 
-    let parsed: Vec<Product> = result
-        .into_iter()
-        .map(|r| Product::from_record(r.into()).unwrap())
-        .collect();
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("DeLorean Doughnut".to_string())
+    );
+    assert_eq!(result[0]["price"].try_get::<i64>(), Some(135));
+    assert_eq!(result[0]["is_deleted"].try_get::<bool>(), Some(false));
 
-    assert_eq!(parsed[0].name, "DeLorean Doughnut");
-    assert_eq!(parsed[0].price, 135);
-    assert!(!parsed[0].is_deleted);
-
-    assert_eq!(parsed[2].name, "Sea Pie");
-    assert_eq!(parsed[2].price, 299);
-    assert!(parsed[2].is_deleted);
-    assert_eq!(parsed[2].inventory_stock, 0);
+    assert_eq!(
+        result[2]["name"].try_get::<String>(),
+        Some("Sea Pie".to_string())
+    );
+    assert_eq!(result[2]["price"].try_get::<i64>(), Some(299));
+    assert_eq!(result[2]["is_deleted"].try_get::<bool>(), Some(true));
+    assert_eq!(result[2]["inventory_stock"].try_get::<i64>(), Some(0));
 }
 
 // ── Type marker verification ────────────────────────────────────────────────
 //
-// The point of using sqlite_expr! (AnySqliteType) instead of sql_expr! (JsonValue)
+// The point of using sqlite_expr! (AnySqliteType) instead of raw expressions
 // is that parameters carry variant tags. Let's verify that matters.
 
 #[tokio::test]
@@ -177,10 +166,13 @@ async fn test_bool_binds_correctly() {
 
     // Query with bool parameter — the type marker ensures it binds as bool, not as string "true"
     let select = sqlite_expr!("SELECT name FROM product WHERE is_deleted = {}", true);
-    let result = rows(db.execute(&select).await.unwrap());
+    let result = records(db.execute(&select).await.unwrap());
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0]["name"], "Gone");
+    assert_eq!(
+        result[0]["name"].try_get::<String>(),
+        Some("Gone".to_string())
+    );
 }
 
 #[tokio::test]
@@ -201,11 +193,11 @@ async fn test_integer_vs_text_binding() {
 
     // Query by integer — Integer variant binds as i64
     let by_price = sqlite_expr!("SELECT id FROM product WHERE price = {}", 100i64);
-    let result = rows(db.execute(&by_price).await.unwrap());
+    let result = records(db.execute(&by_price).await.unwrap());
     assert_eq!(result.len(), 1);
 
     // Query by text — Text variant binds as &str
     let by_name = sqlite_expr!("SELECT id FROM product WHERE name = {}", "Test");
-    let result = rows(db.execute(&by_name).await.unwrap());
+    let result = records(db.execute(&by_name).await.unwrap());
     assert_eq!(result.len(), 1);
 }

--- a/vantage-sql/tests/sqlite/3_complex_queries.rs
+++ b/vantage-sql/tests/sqlite/3_complex_queries.rs
@@ -31,8 +31,8 @@ async fn check_and_run<T: for<'de> Deserialize<'de>>(
 
     let db = get_db().await;
     let result = db.execute(&select.expr()).await.unwrap();
-    let rows = result.into_value();
-    let arr = rows.as_array().unwrap();
+    let json: serde_json::Value = result.into();
+    let arr = json.as_array().unwrap();
 
     let records: Vec<Record<serde_json::Value>> = arr.iter().map(|v| v.clone().into()).collect();
     records
@@ -605,8 +605,8 @@ async fn test_q8() {
 
     let db = get_db().await;
     let result = db.execute(&compound.expr()).await.unwrap();
-    let rows = result.into_value();
-    let arr = rows.as_array().unwrap();
+    let json: serde_json::Value = result.into();
+    let arr = json.as_array().unwrap();
 
     assert_eq!(
         compound.preview(),

--- a/vantage-sql/tests/sqlite/3_select.rs
+++ b/vantage-sql/tests/sqlite/3_select.rs
@@ -157,8 +157,8 @@ async fn test_execute_select_with_condition() {
         .with_condition(sqlite_expr!("\"is_deleted\" = {}", false));
 
     let result = db.execute(&select.expr()).await.unwrap();
-    let rows = result.into_value();
-    assert_eq!(rows.as_array().unwrap().len(), 2);
+    let json: serde_json::Value = result.into();
+    assert_eq!(json.as_array().unwrap().len(), 2);
 }
 
 #[tokio::test]

--- a/vantage-sql/tests/sqlite/bakery.rs
+++ b/vantage-sql/tests/sqlite/bakery.rs
@@ -4,8 +4,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
-use vantage_sql::sqlite::SqliteDB;
 use vantage_sql::sqlite::statements::SqliteSelect;
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
 use vantage_sql::sqlite_expr;
 use vantage_types::{Record, TryFromRecord};
 
@@ -17,8 +17,9 @@ async fn get_db() -> SqliteDB {
         .expect("Failed to connect to bakery.sqlite")
 }
 
-fn exec_rows(result: serde_json::Value) -> Vec<Record<JsonValue>> {
-    match result {
+fn exec_rows(result: AnySqliteType) -> Vec<Record<JsonValue>> {
+    let json: JsonValue = result.into();
+    match json {
         JsonValue::Array(arr) => arr.into_iter().map(|v| v.into()).collect(),
         other => panic!("expected array, got: {:?}", other),
     }
@@ -57,7 +58,7 @@ struct Product {
 async fn test_read_bakery() {
     let db = get_db().await;
     let select = SqliteSelect::new().with_source("bakery");
-    let rows = exec_rows(db.execute(&select.expr()).await.unwrap().into_value());
+    let rows = exec_rows(db.execute(&select.expr()).await.unwrap());
 
     assert_eq!(rows.len(), 1);
     let bakery: Bakery = Bakery::from_record(rows[0].clone()).unwrap();
@@ -70,7 +71,7 @@ async fn test_read_bakery() {
 async fn test_read_clients() {
     let db = get_db().await;
     let select = SqliteSelect::new().with_source("client");
-    let rows = exec_rows(db.execute(&select.expr()).await.unwrap().into_value());
+    let rows = exec_rows(db.execute(&select.expr()).await.unwrap());
 
     assert_eq!(rows.len(), 3);
     let clients: Vec<Client> = rows
@@ -90,7 +91,7 @@ async fn test_read_clients() {
 async fn test_read_products() {
     let db = get_db().await;
     let select = SqliteSelect::new().with_source("product");
-    let rows = exec_rows(db.execute(&select.expr()).await.unwrap().into_value());
+    let rows = exec_rows(db.execute(&select.expr()).await.unwrap());
 
     assert_eq!(rows.len(), 5);
     let products: Vec<Product> = rows
@@ -109,7 +110,7 @@ async fn test_select_with_where() {
     let select = SqliteSelect::new()
         .with_source("client")
         .with_condition(sqlite_expr!("\"is_paying_client\" = {}", true));
-    let rows = exec_rows(db.execute(&select.expr()).await.unwrap().into_value());
+    let rows = exec_rows(db.execute(&select.expr()).await.unwrap());
 
     assert_eq!(rows.len(), 2);
 }
@@ -121,7 +122,7 @@ async fn test_select_with_order_and_limit() {
         .with_source("product")
         .with_order(sqlite_expr!("\"price\""), Order::Desc)
         .with_limit(Some(2), None);
-    let rows = exec_rows(db.execute(&select.expr()).await.unwrap().into_value());
+    let rows = exec_rows(db.execute(&select.expr()).await.unwrap());
 
     assert_eq!(rows.len(), 2);
     let products: Vec<Product> = rows
@@ -140,7 +141,7 @@ async fn test_select_specific_fields() {
         .with_field("name")
         .with_field("price")
         .with_condition(sqlite_expr!("\"id\" = {}", "flux_cupcake"));
-    let rows = exec_rows(db.execute(&select.expr()).await.unwrap().into_value());
+    let rows = exec_rows(db.execute(&select.expr()).await.unwrap());
 
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].len(), 2);
@@ -158,8 +159,7 @@ async fn test_read_orders_with_lines() {
     let orders = exec_rows(
         db.execute(&SqliteSelect::new().with_source("client_order").expr())
             .await
-            .unwrap()
-            .into_value(),
+            .unwrap(),
     );
     assert_eq!(orders.len(), 3);
 
@@ -171,8 +171,7 @@ async fn test_read_orders_with_lines() {
                 .expr(),
         )
         .await
-        .unwrap()
-        .into_value(),
+        .unwrap(),
     );
     assert_eq!(doc_orders.len(), 2);
 
@@ -184,8 +183,7 @@ async fn test_read_orders_with_lines() {
                 .expr(),
         )
         .await
-        .unwrap()
-        .into_value(),
+        .unwrap(),
     );
     assert_eq!(order1_lines.len(), 3);
 }


### PR DESCRIPTION
Closes the CBOR migration started in #185 (mysql) and #186 (postgres+sqlite). The SQLite backend now stores values as `ciborium::Value` end-to-end — `serde_json::Value` is gone from the read/bind path, and the test ergonomics finally line up with the other backends.

Test code that read SQLite results used to do `result.into_value()` and then unwrap a `JsonValue::Array` by hand. That's gone — `Vec::<Record<AnySqliteType>>::try_from(result)` plus `try_get::<T>()` works now, matching how the postgres tests already read. A `cbor_to_json` / `json_to_cbor` bridge stays in `types/value.rs` for `AnyTable` and serde struct deserialization paths that still need `JsonValue` — ripping those out is a separate cleanup.

Behavioural change touching all three SQL backends: NULL from the database now reads as `variant: None` (was `Some(_::Null)` in mysql/postgres), so `try_get::<Option<T>>()` is permissive regardless of `T`. Also adds `AnySqliteType::unwrap_scalar()` (replaces three copies of inline scalar-extraction logic), a `TerminalRender` impl for grid display, `TryFrom<AnySqliteType> for Vec<Record<AnySqliteType>>`, and updates `bakery_model3::Animal` to the CBOR trait methods.

Postgres tests had latent backtick-quoted identifiers and the wrong port (`5432` → `5433`) — fixed in passing.