### PR TITLE
move some duplacated code that performs CBOR-JSON conversion

### DIFF
--- a/vantage-sql/src/lib.rs
+++ b/vantage-sql/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod primitives;
-pub mod types;
+pub(crate) mod types;
 
 #[cfg(feature = "sqlite")]
 pub mod sqlite;

--- a/vantage-sql/src/lib.rs
+++ b/vantage-sql/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod primitives;
+pub mod types;
 
 #[cfg(feature = "sqlite")]
 pub mod sqlite;

--- a/vantage-sql/src/mysql/row.rs
+++ b/vantage-sql/src/mysql/row.rs
@@ -297,7 +297,7 @@ fn mysql_column_to_cbor(
         "JSON" => {
             if let Ok(v) = row.try_get::<serde_json::Value, _>(ordinal) {
                 // JSON columns: convert the serde_json::Value to CBOR
-                let cbor = json_value_to_cbor(v);
+                let cbor = crate::types::json_to_cbor(v);
                 return (cbor, Some(MysqlTypeVariants::Text));
             }
         }
@@ -408,32 +408,4 @@ fn mysql_column_to_cbor(
         type_name,
     );
     (CborValue::Null, None)
-}
-
-/// Convert a serde_json::Value to CborValue (used for JSON columns).
-fn json_value_to_cbor(val: serde_json::Value) -> CborValue {
-    match val {
-        serde_json::Value::Null => CborValue::Null,
-        serde_json::Value::Bool(b) => CborValue::Bool(b),
-        serde_json::Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                CborValue::Integer(i.into())
-            } else if let Some(u) = n.as_u64() {
-                CborValue::Integer(u.into())
-            } else if let Some(f) = n.as_f64() {
-                CborValue::Float(f)
-            } else {
-                CborValue::Text(n.to_string())
-            }
-        }
-        serde_json::Value::String(s) => CborValue::Text(s),
-        serde_json::Value::Array(arr) => {
-            CborValue::Array(arr.into_iter().map(json_value_to_cbor).collect())
-        }
-        serde_json::Value::Object(map) => CborValue::Map(
-            map.into_iter()
-                .map(|(k, v)| (CborValue::Text(k), json_value_to_cbor(v)))
-                .collect(),
-        ),
-    }
 }

--- a/vantage-sql/src/mysql/types/value.rs
+++ b/vantage-sql/src/mysql/types/value.rs
@@ -7,6 +7,8 @@ use ciborium::Value as CborValue;
 use serde_json::Value as JsonValue;
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
+use crate::types::{cbor_to_json, json_to_cbor};
+
 impl AnyMysqlType {
     /// Create an AnyMysqlType with no type marker. Used for values coming
     /// back from the database where we don't know the original type.
@@ -146,89 +148,6 @@ impl From<JsonValue> for AnyMysqlType {
 impl From<AnyMysqlType> for JsonValue {
     fn from(val: AnyMysqlType) -> Self {
         cbor_to_json(val.into_value())
-    }
-}
-
-fn json_to_cbor(val: JsonValue) -> CborValue {
-    match val {
-        JsonValue::Null => CborValue::Null,
-        JsonValue::Bool(b) => CborValue::Bool(b),
-        JsonValue::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                CborValue::Integer(i.into())
-            } else if let Some(u) = n.as_u64() {
-                CborValue::Integer(u.into())
-            } else if let Some(f) = n.as_f64() {
-                CborValue::Float(f)
-            } else {
-                CborValue::Text(n.to_string())
-            }
-        }
-        JsonValue::String(s) => CborValue::Text(s),
-        JsonValue::Array(arr) => CborValue::Array(arr.into_iter().map(json_to_cbor).collect()),
-        JsonValue::Object(map) => CborValue::Map(
-            map.into_iter()
-                .map(|(k, v)| (CborValue::Text(k), json_to_cbor(v)))
-                .collect(),
-        ),
-    }
-}
-
-fn cbor_to_json(val: CborValue) -> JsonValue {
-    match val {
-        CborValue::Null => JsonValue::Null,
-        CborValue::Bool(b) => JsonValue::Bool(b),
-        CborValue::Integer(i) => {
-            let n = i128::from(i);
-            if let Ok(v) = i64::try_from(n) {
-                JsonValue::Number(v.into())
-            } else if let Ok(v) = u64::try_from(n) {
-                JsonValue::Number(v.into())
-            } else {
-                JsonValue::String(n.to_string())
-            }
-        }
-        CborValue::Float(f) => serde_json::Number::from_f64(f)
-            .map(JsonValue::Number)
-            .unwrap_or(JsonValue::Null),
-        CborValue::Text(s) => JsonValue::String(s),
-        CborValue::Bytes(b) => match String::from_utf8(b) {
-            Ok(s) => JsonValue::String(s),
-            Err(e) => JsonValue::String(hex::encode(e.as_bytes())),
-        },
-        CborValue::Array(arr) => JsonValue::Array(arr.into_iter().map(cbor_to_json).collect()),
-        CborValue::Map(map) => {
-            let obj: serde_json::Map<String, JsonValue> = map
-                .into_iter()
-                .map(|(k, v)| {
-                    let key = match k {
-                        CborValue::Text(s) => s,
-                        other => format!("{:?}", other),
-                    };
-                    (key, cbor_to_json(v))
-                })
-                .collect();
-            JsonValue::Object(obj)
-        }
-        // Tagged values: extract the inner value for JSON (tags have no JSON equivalent)
-        CborValue::Tag(10, inner) => {
-            // Decimal — try to parse as JSON number, fall back to string
-            if let CborValue::Text(s) = *inner {
-                if let Ok(i) = s.parse::<i64>() {
-                    JsonValue::Number(i.into())
-                } else if let Ok(f) = s.parse::<f64>() {
-                    serde_json::Number::from_f64(f)
-                        .map(JsonValue::Number)
-                        .unwrap_or(JsonValue::String(s))
-                } else {
-                    JsonValue::String(s)
-                }
-            } else {
-                cbor_to_json(*inner)
-            }
-        }
-        CborValue::Tag(_, inner) => cbor_to_json(*inner),
-        _ => JsonValue::Null,
     }
 }
 

--- a/vantage-sql/src/postgres/row.rs
+++ b/vantage-sql/src/postgres/row.rs
@@ -375,5 +375,5 @@ fn pg_column_to_cbor(
         row.columns()[ordinal].name(),
         type_name,
     );
-    (CborValue::Null, Some(PostgresTypeVariants::Null))
+    (CborValue::Null, None)
 }

--- a/vantage-sql/src/postgres/row.rs
+++ b/vantage-sql/src/postgres/row.rs
@@ -334,7 +334,7 @@ fn pg_column_to_cbor(
         }
         "JSONB" | "JSON" => {
             if let Ok(v) = row.try_get::<serde_json::Value, _>(ordinal) {
-                let cbor = json_value_to_cbor(v);
+                let cbor = crate::types::json_to_cbor(v);
                 return (cbor, None);
             }
         }
@@ -376,32 +376,4 @@ fn pg_column_to_cbor(
         type_name,
     );
     (CborValue::Null, Some(PostgresTypeVariants::Null))
-}
-
-/// Convert a serde_json::Value to CborValue (used for JSON/JSONB columns).
-fn json_value_to_cbor(val: serde_json::Value) -> CborValue {
-    match val {
-        serde_json::Value::Null => CborValue::Null,
-        serde_json::Value::Bool(b) => CborValue::Bool(b),
-        serde_json::Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                CborValue::Integer(i.into())
-            } else if let Some(u) = n.as_u64() {
-                CborValue::Integer(u.into())
-            } else if let Some(f) = n.as_f64() {
-                CborValue::Float(f)
-            } else {
-                CborValue::Text(n.to_string())
-            }
-        }
-        serde_json::Value::String(s) => CborValue::Text(s),
-        serde_json::Value::Array(arr) => {
-            CborValue::Array(arr.into_iter().map(json_value_to_cbor).collect())
-        }
-        serde_json::Value::Object(map) => CborValue::Map(
-            map.into_iter()
-                .map(|(k, v)| (CborValue::Text(k), json_value_to_cbor(v)))
-                .collect(),
-        ),
-    }
 }

--- a/vantage-sql/src/postgres/types/value.rs
+++ b/vantage-sql/src/postgres/types/value.rs
@@ -7,6 +7,8 @@ use ciborium::Value as CborValue;
 use serde_json::Value as JsonValue;
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
+use crate::types::{cbor_to_json, json_to_cbor};
+
 impl AnyPostgresType {
     /// Create an AnyPostgresType with no type marker. Used for values coming
     /// back from the database where we don't know the original type.
@@ -152,88 +154,6 @@ impl From<JsonValue> for AnyPostgresType {
 impl From<AnyPostgresType> for JsonValue {
     fn from(val: AnyPostgresType) -> Self {
         cbor_to_json(val.into_value())
-    }
-}
-
-fn json_to_cbor(val: JsonValue) -> CborValue {
-    match val {
-        JsonValue::Null => CborValue::Null,
-        JsonValue::Bool(b) => CborValue::Bool(b),
-        JsonValue::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                CborValue::Integer(i.into())
-            } else if let Some(u) = n.as_u64() {
-                CborValue::Integer(u.into())
-            } else if let Some(f) = n.as_f64() {
-                CborValue::Float(f)
-            } else {
-                CborValue::Text(n.to_string())
-            }
-        }
-        JsonValue::String(s) => CborValue::Text(s),
-        JsonValue::Array(arr) => CborValue::Array(arr.into_iter().map(json_to_cbor).collect()),
-        JsonValue::Object(map) => CborValue::Map(
-            map.into_iter()
-                .map(|(k, v)| (CborValue::Text(k), json_to_cbor(v)))
-                .collect(),
-        ),
-    }
-}
-
-fn cbor_to_json(val: CborValue) -> JsonValue {
-    match val {
-        CborValue::Null => JsonValue::Null,
-        CborValue::Bool(b) => JsonValue::Bool(b),
-        CborValue::Integer(i) => {
-            let n = i128::from(i);
-            if let Ok(v) = i64::try_from(n) {
-                JsonValue::Number(v.into())
-            } else if let Ok(v) = u64::try_from(n) {
-                JsonValue::Number(v.into())
-            } else {
-                JsonValue::String(n.to_string())
-            }
-        }
-        CborValue::Float(f) => serde_json::Number::from_f64(f)
-            .map(JsonValue::Number)
-            .unwrap_or(JsonValue::Null),
-        CborValue::Text(s) => JsonValue::String(s),
-        CborValue::Bytes(b) => match String::from_utf8(b) {
-            Ok(s) => JsonValue::String(s),
-            Err(e) => JsonValue::String(hex::encode(e.as_bytes())),
-        },
-        CborValue::Array(arr) => JsonValue::Array(arr.into_iter().map(cbor_to_json).collect()),
-        CborValue::Map(map) => {
-            let obj: serde_json::Map<String, JsonValue> = map
-                .into_iter()
-                .map(|(k, v)| {
-                    let key = match k {
-                        CborValue::Text(s) => s,
-                        other => format!("{:?}", other),
-                    };
-                    (key, cbor_to_json(v))
-                })
-                .collect();
-            JsonValue::Object(obj)
-        }
-        CborValue::Tag(10, inner) => {
-            // Decimal — try to parse as JSON number, fall back to string
-            if let CborValue::Text(s) = *inner {
-                if let Ok(i) = s.parse::<i64>() {
-                    JsonValue::Number(i.into())
-                } else if let Ok(f) = s.parse::<f64>() {
-                    serde_json::Number::from_f64(f)
-                        .map(JsonValue::Number)
-                        .unwrap_or(JsonValue::String(s))
-                } else {
-                    JsonValue::String(s)
-                }
-            } else {
-                cbor_to_json(*inner)
-            }
-        }
-        CborValue::Tag(_, inner) => cbor_to_json(*inner),
-        _ => JsonValue::Null,
     }
 }
 

--- a/vantage-sql/src/sqlite/types/value.rs
+++ b/vantage-sql/src/sqlite/types/value.rs
@@ -7,6 +7,8 @@ use ciborium::Value as CborValue;
 use serde_json::Value as JsonValue;
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
+use crate::types::{cbor_to_json, json_to_cbor};
+
 impl AnySqliteType {
     /// Create an AnySqliteType with no type marker. Used for values coming
     /// back from the database where we don't know the original type.
@@ -32,11 +34,11 @@ impl AnySqliteType {
     pub fn unwrap_scalar(self) -> Self {
         match self.value() {
             CborValue::Array(arr) if arr.len() == 1 => {
-                if let CborValue::Map(map) = &arr[0] {
-                    if map.len() == 1 {
-                        let (_, v) = &map[0];
-                        return AnySqliteType::untyped(v.clone());
-                    }
+                if let CborValue::Map(map) = &arr[0]
+                    && map.len() == 1
+                {
+                    let (_, v) = &map[0];
+                    return AnySqliteType::untyped(v.clone());
                 }
                 self
             }
@@ -161,80 +163,6 @@ impl From<JsonValue> for AnySqliteType {
 impl From<AnySqliteType> for JsonValue {
     fn from(val: AnySqliteType) -> Self {
         cbor_to_json(val.into_value())
-    }
-}
-
-fn json_to_cbor(val: JsonValue) -> CborValue {
-    match val {
-        JsonValue::Null => CborValue::Null,
-        JsonValue::Bool(b) => CborValue::Bool(b),
-        JsonValue::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                CborValue::Integer(i.into())
-            } else if let Some(u) = n.as_u64() {
-                CborValue::Integer(u.into())
-            } else if let Some(f) = n.as_f64() {
-                CborValue::Float(f)
-            } else {
-                CborValue::Text(n.to_string())
-            }
-        }
-        JsonValue::String(s) => CborValue::Text(s),
-        JsonValue::Array(arr) => CborValue::Array(arr.into_iter().map(json_to_cbor).collect()),
-        JsonValue::Object(map) => CborValue::Map(
-            map.into_iter()
-                .map(|(k, v)| (CborValue::Text(k), json_to_cbor(v)))
-                .collect(),
-        ),
-    }
-}
-
-fn cbor_to_json(val: CborValue) -> JsonValue {
-    match val {
-        CborValue::Null => JsonValue::Null,
-        CborValue::Bool(b) => JsonValue::Bool(b),
-        CborValue::Integer(i) => {
-            let n = i128::from(i);
-            if let Ok(v) = i64::try_from(n) {
-                JsonValue::Number(v.into())
-            } else if let Ok(v) = u64::try_from(n) {
-                JsonValue::Number(v.into())
-            } else {
-                JsonValue::String(n.to_string())
-            }
-        }
-        CborValue::Float(f) => serde_json::Number::from_f64(f)
-            .map(JsonValue::Number)
-            .unwrap_or(JsonValue::Null),
-        CborValue::Text(s) => JsonValue::String(s),
-        CborValue::Bytes(b) => match String::from_utf8(b) {
-            Ok(s) => JsonValue::String(s),
-            Err(e) => JsonValue::String(hex::encode(e.as_bytes())),
-        },
-        CborValue::Array(arr) => JsonValue::Array(arr.into_iter().map(cbor_to_json).collect()),
-        CborValue::Map(map) => {
-            let obj: serde_json::Map<String, JsonValue> = map
-                .into_iter()
-                .map(|(k, v)| {
-                    let key = match k {
-                        CborValue::Text(s) => s,
-                        other => format!("{:?}", other),
-                    };
-                    (key, cbor_to_json(v))
-                })
-                .collect();
-            JsonValue::Object(obj)
-        }
-        CborValue::Tag(10, inner) => {
-            // Decimal — preserve as string to avoid precision loss
-            if let CborValue::Text(s) = *inner {
-                JsonValue::String(s)
-            } else {
-                cbor_to_json(*inner)
-            }
-        }
-        CborValue::Tag(_, inner) => cbor_to_json(*inner),
-        _ => JsonValue::Null,
     }
 }
 

--- a/vantage-sql/src/types.rs
+++ b/vantage-sql/src/types.rs
@@ -1,14 +1,17 @@
 //! Shared CBOR ↔ JSON bridge functions.
 //!
-//! These conversions are lossy by design — JSON cannot represent CBOR tags,
-//! binary data, or arbitrary-precision decimals. Used for interop with
-//! serde-based code paths (e.g. AnyTable, struct deserialization).
+//! CBOR→JSON is value-preserving: every CBOR value produces a JSON value that
+//! retains the original data (possibly as a string when JSON has no matching
+//! type). Tags are stripped, bytes become hex strings, NaN/Infinity become
+//! string representations.
+//!
+//! JSON→CBOR is lossless (JSON is a subset of what CBOR can represent).
 
 use ciborium::Value as CborValue;
 use serde_json::Value as JsonValue;
 
 /// Convert a `serde_json::Value` into a `ciborium::Value`.
-pub fn json_to_cbor(val: JsonValue) -> CborValue {
+pub(crate) fn json_to_cbor(val: JsonValue) -> CborValue {
     match val {
         JsonValue::Null => CborValue::Null,
         JsonValue::Bool(b) => CborValue::Bool(b),
@@ -35,9 +38,11 @@ pub fn json_to_cbor(val: JsonValue) -> CborValue {
 
 /// Convert a `ciborium::Value` into a `serde_json::Value`.
 ///
-/// Lossy: CBOR tags are unwrapped, `Bytes` become hex or UTF-8 strings,
-/// and large integers fall back to string representation.
-pub fn cbor_to_json(val: CborValue) -> JsonValue {
+/// Value-preserving: tags are stripped but inner values kept, floats that
+/// can't be represented as JSON numbers become strings, bytes become hex
+/// strings, and high-precision decimals stay as strings when f64 would
+/// lose precision.
+pub(crate) fn cbor_to_json(val: CborValue) -> JsonValue {
     match val {
         CborValue::Null => JsonValue::Null,
         CborValue::Bool(b) => JsonValue::Bool(b),
@@ -51,9 +56,12 @@ pub fn cbor_to_json(val: CborValue) -> JsonValue {
                 JsonValue::String(n.to_string())
             }
         }
-        CborValue::Float(f) => serde_json::Number::from_f64(f)
-            .map(JsonValue::Number)
-            .unwrap_or(JsonValue::Null),
+        CborValue::Float(f) => {
+            // NaN and Infinity have no JSON representation — preserve as string
+            serde_json::Number::from_f64(f)
+                .map(JsonValue::Number)
+                .unwrap_or_else(|| JsonValue::String(f.to_string()))
+        }
         CborValue::Text(s) => JsonValue::String(s),
         CborValue::Bytes(b) => match String::from_utf8(b) {
             Ok(s) => JsonValue::String(s),
@@ -74,14 +82,19 @@ pub fn cbor_to_json(val: CborValue) -> JsonValue {
             JsonValue::Object(obj)
         }
         CborValue::Tag(10, inner) => {
-            // Decimal — try to produce a JSON number, fall back to string
+            // Decimal — only use f64 if it round-trips without precision loss
             if let CborValue::Text(s) = *inner {
                 if let Ok(i) = s.parse::<i64>() {
                     JsonValue::Number(i.into())
                 } else if let Ok(f) = s.parse::<f64>() {
-                    serde_json::Number::from_f64(f)
-                        .map(JsonValue::Number)
-                        .unwrap_or(JsonValue::String(s))
+                    // Check that f64 round-trips to the same string
+                    if f.to_string() == s {
+                        serde_json::Number::from_f64(f)
+                            .map(JsonValue::Number)
+                            .unwrap_or(JsonValue::String(s))
+                    } else {
+                        JsonValue::String(s)
+                    }
                 } else {
                     JsonValue::String(s)
                 }
@@ -91,5 +104,167 @@ pub fn cbor_to_json(val: CborValue) -> JsonValue {
         }
         CborValue::Tag(_, inner) => cbor_to_json(*inner),
         _ => JsonValue::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Basic round-trips ────────────────────────────────────────────────
+
+    #[test]
+    fn null_round_trips() {
+        let cbor = CborValue::Null;
+        let json = cbor_to_json(cbor);
+        assert_eq!(json, JsonValue::Null);
+        assert_eq!(json_to_cbor(json), CborValue::Null);
+    }
+
+    #[test]
+    fn bool_round_trips() {
+        let json = cbor_to_json(CborValue::Bool(true));
+        assert_eq!(json, JsonValue::Bool(true));
+        assert_eq!(json_to_cbor(json), CborValue::Bool(true));
+    }
+
+    #[test]
+    fn integer_round_trips() {
+        let json = cbor_to_json(CborValue::Integer(42.into()));
+        assert_eq!(json, serde_json::json!(42));
+        assert_eq!(json_to_cbor(json), CborValue::Integer(42.into()));
+    }
+
+    #[test]
+    fn float_round_trips() {
+        let json = cbor_to_json(CborValue::Float(3.14));
+        assert_eq!(json, serde_json::json!(3.14));
+        // JSON→CBOR for floats goes through as_f64
+        assert_eq!(json_to_cbor(json), CborValue::Float(3.14));
+    }
+
+    #[test]
+    fn text_round_trips() {
+        let json = cbor_to_json(CborValue::Text("hello".into()));
+        assert_eq!(json, serde_json::json!("hello"));
+        assert_eq!(json_to_cbor(json), CborValue::Text("hello".into()));
+    }
+
+    // ── Value preservation (lossy but no data destroyed) ─────────────────
+
+    #[test]
+    fn nan_preserved_as_string() {
+        let json = cbor_to_json(CborValue::Float(f64::NAN));
+        assert_eq!(json, JsonValue::String("NaN".into()));
+    }
+
+    #[test]
+    fn infinity_preserved_as_string() {
+        let json = cbor_to_json(CborValue::Float(f64::INFINITY));
+        assert_eq!(json, JsonValue::String("inf".into()));
+
+        let json = cbor_to_json(CborValue::Float(f64::NEG_INFINITY));
+        assert_eq!(json, JsonValue::String("-inf".into()));
+    }
+
+    #[test]
+    fn u64_max_preserved_as_number() {
+        // u64::MAX is beyond i64 but ciborium can represent it
+        let cbor = CborValue::Integer(u64::MAX.into());
+        let json = cbor_to_json(cbor);
+        assert_eq!(json, serde_json::json!(u64::MAX));
+    }
+
+    #[test]
+    fn bytes_valid_utf8_becomes_string() {
+        let json = cbor_to_json(CborValue::Bytes(b"hello".to_vec()));
+        assert_eq!(json, JsonValue::String("hello".into()));
+    }
+
+    #[test]
+    fn bytes_invalid_utf8_becomes_hex() {
+        let json = cbor_to_json(CborValue::Bytes(vec![0xFF, 0xFE]));
+        assert_eq!(json, JsonValue::String("fffe".into()));
+    }
+
+    // ── Tag handling (tags stripped, values preserved) ────────────────────
+
+    #[test]
+    fn tag_datetime_stripped() {
+        let cbor = CborValue::Tag(0, Box::new(CborValue::Text("2024-01-15T10:30:00Z".into())));
+        let json = cbor_to_json(cbor);
+        assert_eq!(json, JsonValue::String("2024-01-15T10:30:00Z".into()));
+    }
+
+    #[test]
+    fn tag_decimal_integer_becomes_number() {
+        let cbor = CborValue::Tag(10, Box::new(CborValue::Text("42".into())));
+        let json = cbor_to_json(cbor);
+        assert_eq!(json, serde_json::json!(42));
+    }
+
+    #[test]
+    fn tag_decimal_safe_float_becomes_number() {
+        // "3.5" round-trips through f64 cleanly
+        let cbor = CborValue::Tag(10, Box::new(CborValue::Text("3.5".into())));
+        let json = cbor_to_json(cbor);
+        assert_eq!(json, serde_json::json!(3.5));
+    }
+
+    #[test]
+    fn tag_decimal_high_precision_stays_string() {
+        // This value would lose precision as f64
+        let s = "99999999999999999.123456789";
+        let cbor = CborValue::Tag(10, Box::new(CborValue::Text(s.into())));
+        let json = cbor_to_json(cbor);
+        assert_eq!(json, JsonValue::String(s.into()));
+    }
+
+    #[test]
+    fn tag_decimal_trailing_zeros_stay_string() {
+        // "1.10" → f64 → "1.1" — doesn't match, so preserve as string
+        let cbor = CborValue::Tag(10, Box::new(CborValue::Text("1.10".into())));
+        let json = cbor_to_json(cbor);
+        assert_eq!(json, JsonValue::String("1.10".into()));
+    }
+
+    // ── Nested structures ────────────────────────────────────────────────
+
+    #[test]
+    fn array_round_trips() {
+        let cbor = CborValue::Array(vec![
+            CborValue::Integer(1.into()),
+            CborValue::Text("two".into()),
+        ]);
+        let json = cbor_to_json(cbor);
+        assert_eq!(json, serde_json::json!([1, "two"]));
+    }
+
+    #[test]
+    fn map_with_text_keys_round_trips() {
+        let cbor = CborValue::Map(vec![(
+            CborValue::Text("key".into()),
+            CborValue::Integer(99.into()),
+        )]);
+        let json = cbor_to_json(cbor);
+        assert_eq!(json, serde_json::json!({"key": 99}));
+    }
+
+    #[test]
+    fn map_non_text_key_uses_debug() {
+        let cbor = CborValue::Map(vec![(
+            CborValue::Integer(1.into()),
+            CborValue::Text("val".into()),
+        )]);
+        let json = cbor_to_json(cbor);
+        // Key becomes Debug representation
+        assert!(
+            json.as_object()
+                .unwrap()
+                .keys()
+                .next()
+                .unwrap()
+                .contains("Integer")
+        );
     }
 }

--- a/vantage-sql/src/types.rs
+++ b/vantage-sql/src/types.rs
@@ -1,0 +1,95 @@
+//! Shared CBOR ↔ JSON bridge functions.
+//!
+//! These conversions are lossy by design — JSON cannot represent CBOR tags,
+//! binary data, or arbitrary-precision decimals. Used for interop with
+//! serde-based code paths (e.g. AnyTable, struct deserialization).
+
+use ciborium::Value as CborValue;
+use serde_json::Value as JsonValue;
+
+/// Convert a `serde_json::Value` into a `ciborium::Value`.
+pub fn json_to_cbor(val: JsonValue) -> CborValue {
+    match val {
+        JsonValue::Null => CborValue::Null,
+        JsonValue::Bool(b) => CborValue::Bool(b),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                CborValue::Integer(i.into())
+            } else if let Some(u) = n.as_u64() {
+                CborValue::Integer(u.into())
+            } else if let Some(f) = n.as_f64() {
+                CborValue::Float(f)
+            } else {
+                CborValue::Text(n.to_string())
+            }
+        }
+        JsonValue::String(s) => CborValue::Text(s),
+        JsonValue::Array(arr) => CborValue::Array(arr.into_iter().map(json_to_cbor).collect()),
+        JsonValue::Object(map) => CborValue::Map(
+            map.into_iter()
+                .map(|(k, v)| (CborValue::Text(k), json_to_cbor(v)))
+                .collect(),
+        ),
+    }
+}
+
+/// Convert a `ciborium::Value` into a `serde_json::Value`.
+///
+/// Lossy: CBOR tags are unwrapped, `Bytes` become hex or UTF-8 strings,
+/// and large integers fall back to string representation.
+pub fn cbor_to_json(val: CborValue) -> JsonValue {
+    match val {
+        CborValue::Null => JsonValue::Null,
+        CborValue::Bool(b) => JsonValue::Bool(b),
+        CborValue::Integer(i) => {
+            let n = i128::from(i);
+            if let Ok(v) = i64::try_from(n) {
+                JsonValue::Number(v.into())
+            } else if let Ok(v) = u64::try_from(n) {
+                JsonValue::Number(v.into())
+            } else {
+                JsonValue::String(n.to_string())
+            }
+        }
+        CborValue::Float(f) => serde_json::Number::from_f64(f)
+            .map(JsonValue::Number)
+            .unwrap_or(JsonValue::Null),
+        CborValue::Text(s) => JsonValue::String(s),
+        CborValue::Bytes(b) => match String::from_utf8(b) {
+            Ok(s) => JsonValue::String(s),
+            Err(e) => JsonValue::String(hex::encode(e.as_bytes())),
+        },
+        CborValue::Array(arr) => JsonValue::Array(arr.into_iter().map(cbor_to_json).collect()),
+        CborValue::Map(map) => {
+            let obj: serde_json::Map<String, JsonValue> = map
+                .into_iter()
+                .map(|(k, v)| {
+                    let key = match k {
+                        CborValue::Text(s) => s,
+                        other => format!("{:?}", other),
+                    };
+                    (key, cbor_to_json(v))
+                })
+                .collect();
+            JsonValue::Object(obj)
+        }
+        CborValue::Tag(10, inner) => {
+            // Decimal — try to produce a JSON number, fall back to string
+            if let CborValue::Text(s) = *inner {
+                if let Ok(i) = s.parse::<i64>() {
+                    JsonValue::Number(i.into())
+                } else if let Ok(f) = s.parse::<f64>() {
+                    serde_json::Number::from_f64(f)
+                        .map(JsonValue::Number)
+                        .unwrap_or(JsonValue::String(s))
+                } else {
+                    JsonValue::String(s)
+                }
+            } else {
+                cbor_to_json(*inner)
+            }
+        }
+        CborValue::Tag(_, inner) => cbor_to_json(*inner),
+        _ => JsonValue::Null,
+    }
+}


### PR DESCRIPTION
Post-#187 cleanup: hoists the duplicated `cbor_to_json` / `json_to_cbor` helpers out of the mysql/postgres/sqlite `value.rs` files (and the JSON-column path in mysql/postgres `row.rs`) into a single `pub(crate)` module at `vantage-sql/src/types.rs`. No behaviour change, no public API change.