### PR TITLE
use expression's builder pattern for aliasing, not extra field.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,9 +33,9 @@
 
 # Query Builder Improvements (from MySQL work, 2026-04)
 
-- [ ] `expr.as_alias()` — add alias method on `Expression<T>`, then remove `Option<String>` from
-      `with_expression` and all `with_alias()` from primitives (Fx, Iif, Concat, GroupConcat,
-      JsonExtract, DateFormat, Case). Also fixes Fx alias hardcoding `"` instead of backticks.
+- [x] `expr.as_alias()` — `AliasExt` blanket impl in vantage-sql, removed `Option<String>` from
+      `Selectable::with_expression`, stripped alias from all primitives (Fx, Iif, Concat,
+      GroupConcat, JsonExtract, DateFormat, Case, Ternary). Fixes Fx/Case hardcoded `"` quoting.
 - [ ] `sql_fx!()` macro — mixed-type args for function calls:
       `sql_fx!("find_in_set", "write", (ident("permissions")))` instead of wrapping every arg in
       `mysql_expr!`

--- a/vantage-expressions/src/mocks/select.rs
+++ b/vantage-expressions/src/mocks/select.rs
@@ -141,7 +141,7 @@ impl Selectable<serde_json::Value> for MockSelect {
         self.fields.push(field.into());
     }
 
-    fn add_expression(&mut self, _expression: impl Expressive<Value>, _alias: Option<String>) {
+    fn add_expression(&mut self, _expression: impl Expressive<Value>) {
         panic!("You may only use field() in this mock")
     }
 

--- a/vantage-expressions/src/traits/datasource.rs
+++ b/vantage-expressions/src/traits/datasource.rs
@@ -47,4 +47,20 @@ pub trait SelectableDataSource<T = Value, C = Expression<T>>: DataSource {
 
     // Execute select query directly
     fn execute_select(&self, select: &Self::Select) -> impl Future<Output = Result<Vec<T>>> + Send;
+
+    /// Add a column expression to a select query with optional alias.
+    /// Backends must override this if they support aliases.
+    fn add_select_column(
+        &self,
+        select: &mut Self::Select,
+        expression: Expression<T>,
+        alias: Option<&str>,
+    ) where
+        T: Clone,
+    {
+        if alias.is_some() {
+            panic!("add_select_column with alias not implemented for this backend");
+        }
+        select.add_expression(expression);
+    }
 }

--- a/vantage-expressions/src/traits/selectable.rs
+++ b/vantage-expressions/src/traits/selectable.rs
@@ -84,8 +84,8 @@ pub trait Selectable<T, C = Expression<T>>: Send + Sync + Debug + Clone {
     /// Adds a column name to the SELECT clause.
     fn add_field(&mut self, field: impl Into<String>);
 
-    /// Adds a complex expression to the SELECT clause with optional alias.
-    fn add_expression(&mut self, expression: impl Expressive<T>, alias: Option<String>);
+    /// Adds a complex expression to the SELECT clause.
+    fn add_expression(&mut self, expression: impl Expressive<T>);
 
     /// Adds a condition to the WHERE clause.
     fn add_where_condition(&mut self, condition: impl Into<C>);
@@ -195,11 +195,11 @@ pub trait Selectable<T, C = Expression<T>>: Send + Sync + Debug + Clone {
     }
 
     /// Builder pattern method identical to [`Self::add_expression`].
-    fn with_expression(mut self, expression: impl Expressive<T>, alias: Option<String>) -> Self
+    fn with_expression(mut self, expression: impl Expressive<T>) -> Self
     where
         Self: Sized,
     {
-        Self::add_expression(&mut self, expression, alias);
+        Self::add_expression(&mut self, expression);
         self
     }
 

--- a/vantage-mongodb/src/mongodb/impls/selectable_data_source.rs
+++ b/vantage-mongodb/src/mongodb/impls/selectable_data_source.rs
@@ -5,6 +5,7 @@
 
 use futures_util::TryStreamExt;
 
+use vantage_expressions::Expression;
 use vantage_expressions::traits::datasource::SelectableDataSource;
 
 use crate::condition::MongoCondition;
@@ -17,6 +18,19 @@ impl SelectableDataSource<AnyMongoType, MongoCondition> for MongoDB {
 
     fn select(&self) -> Self::Select {
         MongoSelect::new()
+    }
+
+    fn add_select_column(
+        &self,
+        select: &mut Self::Select,
+        _expression: Expression<AnyMongoType>,
+        alias: Option<&str>,
+    ) {
+        // MongoDB projections use field names, not expressions.
+        // If an alias is given, use it as the projected field name.
+        if let Some(alias) = alias {
+            select.fields.push(alias.to_string());
+        }
     }
 
     async fn execute_select(

--- a/vantage-mongodb/src/select/impls/selectable.rs
+++ b/vantage-mongodb/src/select/impls/selectable.rs
@@ -21,16 +21,8 @@ impl Selectable<AnyMongoType, MongoCondition> for MongoSelect {
         self.fields.push(field.into());
     }
 
-    fn add_expression(
-        &mut self,
-        _expression: impl Expressive<AnyMongoType>,
-        alias: Option<String>,
-    ) {
+    fn add_expression(&mut self, _expression: impl Expressive<AnyMongoType>) {
         // MongoDB projections don't support arbitrary expressions in find().
-        // If an alias is given, treat it as a renamed field.
-        if let Some(alias) = alias {
-            self.fields.push(alias);
-        }
     }
 
     fn add_where_condition(&mut self, condition: impl Into<MongoCondition>) {

--- a/vantage-redb/src/select.rs
+++ b/vantage-redb/src/select.rs
@@ -106,7 +106,7 @@ impl<E: Entity> Selectable<RedbExpression> for RedbSelect<E> {
         // ReDB is key-value, fields don't apply
     }
 
-    fn add_expression(&mut self, _expression: RedbExpression, _alias: Option<String>) {
+    fn add_expression(&mut self, _expression: RedbExpression) {
         // ReDB doesn't support complex expressions
     }
 

--- a/vantage-sql/src/mysql/selectable_data_source.rs
+++ b/vantage-sql/src/mysql/selectable_data_source.rs
@@ -1,15 +1,28 @@
-use vantage_expressions::Expressive;
 use vantage_expressions::traits::datasource::SelectableDataSource;
+use vantage_expressions::{Expression, Expressive, Selectable};
 
 use crate::mysql::MysqlDB;
 use crate::mysql::statements::MysqlSelect;
 use crate::mysql::types::AnyMysqlType;
+use crate::primitives::alias::AliasExt;
 
 impl SelectableDataSource<AnyMysqlType> for MysqlDB {
     type Select = MysqlSelect;
 
     fn select(&self) -> Self::Select {
         MysqlSelect::new()
+    }
+
+    fn add_select_column(
+        &self,
+        select: &mut Self::Select,
+        expression: Expression<AnyMysqlType>,
+        alias: Option<&str>,
+    ) {
+        match alias {
+            Some(a) => select.add_expression(expression.as_alias(a)),
+            None => select.add_expression(expression),
+        }
     }
 
     async fn execute_select(

--- a/vantage-sql/src/mysql/statements/primitives/group_concat.rs
+++ b/vantage-sql/src/mysql/statements/primitives/group_concat.rs
@@ -99,8 +99,6 @@ impl Expressive<AnyMysqlType> for GroupConcat {
         }
 
         let inner = Expression::from_vec(parts, " ");
-        let base = Expression::new("GROUP_CONCAT({})", vec![ExpressiveEnum::Nested(inner)]);
-
-        base
+        Expression::new("GROUP_CONCAT({})", vec![ExpressiveEnum::Nested(inner)])
     }
 }

--- a/vantage-sql/src/mysql/statements/primitives/group_concat.rs
+++ b/vantage-sql/src/mysql/statements/primitives/group_concat.rs
@@ -1,7 +1,6 @@
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum, Order};
 
 use crate::mysql::types::AnyMysqlType;
-use crate::primitives::identifier::Identifier;
 
 /// Helper: create an inline SQL string literal (single-quoted, with escaping).
 fn sql_lit(s: &str) -> Expr {
@@ -30,7 +29,6 @@ pub struct GroupConcat {
     distinct: bool,
     order_by: Vec<(Expr, Order)>,
     separator: Option<String>,
-    alias: Option<String>,
 }
 
 impl GroupConcat {
@@ -40,7 +38,6 @@ impl GroupConcat {
             distinct: false,
             order_by: Vec::new(),
             separator: None,
-            alias: None,
         }
     }
 
@@ -59,10 +56,6 @@ impl GroupConcat {
         self
     }
 
-    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
-        self.alias = Some(alias.into());
-        self
-    }
 }
 
 impl Expressive<AnyMysqlType> for GroupConcat {
@@ -109,15 +102,6 @@ impl Expressive<AnyMysqlType> for GroupConcat {
         let inner = Expression::from_vec(parts, " ");
         let base = Expression::new("GROUP_CONCAT({})", vec![ExpressiveEnum::Nested(inner)]);
 
-        match &self.alias {
-            Some(alias) => Expression::new(
-                "{} AS {}",
-                vec![
-                    ExpressiveEnum::Nested(base),
-                    ExpressiveEnum::Nested(Identifier::new(alias).expr()),
-                ],
-            ),
-            None => base,
-        }
+        base
     }
 }

--- a/vantage-sql/src/mysql/statements/primitives/group_concat.rs
+++ b/vantage-sql/src/mysql/statements/primitives/group_concat.rs
@@ -55,7 +55,6 @@ impl GroupConcat {
         self.separator = Some(sep.into());
         self
     }
-
 }
 
 impl Expressive<AnyMysqlType> for GroupConcat {

--- a/vantage-sql/src/mysql/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/mysql/statements/select/impls/selectable.rs
@@ -17,9 +17,9 @@ impl MysqlSelect {
         let needs_cast = matches!(func, "sum" | "avg");
         if needs_cast {
             let cast = expr_any!("CAST({} AS SIGNED)", (agg));
-            s.add_expression(cast, None);
+            s.add_expression(cast);
         } else {
-            s.add_expression(agg, None);
+            s.add_expression(agg);
         }
 
         s.clear_order_by();
@@ -56,13 +56,8 @@ impl Selectable<AnyMysqlType> for MysqlSelect {
         self.fields.push(ident(field).expr());
     }
 
-    fn add_expression(&mut self, expression: impl Expressive<AnyMysqlType>, alias: Option<String>) {
-        let expr = expression.expr();
-        let field = match alias {
-            Some(a) => expr_any!("{} AS {}", (expr), (ident(a))),
-            None => expr,
-        };
-        self.fields.push(field);
+    fn add_expression(&mut self, expression: impl Expressive<AnyMysqlType>) {
+        self.fields.push(expression.expr());
     }
 
     fn add_where_condition(&mut self, condition: impl Into<Expression<AnyMysqlType>>) {

--- a/vantage-sql/src/postgres/impls/selectable_data_source.rs
+++ b/vantage-sql/src/postgres/impls/selectable_data_source.rs
@@ -1,15 +1,28 @@
-use vantage_expressions::Expressive;
 use vantage_expressions::traits::datasource::SelectableDataSource;
+use vantage_expressions::{Expression, Expressive, Selectable};
 
 use crate::postgres::PostgresDB;
 use crate::postgres::statements::PostgresSelect;
 use crate::postgres::types::AnyPostgresType;
+use crate::primitives::alias::AliasExt;
 
 impl SelectableDataSource<AnyPostgresType> for PostgresDB {
     type Select = PostgresSelect;
 
     fn select(&self) -> Self::Select {
         PostgresSelect::new()
+    }
+
+    fn add_select_column(
+        &self,
+        select: &mut Self::Select,
+        expression: Expression<AnyPostgresType>,
+        alias: Option<&str>,
+    ) {
+        match alias {
+            Some(a) => select.add_expression(expression.as_alias(a)),
+            None => select.add_expression(expression),
+        }
     }
 
     async fn execute_select(

--- a/vantage-sql/src/postgres/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/postgres/statements/select/impls/selectable.rs
@@ -17,9 +17,9 @@ impl PostgresSelect {
         let needs_cast = matches!(func, "sum" | "avg");
         if needs_cast {
             let cast = expr_any!("CAST({} AS BIGINT)", (agg));
-            s.add_expression(cast, None);
+            s.add_expression(cast);
         } else {
-            s.add_expression(agg, None);
+            s.add_expression(agg);
         }
 
         s.clear_order_by();
@@ -56,17 +56,8 @@ impl Selectable<AnyPostgresType> for PostgresSelect {
         self.fields.push(ident(field).expr());
     }
 
-    fn add_expression(
-        &mut self,
-        expression: impl Expressive<AnyPostgresType>,
-        alias: Option<String>,
-    ) {
-        let expr = expression.expr();
-        let field = match alias {
-            Some(a) => expr_any!("{} AS {}", (expr), (ident(a))),
-            None => expr,
-        };
-        self.fields.push(field);
+    fn add_expression(&mut self, expression: impl Expressive<AnyPostgresType>) {
+        self.fields.push(expression.expr());
     }
 
     fn add_where_condition(&mut self, condition: impl Into<Expression<AnyPostgresType>>) {

--- a/vantage-sql/src/primitives/alias.rs
+++ b/vantage-sql/src/primitives/alias.rs
@@ -3,15 +3,15 @@ use vantage_expressions::{Expression, Expressive, expr_any};
 
 /// Extension trait that adds `.as_alias()` to any [`Expressive<T>`] type.
 ///
-/// Wraps the expression as `(expr) AS <quoted_alias>`, using [`Identifier`]
+/// Wraps the expression as `expr AS <quoted_alias>`, using [`Identifier`]
 /// for backend-aware quoting.
 ///
 /// ```ignore
 /// use vantage_sql::primitives::alias::AliasExt;
 ///
 /// Fx::new("count", [mysql_expr!("*")]).as_alias("cnt")
-/// // → (COUNT(*)) AS `cnt`   (MySQL)
-/// // → (COUNT(*)) AS "cnt"   (PostgreSQL)
+/// // → COUNT(*) AS `cnt`   (MySQL)
+/// // → COUNT(*) AS "cnt"   (PostgreSQL)
 /// ```
 pub trait AliasExt<T>: Expressive<T> + Sized {
     #[allow(clippy::wrong_self_convention)]

--- a/vantage-sql/src/primitives/alias.rs
+++ b/vantage-sql/src/primitives/alias.rs
@@ -1,0 +1,25 @@
+use super::identifier::Identifier;
+use vantage_expressions::{expr_any, Expression, Expressive};
+
+/// Extension trait that adds `.as_alias()` to any [`Expressive<T>`] type.
+///
+/// Wraps the expression as `(expr) AS <quoted_alias>`, using [`Identifier`]
+/// for backend-aware quoting.
+///
+/// ```ignore
+/// use vantage_sql::primitives::alias::AliasExt;
+///
+/// Fx::new("count", [mysql_expr!("*")]).as_alias("cnt")
+/// // → (COUNT(*)) AS `cnt`   (MySQL)
+/// // → (COUNT(*)) AS "cnt"   (PostgreSQL)
+/// ```
+pub trait AliasExt<T>: Expressive<T> + Sized {
+    fn as_alias(self, alias: impl Into<String>) -> Expression<T>
+    where
+        Identifier: Expressive<T>,
+    {
+        expr_any!("{} AS {}", (self), (Identifier::new(alias)))
+    }
+}
+
+impl<T, E: Expressive<T> + Sized> AliasExt<T> for E {}

--- a/vantage-sql/src/primitives/alias.rs
+++ b/vantage-sql/src/primitives/alias.rs
@@ -1,5 +1,5 @@
 use super::identifier::Identifier;
-use vantage_expressions::{expr_any, Expression, Expressive};
+use vantage_expressions::{Expression, Expressive, expr_any};
 
 /// Extension trait that adds `.as_alias()` to any [`Expressive<T>`] type.
 ///
@@ -14,6 +14,7 @@ use vantage_expressions::{expr_any, Expression, Expressive};
 /// // → (COUNT(*)) AS "cnt"   (PostgreSQL)
 /// ```
 pub trait AliasExt<T>: Expressive<T> + Sized {
+    #[allow(clippy::wrong_self_convention)]
     fn as_alias(self, alias: impl Into<String>) -> Expression<T>
     where
         Identifier: Expressive<T>,

--- a/vantage-sql/src/primitives/case.rs
+++ b/vantage-sql/src/primitives/case.rs
@@ -17,7 +17,6 @@ use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 pub struct Case<T: Debug + Display + Clone> {
     branches: Vec<(Expression<T>, Expression<T>)>,
     else_branch: Option<Expression<T>>,
-    alias: Option<String>,
 }
 
 impl<T: Debug + Display + Clone> Default for Case<T> {
@@ -31,7 +30,6 @@ impl<T: Debug + Display + Clone> Case<T> {
         Self {
             branches: Vec::new(),
             else_branch: None,
-            alias: None,
         }
     }
 
@@ -45,10 +43,6 @@ impl<T: Debug + Display + Clone> Case<T> {
         self
     }
 
-    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
-        self.alias = Some(alias.into());
-        self
-    }
 }
 
 impl<T: Debug + Display + Clone> Expressive<T> for Case<T> {
@@ -77,12 +71,6 @@ impl<T: Debug + Display + Clone> Expressive<T> for Case<T> {
             None => Expression::new("CASE{} END", vec![ExpressiveEnum::Nested(branches_expr)]),
         };
 
-        match &self.alias {
-            Some(alias) => Expression::new(
-                format!("{{}} AS \"{}\"", alias),
-                vec![ExpressiveEnum::Nested(base)],
-            ),
-            None => base,
-        }
+        base
     }
 }

--- a/vantage-sql/src/primitives/case.rs
+++ b/vantage-sql/src/primitives/case.rs
@@ -11,7 +11,7 @@ use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 ///     .when(sqlite_expr!("{} >= {}", (Identifier::new("salary")), 100000.0f64), sqlite_expr!("{}", "senior"))
 ///     .when(sqlite_expr!("{} >= {}", (Identifier::new("salary")), 60000.0f64), sqlite_expr!("{}", "mid"))
 ///     .else_(sqlite_expr!("{}", "intern"))
-///     .with_alias("band")
+///     .as_alias("band")
 /// ```
 #[derive(Debug, Clone)]
 pub struct Case<T: Debug + Display + Clone> {

--- a/vantage-sql/src/primitives/case.rs
+++ b/vantage-sql/src/primitives/case.rs
@@ -42,7 +42,6 @@ impl<T: Debug + Display + Clone> Case<T> {
         self.else_branch = Some(value.expr());
         self
     }
-
 }
 
 impl<T: Debug + Display + Clone> Expressive<T> for Case<T> {
@@ -60,7 +59,7 @@ impl<T: Debug + Display + Clone> Expressive<T> for Case<T> {
 
         let branches_expr = Expression::from_vec(parts, "");
 
-        let base = match &self.else_branch {
+        match &self.else_branch {
             Some(else_val) => Expression::new(
                 "CASE{} ELSE {} END",
                 vec![
@@ -69,8 +68,6 @@ impl<T: Debug + Display + Clone> Expressive<T> for Case<T> {
                 ],
             ),
             None => Expression::new("CASE{} END", vec![ExpressiveEnum::Nested(branches_expr)]),
-        };
-
-        base
+        }
     }
 }

--- a/vantage-sql/src/primitives/concat.rs
+++ b/vantage-sql/src/primitives/concat.rs
@@ -1,9 +1,7 @@
 use std::fmt::{Debug, Display};
 
 use vantage_core::util::IntoVec;
-use vantage_expressions::{Expression, Expressive, expr_any};
-
-use super::identifier::Identifier;
+use vantage_expressions::{Expression, Expressive};
 
 /// Vendor-aware string concatenation.
 ///
@@ -26,7 +24,6 @@ use super::identifier::Identifier;
 pub struct Concat<T: Debug + Display + Clone> {
     parts: Vec<Expression<T>>,
     separator: Option<Expression<T>>,
-    alias: Option<String>,
 }
 
 impl<T: Debug + Display + Clone> Concat<T> {
@@ -34,18 +31,12 @@ impl<T: Debug + Display + Clone> Concat<T> {
         Self {
             parts: parts.into_vec(),
             separator: None,
-            alias: None,
         }
     }
 
     /// Use CONCAT_WS with a separator instead of plain CONCAT.
     pub fn ws(mut self, separator: impl Expressive<T>) -> Self {
         self.separator = Some(separator.expr());
-        self
-    }
-
-    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
-        self.alias = Some(alias.into());
         self
     }
 }
@@ -82,7 +73,7 @@ impl Expressive<crate::sqlite::types::AnySqliteType>
     for Concat<crate::sqlite::types::AnySqliteType>
 {
     fn expr(&self) -> Expression<crate::sqlite::types::AnySqliteType> {
-        let base = if let Some(sep) = &self.separator {
+        if let Some(sep) = &self.separator {
             // Interleave parts with separator: a || sep || b || sep || c
             let mut interleaved = Vec::with_capacity(self.parts.len() * 2 - 1);
             for (i, part) in self.parts.iter().enumerate() {
@@ -94,10 +85,6 @@ impl Expressive<crate::sqlite::types::AnySqliteType>
             Expression::from_vec(interleaved, " || ")
         } else {
             Expression::from_vec(self.parts.clone(), " || ")
-        };
-        match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (base), (Identifier::new(alias))),
-            None => base,
         }
     }
 }
@@ -109,7 +96,7 @@ impl Expressive<crate::mysql::types::AnyMysqlType> for Concat<crate::mysql::type
     fn expr(&self) -> Expression<crate::mysql::types::AnyMysqlType> {
         use vantage_expressions::ExpressiveEnum;
 
-        let base = if let Some(sep) = &self.separator {
+        if let Some(sep) = &self.separator {
             let mut all = vec![sep.clone()];
             all.extend(self.parts.clone());
             let args = Expression::from_vec(all, ", ");
@@ -117,10 +104,6 @@ impl Expressive<crate::mysql::types::AnyMysqlType> for Concat<crate::mysql::type
         } else {
             let args = Expression::from_vec(self.parts.clone(), ", ");
             Expression::new("CONCAT({})", vec![ExpressiveEnum::Nested(args)])
-        };
-        match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (base), (Identifier::new(alias))),
-            None => base,
         }
     }
 }
@@ -134,17 +117,13 @@ impl Expressive<crate::postgres::types::AnyPostgresType>
     fn expr(&self) -> Expression<crate::postgres::types::AnyPostgresType> {
         use vantage_expressions::ExpressiveEnum;
 
-        let base = if let Some(sep) = &self.separator {
+        if let Some(sep) = &self.separator {
             let mut all = vec![sep.clone()];
             all.extend(self.parts.clone());
             let args = Expression::from_vec(all, ", ");
             Expression::new("CONCAT_WS({})", vec![ExpressiveEnum::Nested(args)])
         } else {
             Expression::from_vec(self.parts.clone(), " || ")
-        };
-        match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (base), (Identifier::new(alias))),
-            None => base,
         }
     }
 }

--- a/vantage-sql/src/primitives/date_format.rs
+++ b/vantage-sql/src/primitives/date_format.rs
@@ -1,8 +1,6 @@
 use std::fmt::{Debug, Display};
 
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
-
-use super::identifier::Identifier;
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
 /// Vendor-aware date formatting expression.
 ///
@@ -28,7 +26,6 @@ use super::identifier::Identifier;
 pub struct DateFormat<T: Debug + Display + Clone> {
     expr: Expression<T>,
     format: String,
-    alias: Option<String>,
     /// When true, pass the format string as-is without token translation.
     raw: bool,
 }
@@ -39,7 +36,6 @@ impl<T: Debug + Display + Clone> DateFormat<T> {
         Self {
             expr: expr.expr(),
             format: format.into(),
-            alias: None,
             raw: false,
         }
     }
@@ -49,14 +45,8 @@ impl<T: Debug + Display + Clone> DateFormat<T> {
         Self {
             expr: expr.expr(),
             format: format.into(),
-            alias: None,
             raw: true,
         }
-    }
-
-    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
-        self.alias = Some(alias.into());
-        self
     }
 }
 
@@ -137,10 +127,7 @@ impl Expressive<crate::sqlite::types::AnySqliteType>
                 ExpressiveEnum::Nested(self.expr.clone()),
             ],
         );
-        match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (base), (Identifier::new(alias))),
-            None => base,
-        }
+        base
     }
 }
 
@@ -163,10 +150,7 @@ impl Expressive<crate::mysql::types::AnyMysqlType>
                 ExpressiveEnum::Scalar(fmt.into()),
             ],
         );
-        match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (base), (Identifier::new(alias))),
-            None => base,
-        }
+        base
     }
 }
 
@@ -189,9 +173,6 @@ impl Expressive<crate::postgres::types::AnyPostgresType>
                 ExpressiveEnum::Scalar(fmt.into()),
             ],
         );
-        match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (base), (Identifier::new(alias))),
-            None => base,
-        }
+        base
     }
 }

--- a/vantage-sql/src/primitives/date_format.rs
+++ b/vantage-sql/src/primitives/date_format.rs
@@ -20,7 +20,7 @@ use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 /// use vantage_sql::primitives::date_format::DateFormat;
 ///
 /// DateFormat::new(ident("created_at").dot_of("o"), "%Y-%m")
-///     .with_alias("month")
+///     .as_alias("month")
 /// ```
 #[derive(Debug, Clone)]
 pub struct DateFormat<T: Debug + Display + Clone> {

--- a/vantage-sql/src/primitives/date_format.rs
+++ b/vantage-sql/src/primitives/date_format.rs
@@ -120,14 +120,13 @@ impl Expressive<crate::sqlite::types::AnySqliteType>
         // SQLite uses strftime natively — no translation needed regardless of `raw`
         let fmt = self.format.clone();
         let _ = self.raw;
-        let base = Expression::new(
+        Expression::new(
             "STRFTIME({}, {})",
             vec![
                 ExpressiveEnum::Scalar(fmt.into()),
                 ExpressiveEnum::Nested(self.expr.clone()),
             ],
-        );
-        base
+        )
     }
 }
 
@@ -143,14 +142,13 @@ impl Expressive<crate::mysql::types::AnyMysqlType>
         } else {
             strftime_to_mysql(&self.format)
         };
-        let base = Expression::new(
+        Expression::new(
             "DATE_FORMAT({}, {})",
             vec![
                 ExpressiveEnum::Nested(self.expr.clone()),
                 ExpressiveEnum::Scalar(fmt.into()),
             ],
-        );
-        base
+        )
     }
 }
 
@@ -166,13 +164,12 @@ impl Expressive<crate::postgres::types::AnyPostgresType>
         } else {
             strftime_to_pg(&self.format)
         };
-        let base = Expression::new(
+        Expression::new(
             "TO_CHAR({}, {})",
             vec![
                 ExpressiveEnum::Nested(self.expr.clone()),
                 ExpressiveEnum::Scalar(fmt.into()),
             ],
-        );
-        base
+        )
     }
 }

--- a/vantage-sql/src/primitives/fx.rs
+++ b/vantage-sql/src/primitives/fx.rs
@@ -35,7 +35,6 @@ impl<T: Debug + Display + Clone> Fx<T> {
             args: args.into_vec(),
         }
     }
-
 }
 
 impl<T: Debug + Display + Clone> Expressive<T> for Fx<T> {

--- a/vantage-sql/src/primitives/fx.rs
+++ b/vantage-sql/src/primitives/fx.rs
@@ -26,7 +26,6 @@ use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 pub struct Fx<T: Debug + Display + Clone> {
     name: String,
     args: Vec<Expression<T>>,
-    alias: Option<String>,
 }
 
 impl<T: Debug + Display + Clone> Fx<T> {
@@ -34,30 +33,18 @@ impl<T: Debug + Display + Clone> Fx<T> {
         Self {
             name: name.into().to_uppercase(),
             args: args.into_vec(),
-            alias: None,
         }
     }
 
-    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
-        self.alias = Some(alias.into());
-        self
-    }
 }
 
 impl<T: Debug + Display + Clone> Expressive<T> for Fx<T> {
     fn expr(&self) -> Expression<T> {
         let args_expr = Expression::from_vec(self.args.clone(), ", ");
-        let base = Expression::new(
+        Expression::new(
             format!("{}({{}})", self.name),
             vec![ExpressiveEnum::Nested(args_expr)],
-        );
-        match &self.alias {
-            Some(alias) => Expression::new(
-                format!("{{}} AS \"{}\"", alias),
-                vec![ExpressiveEnum::Nested(base)],
-            ),
-            None => base,
-        }
+        )
     }
 }
 

--- a/vantage-sql/src/primitives/identifier.rs
+++ b/vantage-sql/src/primitives/identifier.rs
@@ -73,7 +73,6 @@ pub fn ident(name: impl Into<String>) -> Identifier {
     Identifier::new(name)
 }
 
-
 // Each backend impl owns its quoting style.
 
 #[cfg(feature = "sqlite")]

--- a/vantage-sql/src/primitives/identifier.rs
+++ b/vantage-sql/src/primitives/identifier.rs
@@ -73,6 +73,7 @@ pub fn ident(name: impl Into<String>) -> Identifier {
     Identifier::new(name)
 }
 
+
 // Each backend impl owns its quoting style.
 
 #[cfg(feature = "sqlite")]

--- a/vantage-sql/src/primitives/iif.rs
+++ b/vantage-sql/src/primitives/iif.rs
@@ -1,8 +1,6 @@
 use std::fmt::{Debug, Display};
 
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
-
-use super::identifier::Identifier;
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
 /// Vendor-aware conditional expression.
 ///
@@ -25,7 +23,6 @@ pub struct Iif<T: Debug + Display + Clone> {
     condition: Expression<T>,
     true_val: Expression<T>,
     false_val: Expression<T>,
-    alias: Option<String>,
 }
 
 impl<T: Debug + Display + Clone> Iif<T> {
@@ -38,27 +35,7 @@ impl<T: Debug + Display + Clone> Iif<T> {
             condition: condition.expr(),
             true_val: true_val.expr(),
             false_val: false_val.expr(),
-            alias: None,
         }
-    }
-
-    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
-        self.alias = Some(alias.into());
-        self
-    }
-}
-
-/// Helper: apply optional alias to an expression.
-fn apply_alias<T: Debug + Display + Clone>(
-    base: Expression<T>,
-    alias: &Option<String>,
-) -> Expression<T>
-where
-    Identifier: Expressive<T>,
-{
-    match alias {
-        Some(a) => expr_any!("{} AS {}", (base), (Identifier::new(a))),
-        None => base,
     }
 }
 
@@ -75,7 +52,7 @@ impl Expressive<crate::sqlite::types::AnySqliteType> for Iif<crate::sqlite::type
                 ExpressiveEnum::Nested(self.false_val.clone()),
             ],
         );
-        apply_alias(base, &self.alias)
+        base
     }
 }
 
@@ -92,7 +69,7 @@ impl Expressive<crate::mysql::types::AnyMysqlType> for Iif<crate::mysql::types::
                 ExpressiveEnum::Nested(self.false_val.clone()),
             ],
         );
-        apply_alias(base, &self.alias)
+        base
     }
 }
 
@@ -111,6 +88,6 @@ impl Expressive<crate::postgres::types::AnyPostgresType>
                 ExpressiveEnum::Nested(self.false_val.clone()),
             ],
         );
-        apply_alias(base, &self.alias)
+        base
     }
 }

--- a/vantage-sql/src/primitives/iif.rs
+++ b/vantage-sql/src/primitives/iif.rs
@@ -44,15 +44,14 @@ impl<T: Debug + Display + Clone> Iif<T> {
 #[cfg(feature = "sqlite")]
 impl Expressive<crate::sqlite::types::AnySqliteType> for Iif<crate::sqlite::types::AnySqliteType> {
     fn expr(&self) -> Expression<crate::sqlite::types::AnySqliteType> {
-        let base = Expression::new(
+        Expression::new(
             "IIF({}, {}, {})",
             vec![
                 ExpressiveEnum::Nested(self.condition.clone()),
                 ExpressiveEnum::Nested(self.true_val.clone()),
                 ExpressiveEnum::Nested(self.false_val.clone()),
             ],
-        );
-        base
+        )
     }
 }
 
@@ -61,15 +60,14 @@ impl Expressive<crate::sqlite::types::AnySqliteType> for Iif<crate::sqlite::type
 #[cfg(feature = "mysql")]
 impl Expressive<crate::mysql::types::AnyMysqlType> for Iif<crate::mysql::types::AnyMysqlType> {
     fn expr(&self) -> Expression<crate::mysql::types::AnyMysqlType> {
-        let base = Expression::new(
+        Expression::new(
             "IF({}, {}, {})",
             vec![
                 ExpressiveEnum::Nested(self.condition.clone()),
                 ExpressiveEnum::Nested(self.true_val.clone()),
                 ExpressiveEnum::Nested(self.false_val.clone()),
             ],
-        );
-        base
+        )
     }
 }
 
@@ -80,14 +78,13 @@ impl Expressive<crate::postgres::types::AnyPostgresType>
     for Iif<crate::postgres::types::AnyPostgresType>
 {
     fn expr(&self) -> Expression<crate::postgres::types::AnyPostgresType> {
-        let base = Expression::new(
+        Expression::new(
             "CASE WHEN {} THEN {} ELSE {} END",
             vec![
                 ExpressiveEnum::Nested(self.condition.clone()),
                 ExpressiveEnum::Nested(self.true_val.clone()),
                 ExpressiveEnum::Nested(self.false_val.clone()),
             ],
-        );
-        base
+        )
     }
 }

--- a/vantage-sql/src/primitives/json_extract.rs
+++ b/vantage-sql/src/primitives/json_extract.rs
@@ -74,14 +74,13 @@ impl Expressive<crate::sqlite::types::AnySqliteType>
 {
     fn expr(&self) -> Expression<crate::sqlite::types::AnySqliteType> {
         let json_path = format!("$.{}", self.path.join("."));
-        let base = Expression::new(
+        Expression::new(
             "JSON_EXTRACT({}, {})",
             vec![
                 ExpressiveEnum::Nested(self.source.clone()),
                 ExpressiveEnum::Nested(sql_lit(&json_path)),
             ],
-        );
-        base
+        )
     }
 }
 

--- a/vantage-sql/src/primitives/json_extract.rs
+++ b/vantage-sql/src/primitives/json_extract.rs
@@ -1,9 +1,7 @@
 use std::fmt::{Debug, Display};
 
 use vantage_core::util::IntoVec;
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
-
-use super::identifier::Identifier;
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
 /// Vendor-aware JSON field extraction.
 ///
@@ -33,7 +31,6 @@ use super::identifier::Identifier;
 pub struct JsonExtract<T: Debug + Display + Clone> {
     source: Expression<T>,
     path: Vec<String>,
-    alias: Option<String>,
     /// When true, return the raw JSON value instead of extracting as text.
     /// Affects MySQL (`->` vs `->>`) and PostgreSQL (all `->` vs final `->>`)
     as_json: bool,
@@ -44,7 +41,6 @@ impl<T: Debug + Display + Clone> JsonExtract<T> {
         Self {
             source: source.expr(),
             path: path.into_vec(),
-            alias: None,
             as_json: false,
         }
     }
@@ -52,11 +48,6 @@ impl<T: Debug + Display + Clone> JsonExtract<T> {
     /// Return raw JSON instead of text. Renders `->` instead of `->>` in MySQL/PG.
     pub fn as_json(mut self) -> Self {
         self.as_json = true;
-        self
-    }
-
-    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
-        self.alias = Some(alias.into());
         self
     }
 }
@@ -90,10 +81,7 @@ impl Expressive<crate::sqlite::types::AnySqliteType>
                 ExpressiveEnum::Nested(sql_lit(&json_path)),
             ],
         );
-        match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (base), (Identifier::new(alias))),
-            None => base,
-        }
+        base
     }
 }
 
@@ -113,10 +101,7 @@ impl Expressive<crate::mysql::types::AnyMysqlType>
                 ExpressiveEnum::Nested(sql_lit(&json_path)),
             ],
         );
-        match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (base), (Identifier::new(alias))),
-            None => base,
-        }
+        base
     }
 }
 
@@ -151,9 +136,6 @@ impl Expressive<crate::postgres::types::AnyPostgresType>
             );
         }
 
-        match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (current), (Identifier::new(alias))),
-            None => current,
-        }
+        current
     }
 }

--- a/vantage-sql/src/primitives/json_extract.rs
+++ b/vantage-sql/src/primitives/json_extract.rs
@@ -93,14 +93,13 @@ impl Expressive<crate::mysql::types::AnyMysqlType>
     fn expr(&self) -> Expression<crate::mysql::types::AnyMysqlType> {
         let json_path = format!("$.{}", self.path.join("."));
         let op = if self.as_json { " -> " } else { " ->> " };
-        let base = Expression::new(
+        Expression::new(
             format!("{{}}{op}{{}}"),
             vec![
                 ExpressiveEnum::Nested(self.source.clone()),
                 ExpressiveEnum::Nested(sql_lit(&json_path)),
             ],
-        );
-        base
+        )
     }
 }
 

--- a/vantage-sql/src/primitives/mod.rs
+++ b/vantage-sql/src/primitives/mod.rs
@@ -1,3 +1,4 @@
+pub mod alias;
 pub mod case;
 pub mod concat;
 pub mod date_format;

--- a/vantage-sql/src/primitives/ternary.rs
+++ b/vantage-sql/src/primitives/ternary.rs
@@ -1,8 +1,6 @@
 use std::fmt::{Debug, Display};
 
-use vantage_expressions::{Expression, Expressive, ExpressiveEnum, expr_any};
-
-use super::identifier::Identifier;
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
 /// Vendor-aware inline conditional expression.
 ///
@@ -32,7 +30,6 @@ pub struct Ternary<T: Debug + Display + Clone> {
     condition: Expression<T>,
     true_val: Expression<T>,
     false_val: Expression<T>,
-    alias: Option<String>,
 }
 
 impl<T: Debug + Display + Clone> Ternary<T> {
@@ -45,13 +42,7 @@ impl<T: Debug + Display + Clone> Ternary<T> {
             condition: condition.expr(),
             true_val: true_val.expr(),
             false_val: false_val.expr(),
-            alias: None,
         }
-    }
-
-    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
-        self.alias = Some(alias.into());
-        self
     }
 
     fn args(&self) -> Vec<ExpressiveEnum<T>> {
@@ -79,11 +70,7 @@ impl Expressive<crate::sqlite::types::AnySqliteType>
     for Ternary<crate::sqlite::types::AnySqliteType>
 {
     fn expr(&self) -> Expression<crate::sqlite::types::AnySqliteType> {
-        let base = Expression::new("IIF({}, {}, {})", self.args());
-        match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (base), (Identifier::new(alias))),
-            None => base,
-        }
+        Expression::new("IIF({}, {}, {})", self.args())
     }
 }
 
@@ -92,11 +79,7 @@ impl Expressive<crate::sqlite::types::AnySqliteType>
 #[cfg(feature = "mysql")]
 impl Expressive<crate::mysql::types::AnyMysqlType> for Ternary<crate::mysql::types::AnyMysqlType> {
     fn expr(&self) -> Expression<crate::mysql::types::AnyMysqlType> {
-        let base = Expression::new("IF({}, {}, {})", self.args());
-        match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (base), (Identifier::new(alias))),
-            None => base,
-        }
+        Expression::new("IF({}, {}, {})", self.args())
     }
 }
 
@@ -107,10 +90,6 @@ impl Expressive<crate::postgres::types::AnyPostgresType>
     for Ternary<crate::postgres::types::AnyPostgresType>
 {
     fn expr(&self) -> Expression<crate::postgres::types::AnyPostgresType> {
-        let base = Expression::new("CASE WHEN {} THEN {} ELSE {} END", self.args());
-        match &self.alias {
-            Some(alias) => expr_any!("{} AS {}", (base), (Identifier::new(alias))),
-            None => base,
-        }
+        Expression::new("CASE WHEN {} THEN {} ELSE {} END", self.args())
     }
 }

--- a/vantage-sql/src/primitives/ternary.rs
+++ b/vantage-sql/src/primitives/ternary.rs
@@ -16,7 +16,7 @@ use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 ///
 /// // With Identifier + Operation:
 /// ternary(Identifier::new("role").eq("admin"), "Yes", "No")
-///     .with_alias("is_admin")
+///     .as_alias("is_admin")
 ///
 /// // With vendor expression for the condition:
 /// ternary(

--- a/vantage-sql/src/sqlite/impls/selectable_data_source.rs
+++ b/vantage-sql/src/sqlite/impls/selectable_data_source.rs
@@ -1,6 +1,7 @@
-use vantage_expressions::Expressive;
 use vantage_expressions::traits::datasource::SelectableDataSource;
+use vantage_expressions::{Expression, Expressive, Selectable};
 
+use crate::primitives::alias::AliasExt;
 use crate::sqlite::SqliteDB;
 use crate::sqlite::statements::SqliteSelect;
 use crate::sqlite::types::AnySqliteType;
@@ -10,6 +11,18 @@ impl SelectableDataSource<AnySqliteType> for SqliteDB {
 
     fn select(&self) -> Self::Select {
         SqliteSelect::new()
+    }
+
+    fn add_select_column(
+        &self,
+        select: &mut Self::Select,
+        expression: Expression<AnySqliteType>,
+        alias: Option<&str>,
+    ) {
+        match alias {
+            Some(a) => select.add_expression(expression.as_alias(a)),
+            None => select.add_expression(expression),
+        }
     }
 
     async fn execute_select(

--- a/vantage-sql/src/sqlite/statements/select/impls/selectable.rs
+++ b/vantage-sql/src/sqlite/statements/select/impls/selectable.rs
@@ -12,7 +12,7 @@ impl SqliteSelect {
     pub fn as_aggregate(&self, func: &str, column: impl Expressive<AnySqliteType>) -> Expr {
         let mut s = self.clone();
         s.clear_fields();
-        s.add_expression(Fx::new(func, [column.expr()]), None);
+        s.add_expression(Fx::new(func, [column.expr()]));
         s.clear_order_by();
         s.render()
     }
@@ -47,17 +47,8 @@ impl Selectable<AnySqliteType> for SqliteSelect {
         self.fields.push(ident(field).expr());
     }
 
-    fn add_expression(
-        &mut self,
-        expression: impl Expressive<AnySqliteType>,
-        alias: Option<String>,
-    ) {
-        let expr = expression.expr();
-        let field = match alias {
-            Some(a) => expr_any!("{} AS {}", (expr), (ident(a))),
-            None => expr,
-        };
-        self.fields.push(field);
+    fn add_expression(&mut self, expression: impl Expressive<AnySqliteType>) {
+        self.fields.push(expression.expr());
     }
 
     fn add_where_condition(&mut self, condition: impl Into<Expression<AnySqliteType>>) {

--- a/vantage-sql/tests/mysql/3_complex_queries.rs
+++ b/vantage-sql/tests/mysql/3_complex_queries.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 use vantage_sql::mysql::MysqlDB;
 use vantage_sql::mysql::statements::MysqlSelect;
+use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::mysql::statements::select::join::MysqlSelectJoin;
 use vantage_sql::mysql_expr;
 use vantage_sql::primitives::fx::Fx;
@@ -105,8 +106,8 @@ async fn test_q2() {
     let users: Vec<UserWithDept> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("id").dot_of("u"), None)
-            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(ident("id").dot_of("u"))
+            .with_expression(ident("name").dot_of("u"))
             .with_expression(
                 ident("name").dot_of("d").with_alias("department_name"),
                 None,
@@ -173,8 +174,8 @@ async fn test_q3() {
 
     let select = MysqlSelect::new()
         .with_source_as("users", "u")
-        .with_expression(ident("id").dot_of("u"), None)
-        .with_expression(ident("name").dot_of("u"), None)
+        .with_expression(ident("id").dot_of("u"))
+        .with_expression(ident("name").dot_of("u"))
         .with_expression(
             Fx::new(
                 "coalesce",
@@ -182,8 +183,8 @@ async fn test_q3() {
                     Fx::new("sum", [ident("total").dot_of("o").expr()]).expr(),
                     mysql_expr!("{}", 0.0f64),
                 ],
-            ),
-            Some("total_spent".into()),
+            )
+            .as_alias("total_spent"),
         )
         .with_join(MysqlSelectJoin::left(
             "orders",
@@ -261,14 +262,14 @@ async fn test_q4() {
             .with_source("products")
             .with_field("category")
             .with_expression(
-                Fx::new("count", [mysql_expr!("*")]),
-                Some("product_count".into()),
+                Fx::new("count", [mysql_expr!("*")])
+                .as_alias("product_count"),
             )
-            .with_expression(Fx::new("avg", [price.expr()]), Some("avg_price".into()))
-            .with_expression(Fx::new("min", [price.expr()]), Some("cheapest".into()))
+            .with_expression(Fx::new("avg", [price.expr()]).as_alias("avg_price"))
+            .with_expression(Fx::new("min", [price.expr()]).as_alias("cheapest"))
             .with_expression(
-                Fx::new("max", [price.expr()]),
-                Some("most_expensive".into()),
+                Fx::new("max", [price.expr()])
+                .as_alias("most_expensive"),
             )
             .with_group_by(ident("category"))
             .with_having(mysql_expr!(
@@ -335,12 +336,12 @@ async fn test_q5() {
 
     let count_subquery = MysqlSelect::new()
         .with_source_as("orders", "o")
-        .with_expression(Fx::new("count", [mysql_expr!("*")]), None)
+        .with_expression(Fx::new("count", [mysql_expr!("*")]))
         .with_condition(user_id_match.clone());
 
     let exists_subquery = MysqlSelect::new()
         .with_source_as("orders", "o")
-        .with_expression(mysql_expr!("1"), None)
+        .with_expression(mysql_expr!("1"))
         .with_condition(user_id_match)
         .with_condition(mysql_expr!(
             "{} = {}",
@@ -351,11 +352,11 @@ async fn test_q5() {
     let users: Vec<UserOrderCount> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("id").dot_of("u"), None)
-            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(ident("id").dot_of("u"))
+            .with_expression(ident("name").dot_of("u"))
             .with_expression(
-                mysql_expr!("({})", (count_subquery)),
-                Some("order_count".into()),
+                mysql_expr!("({})", (count_subquery))
+                .as_alias("order_count"),
             )
             .with_condition(Fx::new("exists", [exists_subquery.expr()]))
             .with_order(ident("order_count"), Order::Desc)
@@ -413,12 +414,12 @@ async fn test_q6() {
         .with_source("orders")
         .with_field("user_id")
         .with_expression(
-            Fx::new("count", [mysql_expr!("*")]),
-            Some("order_count".into()),
+            Fx::new("count", [mysql_expr!("*")])
+            .as_alias("order_count"),
         )
         .with_expression(
-            Fx::new("avg", [ident("total").expr()]),
-            Some("avg_total".into()),
+            Fx::new("avg", [ident("total").expr()])
+            .as_alias("avg_total"),
         )
         .with_condition(mysql_expr!("{} != {}", (ident("status")), "cancelled"))
         .with_group_by(ident("user_id"));
@@ -426,9 +427,9 @@ async fn test_q6() {
     let users: Vec<UserOrderStats> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("order_count").dot_of("stats"), None)
-            .with_expression(ident("avg_total").dot_of("stats"), None)
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("order_count").dot_of("stats"))
+            .with_expression(ident("avg_total").dot_of("stats"))
             .with_join(MysqlSelectJoin::inner_expr(
                 stats_subquery,
                 "stats",
@@ -524,8 +525,8 @@ async fn test_q7() {
                         mysql_expr!("{} >= {}", (salary.clone()), 30000.0f64),
                         mysql_expr!("{}", "junior"),
                     )
-                    .else_(mysql_expr!("{}", "intern")),
-                Some("band".into()),
+                    .else_(mysql_expr!("{}", "intern"))
+                .as_alias("band"),
             )
             .with_expression(
                 ternary(ident("role").eq("admin"), "Yes", "No").with_alias("is_admin"),
@@ -583,21 +584,21 @@ async fn test_q8() {
         .with_source("users")
         .with_field("id")
         .with_field("name")
-        .with_expression(mysql_expr!("{}", "user"), Some("source".into()))
+        .with_expression(mysql_expr!("{}", "user").as_alias("source"))
         .with_condition(mysql_expr!("{} = {}", (ident("role")), "admin"));
 
     let depts_with_budget = MysqlSelect::new()
         .with_source("departments")
         .with_field("id")
         .with_field("name")
-        .with_expression(mysql_expr!("{}", "department"), Some("source".into()))
+        .with_expression(mysql_expr!("{}", "department").as_alias("source"))
         .with_condition(mysql_expr!("{} IS NOT NULL", (ident("budget"))));
 
     let depts_zero_budget = MysqlSelect::new()
         .with_source("departments")
         .with_field("id")
         .with_field("name")
-        .with_expression(mysql_expr!("{}", "department"), Some("source".into()))
+        .with_expression(mysql_expr!("{}", "department").as_alias("source"))
         .with_condition(mysql_expr!("{} = {}", (ident("budget")), 0.0f64));
 
     let compound = Union::new(admins)
@@ -675,24 +676,24 @@ async fn test_q9() {
     let rows: Vec<SalaryRanking> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("users", "u")
-            .with_expression(dept.clone(), None)
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(salary.clone(), None)
+            .with_expression(dept.clone())
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(salary.clone())
             .with_expression(
-                Window::named("win").apply(Fx::new("row_number", vec![])),
-                Some("row_num".into()),
+                Window::named("win").apply(Fx::new("row_number", vec![]))
+                .as_alias("row_num"),
             )
             .with_expression(
-                Window::named("win").apply(Fx::new("rank", vec![])),
-                Some("salary_rank".into()),
+                Window::named("win").apply(Fx::new("rank", vec![]))
+                .as_alias("salary_rank"),
             )
             .with_expression(
                 Window::new()
                     .partition_by(dept.clone())
                     .order_by(salary.clone(), Order::Desc)
                     .rows("UNBOUNDED PRECEDING", "CURRENT ROW")
-                    .apply(Fx::new("sum", [salary.expr()])),
-                Some("running_total".into()),
+                    .apply(Fx::new("sum", [salary.expr()]))
+                .as_alias("running_total"),
             )
             .with_condition(mysql_expr!("{} IS NOT NULL", (dept)))
             .with_window("win", Window::new()
@@ -761,8 +762,8 @@ async fn test_q10() {
             .with_cte("active_orders", MysqlSelect::new()
                 .with_source("orders")
                 .with_field("user_id")
-                .with_expression(Fx::new("count", [mysql_expr!("*")]), Some("cnt".into()))
-                .with_expression(Fx::new("sum", [ident("total").expr()]), Some("revenue".into()))
+                .with_expression(Fx::new("count", [mysql_expr!("*")]).as_alias("cnt"))
+                .with_expression(Fx::new("sum", [ident("total").expr()]).as_alias("revenue"))
                 .with_condition(mysql_expr!("{} IN ({}, {})",
                     (ident("status")), "completed", "shipped"))
                 .with_group_by(ident("user_id")), false)
@@ -772,8 +773,8 @@ async fn test_q10() {
                 .with_field("revenue")
                 .with_condition(mysql_expr!("{} > {}", (ident("revenue")), 400.0f64)), false)
             .with_source_as("top_spenders", "t")
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("revenue").dot_of("t"), None)
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("revenue").dot_of("t"))
             .with_join(MysqlSelectJoin::inner("users", "u",
                 mysql_expr!("{} = {}",
                     (ident("id").dot_of("u")),
@@ -841,15 +842,15 @@ async fn test_q11() {
         .with_source("departments")
         .with_field("id")
         .with_field("name")
-        .with_expression(mysql_expr!("0"), None)
-        .with_expression(ident("name"), None)
+        .with_expression(mysql_expr!("0"))
+        .with_expression(ident("name"))
         .with_condition(mysql_expr!("{} IS NULL", (ident("parent_id"))));
 
     let recursive = MysqlSelect::new()
         .with_source_as("departments", "d")
-        .with_expression(ident("id").dot_of("d"), None)
-        .with_expression(ident("name").dot_of("d"), None)
-        .with_expression(mysql_expr!("{} + 1", (ident("depth").dot_of("dt"))), None)
+        .with_expression(ident("id").dot_of("d"))
+        .with_expression(ident("name").dot_of("d"))
+        .with_expression(mysql_expr!("{} + 1", (ident("depth").dot_of("dt"))))
         .with_expression(
             concat_sql!(ident("path").dot_of("dt"), " > ", ident("name").dot_of("d")),
             None,
@@ -930,9 +931,9 @@ async fn test_q12() {
         &MysqlSelect::new()
             .with_distinct(true)
             .with_source_as("products", "p")
-            .with_expression(ident("id").dot_of("p"), None)
-            .with_expression(ident("name").dot_of("p"), None)
-            .with_expression(ident("price").dot_of("p"), None)
+            .with_expression(ident("id").dot_of("p"))
+            .with_expression(ident("name").dot_of("p"))
+            .with_expression(ident("price").dot_of("p"))
             .with_join(MysqlSelectJoin::inner(
                 "product_tags",
                 "pt",
@@ -1024,8 +1025,8 @@ async fn test_q13() {
             .with_field("id")
             .with_field("name")
             .with_expression(
-                Fx::new("json_extract", [metadata.expr(), mysql_expr!("'$.color'")]),
-                Some("color".into()),
+                Fx::new("json_extract", [metadata.expr(), mysql_expr!("'$.color'")])
+                .as_alias("color"),
             )
             .with_expression(
                 mysql_expr!(
@@ -1034,19 +1035,19 @@ async fn test_q13() {
                         "json_extract",
                         [metadata.expr(), mysql_expr!("'$.weight_kg'")]
                     ))
-                ),
-                Some("weight".into()),
+                )
+                .as_alias("weight"),
             )
             .with_expression(
-                mysql_expr!("CAST({} AS DOUBLE)", (rating_expr.clone())),
-                Some("rating".into()),
+                mysql_expr!("CAST({} AS DOUBLE)", (rating_expr.clone()))
+                .as_alias("rating"),
             )
             .with_expression(
                 Fx::new(
                     "nullif",
                     [ident("category").expr(), mysql_expr!("{}", "uncategorized")],
-                ),
-                Some("clean_category".into()),
+                )
+                .as_alias("clean_category"),
             )
             .with_condition(mysql_expr!(
                 "CAST({} AS DOUBLE) BETWEEN {} AND {}",
@@ -1124,15 +1125,15 @@ async fn test_q14() {
     let rows: Vec<MonthlyRevenue> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("orders", "o")
-            .with_expression(month_expr.clone(), Some("month".into()))
-            .with_expression(ident("name").dot_of("d"), Some("department".into()))
+            .with_expression(month_expr.clone().as_alias("month"))
+            .with_expression(ident("name").dot_of("d").as_alias("department"))
             .with_expression(
-                Fx::new("count", [ident("id").dot_of("o").expr()]),
-                Some("order_count".into()),
+                Fx::new("count", [ident("id").dot_of("o").expr()])
+                .as_alias("order_count"),
             )
             .with_expression(
-                Fx::new("round", [sum_total.expr(), mysql_expr!("{}", 2i64)]),
-                Some("monthly_revenue".into()),
+                Fx::new("round", [sum_total.expr(), mysql_expr!("{}", 2i64)])
+                .as_alias("monthly_revenue"),
             )
             .with_join(MysqlSelectJoin::inner(
                 "users",

--- a/vantage-sql/tests/mysql/3_complex_queries.rs
+++ b/vantage-sql/tests/mysql/3_complex_queries.rs
@@ -7,9 +7,9 @@ use serde::Deserialize;
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 use vantage_sql::mysql::MysqlDB;
 use vantage_sql::mysql::statements::MysqlSelect;
-use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::mysql::statements::select::join::MysqlSelectJoin;
 use vantage_sql::mysql_expr;
+use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::primitives::fx::Fx;
 use vantage_sql::primitives::identifier::ident;
 use vantage_table::operation::Operation;
@@ -261,16 +261,10 @@ async fn test_q4() {
         &MysqlSelect::new()
             .with_source("products")
             .with_field("category")
-            .with_expression(
-                Fx::new("count", [mysql_expr!("*")])
-                .as_alias("product_count"),
-            )
+            .with_expression(Fx::new("count", [mysql_expr!("*")]).as_alias("product_count"))
             .with_expression(Fx::new("avg", [price.expr()]).as_alias("avg_price"))
             .with_expression(Fx::new("min", [price.expr()]).as_alias("cheapest"))
-            .with_expression(
-                Fx::new("max", [price.expr()])
-                .as_alias("most_expensive"),
-            )
+            .with_expression(Fx::new("max", [price.expr()]).as_alias("most_expensive"))
             .with_group_by(ident("category"))
             .with_having(mysql_expr!(
                 "{} > {}",
@@ -413,14 +407,8 @@ async fn test_q6() {
     let stats_subquery = MysqlSelect::new()
         .with_source("orders")
         .with_field("user_id")
-        .with_expression(
-            Fx::new("count", [mysql_expr!("*")])
-            .as_alias("order_count"),
-        )
-        .with_expression(
-            Fx::new("avg", [ident("total").expr()])
-            .as_alias("avg_total"),
-        )
+        .with_expression(Fx::new("count", [mysql_expr!("*")]).as_alias("order_count"))
+        .with_expression(Fx::new("avg", [ident("total").expr()]).as_alias("avg_total"))
         .with_condition(mysql_expr!("{} != {}", (ident("status")), "cancelled"))
         .with_group_by(ident("user_id"));
 
@@ -526,7 +514,7 @@ async fn test_q7() {
                         mysql_expr!("{}", "junior"),
                     )
                     .else_(mysql_expr!("{}", "intern"))
-                .as_alias("band"),
+                    .as_alias("band"),
             )
             .with_expression(
                 ternary(ident("role").eq("admin"), "Yes", "No").with_alias("is_admin"),
@@ -1026,7 +1014,7 @@ async fn test_q13() {
             .with_field("name")
             .with_expression(
                 Fx::new("json_extract", [metadata.expr(), mysql_expr!("'$.color'")])
-                .as_alias("color"),
+                    .as_alias("color"),
             )
             .with_expression(
                 mysql_expr!(
@@ -1039,8 +1027,7 @@ async fn test_q13() {
                 .as_alias("weight"),
             )
             .with_expression(
-                mysql_expr!("CAST({} AS DOUBLE)", (rating_expr.clone()))
-                .as_alias("rating"),
+                mysql_expr!("CAST({} AS DOUBLE)", (rating_expr.clone())).as_alias("rating"),
             )
             .with_expression(
                 Fx::new(
@@ -1128,12 +1115,11 @@ async fn test_q14() {
             .with_expression(month_expr.clone().as_alias("month"))
             .with_expression(ident("name").dot_of("d").as_alias("department"))
             .with_expression(
-                Fx::new("count", [ident("id").dot_of("o").expr()])
-                .as_alias("order_count"),
+                Fx::new("count", [ident("id").dot_of("o").expr()]).as_alias("order_count"),
             )
             .with_expression(
                 Fx::new("round", [sum_total.expr(), mysql_expr!("{}", 2i64)])
-                .as_alias("monthly_revenue"),
+                    .as_alias("monthly_revenue"),
             )
             .with_join(MysqlSelectJoin::inner(
                 "users",

--- a/vantage-sql/tests/mysql/3_complex_queries.rs
+++ b/vantage-sql/tests/mysql/3_complex_queries.rs
@@ -108,10 +108,7 @@ async fn test_q2() {
             .with_source_as("users", "u")
             .with_expression(ident("id").dot_of("u"))
             .with_expression(ident("name").dot_of("u"))
-            .with_expression(
-                ident("name").dot_of("d").with_alias("department_name"),
-                None,
-            )
+            .with_expression(ident("name").dot_of("d").with_alias("department_name"))
             .with_join(MysqlSelectJoin::inner(
                 "departments",
                 "d",
@@ -516,10 +513,7 @@ async fn test_q7() {
                     .else_(mysql_expr!("{}", "intern"))
                     .as_alias("band"),
             )
-            .with_expression(
-                ternary(ident("role").eq("admin"), "Yes", "No").with_alias("is_admin"),
-                None,
-            )
+            .with_expression(ternary(ident("role").eq("admin"), "Yes", "No").as_alias("is_admin"))
             .with_field("display_name")
             .with_order(ident("salary"), Order::Desc),
         "SELECT `id`, `name`, `salary`, \
@@ -839,10 +833,11 @@ async fn test_q11() {
         .with_expression(ident("id").dot_of("d"))
         .with_expression(ident("name").dot_of("d"))
         .with_expression(mysql_expr!("{} + 1", (ident("depth").dot_of("dt"))))
-        .with_expression(
-            concat_sql!(ident("path").dot_of("dt"), " > ", ident("name").dot_of("d")),
-            None,
-        )
+        .with_expression(concat_sql!(
+            ident("path").dot_of("dt"),
+            " > ",
+            ident("name").dot_of("d")
+        ))
         .with_join(MysqlSelectJoin::inner(
             "dept_tree",
             "dt",

--- a/vantage-sql/tests/mysql/3_complex_queries_my.rs
+++ b/vantage-sql/tests/mysql/3_complex_queries_my.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use vantage_expressions::{ExprDataSource, Expression, Expressive, Order, Selectable};
 use vantage_sql::mysql::MysqlDB;
 use vantage_sql::mysql::operation::MysqlOperation;
+use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::mysql::statements::MysqlSelect;
 use vantage_sql::mysql::statements::primitives::GroupConcat;
 use vantage_sql::mysql::statements::select::join::MysqlSelectJoin;
@@ -74,23 +75,23 @@ async fn test_my_q1_group_concat() {
     let rows: Vec<CategoryAgg> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("products", "p")
-            .with_expression(ident("category").dot_of("p"), None)
+            .with_expression(ident("category").dot_of("p"))
             .with_expression(
-                Fx::new("count", [mysql_expr!("*")]),
-                Some("total".into()),
+                Fx::new("count", [mysql_expr!("*")])
+                .as_alias("total"),
             )
             .with_expression(
                 GroupConcat::new(ident("name").dot_of("p"))
                     .distinct()
                     .order_by(ident("name").dot_of("p"), Order::Asc)
-                    .separator(", "),
-                Some("product_names".into()),
+                    .separator(", ")
+                .as_alias("product_names"),
             )
             .with_expression(
                 GroupConcat::new(ident("price").dot_of("p"))
                     .order_by(ident("price").dot_of("p"), Order::Desc)
-                    .separator("; "),
-                Some("prices_desc".into()),
+                    .separator("; ")
+                .as_alias("prices_desc"),
             )
             .with_group_by(ident("category").dot_of("p"))
             .with_order(ident("total"), Order::Desc),
@@ -159,12 +160,12 @@ async fn test_my_q2_find_in_set() {
     let rows: Vec<UserPermissions> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("id").dot_of("u"), None)
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("role").dot_of("u"), None)
-            .with_expression(ident("permissions").dot_of("u"), None)
-            .with_expression(find_write.clone(), Some("has_write_at_pos".into()))
-            .with_expression(find_admin.clone(), Some("has_admin_at_pos".into()))
+            .with_expression(ident("id").dot_of("u"))
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("role").dot_of("u"))
+            .with_expression(ident("permissions").dot_of("u"))
+            .with_expression(find_write.clone().as_alias("has_write_at_pos"))
+            .with_expression(find_admin.clone().as_alias("has_admin_at_pos"))
             .with_condition(find_write.gt(mysql_expr!("{}", 0i64)))
             .with_order(
                 Fx::new(
@@ -240,11 +241,11 @@ async fn test_my_q3_json_operators() {
     let rows: Vec<ProductJson> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("products", "p")
-            .with_expression(ident("id").dot_of("p"), None)
-            .with_expression(ident("name").dot_of("p"), None)
-            .with_expression(color, Some("color".into()))
-            .with_expression(rating.clone(), Some("rating".into()))
-            .with_expression(specs, Some("specs_json".into()))
+            .with_expression(ident("id").dot_of("p"))
+            .with_expression(ident("name").dot_of("p"))
+            .with_expression(color.as_alias("color"))
+            .with_expression(rating.clone().as_alias("rating"))
+            .with_expression(specs.as_alias("specs_json"))
             .with_expression(
                 Fx::new(
                     "json_unquote",
@@ -253,8 +254,8 @@ async fn test_my_q3_json_operators() {
                         [metadata.expr(), mysql_expr!("'$.specs.voltage'")],
                     )
                     .expr()],
-                ),
-                Some("voltage".into()),
+                )
+                .as_alias("voltage"),
             )
             .with_condition(Fx::new(
                 "json_contains",
@@ -339,10 +340,10 @@ async fn test_my_q4_json_table() {
                     .expr(),
                 "specs",
             )
-            .with_expression(ident("id").dot_of("p"), None)
-            .with_expression(ident("name").dot_of("p"), None)
-            .with_expression(ident("voltage").dot_of("specs"), None)
-            .with_expression(ident("watts").dot_of("specs"), None)
+            .with_expression(ident("id").dot_of("p"))
+            .with_expression(ident("name").dot_of("p"))
+            .with_expression(ident("voltage").dot_of("specs"))
+            .with_expression(ident("watts").dot_of("specs"))
             .with_condition(ident("voltage").dot_of("specs").gt(mysql_expr!("{}", 0i64)))
             .with_order(ident("watts").dot_of("specs"), Order::Desc),
         concat!(
@@ -403,14 +404,14 @@ async fn test_my_q5_json_agg() {
                     .dot_of("u")
                     .eq(ident("id").dot_of("d")),
             ))
-            .with_expression(ident("name").dot_of("d"), Some("department".into()))
+            .with_expression(ident("name").dot_of("d").as_alias("department"))
             .with_expression(
-                Fx::new("json_arrayagg", [u_name.expr()]),
-                Some("user_names".into()),
+                Fx::new("json_arrayagg", [u_name.expr()])
+                .as_alias("user_names"),
             )
             .with_expression(
-                Fx::new("json_objectagg", [u_name.expr(), u_salary.expr()]),
-                Some("salary_map".into()),
+                Fx::new("json_objectagg", [u_name.expr(), u_salary.expr()])
+                .as_alias("salary_map"),
             )
             .with_condition(mysql_expr!("{} = b'1'", (ident("is_active").dot_of("u"))))
             .with_group_by(ident("id").dot_of("d"))
@@ -471,10 +472,10 @@ async fn test_my_q6_fulltext_search() {
     let rows: Vec<FulltextResult> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("products", "p")
-            .with_expression(ident("id").dot_of("p"), None)
-            .with_expression(ident("name").dot_of("p"), None)
-            .with_expression(ident("description").dot_of("p"), None)
-            .with_expression(match_expr.clone(), Some("relevance".into()))
+            .with_expression(ident("id").dot_of("p"))
+            .with_expression(ident("name").dot_of("p"))
+            .with_expression(ident("description").dot_of("p"))
+            .with_expression(match_expr.clone().as_alias("relevance"))
             .with_condition(match_expr)
             .with_order(ident("relevance"), Order::Desc),
         concat!(
@@ -526,16 +527,16 @@ async fn test_my_q7_regexp() {
     let rows: Vec<UserRegexp> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("id").dot_of("u"), None)
-            .with_expression(u_name.clone(), None)
-            .with_expression(u_email.clone(), None)
+            .with_expression(ident("id").dot_of("u"))
+            .with_expression(u_name.clone())
+            .with_expression(u_email.clone())
             .with_expression(
-                Fx::new("regexp_substr", [u_email.expr(), mysql_expr!("'@(.+)$'")]),
-                Some("domain_part".into()),
+                Fx::new("regexp_substr", [u_email.expr(), mysql_expr!("'@(.+)$'")])
+                .as_alias("domain_part"),
             )
             .with_expression(
-                Fx::new("regexp_like", [u_name.expr(), mysql_expr!("'^[A-E]'")]),
-                Some("name_starts_a_to_e".into()),
+                Fx::new("regexp_like", [u_name.expr(), mysql_expr!("'^[A-E]'")])
+                .as_alias("name_starts_a_to_e"),
             )
             .with_condition(u_email.regexp(mysql_expr!("{}", "^[a-z]+@example\\.com$")))
             .with_order(ident("name").dot_of("u"), Order::Asc),
@@ -597,9 +598,9 @@ async fn test_my_q8_if_ifnull() {
     let rows: Vec<OrderConditional> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("orders", "o")
-            .with_expression(ident("id").dot_of("o"), None)
-            .with_expression(ident("total").dot_of("o"), None)
-            .with_expression(o_status.clone(), None)
+            .with_expression(ident("id").dot_of("o"))
+            .with_expression(ident("total").dot_of("o"))
+            .with_expression(o_status.clone())
             .with_expression(
                 Iif::new(
                     o_status.eq(mysql_expr!("{}", "completed")),
@@ -609,21 +610,21 @@ async fn test_my_q8_if_ifnull() {
                         mysql_expr!("'Void'"),
                         mysql_expr!("'Active'"),
                     ),
-                ),
-                Some("status_label".into()),
+                )
+                .as_alias("status_label"),
             )
             .with_expression(
-                Fx::new("ifnull", [o_notes.expr(), mysql_expr!("'(no notes)'")]),
-                Some("safe_notes".into()),
+                Fx::new("ifnull", [o_notes.expr(), mysql_expr!("'(no notes)'")])
+                .as_alias("safe_notes"),
             )
             .with_expression(
-                Fx::new("nullif", [o_status.expr(), mysql_expr!("{}", "pending")]),
-                Some("non_pending_status".into()),
+                Fx::new("nullif", [o_status.expr(), mysql_expr!("{}", "pending")])
+                .as_alias("non_pending_status"),
             )
             .with_expression(
                 Concat::new([o_status.expr(), o_notes.expr()])
-                    .ws(mysql_expr!("' | '")),
-                Some("combined".into()),
+                    .ws(mysql_expr!("' | '"))
+                .as_alias("combined"),
             )
             .with_order(ident("created_at").dot_of("o"), Order::Desc),
         concat!(
@@ -695,18 +696,18 @@ async fn test_my_q9_rollup() {
     let rows: Vec<RollupRow> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("orders", "o")
-            .with_expression(o_status.clone(), None)
-            .with_expression(date_fmt.clone(), Some("month".into()))
+            .with_expression(o_status.clone())
+            .with_expression(date_fmt.clone().as_alias("month"))
             .with_expression(
-                Fx::new("count", [mysql_expr!("*")]),
-                Some("order_count".into()),
+                Fx::new("count", [mysql_expr!("*")])
+                .as_alias("order_count"),
             )
             .with_expression(
-                Fx::new("sum", [ident("total").dot_of("o").expr()]),
-                Some("revenue".into()),
+                Fx::new("sum", [ident("total").dot_of("o").expr()])
+                .as_alias("revenue"),
             )
-            .with_expression(grouping_status.clone(), Some("is_status_total".into()))
-            .with_expression(grouping_month.clone(), Some("is_month_total".into()))
+            .with_expression(grouping_status.clone().as_alias("is_status_total"))
+            .with_expression(grouping_month.clone().as_alias("is_month_total"))
             .with_condition(o_status.ne(mysql_expr!("{}", "cancelled")))
             .with_group_by(o_status.clone())
             .with_group_by(ident("month"))
@@ -790,38 +791,38 @@ async fn test_my_q10_bit_operations() {
                 "u",
                 ident("id").dot_of("u").eq(ident("user_id").dot_of("s")),
             ))
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("day_of_week").dot_of("s"), None)
-            .with_expression(ident("start_time").dot_of("s"), None)
-            .with_expression(ident("end_time").dot_of("s"), None)
-            .with_expression(Fx::new("bin", [flags.expr()]), Some("flags_binary".into()))
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("day_of_week").dot_of("s"))
+            .with_expression(ident("start_time").dot_of("s"))
+            .with_expression(ident("end_time").dot_of("s"))
+            .with_expression(Fx::new("bin", [flags.expr()]).as_alias("flags_binary"))
             .with_expression(
                 Iif::new(
                     flags.bitand(mysql_expr!("b'00000001'")),
                     mysql_expr!("'Yes'"),
                     mysql_expr!("'No'"),
-                ),
-                Some("is_remote".into()),
+                )
+                .as_alias("is_remote"),
             )
             .with_expression(
                 Iif::new(
                     flags.bitand(mysql_expr!("b'00000010'")),
                     mysql_expr!("'Yes'"),
                     mysql_expr!("'No'"),
-                ),
-                Some("is_flexible".into()),
+                )
+                .as_alias("is_flexible"),
             )
             .with_expression(
                 Iif::new(
                     flags.bitand(mysql_expr!("b'00000100'")),
                     mysql_expr!("'Yes'"),
                     mysql_expr!("'No'"),
-                ),
-                Some("is_oncall".into()),
+                )
+                .as_alias("is_oncall"),
             )
             .with_expression(
-                Fx::new("bit_count", [flags.expr()]),
-                Some("active_flag_count".into()),
+                Fx::new("bit_count", [flags.expr()])
+                .as_alias("active_flag_count"),
             )
             .with_expression(
                 Fx::new(
@@ -830,8 +831,8 @@ async fn test_my_q10_bit_operations() {
                         ident("end_time").dot_of("s").expr(),
                         ident("start_time").dot_of("s").expr(),
                     ],
-                ),
-                Some("duration".into()),
+                )
+                .as_alias("duration"),
             )
             .with_order(ident("name").dot_of("u"), Order::Asc)
             .with_order(ident("day_of_week").dot_of("s"), Order::Asc),
@@ -902,27 +903,27 @@ async fn test_my_q11_year_date_functions() {
     let rows: Vec<UserDateInfo> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("hire_year").dot_of("u"), None)
-            .with_expression(created_at.clone(), None)
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("hire_year").dot_of("u"))
+            .with_expression(created_at.clone())
             .with_expression(
-                DateFormat::raw_format(created_at.clone(), "%W, %M %D %Y"),
-                Some("formatted_date".into()),
+                DateFormat::raw_format(created_at.clone(), "%W, %M %D %Y")
+                .as_alias("formatted_date"),
             )
             .with_expression(
-                Fx::new("last_day", [created_at.expr()]),
-                Some("month_end".into()),
+                Fx::new("last_day", [created_at.expr()])
+                .as_alias("month_end"),
             )
             .with_expression(
-                Fx::new("datediff", [now.expr(), created_at.expr()]),
-                Some("days_since_creation".into()),
+                Fx::new("datediff", [now.expr(), created_at.expr()])
+                .as_alias("days_since_creation"),
             )
             .with_expression(
                 Fx::new(
                     "timestampdiff",
                     [mysql_expr!("MONTH"), created_at.expr(), now.expr()],
-                ),
-                Some("months_active".into()),
+                )
+                .as_alias("months_active"),
             )
             .with_condition(
                 ident("hire_year")
@@ -994,19 +995,19 @@ async fn test_my_q12_spatial() {
     let rows: Vec<ProductSpatial> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("products", "p")
-            .with_expression(ident("id").dot_of("p"), None)
-            .with_expression(ident("name").dot_of("p"), None)
+            .with_expression(ident("id").dot_of("p"))
+            .with_expression(ident("name").dot_of("p"))
             .with_expression(
-                Fx::new("st_x", [location.expr()]),
-                Some("lon".into()),
+                Fx::new("st_x", [location.expr()])
+                .as_alias("lon"),
             )
             .with_expression(
-                Fx::new("st_y", [location.expr()]),
-                Some("lat".into()),
+                Fx::new("st_y", [location.expr()])
+                .as_alias("lat"),
             )
             .with_expression(
-                Fx::new("round", [distance, mysql_expr!("1")]),
-                Some("distance_km".into()),
+                Fx::new("round", [distance, mysql_expr!("1")])
+                .as_alias("distance_km"),
             )
             .with_condition(
                 Fx::new("st_x", [location.expr()]).ne(mysql_expr!("{}", 0i64)),
@@ -1064,11 +1065,11 @@ async fn test_my_q13_generated_columns() {
     let rows: Vec<UserGenerated> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("id").dot_of("u"), None)
-            .with_expression(ident("display_name").dot_of("u"), None)
-            .with_expression(ident("salary_band").dot_of("u"), None)
-            .with_expression(ident("salary").dot_of("u"), None)
-            .with_expression(ident("role").dot_of("u"), None)
+            .with_expression(ident("id").dot_of("u"))
+            .with_expression(ident("display_name").dot_of("u"))
+            .with_expression(ident("salary_band").dot_of("u"))
+            .with_expression(ident("salary").dot_of("u"))
+            .with_expression(ident("role").dot_of("u"))
             .with_condition(ident("salary_band").dot_of("u").in_list(&["senior", "mid"]))
             .with_order(ident("salary").dot_of("u"), Order::Desc),
         concat!(
@@ -1157,19 +1158,19 @@ async fn test_my_q14_hex_uuid() {
     let rows: Vec<AuditEntry> = check_and_run(
         &MysqlSelect::new()
             .with_source_as("audit_log", "a")
-            .with_expression(ident("id").dot_of("a"), None)
-            .with_expression(ident("table_name").dot_of("a"), None)
-            .with_expression(ident("action").dot_of("a"), None)
-            .with_expression(ident("details").dot_of("a"), None)
-            .with_expression(hex_session, Some("session_hex".into()))
+            .with_expression(ident("id").dot_of("a"))
+            .with_expression(ident("table_name").dot_of("a"))
+            .with_expression(ident("action").dot_of("a"))
+            .with_expression(ident("details").dot_of("a"))
+            .with_expression(hex_session.as_alias("session_hex"))
             .with_expression(
                 Case::new().when(
                     mysql_expr!("{} IS NOT NULL", (session_id)),
                     uuid_formatted,
-                ),
-                Some("session_uuid".into()),
+                )
+                .as_alias("session_uuid"),
             )
-            .with_expression(ident("changed_at").dot_of("a"), None)
+            .with_expression(ident("changed_at").dot_of("a"))
             .with_order(ident("changed_at").dot_of("a"), Order::Desc),
         concat!(
             "SELECT `a`.`id`, `a`.`table_name`, `a`.`action`, `a`.`details`, ",
@@ -1251,36 +1252,36 @@ async fn test_my_q15_window_functions() {
                 "d",
                 ident("id").dot_of("d").eq(dept_id.clone()),
             ))
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("name").dot_of("d"), Some("department".into()))
-            .with_expression(salary.clone(), None)
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("name").dot_of("d").as_alias("department"))
+            .with_expression(salary.clone())
             .with_expression(
-                named.apply(Fx::new("row_number", Vec::<Expression<_>>::new())),
-                Some("row_num".into()),
+                named.apply(Fx::new("row_number", Vec::<Expression<_>>::new()))
+                .as_alias("row_num"),
             )
             .with_expression(
-                named.apply(Fx::new("dense_rank", Vec::<Expression<_>>::new())),
-                Some("salary_rank".into()),
+                named.apply(Fx::new("dense_rank", Vec::<Expression<_>>::new()))
+                .as_alias("salary_rank"),
             )
             .with_expression(
-                named.apply(Fx::new("ntile", [mysql_expr!("{}", 3i64)])),
-                Some("salary_tercile".into()),
+                named.apply(Fx::new("ntile", [mysql_expr!("{}", 3i64)]))
+                .as_alias("salary_tercile"),
             )
             .with_expression(
-                named.apply(Fx::new("percent_rank", Vec::<Expression<_>>::new())),
-                Some("pct_rank".into()),
+                named.apply(Fx::new("percent_rank", Vec::<Expression<_>>::new()))
+                .as_alias("pct_rank"),
             )
             .with_expression(
                 Window::new()
                     .partition_by(dept_id.clone())
                     .order_by(salary.clone(), Order::Desc)
                     .rows("UNBOUNDED PRECEDING", "CURRENT ROW")
-                    .apply(Fx::new("sum", [salary.expr()])),
-                Some("running_total".into()),
+                    .apply(Fx::new("sum", [salary.expr()]))
+                .as_alias("running_total"),
             )
             .with_expression(
-                named.apply(Fx::new("first_value", [ident("name").dot_of("u").expr()])),
-                Some("top_earner".into()),
+                named.apply(Fx::new("first_value", [ident("name").dot_of("u").expr()]))
+                .as_alias("top_earner"),
             )
             .with_condition(mysql_expr!("{} = b'1'", (ident("is_active").dot_of("u"))))
             .with_window(

--- a/vantage-sql/tests/mysql/3_complex_queries_my.rs
+++ b/vantage-sql/tests/mysql/3_complex_queries_my.rs
@@ -8,11 +8,11 @@ use serde::Deserialize;
 use vantage_expressions::{ExprDataSource, Expression, Expressive, Order, Selectable};
 use vantage_sql::mysql::MysqlDB;
 use vantage_sql::mysql::operation::MysqlOperation;
-use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::mysql::statements::MysqlSelect;
 use vantage_sql::mysql::statements::primitives::GroupConcat;
 use vantage_sql::mysql::statements::select::join::MysqlSelectJoin;
 use vantage_sql::mysql_expr;
+use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::primitives::concat::Concat;
 use vantage_sql::primitives::fx::Fx;
 use vantage_sql::primitives::identifier::ident;
@@ -405,13 +405,9 @@ async fn test_my_q5_json_agg() {
                     .eq(ident("id").dot_of("d")),
             ))
             .with_expression(ident("name").dot_of("d").as_alias("department"))
+            .with_expression(Fx::new("json_arrayagg", [u_name.expr()]).as_alias("user_names"))
             .with_expression(
-                Fx::new("json_arrayagg", [u_name.expr()])
-                .as_alias("user_names"),
-            )
-            .with_expression(
-                Fx::new("json_objectagg", [u_name.expr(), u_salary.expr()])
-                .as_alias("salary_map"),
+                Fx::new("json_objectagg", [u_name.expr(), u_salary.expr()]).as_alias("salary_map"),
             )
             .with_condition(mysql_expr!("{} = b'1'", (ident("is_active").dot_of("u"))))
             .with_group_by(ident("id").dot_of("d"))
@@ -532,11 +528,11 @@ async fn test_my_q7_regexp() {
             .with_expression(u_email.clone())
             .with_expression(
                 Fx::new("regexp_substr", [u_email.expr(), mysql_expr!("'@(.+)$'")])
-                .as_alias("domain_part"),
+                    .as_alias("domain_part"),
             )
             .with_expression(
                 Fx::new("regexp_like", [u_name.expr(), mysql_expr!("'^[A-E]'")])
-                .as_alias("name_starts_a_to_e"),
+                    .as_alias("name_starts_a_to_e"),
             )
             .with_condition(u_email.regexp(mysql_expr!("{}", "^[a-z]+@example\\.com$")))
             .with_order(ident("name").dot_of("u"), Order::Asc),
@@ -698,13 +694,9 @@ async fn test_my_q9_rollup() {
             .with_source_as("orders", "o")
             .with_expression(o_status.clone())
             .with_expression(date_fmt.clone().as_alias("month"))
+            .with_expression(Fx::new("count", [mysql_expr!("*")]).as_alias("order_count"))
             .with_expression(
-                Fx::new("count", [mysql_expr!("*")])
-                .as_alias("order_count"),
-            )
-            .with_expression(
-                Fx::new("sum", [ident("total").dot_of("o").expr()])
-                .as_alias("revenue"),
+                Fx::new("sum", [ident("total").dot_of("o").expr()]).as_alias("revenue"),
             )
             .with_expression(grouping_status.clone().as_alias("is_status_total"))
             .with_expression(grouping_month.clone().as_alias("is_month_total"))
@@ -820,10 +812,7 @@ async fn test_my_q10_bit_operations() {
                 )
                 .as_alias("is_oncall"),
             )
-            .with_expression(
-                Fx::new("bit_count", [flags.expr()])
-                .as_alias("active_flag_count"),
-            )
+            .with_expression(Fx::new("bit_count", [flags.expr()]).as_alias("active_flag_count"))
             .with_expression(
                 Fx::new(
                     "timediff",
@@ -908,15 +897,12 @@ async fn test_my_q11_year_date_functions() {
             .with_expression(created_at.clone())
             .with_expression(
                 DateFormat::raw_format(created_at.clone(), "%W, %M %D %Y")
-                .as_alias("formatted_date"),
+                    .as_alias("formatted_date"),
             )
-            .with_expression(
-                Fx::new("last_day", [created_at.expr()])
-                .as_alias("month_end"),
-            )
+            .with_expression(Fx::new("last_day", [created_at.expr()]).as_alias("month_end"))
             .with_expression(
                 Fx::new("datediff", [now.expr(), created_at.expr()])
-                .as_alias("days_since_creation"),
+                    .as_alias("days_since_creation"),
             )
             .with_expression(
                 Fx::new(
@@ -1256,20 +1242,24 @@ async fn test_my_q15_window_functions() {
             .with_expression(ident("name").dot_of("d").as_alias("department"))
             .with_expression(salary.clone())
             .with_expression(
-                named.apply(Fx::new("row_number", Vec::<Expression<_>>::new()))
-                .as_alias("row_num"),
+                named
+                    .apply(Fx::new("row_number", Vec::<Expression<_>>::new()))
+                    .as_alias("row_num"),
             )
             .with_expression(
-                named.apply(Fx::new("dense_rank", Vec::<Expression<_>>::new()))
-                .as_alias("salary_rank"),
+                named
+                    .apply(Fx::new("dense_rank", Vec::<Expression<_>>::new()))
+                    .as_alias("salary_rank"),
             )
             .with_expression(
-                named.apply(Fx::new("ntile", [mysql_expr!("{}", 3i64)]))
-                .as_alias("salary_tercile"),
+                named
+                    .apply(Fx::new("ntile", [mysql_expr!("{}", 3i64)]))
+                    .as_alias("salary_tercile"),
             )
             .with_expression(
-                named.apply(Fx::new("percent_rank", Vec::<Expression<_>>::new()))
-                .as_alias("pct_rank"),
+                named
+                    .apply(Fx::new("percent_rank", Vec::<Expression<_>>::new()))
+                    .as_alias("pct_rank"),
             )
             .with_expression(
                 Window::new()
@@ -1277,11 +1267,12 @@ async fn test_my_q15_window_functions() {
                     .order_by(salary.clone(), Order::Desc)
                     .rows("UNBOUNDED PRECEDING", "CURRENT ROW")
                     .apply(Fx::new("sum", [salary.expr()]))
-                .as_alias("running_total"),
+                    .as_alias("running_total"),
             )
             .with_expression(
-                named.apply(Fx::new("first_value", [ident("name").dot_of("u").expr()]))
-                .as_alias("top_earner"),
+                named
+                    .apply(Fx::new("first_value", [ident("name").dot_of("u").expr()]))
+                    .as_alias("top_earner"),
             )
             .with_condition(mysql_expr!("{} = b'1'", (ident("is_active").dot_of("u"))))
             .with_window(

--- a/vantage-sql/tests/mysql/3_select.rs
+++ b/vantage-sql/tests/mysql/3_select.rs
@@ -1,12 +1,12 @@
 //! Test 3a: MysqlSelect via Selectable trait + SelectableDataSource execution.
 
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
-use vantage_sql::primitives::alias::AliasExt;
 #[allow(unused_imports)]
 use vantage_sql::mysql::MysqlType;
 use vantage_sql::mysql::statements::MysqlSelect;
 use vantage_sql::mysql::{AnyMysqlType, MysqlDB};
 use vantage_sql::mysql_expr;
+use vantage_sql::primitives::alias::AliasExt;
 use vantage_types::{Record, TryFromRecord, entity};
 
 const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";

--- a/vantage-sql/tests/mysql/3_select.rs
+++ b/vantage-sql/tests/mysql/3_select.rs
@@ -1,6 +1,7 @@
 //! Test 3a: MysqlSelect via Selectable trait + SelectableDataSource execution.
 
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
+use vantage_sql::primitives::alias::AliasExt;
 #[allow(unused_imports)]
 use vantage_sql::mysql::MysqlType;
 use vantage_sql::mysql::statements::MysqlSelect;
@@ -99,7 +100,7 @@ fn test_select_group_by_with_expression() {
     let s = MysqlSelect::new()
         .with_source("product")
         .with_field("is_deleted")
-        .with_expression(mysql_expr!("COUNT(*)"), Some("cnt".to_string()));
+        .with_expression(mysql_expr!("COUNT(*)").as_alias("cnt"));
     let mut s = s;
     s.add_group_by(mysql_expr!("`is_deleted`"));
     assert_eq!(

--- a/vantage-sql/tests/postgres/3_complex_queries.rs
+++ b/vantage-sql/tests/postgres/3_complex_queries.rs
@@ -7,9 +7,9 @@ use serde::Deserialize;
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 use vantage_sql::postgres::PostgresDB;
 use vantage_sql::postgres::statements::PostgresSelect;
-use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::postgres::statements::select::join::PostgresSelectJoin;
 use vantage_sql::postgres_expr;
+use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::primitives::identifier::ident;
 use vantage_table::operation::Operation;
 use vantage_types::{Record, TryFromRecord};
@@ -257,16 +257,10 @@ async fn test_q4() {
         &PostgresSelect::new()
             .with_source("products")
             .with_field("category")
-            .with_expression(
-                Fx::new("count", [postgres_expr!("*")])
-                .as_alias("product_count"),
-            )
+            .with_expression(Fx::new("count", [postgres_expr!("*")]).as_alias("product_count"))
             .with_expression(Fx::new("avg", [price.expr()]).as_alias("avg_price"))
             .with_expression(Fx::new("min", [price.expr()]).as_alias("cheapest"))
-            .with_expression(
-                Fx::new("max", [price.expr()])
-                .as_alias("most_expensive"),
-            )
+            .with_expression(Fx::new("max", [price.expr()]).as_alias("most_expensive"))
             .with_group_by(ident("category"))
             .with_having(postgres_expr!(
                 "{} > {}",
@@ -409,14 +403,8 @@ async fn test_q6() {
     let stats_subquery = PostgresSelect::new()
         .with_source("orders")
         .with_field("user_id")
-        .with_expression(
-            Fx::new("count", [postgres_expr!("*")])
-            .as_alias("order_count"),
-        )
-        .with_expression(
-            Fx::new("avg", [ident("total").expr()])
-            .as_alias("avg_total"),
-        )
+        .with_expression(Fx::new("count", [postgres_expr!("*")]).as_alias("order_count"))
+        .with_expression(Fx::new("avg", [ident("total").expr()]).as_alias("avg_total"))
         .with_condition(postgres_expr!("{} != {}", (ident("status")), "cancelled"))
         .with_group_by(ident("user_id"));
 
@@ -522,11 +510,9 @@ async fn test_q7() {
                         postgres_expr!("{}", "junior"),
                     )
                     .else_(postgres_expr!("{}", "intern"))
-                .as_alias("band"),
+                    .as_alias("band"),
             )
-            .with_expression(
-                ternary(ident("role").eq("admin"), "Yes", "No").as_alias("is_admin"),
-            )
+            .with_expression(ternary(ident("role").eq("admin"), "Yes", "No").as_alias("is_admin"))
             .with_field("display_name")
             .with_order(ident("salary"), Order::Desc),
         "SELECT \"id\", \"name\", \"salary\", \
@@ -845,12 +831,12 @@ async fn test_q11() {
         .with_source_as("departments", "d")
         .with_expression(ident("id").dot_of("d"))
         .with_expression(ident("name").dot_of("d"))
-        .with_expression(
-            postgres_expr!("{} + 1", (ident("depth").dot_of("dt"))),
-        )
-        .with_expression(
-            concat_sql!(ident("path").dot_of("dt"), " > ", ident("name").dot_of("d")),
-        )
+        .with_expression(postgres_expr!("{} + 1", (ident("depth").dot_of("dt"))))
+        .with_expression(concat_sql!(
+            ident("path").dot_of("dt"),
+            " > ",
+            ident("name").dot_of("d")
+        ))
         .with_join(PostgresSelectJoin::inner(
             "dept_tree",
             "dt",
@@ -1027,9 +1013,7 @@ async fn test_q13() {
             .with_source("products")
             .with_field("id")
             .with_field("name")
-            .with_expression(
-                JsonExtract::new(metadata.clone(), "color").as_alias("color"),
-            )
+            .with_expression(JsonExtract::new(metadata.clone(), "color").as_alias("color"))
             .with_expression(
                 postgres_expr!(
                     "CAST({} AS DOUBLE PRECISION)",
@@ -1039,7 +1023,7 @@ async fn test_q13() {
             )
             .with_expression(
                 postgres_expr!("CAST({} AS DOUBLE PRECISION)", (rating_expr.clone()))
-                .as_alias("rating"),
+                    .as_alias("rating"),
             )
             .with_expression(
                 Fx::new(
@@ -1125,12 +1109,11 @@ async fn test_q14() {
             .with_expression(month_expr.clone().as_alias("month"))
             .with_expression(ident("name").dot_of("d").as_alias("department"))
             .with_expression(
-                Fx::new("count", [ident("id").dot_of("o").expr()])
-                .as_alias("order_count"),
+                Fx::new("count", [ident("id").dot_of("o").expr()]).as_alias("order_count"),
             )
             .with_expression(
                 Fx::new("round", [sum_total.expr(), postgres_expr!("{}", 2i32)])
-                .as_alias("monthly_revenue"),
+                    .as_alias("monthly_revenue"),
             )
             .with_join(PostgresSelectJoin::inner(
                 "users",

--- a/vantage-sql/tests/postgres/3_complex_queries.rs
+++ b/vantage-sql/tests/postgres/3_complex_queries.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 use vantage_sql::postgres::PostgresDB;
 use vantage_sql::postgres::statements::PostgresSelect;
+use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::postgres::statements::select::join::PostgresSelectJoin;
 use vantage_sql::postgres_expr;
 use vantage_sql::primitives::identifier::ident;
@@ -104,12 +105,9 @@ async fn test_q2() {
     let users: Vec<UserWithDept> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("id").dot_of("u"), None)
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(
-                ident("name").dot_of("d").with_alias("department_name"),
-                None,
-            )
+            .with_expression(ident("id").dot_of("u"))
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("name").dot_of("d").with_alias("department_name"))
             .with_join(PostgresSelectJoin::inner(
                 "departments",
                 "d",
@@ -172,8 +170,8 @@ async fn test_q3() {
 
     let select = PostgresSelect::new()
         .with_source_as("users", "u")
-        .with_expression(ident("id").dot_of("u"), None)
-        .with_expression(ident("name").dot_of("u"), None)
+        .with_expression(ident("id").dot_of("u"))
+        .with_expression(ident("name").dot_of("u"))
         .with_expression(
             Fx::new(
                 "coalesce",
@@ -181,8 +179,8 @@ async fn test_q3() {
                     Fx::new("sum", [ident("total").dot_of("o").expr()]).expr(),
                     postgres_expr!("{}", 0.0f64),
                 ],
-            ),
-            Some("total_spent".into()),
+            )
+            .as_alias("total_spent"),
         )
         .with_join(PostgresSelectJoin::left(
             "orders",
@@ -260,14 +258,14 @@ async fn test_q4() {
             .with_source("products")
             .with_field("category")
             .with_expression(
-                Fx::new("count", [postgres_expr!("*")]),
-                Some("product_count".into()),
+                Fx::new("count", [postgres_expr!("*")])
+                .as_alias("product_count"),
             )
-            .with_expression(Fx::new("avg", [price.expr()]), Some("avg_price".into()))
-            .with_expression(Fx::new("min", [price.expr()]), Some("cheapest".into()))
+            .with_expression(Fx::new("avg", [price.expr()]).as_alias("avg_price"))
+            .with_expression(Fx::new("min", [price.expr()]).as_alias("cheapest"))
             .with_expression(
-                Fx::new("max", [price.expr()]),
-                Some("most_expensive".into()),
+                Fx::new("max", [price.expr()])
+                .as_alias("most_expensive"),
             )
             .with_group_by(ident("category"))
             .with_having(postgres_expr!(
@@ -334,12 +332,12 @@ async fn test_q5() {
 
     let count_subquery = PostgresSelect::new()
         .with_source_as("orders", "o")
-        .with_expression(Fx::new("count", [postgres_expr!("*")]), None)
+        .with_expression(Fx::new("count", [postgres_expr!("*")]))
         .with_condition(user_id_match.clone());
 
     let exists_subquery = PostgresSelect::new()
         .with_source_as("orders", "o")
-        .with_expression(postgres_expr!("1"), None)
+        .with_expression(postgres_expr!("1"))
         .with_condition(user_id_match)
         .with_condition(postgres_expr!(
             "{} = {}",
@@ -350,11 +348,11 @@ async fn test_q5() {
     let users: Vec<UserOrderCount> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("id").dot_of("u"), None)
-            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(ident("id").dot_of("u"))
+            .with_expression(ident("name").dot_of("u"))
             .with_expression(
-                postgres_expr!("({})", (count_subquery)),
-                Some("order_count".into()),
+                postgres_expr!("({})", (count_subquery))
+                .as_alias("order_count"),
             )
             .with_condition(Fx::new("exists", [exists_subquery.expr()]))
             .with_order(ident("order_count"), Order::Desc)
@@ -412,12 +410,12 @@ async fn test_q6() {
         .with_source("orders")
         .with_field("user_id")
         .with_expression(
-            Fx::new("count", [postgres_expr!("*")]),
-            Some("order_count".into()),
+            Fx::new("count", [postgres_expr!("*")])
+            .as_alias("order_count"),
         )
         .with_expression(
-            Fx::new("avg", [ident("total").expr()]),
-            Some("avg_total".into()),
+            Fx::new("avg", [ident("total").expr()])
+            .as_alias("avg_total"),
         )
         .with_condition(postgres_expr!("{} != {}", (ident("status")), "cancelled"))
         .with_group_by(ident("user_id"));
@@ -425,9 +423,9 @@ async fn test_q6() {
     let users: Vec<UserOrderStats> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("order_count").dot_of("stats"), None)
-            .with_expression(ident("avg_total").dot_of("stats"), None)
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("order_count").dot_of("stats"))
+            .with_expression(ident("avg_total").dot_of("stats"))
             .with_join(PostgresSelectJoin::inner_expr(
                 stats_subquery,
                 "stats",
@@ -523,12 +521,11 @@ async fn test_q7() {
                         postgres_expr!("{} >= {}", (salary.clone()), 30000.0f64),
                         postgres_expr!("{}", "junior"),
                     )
-                    .else_(postgres_expr!("{}", "intern")),
-                Some("band".into()),
+                    .else_(postgres_expr!("{}", "intern"))
+                .as_alias("band"),
             )
             .with_expression(
-                ternary(ident("role").eq("admin"), "Yes", "No").with_alias("is_admin"),
-                None,
+                ternary(ident("role").eq("admin"), "Yes", "No").as_alias("is_admin"),
             )
             .with_field("display_name")
             .with_order(ident("salary"), Order::Desc),
@@ -582,21 +579,21 @@ async fn test_q8() {
         .with_source("users")
         .with_field("id")
         .with_field("name")
-        .with_expression(postgres_expr!("{}", "user"), Some("source".into()))
+        .with_expression(postgres_expr!("{}", "user").as_alias("source"))
         .with_condition(postgres_expr!("{} = {}", (ident("role")), "admin"));
 
     let depts_with_budget = PostgresSelect::new()
         .with_source("departments")
         .with_field("id")
         .with_field("name")
-        .with_expression(postgres_expr!("{}", "department"), Some("source".into()))
+        .with_expression(postgres_expr!("{}", "department").as_alias("source"))
         .with_condition(postgres_expr!("{} IS NOT NULL", (ident("budget"))));
 
     let depts_zero_budget = PostgresSelect::new()
         .with_source("departments")
         .with_field("id")
         .with_field("name")
-        .with_expression(postgres_expr!("{}", "department"), Some("source".into()))
+        .with_expression(postgres_expr!("{}", "department").as_alias("source"))
         .with_condition(postgres_expr!("{} = {}", (ident("budget")), 0.0f64));
 
     let compound = Union::new(admins)
@@ -674,24 +671,24 @@ async fn test_q9() {
     let rows: Vec<SalaryRanking> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("users", "u")
-            .with_expression(dept.clone(), None)
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(salary.clone(), None)
+            .with_expression(dept.clone())
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(salary.clone())
             .with_expression(
-                Window::named("win").apply(Fx::new("row_number", vec![])),
-                Some("row_num".into()),
+                Window::named("win").apply(Fx::new("row_number", vec![]))
+                .as_alias("row_num"),
             )
             .with_expression(
-                Window::named("win").apply(Fx::new("rank", vec![])),
-                Some("salary_rank".into()),
+                Window::named("win").apply(Fx::new("rank", vec![]))
+                .as_alias("salary_rank"),
             )
             .with_expression(
                 Window::new()
                     .partition_by(dept.clone())
                     .order_by(salary.clone(), Order::Desc)
                     .rows("UNBOUNDED PRECEDING", "CURRENT ROW")
-                    .apply(Fx::new("sum", [salary.expr()])),
-                Some("running_total".into()),
+                    .apply(Fx::new("sum", [salary.expr()]))
+                .as_alias("running_total"),
             )
             .with_condition(postgres_expr!("{} IS NOT NULL", (dept)))
             .with_window("win", Window::new()
@@ -760,8 +757,8 @@ async fn test_q10() {
             .with_cte("active_orders", PostgresSelect::new()
                 .with_source("orders")
                 .with_field("user_id")
-                .with_expression(Fx::new("count", [postgres_expr!("*")]), Some("cnt".into()))
-                .with_expression(Fx::new("sum", [ident("total").expr()]), Some("revenue".into()))
+                .with_expression(Fx::new("count", [postgres_expr!("*")]).as_alias("cnt"))
+                .with_expression(Fx::new("sum", [ident("total").expr()]).as_alias("revenue"))
                 .with_condition(postgres_expr!("{} IN ({}, {})",
                     (ident("status")), "completed", "shipped"))
                 .with_group_by(ident("user_id")), false)
@@ -771,8 +768,8 @@ async fn test_q10() {
                 .with_field("revenue")
                 .with_condition(postgres_expr!("{} > {}", (ident("revenue")), 400.0f64)), false)
             .with_source_as("top_spenders", "t")
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("revenue").dot_of("t"), None)
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("revenue").dot_of("t"))
             .with_join(PostgresSelectJoin::inner("users", "u",
                 postgres_expr!("{} = {}",
                     (ident("id").dot_of("u")),
@@ -840,21 +837,19 @@ async fn test_q11() {
         .with_source("departments")
         .with_field("id")
         .with_field("name")
-        .with_expression(postgres_expr!("0"), None)
-        .with_expression(ident("name"), None)
+        .with_expression(postgres_expr!("0"))
+        .with_expression(ident("name"))
         .with_condition(postgres_expr!("{} IS NULL", (ident("parent_id"))));
 
     let recursive = PostgresSelect::new()
         .with_source_as("departments", "d")
-        .with_expression(ident("id").dot_of("d"), None)
-        .with_expression(ident("name").dot_of("d"), None)
+        .with_expression(ident("id").dot_of("d"))
+        .with_expression(ident("name").dot_of("d"))
         .with_expression(
             postgres_expr!("{} + 1", (ident("depth").dot_of("dt"))),
-            None,
         )
         .with_expression(
             concat_sql!(ident("path").dot_of("dt"), " > ", ident("name").dot_of("d")),
-            None,
         )
         .with_join(PostgresSelectJoin::inner(
             "dept_tree",
@@ -932,9 +927,9 @@ async fn test_q12() {
         &PostgresSelect::new()
             .with_distinct(true)
             .with_source_as("products", "p")
-            .with_expression(ident("id").dot_of("p"), None)
-            .with_expression(ident("name").dot_of("p"), None)
-            .with_expression(ident("price").dot_of("p"), None)
+            .with_expression(ident("id").dot_of("p"))
+            .with_expression(ident("name").dot_of("p"))
+            .with_expression(ident("price").dot_of("p"))
             .with_join(PostgresSelectJoin::inner(
                 "product_tags",
                 "pt",
@@ -1033,19 +1028,18 @@ async fn test_q13() {
             .with_field("id")
             .with_field("name")
             .with_expression(
-                JsonExtract::new(metadata.clone(), "color").with_alias("color"),
-                None,
+                JsonExtract::new(metadata.clone(), "color").as_alias("color"),
             )
             .with_expression(
                 postgres_expr!(
                     "CAST({} AS DOUBLE PRECISION)",
                     (JsonExtract::new(metadata.clone(), "weight_kg"))
-                ),
-                Some("weight".into()),
+                )
+                .as_alias("weight"),
             )
             .with_expression(
-                postgres_expr!("CAST({} AS DOUBLE PRECISION)", (rating_expr.clone())),
-                Some("rating".into()),
+                postgres_expr!("CAST({} AS DOUBLE PRECISION)", (rating_expr.clone()))
+                .as_alias("rating"),
             )
             .with_expression(
                 Fx::new(
@@ -1054,8 +1048,8 @@ async fn test_q13() {
                         ident("category").expr(),
                         postgres_expr!("{}", "uncategorized"),
                     ],
-                ),
-                Some("clean_category".into()),
+                )
+                .as_alias("clean_category"),
             )
             .with_condition(postgres_expr!(
                 "CAST({} AS DOUBLE PRECISION) BETWEEN {} AND {}",
@@ -1128,15 +1122,15 @@ async fn test_q14() {
     let rows: Vec<MonthlyRevenue> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("orders", "o")
-            .with_expression(month_expr.clone(), Some("month".into()))
-            .with_expression(ident("name").dot_of("d"), Some("department".into()))
+            .with_expression(month_expr.clone().as_alias("month"))
+            .with_expression(ident("name").dot_of("d").as_alias("department"))
             .with_expression(
-                Fx::new("count", [ident("id").dot_of("o").expr()]),
-                Some("order_count".into()),
+                Fx::new("count", [ident("id").dot_of("o").expr()])
+                .as_alias("order_count"),
             )
             .with_expression(
-                Fx::new("round", [sum_total.expr(), postgres_expr!("{}", 2i32)]),
-                Some("monthly_revenue".into()),
+                Fx::new("round", [sum_total.expr(), postgres_expr!("{}", 2i32)])
+                .as_alias("monthly_revenue"),
             )
             .with_join(PostgresSelectJoin::inner(
                 "users",
@@ -1244,39 +1238,39 @@ async fn test_q15() {
     let rows: Vec<UserWindowStats> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("id").dot_of("u"), None)
-            .with_expression(u_name.clone(), None)
-            .with_expression(salary.clone(), None)
-            .with_expression(dept.clone(), None)
+            .with_expression(ident("id").dot_of("u"))
+            .with_expression(u_name.clone())
+            .with_expression(salary.clone())
+            .with_expression(dept.clone())
             .with_expression(
                 postgres_expr!(
                     "COUNT(*) FILTER (WHERE {} = {}) OVER (PARTITION BY {})",
                     (ident("status").dot_of("o")), "completed",
                     (ident("id").dot_of("u"))
-                ),
-                Some("completed_count".into()),
+                )
+                .as_alias("completed_count"),
             )
             .with_expression(
                 Window::new().order_by(salary.clone(), Order::Asc)
-                    .apply(postgres_expr!("LAG({}, 1)", (salary.clone()))),
-                Some("prev_salary".into()),
+                    .apply(postgres_expr!("LAG({}, 1)", (salary.clone())))
+                .as_alias("prev_salary"),
             )
             .with_expression(
                 Window::new().order_by(salary.clone(), Order::Asc)
-                    .apply(postgres_expr!("LEAD({}, 1)", (salary.clone()))),
-                Some("next_salary".into()),
+                    .apply(postgres_expr!("LEAD({}, 1)", (salary.clone())))
+                .as_alias("next_salary"),
             )
             .with_expression(
                 dept_salary_win.clone()
                     .range("UNBOUNDED PRECEDING", "UNBOUNDED FOLLOWING")
-                    .apply(Fx::new("first_value", [u_name.expr()])),
-                Some("top_earner".into()),
+                    .apply(Fx::new("first_value", [u_name.expr()]))
+                .as_alias("top_earner"),
             )
             .with_expression(
                 dept_salary_win.clone()
                     .rows("UNBOUNDED PRECEDING", "UNBOUNDED FOLLOWING")
-                    .apply(Fx::new("nth_value", [u_name.expr(), postgres_expr!("2")])),
-                Some("second_earner".into()),
+                    .apply(Fx::new("nth_value", [u_name.expr(), postgres_expr!("2")]))
+                .as_alias("second_earner"),
             )
             .with_join(PostgresSelectJoin::left("orders", "o",
                 postgres_expr!("{} = {}",

--- a/vantage-sql/tests/postgres/3_complex_queries_pg.rs
+++ b/vantage-sql/tests/postgres/3_complex_queries_pg.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 use vantage_sql::postgres::PostgresDB;
 use vantage_sql::postgres::statements::PostgresSelect;
+use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::postgres::statements::select::join::PostgresSelectJoin;
 use vantage_sql::postgres_expr;
 use vantage_sql::primitives::identifier::ident;
@@ -63,11 +64,11 @@ async fn test_pg_q1_distinct_on() {
         &PostgresSelect::new()
             .with_distinct_on(ident("user_id").dot_of("o"))
             .with_source_as("orders", "o")
-            .with_expression(ident("user_id").dot_of("o"), None)
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("id").dot_of("o").with_alias("order_id"), None)
-            .with_expression(ident("total").dot_of("o"), None)
-            .with_expression(ident("status").dot_of("o"), None)
+            .with_expression(ident("user_id").dot_of("o"))
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("id").dot_of("o").with_alias("order_id"))
+            .with_expression(ident("total").dot_of("o"))
+            .with_expression(ident("status").dot_of("o"))
             .with_join(PostgresSelectJoin::inner(
                 "users",
                 "u",
@@ -123,12 +124,12 @@ async fn test_pg_q2_array_ops() {
     let rows: Vec<UserSkills> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("id").dot_of("u"), None)
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(skills.clone(), None)
+            .with_expression(ident("id").dot_of("u"))
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(skills.clone())
             .with_expression(
-                Fx::new("array_length", [skills.expr(), postgres_expr!("{}", 1i32)]),
-                Some("skill_count".into()),
+                Fx::new("array_length", [skills.expr(), postgres_expr!("{}", 1i32)])
+                .as_alias("skill_count"),
             )
             .with_condition(postgres_expr!(
                 "{} @> ARRAY[{}] OR {} = ANY({})",
@@ -191,20 +192,18 @@ async fn test_pg_q3_jsonb_ops() {
     let rows: Vec<ProductJsonb> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("products", "p")
-            .with_expression(ident("id").dot_of("p"), None)
-            .with_expression(ident("name").dot_of("p"), None)
+            .with_expression(ident("id").dot_of("p"))
+            .with_expression(ident("name").dot_of("p"))
             .with_expression(
-                JsonExtract::new(metadata.clone(), "color").with_alias("color"),
-                None,
+                JsonExtract::new(metadata.clone(), "color").as_alias("color"),
             )
-            .with_expression(rating.clone(), Some("rating".into()))
+            .with_expression(rating.clone().as_alias("rating"))
             .with_expression(
-                JsonExtract::new(metadata.clone(), ["specs", "voltage"]).with_alias("voltage"),
-                None,
+                JsonExtract::new(metadata.clone(), ["specs", "voltage"]).as_alias("voltage"),
             )
             .with_expression(
-                postgres_expr!("{} #> {}", (metadata.clone()), (lit("{specs,watts}"))),
-                Some("watts_json".into()),
+                postgres_expr!("{} #> {}", (metadata.clone()), (lit("{specs,watts}")))
+                .as_alias("watts_json"),
             )
             .with_condition(postgres_expr!(
                 "{} @> {}",
@@ -236,7 +235,7 @@ async fn test_pg_q3_jsonb_ops() {
     assert_eq!(rows.len(), 3);
     assert_eq!(rows[0].name, "Widget Pro");
     assert_eq!(rows[0].color, "black");
-    assert_eq!(rows[0].voltage, Some("5".to_string()));
+    assert_eq!(rows[0].voltage, Some("5".into()));
 
     // USB-C Cable has no specs
     assert_eq!(rows[2].name, "USB-C Cable");
@@ -262,10 +261,10 @@ struct UserRecentOrder {
 async fn test_pg_q4_lateral_join() {
     let lateral_subquery = PostgresSelect::new()
         .with_source_as("orders", "o")
-        .with_expression(ident("id").dot_of("o").with_alias("order_id"), None)
-        .with_expression(ident("total").dot_of("o"), None)
-        .with_expression(ident("status").dot_of("o"), None)
-        .with_expression(ident("created_at").dot_of("o"), None)
+        .with_expression(ident("id").dot_of("o").with_alias("order_id"))
+        .with_expression(ident("total").dot_of("o"))
+        .with_expression(ident("status").dot_of("o"))
+        .with_expression(ident("created_at").dot_of("o"))
         .with_condition(ident("user_id").dot_of("o").eq(ident("id").dot_of("u")))
         .with_order(ident("created_at").dot_of("o"), Order::Desc)
         .with_limit(Some(2), None);
@@ -273,10 +272,10 @@ async fn test_pg_q4_lateral_join() {
     let rows: Vec<UserRecentOrder> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("order_id").dot_of("recent"), None)
-            .with_expression(ident("total").dot_of("recent"), None)
-            .with_expression(ident("status").dot_of("recent"), None)
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("order_id").dot_of("recent"))
+            .with_expression(ident("total").dot_of("recent"))
+            .with_expression(ident("status").dot_of("recent"))
             .with_join(PostgresSelectJoin::left_lateral(lateral_subquery, "recent"))
             .with_order(ident("name").dot_of("u"), Order::Asc)
             .with_order(ident("created_at").dot_of("recent"), Order::Desc.nulls_last()),
@@ -301,7 +300,7 @@ async fn test_pg_q4_lateral_join() {
         rows.iter().filter(|r| r.name == "Alice Chen").collect();
     assert_eq!(alice_rows.len(), 2);
     assert_eq!(alice_rows[0].order_id, Some(15));
-    assert_eq!(alice_rows[0].status, Some("pending".to_string()));
+    assert_eq!(alice_rows[0].status, Some("pending".into()));
 
     // Dan Brown has no orders → null fields
     let dan = rows.iter().find(|r| r.name == "Dan Brown").unwrap();
@@ -337,7 +336,7 @@ async fn test_pg_q5_generate_series() {
     let rows: Vec<DailyRevenue> = check_and_run(
         &PostgresSelect::new()
             .with_source(postgres_expr!("{} AS d(day)", (series)))
-            .with_expression(ident("day").dot_of("d"), None)
+            .with_expression(ident("day").dot_of("d"))
             .with_expression(
                 Fx::new(
                     "coalesce",
@@ -345,8 +344,8 @@ async fn test_pg_q5_generate_series() {
                         Fx::new("count", [ident("id").dot_of("o").expr()]).expr(),
                         postgres_expr!("{}", 0i64),
                     ],
-                ),
-                Some("order_count".into()),
+                )
+                .as_alias("order_count"),
             )
             .with_expression(
                 Fx::new(
@@ -355,8 +354,8 @@ async fn test_pg_q5_generate_series() {
                         Fx::new("sum", [ident("total").dot_of("o").expr()]).expr(),
                         postgres_expr!("{}", 0i64),
                     ],
-                ),
-                Some("daily_revenue".into()),
+                )
+                .as_alias("daily_revenue"),
             )
             .with_join(PostgresSelectJoin::left(
                 "orders",
@@ -419,18 +418,18 @@ async fn test_pg_q6_array_aggregation() {
     let rows: Vec<CategoryAgg> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("products", "p")
-            .with_expression(ident("category").dot_of("p"), None)
+            .with_expression(ident("category").dot_of("p"))
             .with_expression(
-                Fx::new("count", [postgres_expr!("*")]),
-                Some("total".into()),
+                Fx::new("count", [postgres_expr!("*")])
+                .as_alias("total"),
             )
             .with_expression(
                 postgres_expr!(
                     "array_agg(DISTINCT {} ORDER BY {})",
                     (name.clone()),
                     (name.clone())
-                ),
-                Some("product_names".into()),
+                )
+                .as_alias("product_names"),
             )
             .with_expression(
                 postgres_expr!(
@@ -438,20 +437,20 @@ async fn test_pg_q6_array_aggregation() {
                     (name),
                     ", ",
                     (ident("price").dot_of("p"))
-                ),
-                Some("names_by_price_desc".into()),
+                )
+                .as_alias("names_by_price_desc"),
             )
             .with_expression(
                 postgres_expr!(
                     "COUNT(*) FILTER (WHERE {} @> ARRAY[{}])",
                     (tags.clone()),
                     "featured"
-                ),
-                Some("featured_count".into()),
+                )
+                .as_alias("featured_count"),
             )
             .with_expression(
-                postgres_expr!("COUNT(*) FILTER (WHERE {} @> ARRAY[{}])", (tags), "sale"),
-                Some("sale_count".into()),
+                postgres_expr!("COUNT(*) FILTER (WHERE {} @> ARRAY[{}])", (tags), "sale")
+                .as_alias("sale_count"),
             )
             .with_group_by(ident("category").dot_of("p"))
             .with_order(ident("total"), Order::Desc),
@@ -513,22 +512,22 @@ async fn test_pg_q7_rollup() {
             .with_expression(
                 Case::new()
                     .when(grouping_status.clone().eq(1i64), "** ALL **")
-                    .else_(status.clone()),
-                Some("status".into()),
+                    .else_(status.clone())
+                .as_alias("status"),
             )
             .with_expression(
                 Case::new()
                     .when(grouping_month.eq(1i64), postgres_expr!("NULL"))
-                    .else_(date_trunc.clone()),
-                Some("month".into()),
+                    .else_(date_trunc.clone())
+                .as_alias("month"),
             )
             .with_expression(
-                Fx::new("count", [postgres_expr!("*")]),
-                Some("order_count".into()),
+                Fx::new("count", [postgres_expr!("*")])
+                .as_alias("order_count"),
             )
             .with_expression(
-                Fx::new("sum", [ident("total").dot_of("o").expr()]),
-                Some("revenue".into()),
+                Fx::new("sum", [ident("total").dot_of("o").expr()])
+                .as_alias("revenue"),
             )
             .with_condition(status.ne("cancelled"))
             .with_group_by(postgres_expr!("ROLLUP ({}, {})", (status.clone()), (date_trunc)))
@@ -590,17 +589,17 @@ async fn test_pg_q8_date_time() {
     let rows: Vec<UserTenure> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(ident("name").dot_of("u"))
             .with_expression(
-                postgres_expr!("EXTRACT(DOW FROM {})", (created.clone())),
-                Some("signup_day_of_week".into()),
+                postgres_expr!("EXTRACT(DOW FROM {})", (created.clone()))
+                .as_alias("signup_day_of_week"),
             )
             .with_expression(
                 Case::new()
                     .when(age.clone().gte(Interval::new(1, "year")), "veteran")
                     .when(age.clone().gte(Interval::new(6, "month")), "established")
-                    .else_(postgres_expr!("{}", "new")),
-                Some("cohort".into()),
+                    .else_(postgres_expr!("{}", "new"))
+                .as_alias("cohort"),
             )
             .with_condition(ident("is_active").dot_of("u").eq(true))
             .with_order(created, Order::Asc)
@@ -654,12 +653,12 @@ async fn test_pg_q9_enum() {
     let rows: Vec<TicketPriority> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("tickets", "t")
-            .with_expression(ident("id").dot_of("t"), None)
-            .with_expression(ident("title").dot_of("t"), None)
-            .with_expression(priority.cast("TEXT"), Some("priority_text".into()))
+            .with_expression(ident("id").dot_of("t"))
+            .with_expression(ident("title").dot_of("t"))
+            .with_expression(priority.cast("TEXT").as_alias("priority_text"))
             .with_expression(
-                ident("status").dot_of("t").cast("TEXT"),
-                Some("status_text".into()),
+                ident("status").dot_of("t").cast("TEXT")
+                .as_alias("status_text"),
             )
             .with_expression(
                 {
@@ -669,8 +668,8 @@ async fn test_pg_q9_enum() {
                         .when(p.clone().eq("high"), postgres_expr!("{}", 2i64))
                         .when(p.clone().eq("medium"), postgres_expr!("{}", 3i64))
                         .when(p.eq("low"), postgres_expr!("{}", 4i64))
-                },
-                Some("priority_rank".into()),
+                }
+                .as_alias("priority_rank"),
             )
             .with_condition(postgres_expr!("{} >= 'high'", (priority)))
             .with_order(priority, Order::Desc)
@@ -729,14 +728,14 @@ async fn test_pg_q10_daterange() {
     let rows: Vec<Booking> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("bookings", "b")
-            .with_expression(ident("id").dot_of("b"), None)
-            .with_expression(ident("room").dot_of("b"), None)
-            .with_expression(ident("name").dot_of("u"), Some("booked_by".into()))
-            .with_expression(Fx::new("lower", [during.expr()]), Some("check_in".into()))
-            .with_expression(Fx::new("upper", [during.expr()]), Some("check_out".into()))
+            .with_expression(ident("id").dot_of("b"))
+            .with_expression(ident("room").dot_of("b"))
+            .with_expression(ident("name").dot_of("u").as_alias("booked_by"))
+            .with_expression(Fx::new("lower", [during.expr()]).as_alias("check_in"))
+            .with_expression(Fx::new("upper", [during.expr()]).as_alias("check_out"))
             .with_expression(
-                Fx::new("upper", [during.expr()]).expr() - Fx::new("lower", [during.expr()]).expr(),
-                Some("duration_days".into()),
+                Fx::new("upper", [during.expr()]).expr() - Fx::new("lower", [during.expr()]).expr()
+                .as_alias("duration_days"),
             )
             .with_join(PostgresSelectJoin::inner(
                 "users",
@@ -801,9 +800,9 @@ async fn test_pg_q11_unnest_ordinality() {
     let rows: Vec<UserSkillRow> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("value").dot_of("skill"), Some("skill".into()))
-            .with_expression(ident("pos").dot_of("skill"), Some("skill_position".into()))
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("value").dot_of("skill").as_alias("skill"))
+            .with_expression(ident("pos").dot_of("skill").as_alias("skill_position"))
             .with_join(PostgresSelectJoin::cross_lateral_raw(postgres_expr!(
                 "UNNEST({}) WITH ORDINALITY AS skill(value, pos)",
                 (skills.clone())
@@ -860,23 +859,21 @@ async fn test_pg_q12_recursive_cte() {
         .with_source("departments")
         .with_field("id")
         .with_field("name")
-        .with_expression(ident("parent_id"), None)
-        .with_expression(postgres_expr!("0"), None)
-        .with_expression(ident("name").cast("TEXT"), None)
+        .with_expression(ident("parent_id"))
+        .with_expression(postgres_expr!("0"))
+        .with_expression(ident("name").cast("TEXT"))
         .with_condition(postgres_expr!("{} IS NULL", (ident("parent_id"))));
 
     let recursive = PostgresSelect::new()
         .with_source_as("departments", "d")
-        .with_expression(ident("id").dot_of("d"), None)
-        .with_expression(ident("name").dot_of("d"), None)
-        .with_expression(ident("parent_id").dot_of("d"), None)
+        .with_expression(ident("id").dot_of("d"))
+        .with_expression(ident("name").dot_of("d"))
+        .with_expression(ident("parent_id").dot_of("d"))
         .with_expression(
             ident("depth").dot_of("dt").expr() + postgres_expr!("1"),
-            None,
         )
         .with_expression(
             concat_sql!(ident("path").dot_of("dt"), " > ", ident("name").dot_of("d")),
-            None,
         )
         .with_join(PostgresSelectJoin::inner(
             "dept_tree",
@@ -950,24 +947,24 @@ async fn test_pg_q13_window_functions() {
     let rows: Vec<SalaryStats> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("name").dot_of("d"), Some("department".into()))
-            .with_expression(salary.clone(), None)
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("name").dot_of("d").as_alias("department"))
+            .with_expression(salary.clone())
             .with_expression(
-                Window::named("dept_sal").apply(Fx::new("dense_rank", vec![])),
-                Some("salary_dense_rank".into()),
+                Window::named("dept_sal").apply(Fx::new("dense_rank", vec![]))
+                .as_alias("salary_dense_rank"),
             )
             .with_expression(
                 Window::new()
                     .partition_by(dept_id.clone())
                     .order_by(salary.clone(), Order::Desc)
                     .rows("UNBOUNDED PRECEDING", "CURRENT ROW")
-                    .apply(Fx::new("sum", [salary.expr()])),
-                Some("running_total".into()),
+                    .apply(Fx::new("sum", [salary.expr()]))
+                .as_alias("running_total"),
             )
             .with_expression(
-                Window::named("dept_sal").apply(Fx::new("avg", [salary.expr()])),
-                Some("dept_avg_salary".into()),
+                Window::named("dept_sal").apply(Fx::new("avg", [salary.expr()]))
+                .as_alias("dept_avg_salary"),
             )
             .with_join(PostgresSelectJoin::inner(
                 "departments",
@@ -1049,14 +1046,13 @@ async fn test_pg_q14_jsonb_aggregation() {
                     postgres_expr!("jsonb_agg(DISTINCT {})", (o_status)),
                 ],
             ),
-            None,
         )
         .with_condition(ident("user_id").dot_of("o").eq(ident("id").dot_of("u")));
 
     let rows: Vec<UserProfile> = check_and_run(
         &PostgresSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(ident("name").dot_of("u"))
             .with_expression(
                 Fx::new(
                     "jsonb_build_object",
@@ -1072,8 +1068,8 @@ async fn test_pg_q14_jsonb_aggregation() {
                         postgres_expr!("{}", "order_summary"),
                         postgres_expr!("({})", (order_summary_subquery)),
                     ],
-                ),
-                Some("user_profile".into()),
+                )
+                .as_alias("user_profile"),
             )
             .with_condition(ident("is_active").dot_of("u").eq(true))
             .with_order(ident("name").dot_of("u"), Order::Asc)
@@ -1138,8 +1134,8 @@ async fn test_pg_q15_inet_ilike_full_join() {
                         ident("name").dot_of("u").expr(),
                         postgres_expr!("{}", "(no user)"),
                     ],
-                ),
-                Some("name".into()),
+                )
+                .as_alias("name"),
             )
             .with_expression(
                 Fx::new(
@@ -1148,8 +1144,8 @@ async fn test_pg_q15_inet_ilike_full_join() {
                         ident("name").dot_of("d").expr(),
                         postgres_expr!("{}", "(no department)"),
                     ],
-                ),
-                Some("department".into()),
+                )
+                .as_alias("department"),
             )
             .with_expression(
                 Case::new()
@@ -1166,8 +1162,8 @@ async fn test_pg_q15_inet_ilike_full_join() {
                         "private-class-b",
                     )
                     .when(postgres_expr!("{} IS NULL", (ip)), "unknown")
-                    .else_(postgres_expr!("{}", "public")),
-                Some("network_class".into()),
+                    .else_(postgres_expr!("{}", "public"))
+                .as_alias("network_class"),
             )
             .with_expression(
                 Fx::new(
@@ -1176,8 +1172,8 @@ async fn test_pg_q15_inet_ilike_full_join() {
                         ident("role").dot_of("u").expr(),
                         postgres_expr!("{}", "viewer"),
                     ],
-                ),
-                Some("notable_role".into()),
+                )
+                .as_alias("notable_role"),
             )
             .with_join(PostgresSelectJoin::full_outer(
                 "departments",
@@ -1216,7 +1212,7 @@ async fn test_pg_q15_inet_ilike_full_join() {
     // Alice: private-class-c, admin
     let alice = rows.iter().find(|r| r.name == "Alice Chen").unwrap();
     assert_eq!(alice.network_class, "private-class-c");
-    assert_eq!(alice.notable_role, Some("admin".to_string()));
+    assert_eq!(alice.notable_role, Some("admin".into()));
 
     // Frank: no IP → unknown, viewer → notable_role is None
     let frank = rows.iter().find(|r| r.name == "Frank Lee").unwrap();

--- a/vantage-sql/tests/postgres/3_complex_queries_pg.rs
+++ b/vantage-sql/tests/postgres/3_complex_queries_pg.rs
@@ -8,9 +8,9 @@ use serde::Deserialize;
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
 use vantage_sql::postgres::PostgresDB;
 use vantage_sql::postgres::statements::PostgresSelect;
-use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::postgres::statements::select::join::PostgresSelectJoin;
 use vantage_sql::postgres_expr;
+use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::primitives::identifier::ident;
 use vantage_table::operation::Operation;
 use vantage_types::{Record, TryFromRecord};
@@ -129,7 +129,7 @@ async fn test_pg_q2_array_ops() {
             .with_expression(skills.clone())
             .with_expression(
                 Fx::new("array_length", [skills.expr(), postgres_expr!("{}", 1i32)])
-                .as_alias("skill_count"),
+                    .as_alias("skill_count"),
             )
             .with_condition(postgres_expr!(
                 "{} @> ARRAY[{}] OR {} = ANY({})",
@@ -194,16 +194,14 @@ async fn test_pg_q3_jsonb_ops() {
             .with_source_as("products", "p")
             .with_expression(ident("id").dot_of("p"))
             .with_expression(ident("name").dot_of("p"))
-            .with_expression(
-                JsonExtract::new(metadata.clone(), "color").as_alias("color"),
-            )
+            .with_expression(JsonExtract::new(metadata.clone(), "color").as_alias("color"))
             .with_expression(rating.clone().as_alias("rating"))
             .with_expression(
                 JsonExtract::new(metadata.clone(), ["specs", "voltage"]).as_alias("voltage"),
             )
             .with_expression(
                 postgres_expr!("{} #> {}", (metadata.clone()), (lit("{specs,watts}")))
-                .as_alias("watts_json"),
+                    .as_alias("watts_json"),
             )
             .with_condition(postgres_expr!(
                 "{} @> {}",
@@ -419,10 +417,7 @@ async fn test_pg_q6_array_aggregation() {
         &PostgresSelect::new()
             .with_source_as("products", "p")
             .with_expression(ident("category").dot_of("p"))
-            .with_expression(
-                Fx::new("count", [postgres_expr!("*")])
-                .as_alias("total"),
-            )
+            .with_expression(Fx::new("count", [postgres_expr!("*")]).as_alias("total"))
             .with_expression(
                 postgres_expr!(
                     "array_agg(DISTINCT {} ORDER BY {})",
@@ -450,7 +445,7 @@ async fn test_pg_q6_array_aggregation() {
             )
             .with_expression(
                 postgres_expr!("COUNT(*) FILTER (WHERE {} @> ARRAY[{}])", (tags), "sale")
-                .as_alias("sale_count"),
+                    .as_alias("sale_count"),
             )
             .with_group_by(ident("category").dot_of("p"))
             .with_order(ident("total"), Order::Desc),
@@ -592,14 +587,14 @@ async fn test_pg_q8_date_time() {
             .with_expression(ident("name").dot_of("u"))
             .with_expression(
                 postgres_expr!("EXTRACT(DOW FROM {})", (created.clone()))
-                .as_alias("signup_day_of_week"),
+                    .as_alias("signup_day_of_week"),
             )
             .with_expression(
                 Case::new()
                     .when(age.clone().gte(Interval::new(1, "year")), "veteran")
                     .when(age.clone().gte(Interval::new(6, "month")), "established")
                     .else_(postgres_expr!("{}", "new"))
-                .as_alias("cohort"),
+                    .as_alias("cohort"),
             )
             .with_condition(ident("is_active").dot_of("u").eq(true))
             .with_order(created, Order::Asc)
@@ -657,8 +652,10 @@ async fn test_pg_q9_enum() {
             .with_expression(ident("title").dot_of("t"))
             .with_expression(priority.cast("TEXT").as_alias("priority_text"))
             .with_expression(
-                ident("status").dot_of("t").cast("TEXT")
-                .as_alias("status_text"),
+                ident("status")
+                    .dot_of("t")
+                    .cast("TEXT")
+                    .as_alias("status_text"),
             )
             .with_expression(
                 {
@@ -734,8 +731,10 @@ async fn test_pg_q10_daterange() {
             .with_expression(Fx::new("lower", [during.expr()]).as_alias("check_in"))
             .with_expression(Fx::new("upper", [during.expr()]).as_alias("check_out"))
             .with_expression(
-                Fx::new("upper", [during.expr()]).expr() - Fx::new("lower", [during.expr()]).expr()
-                .as_alias("duration_days"),
+                Fx::new("upper", [during.expr()]).expr()
+                    - Fx::new("lower", [during.expr()])
+                        .expr()
+                        .as_alias("duration_days"),
             )
             .with_join(PostgresSelectJoin::inner(
                 "users",
@@ -869,12 +868,12 @@ async fn test_pg_q12_recursive_cte() {
         .with_expression(ident("id").dot_of("d"))
         .with_expression(ident("name").dot_of("d"))
         .with_expression(ident("parent_id").dot_of("d"))
-        .with_expression(
-            ident("depth").dot_of("dt").expr() + postgres_expr!("1"),
-        )
-        .with_expression(
-            concat_sql!(ident("path").dot_of("dt"), " > ", ident("name").dot_of("d")),
-        )
+        .with_expression(ident("depth").dot_of("dt").expr() + postgres_expr!("1"))
+        .with_expression(concat_sql!(
+            ident("path").dot_of("dt"),
+            " > ",
+            ident("name").dot_of("d")
+        ))
         .with_join(PostgresSelectJoin::inner(
             "dept_tree",
             "dt",
@@ -1027,26 +1026,24 @@ async fn test_pg_q14_jsonb_aggregation() {
 
     let order_summary_subquery = PostgresSelect::new()
         .with_source_as("orders", "o")
-        .with_expression(
-            Fx::new(
-                "jsonb_build_object",
-                [
-                    postgres_expr!("{}", "count"),
-                    Fx::new("count", [postgres_expr!("*")]).expr(),
-                    postgres_expr!("{}", "total"),
-                    Fx::new(
-                        "coalesce",
-                        [
-                            Fx::new("sum", [o_total.expr()]).expr(),
-                            postgres_expr!("{}", 0i64),
-                        ],
-                    )
-                    .expr(),
-                    postgres_expr!("{}", "statuses"),
-                    postgres_expr!("jsonb_agg(DISTINCT {})", (o_status)),
-                ],
-            ),
-        )
+        .with_expression(Fx::new(
+            "jsonb_build_object",
+            [
+                postgres_expr!("{}", "count"),
+                Fx::new("count", [postgres_expr!("*")]).expr(),
+                postgres_expr!("{}", "total"),
+                Fx::new(
+                    "coalesce",
+                    [
+                        Fx::new("sum", [o_total.expr()]).expr(),
+                        postgres_expr!("{}", 0i64),
+                    ],
+                )
+                .expr(),
+                postgres_expr!("{}", "statuses"),
+                postgres_expr!("jsonb_agg(DISTINCT {})", (o_status)),
+            ],
+        ))
         .with_condition(ident("user_id").dot_of("o").eq(ident("id").dot_of("u")));
 
     let rows: Vec<UserProfile> = check_and_run(
@@ -1163,7 +1160,7 @@ async fn test_pg_q15_inet_ilike_full_join() {
                     )
                     .when(postgres_expr!("{} IS NULL", (ip)), "unknown")
                     .else_(postgres_expr!("{}", "public"))
-                .as_alias("network_class"),
+                    .as_alias("network_class"),
             )
             .with_expression(
                 Fx::new(

--- a/vantage-sql/tests/postgres/3_select.rs
+++ b/vantage-sql/tests/postgres/3_select.rs
@@ -1,12 +1,12 @@
 //! Test 3a: PostgresSelect via Selectable trait + SelectableDataSource execution.
 
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
-use vantage_sql::primitives::alias::AliasExt;
 #[allow(unused_imports)]
 use vantage_sql::postgres::PostgresType;
 use vantage_sql::postgres::statements::PostgresSelect;
 use vantage_sql::postgres::{AnyPostgresType, PostgresDB};
 use vantage_sql::postgres_expr;
+use vantage_sql::primitives::alias::AliasExt;
 use vantage_types::{Record, TryFromRecord, entity};
 
 const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";

--- a/vantage-sql/tests/postgres/3_select.rs
+++ b/vantage-sql/tests/postgres/3_select.rs
@@ -1,6 +1,7 @@
 //! Test 3a: PostgresSelect via Selectable trait + SelectableDataSource execution.
 
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
+use vantage_sql::primitives::alias::AliasExt;
 #[allow(unused_imports)]
 use vantage_sql::postgres::PostgresType;
 use vantage_sql::postgres::statements::PostgresSelect;
@@ -104,7 +105,7 @@ fn test_select_group_by_with_expression() {
     let s = PostgresSelect::new()
         .with_source("product")
         .with_field("is_deleted")
-        .with_expression(postgres_expr!("COUNT(*)"), Some("cnt".to_string()));
+        .with_expression(postgres_expr!("COUNT(*)").as_alias("cnt"));
     let mut s = s;
     s.add_group_by(postgres_expr!("\"is_deleted\""));
     assert_eq!(

--- a/vantage-sql/tests/sqlite/3_complex_queries.rs
+++ b/vantage-sql/tests/sqlite/3_complex_queries.rs
@@ -5,6 +5,7 @@
 
 use serde::Deserialize;
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
+use vantage_sql::primitives::alias::AliasExt;
 use vantage_sql::primitives::identifier::ident;
 use vantage_sql::sqlite::SqliteDB;
 use vantage_sql::sqlite::statements::SqliteSelect;
@@ -104,12 +105,9 @@ async fn test_q2() {
     let users: Vec<UserWithDept> = check_and_run(
         &SqliteSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("id").dot_of("u"), None)
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(
-                ident("name").dot_of("d").with_alias("department_name"),
-                None,
-            )
+            .with_expression(ident("id").dot_of("u"))
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("name").dot_of("d").with_alias("department_name"))
             .with_join(SqliteSelectJoin::inner(
                 "departments",
                 "d",
@@ -172,8 +170,8 @@ async fn test_q3() {
 
     let select = SqliteSelect::new()
         .with_source_as("users", "u")
-        .with_expression(ident("id").dot_of("u"), None)
-        .with_expression(ident("name").dot_of("u"), None)
+        .with_expression(ident("id").dot_of("u"))
+        .with_expression(ident("name").dot_of("u"))
         .with_expression(
             Fx::new(
                 "coalesce",
@@ -181,8 +179,8 @@ async fn test_q3() {
                     Fx::new("sum", [ident("total").dot_of("o").expr()]).expr(),
                     sqlite_expr!("{}", 0.0f64),
                 ],
-            ),
-            Some("total_spent".into()),
+            )
+            .as_alias("total_spent"),
         )
         .with_join(SqliteSelectJoin::left(
             "orders",
@@ -260,14 +258,14 @@ async fn test_q4() {
             .with_source("products")
             .with_field("category")
             .with_expression(
-                Fx::new("count", [sqlite_expr!("*")]),
-                Some("product_count".into()),
+                Fx::new("count", [sqlite_expr!("*")])
+                .as_alias("product_count"),
             )
-            .with_expression(Fx::new("avg", [price.expr()]), Some("avg_price".into()))
-            .with_expression(Fx::new("min", [price.expr()]), Some("cheapest".into()))
+            .with_expression(Fx::new("avg", [price.expr()]).as_alias("avg_price"))
+            .with_expression(Fx::new("min", [price.expr()]).as_alias("cheapest"))
             .with_expression(
-                Fx::new("max", [price.expr()]),
-                Some("most_expensive".into()),
+                Fx::new("max", [price.expr()])
+                .as_alias("most_expensive"),
             )
             .with_group_by(ident("category"))
             .with_having(sqlite_expr!(
@@ -334,12 +332,12 @@ async fn test_q5() {
 
     let count_subquery = SqliteSelect::new()
         .with_source_as("orders", "o")
-        .with_expression(Fx::new("count", [sqlite_expr!("*")]), None)
+        .with_expression(Fx::new("count", [sqlite_expr!("*")]))
         .with_condition(user_id_match.clone());
 
     let exists_subquery = SqliteSelect::new()
         .with_source_as("orders", "o")
-        .with_expression(sqlite_expr!("1"), None)
+        .with_expression(sqlite_expr!("1"))
         .with_condition(user_id_match)
         .with_condition(sqlite_expr!(
             "{} = {}",
@@ -350,11 +348,11 @@ async fn test_q5() {
     let users: Vec<UserOrderCount> = check_and_run(
         &SqliteSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("id").dot_of("u"), None)
-            .with_expression(ident("name").dot_of("u"), None)
+            .with_expression(ident("id").dot_of("u"))
+            .with_expression(ident("name").dot_of("u"))
             .with_expression(
-                sqlite_expr!("({})", (count_subquery)),
-                Some("order_count".into()),
+                sqlite_expr!("({})", (count_subquery))
+                .as_alias("order_count"),
             )
             .with_condition(Fx::new("exists", [exists_subquery.expr()]))
             .with_order(ident("order_count"), Order::Desc)
@@ -412,12 +410,12 @@ async fn test_q6() {
         .with_source("orders")
         .with_field("user_id")
         .with_expression(
-            Fx::new("count", [sqlite_expr!("*")]),
-            Some("order_count".into()),
+            Fx::new("count", [sqlite_expr!("*")])
+            .as_alias("order_count"),
         )
         .with_expression(
-            Fx::new("avg", [ident("total").expr()]),
-            Some("avg_total".into()),
+            Fx::new("avg", [ident("total").expr()])
+            .as_alias("avg_total"),
         )
         .with_condition(sqlite_expr!("{} != {}", (ident("status")), "cancelled"))
         .with_group_by(ident("user_id"));
@@ -425,9 +423,9 @@ async fn test_q6() {
     let users: Vec<UserOrderStats> = check_and_run(
         &SqliteSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("order_count").dot_of("stats"), None)
-            .with_expression(ident("avg_total").dot_of("stats"), None)
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("order_count").dot_of("stats"))
+            .with_expression(ident("avg_total").dot_of("stats"))
             .with_join(SqliteSelectJoin::inner_expr(
                 stats_subquery,
                 "stats",
@@ -523,12 +521,11 @@ async fn test_q7() {
                         sqlite_expr!("{} >= {}", (salary.clone()), 30000.0f64),
                         sqlite_expr!("{}", "junior"),
                     )
-                    .else_(sqlite_expr!("{}", "intern")),
-                Some("band".into()),
+                    .else_(sqlite_expr!("{}", "intern"))
+                .as_alias("band"),
             )
             .with_expression(
-                ternary(ident("role").eq("admin"), "Yes", "No").with_alias("is_admin"),
-                None,
+                ternary(ident("role").eq("admin"), "Yes", "No").as_alias("is_admin"),
             )
             .with_field("display_name")
             .with_order(ident("salary"), Order::Desc),
@@ -582,21 +579,21 @@ async fn test_q8() {
         .with_source("users")
         .with_field("id")
         .with_field("name")
-        .with_expression(sqlite_expr!("{}", "user"), Some("source".into()))
+        .with_expression(sqlite_expr!("{}", "user").as_alias("source"))
         .with_condition(sqlite_expr!("{} = {}", (ident("role")), "admin"));
 
     let depts_with_budget = SqliteSelect::new()
         .with_source("departments")
         .with_field("id")
         .with_field("name")
-        .with_expression(sqlite_expr!("{}", "department"), Some("source".into()))
+        .with_expression(sqlite_expr!("{}", "department").as_alias("source"))
         .with_condition(sqlite_expr!("{} IS NOT NULL", (ident("budget"))));
 
     let depts_zero_budget = SqliteSelect::new()
         .with_source("departments")
         .with_field("id")
         .with_field("name")
-        .with_expression(sqlite_expr!("{}", "department"), Some("source".into()))
+        .with_expression(sqlite_expr!("{}", "department").as_alias("source"))
         .with_condition(sqlite_expr!("{} = {}", (ident("budget")), 0.0f64));
 
     let compound = Union::new(admins)
@@ -674,24 +671,24 @@ async fn test_q9() {
     let rows: Vec<SalaryRanking> = check_and_run(
         &SqliteSelect::new()
             .with_source_as("users", "u")
-            .with_expression(dept.clone(), None)
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(salary.clone(), None)
+            .with_expression(dept.clone())
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(salary.clone())
             .with_expression(
-                Window::named("win").apply(Fx::new("row_number", vec![])),
-                Some("row_num".into()),
+                Window::named("win").apply(Fx::new("row_number", vec![]))
+                .as_alias("row_num"),
             )
             .with_expression(
-                Window::named("win").apply(Fx::new("rank", vec![])),
-                Some("salary_rank".into()),
+                Window::named("win").apply(Fx::new("rank", vec![]))
+                .as_alias("salary_rank"),
             )
             .with_expression(
                 Window::new()
                     .partition_by(dept.clone())
                     .order_by(salary.clone(), Order::Desc)
                     .rows("UNBOUNDED PRECEDING", "CURRENT ROW")
-                    .apply(Fx::new("sum", [salary.expr()])),
-                Some("running_total".into()),
+                    .apply(Fx::new("sum", [salary.expr()]))
+                .as_alias("running_total"),
             )
             .with_condition(sqlite_expr!("{} IS NOT NULL", (dept)))
             .with_window("win", Window::new()
@@ -760,8 +757,8 @@ async fn test_q10() {
             .with_cte("active_orders", SqliteSelect::new()
                 .with_source("orders")
                 .with_field("user_id")
-                .with_expression(Fx::new("count", [sqlite_expr!("*")]), Some("cnt".into()))
-                .with_expression(Fx::new("sum", [ident("total").expr()]), Some("revenue".into()))
+                .with_expression(Fx::new("count", [sqlite_expr!("*")]).as_alias("cnt"))
+                .with_expression(Fx::new("sum", [ident("total").expr()]).as_alias("revenue"))
                 .with_condition(sqlite_expr!("{} IN ({}, {})",
                     (ident("status")), "completed", "shipped"))
                 .with_group_by(ident("user_id")), false)
@@ -771,8 +768,8 @@ async fn test_q10() {
                 .with_field("revenue")
                 .with_condition(sqlite_expr!("{} > {}", (ident("revenue")), 400.0f64)), false)
             .with_source_as("top_spenders", "t")
-            .with_expression(ident("name").dot_of("u"), None)
-            .with_expression(ident("revenue").dot_of("t"), None)
+            .with_expression(ident("name").dot_of("u"))
+            .with_expression(ident("revenue").dot_of("t"))
             .with_join(SqliteSelectJoin::inner("users", "u",
                 sqlite_expr!("{} = {}",
                     (ident("id").dot_of("u")),
@@ -840,18 +837,17 @@ async fn test_q11() {
         .with_source("departments")
         .with_field("id")
         .with_field("name")
-        .with_expression(sqlite_expr!("0"), None)
-        .with_expression(ident("name"), None)
+        .with_expression(sqlite_expr!("0"))
+        .with_expression(ident("name"))
         .with_condition(sqlite_expr!("{} IS NULL", (ident("parent_id"))));
 
     let recursive = SqliteSelect::new()
         .with_source_as("departments", "d")
-        .with_expression(ident("id").dot_of("d"), None)
-        .with_expression(ident("name").dot_of("d"), None)
-        .with_expression(sqlite_expr!("{} + 1", (ident("depth").dot_of("dt"))), None)
+        .with_expression(ident("id").dot_of("d"))
+        .with_expression(ident("name").dot_of("d"))
+        .with_expression(sqlite_expr!("{} + 1", (ident("depth").dot_of("dt"))))
         .with_expression(
             concat_sql!(ident("path").dot_of("dt"), " > ", ident("name").dot_of("d")),
-            None,
         )
         .with_join(SqliteSelectJoin::inner(
             "dept_tree",
@@ -929,9 +925,9 @@ async fn test_q12() {
         &SqliteSelect::new()
             .with_distinct(true)
             .with_source_as("products", "p")
-            .with_expression(ident("id").dot_of("p"), None)
-            .with_expression(ident("name").dot_of("p"), None)
-            .with_expression(ident("price").dot_of("p"), None)
+            .with_expression(ident("id").dot_of("p"))
+            .with_expression(ident("name").dot_of("p"))
+            .with_expression(ident("price").dot_of("p"))
             .with_join(SqliteSelectJoin::inner(
                 "product_tags",
                 "pt",
@@ -1024,16 +1020,15 @@ async fn test_q13() {
             .with_field("id")
             .with_field("name")
             .with_expression(
-                JsonExtract::new(metadata.clone(), "color").with_alias("color"),
-                None,
+                JsonExtract::new(metadata.clone(), "color").as_alias("color"),
             )
             .with_expression(
-                sqlite_expr!("{} ->> {}", (metadata.clone()), "$.weight_kg"),
-                Some("weight".into()),
+                sqlite_expr!("{} ->> {}", (metadata.clone()), "$.weight_kg")
+                .as_alias("weight"),
             )
             .with_expression(
-                sqlite_expr!("CAST({} ->> {} AS REAL)", (metadata.clone()), "$.rating"),
-                Some("rating".into()),
+                sqlite_expr!("CAST({} ->> {} AS REAL)", (metadata.clone()), "$.rating")
+                .as_alias("rating"),
             )
             .with_expression(
                 Fx::new(
@@ -1042,8 +1037,8 @@ async fn test_q13() {
                         ident("category").expr(),
                         sqlite_expr!("{}", "uncategorized"),
                     ],
-                ),
-                Some("clean_category".into()),
+                )
+                .as_alias("clean_category"),
             )
             .with_condition(sqlite_expr!(
                 "CAST({} ->> {} AS REAL) BETWEEN {} AND {}",
@@ -1117,19 +1112,19 @@ async fn test_q14() {
     let rows: Vec<MonthlyRevenue> = check_and_run(
         &SqliteSelect::new()
             .with_source_as("orders", "o")
-            .with_expression(month_expr.clone(), Some("month".into()))
-            .with_expression(ident("name").dot_of("d"), Some("department".into()))
+            .with_expression(month_expr.clone().as_alias("month"))
+            .with_expression(ident("name").dot_of("d").as_alias("department"))
             .with_expression(
-                Fx::new("count", [ident("id").dot_of("o").expr()]),
-                Some("order_count".into()),
+                Fx::new("count", [ident("id").dot_of("o").expr()])
+                .as_alias("order_count"),
             )
             .with_expression(
-                Fx::new("round", [sum_total.expr(), sqlite_expr!("{}", 2i64)]),
-                Some("monthly_revenue".into()),
+                Fx::new("round", [sum_total.expr(), sqlite_expr!("{}", 2i64)])
+                .as_alias("monthly_revenue"),
             )
             .with_expression(
-                Fx::new("typeof", [sum_total.expr()]),
-                Some("sum_type".into()),
+                Fx::new("typeof", [sum_total.expr()])
+                .as_alias("sum_type"),
             )
             .with_join(SqliteSelectJoin::inner(
                 "users",
@@ -1243,39 +1238,39 @@ async fn test_q15() {
     let rows: Vec<UserWindowStats> = check_and_run(
         &SqliteSelect::new()
             .with_source_as("users", "u")
-            .with_expression(ident("id").dot_of("u"), None)
-            .with_expression(u_name.clone(), None)
-            .with_expression(salary.clone(), None)
-            .with_expression(dept.clone(), None)
+            .with_expression(ident("id").dot_of("u"))
+            .with_expression(u_name.clone())
+            .with_expression(salary.clone())
+            .with_expression(dept.clone())
             .with_expression(
                 sqlite_expr!(
                     "COUNT(*) FILTER (WHERE {} = {}) OVER (PARTITION BY {})",
                     (ident("status").dot_of("o")), "completed",
                     (ident("id").dot_of("u"))
-                ),
-                Some("completed_count".into()),
+                )
+                .as_alias("completed_count"),
             )
             .with_expression(
                 Window::new().order_by(salary.clone(), Order::Asc)
-                    .apply(sqlite_expr!("LAG({}, 1)", (salary.clone()))),
-                Some("prev_salary".into()),
+                    .apply(sqlite_expr!("LAG({}, 1)", (salary.clone())))
+                .as_alias("prev_salary"),
             )
             .with_expression(
                 Window::new().order_by(salary.clone(), Order::Asc)
-                    .apply(sqlite_expr!("LEAD({}, 1)", (salary.clone()))),
-                Some("next_salary".into()),
+                    .apply(sqlite_expr!("LEAD({}, 1)", (salary.clone())))
+                .as_alias("next_salary"),
             )
             .with_expression(
                 dept_salary_win.clone()
                     .range("UNBOUNDED PRECEDING", "UNBOUNDED FOLLOWING")
-                    .apply(Fx::new("first_value", [u_name.expr()])),
-                Some("top_earner".into()),
+                    .apply(Fx::new("first_value", [u_name.expr()]))
+                .as_alias("top_earner"),
             )
             .with_expression(
                 dept_salary_win.clone()
                     .rows("UNBOUNDED PRECEDING", "UNBOUNDED FOLLOWING")
-                    .apply(Fx::new("nth_value", [u_name.expr(), sqlite_expr!("2")])),
-                Some("second_earner".into()),
+                    .apply(Fx::new("nth_value", [u_name.expr(), sqlite_expr!("2")]))
+                .as_alias("second_earner"),
             )
             .with_join(SqliteSelectJoin::left("orders", "o",
                 sqlite_expr!("{} = {}",

--- a/vantage-sql/tests/sqlite/3_complex_queries.rs
+++ b/vantage-sql/tests/sqlite/3_complex_queries.rs
@@ -257,16 +257,10 @@ async fn test_q4() {
         &SqliteSelect::new()
             .with_source("products")
             .with_field("category")
-            .with_expression(
-                Fx::new("count", [sqlite_expr!("*")])
-                .as_alias("product_count"),
-            )
+            .with_expression(Fx::new("count", [sqlite_expr!("*")]).as_alias("product_count"))
             .with_expression(Fx::new("avg", [price.expr()]).as_alias("avg_price"))
             .with_expression(Fx::new("min", [price.expr()]).as_alias("cheapest"))
-            .with_expression(
-                Fx::new("max", [price.expr()])
-                .as_alias("most_expensive"),
-            )
+            .with_expression(Fx::new("max", [price.expr()]).as_alias("most_expensive"))
             .with_group_by(ident("category"))
             .with_having(sqlite_expr!(
                 "{} > {}",
@@ -409,14 +403,8 @@ async fn test_q6() {
     let stats_subquery = SqliteSelect::new()
         .with_source("orders")
         .with_field("user_id")
-        .with_expression(
-            Fx::new("count", [sqlite_expr!("*")])
-            .as_alias("order_count"),
-        )
-        .with_expression(
-            Fx::new("avg", [ident("total").expr()])
-            .as_alias("avg_total"),
-        )
+        .with_expression(Fx::new("count", [sqlite_expr!("*")]).as_alias("order_count"))
+        .with_expression(Fx::new("avg", [ident("total").expr()]).as_alias("avg_total"))
         .with_condition(sqlite_expr!("{} != {}", (ident("status")), "cancelled"))
         .with_group_by(ident("user_id"));
 
@@ -522,11 +510,9 @@ async fn test_q7() {
                         sqlite_expr!("{}", "junior"),
                     )
                     .else_(sqlite_expr!("{}", "intern"))
-                .as_alias("band"),
+                    .as_alias("band"),
             )
-            .with_expression(
-                ternary(ident("role").eq("admin"), "Yes", "No").as_alias("is_admin"),
-            )
+            .with_expression(ternary(ident("role").eq("admin"), "Yes", "No").as_alias("is_admin"))
             .with_field("display_name")
             .with_order(ident("salary"), Order::Desc),
         "SELECT \"id\", \"name\", \"salary\", \
@@ -846,9 +832,11 @@ async fn test_q11() {
         .with_expression(ident("id").dot_of("d"))
         .with_expression(ident("name").dot_of("d"))
         .with_expression(sqlite_expr!("{} + 1", (ident("depth").dot_of("dt"))))
-        .with_expression(
-            concat_sql!(ident("path").dot_of("dt"), " > ", ident("name").dot_of("d")),
-        )
+        .with_expression(concat_sql!(
+            ident("path").dot_of("dt"),
+            " > ",
+            ident("name").dot_of("d")
+        ))
         .with_join(SqliteSelectJoin::inner(
             "dept_tree",
             "dt",
@@ -1019,16 +1007,13 @@ async fn test_q13() {
             .with_source("products")
             .with_field("id")
             .with_field("name")
+            .with_expression(JsonExtract::new(metadata.clone(), "color").as_alias("color"))
             .with_expression(
-                JsonExtract::new(metadata.clone(), "color").as_alias("color"),
-            )
-            .with_expression(
-                sqlite_expr!("{} ->> {}", (metadata.clone()), "$.weight_kg")
-                .as_alias("weight"),
+                sqlite_expr!("{} ->> {}", (metadata.clone()), "$.weight_kg").as_alias("weight"),
             )
             .with_expression(
                 sqlite_expr!("CAST({} ->> {} AS REAL)", (metadata.clone()), "$.rating")
-                .as_alias("rating"),
+                    .as_alias("rating"),
             )
             .with_expression(
                 Fx::new(
@@ -1115,17 +1100,13 @@ async fn test_q14() {
             .with_expression(month_expr.clone().as_alias("month"))
             .with_expression(ident("name").dot_of("d").as_alias("department"))
             .with_expression(
-                Fx::new("count", [ident("id").dot_of("o").expr()])
-                .as_alias("order_count"),
+                Fx::new("count", [ident("id").dot_of("o").expr()]).as_alias("order_count"),
             )
             .with_expression(
                 Fx::new("round", [sum_total.expr(), sqlite_expr!("{}", 2i64)])
-                .as_alias("monthly_revenue"),
+                    .as_alias("monthly_revenue"),
             )
-            .with_expression(
-                Fx::new("typeof", [sum_total.expr()])
-                .as_alias("sum_type"),
-            )
+            .with_expression(Fx::new("typeof", [sum_total.expr()]).as_alias("sum_type"))
             .with_join(SqliteSelectJoin::inner(
                 "users",
                 "u",

--- a/vantage-sql/tests/sqlite/3_select.rs
+++ b/vantage-sql/tests/sqlite/3_select.rs
@@ -3,6 +3,7 @@
 //! All queries built using the Selectable trait methods, not custom builders.
 
 use vantage_expressions::{ExprDataSource, Expressive, Order, Selectable};
+use vantage_sql::primitives::alias::AliasExt;
 #[allow(unused_imports)]
 use vantage_sql::sqlite::SqliteType;
 use vantage_sql::sqlite::statements::SqliteSelect;
@@ -107,7 +108,7 @@ fn test_select_group_by_with_expression() {
     let s = SqliteSelect::new()
         .with_source("product")
         .with_field("is_deleted")
-        .with_expression(sqlite_expr!("COUNT(*)"), Some("cnt".to_string()));
+        .with_expression(sqlite_expr!("COUNT(*)").as_alias("cnt"));
     let mut s = s;
     s.add_group_by(sqlite_expr!("\"is_deleted\""));
     assert_eq!(

--- a/vantage-surrealdb/src/associated_query.rs
+++ b/vantage-surrealdb/src/associated_query.rs
@@ -107,12 +107,8 @@ impl<Q: SurrealQueriable + Selectable + Clone, R: Send + Sync> Selectable
         self.query.add_field(field)
     }
 
-    fn add_expression(
-        &mut self,
-        expression: vantage_expressions::Expression,
-        alias: Option<String>,
-    ) {
-        self.query.add_expression(expression, alias)
+    fn add_expression(&mut self, expression: vantage_expressions::Expression) {
+        self.query.add_expression(expression)
     }
 
     fn add_where_condition(&mut self, condition: vantage_expressions::Expression) {

--- a/vantage-surrealdb/src/statements/select/impls/selectable.rs
+++ b/vantage-surrealdb/src/statements/select/impls/selectable.rs
@@ -17,16 +17,8 @@ impl<T: QueryResult> Selectable<AnySurrealType> for SurrealSelect<T> {
         self.fields.push(SelectField::new(Identifier::new(field)));
     }
 
-    fn add_expression(
-        &mut self,
-        expression: impl Expressive<AnySurrealType>,
-        alias: Option<String>,
-    ) {
-        let mut field = SelectField::new(expression.expr());
-        if let Some(alias) = alias {
-            field = field.with_alias(alias);
-        }
-        self.fields.push(field);
+    fn add_expression(&mut self, expression: impl Expressive<AnySurrealType>) {
+        self.fields.push(SelectField::new(expression.expr()));
     }
 
     fn add_where_condition(&mut self, condition: impl Into<Expr>) {

--- a/vantage-surrealdb/src/statements/select/tests.rs
+++ b/vantage-surrealdb/src/statements/select/tests.rs
@@ -137,7 +137,7 @@ fn test_selectable_trait_methods() {
     select.add_source("users", None);
     select.add_field("name".to_string());
     select.add_field("email".to_string());
-    select.add_expression(surreal_expr!("age * 2"), Some("double_age".to_string()));
+    select.add_expression(surreal_expr!("age * 2"));
     select.add_where_condition(surreal_expr!("age > 18"));
     select.add_order_by(surreal_expr!("name"), Order::Asc);
     select.add_group_by(surreal_expr!("department"));

--- a/vantage-surrealdb/src/surrealdb/impls/selectable_data_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/selectable_data_source.rs
@@ -1,8 +1,9 @@
 use vantage_core::Result;
-use vantage_expressions::Expressive;
 use vantage_expressions::traits::datasource::SelectableDataSource;
+use vantage_expressions::{Expression, Expressive};
 
 use crate::select::SurrealSelect;
+use crate::select::select_field::SelectField;
 use crate::surrealdb::SurrealDB;
 use crate::types::AnySurrealType;
 
@@ -11,6 +12,19 @@ impl SelectableDataSource<AnySurrealType> for SurrealDB {
 
     fn select(&self) -> Self::Select {
         SurrealSelect::new()
+    }
+
+    fn add_select_column(
+        &self,
+        select: &mut Self::Select,
+        expression: Expression<AnySurrealType>,
+        alias: Option<&str>,
+    ) {
+        let mut field = SelectField::new(expression);
+        if let Some(a) = alias {
+            field = field.with_alias(a.to_string());
+        }
+        select.fields.push(field);
     }
 
     async fn execute_select(&self, select: &Self::Select) -> Result<Vec<AnySurrealType>> {

--- a/vantage-surrealdb/tests/select.rs
+++ b/vantage-surrealdb/tests/select.rs
@@ -101,10 +101,7 @@ fn query03() {
 
     select.add_field("name");
     select.add_field("price");
-    select.add_expression(
-        Identifier::new("inventory").dot("stock"),
-        Some("stock".to_string()),
-    );
+    select.add_expression(Identifier::new("inventory").dot("stock"));
 
     select.add_source("product", None);
     select.add_where_condition(Field::new("is_deleted").eq(false));

--- a/vantage-surrealdb/tests/select.rs
+++ b/vantage-surrealdb/tests/select.rs
@@ -109,7 +109,7 @@ fn query03() {
     let result = select.preview();
     assert_eq!(
         result,
-        "SELECT name, price, inventory.stock AS stock FROM product WHERE is_deleted = false"
+        "SELECT name, price, inventory.stock FROM product WHERE is_deleted = false"
     );
 }
 

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -1,6 +1,6 @@
 use vantage_core::Result;
 use vantage_expressions::traits::selectable::Selectable;
-use vantage_expressions::{Expression, Expressive, SelectableDataSource, expr_any};
+use vantage_expressions::{Expression, Expressive, SelectableDataSource};
 use vantage_types::Entity;
 
 use crate::{
@@ -25,15 +25,17 @@ where
         for column in self.columns.values() {
             if let Some(expr_fn) = self.expressions.get(column.name()) {
                 let expr = expr_fn(self);
-                select.add_expression(expr_any!("({})", (expr)), Some(column.name().to_string()));
+                self.data_source.add_select_column(
+                    &mut select,
+                    expr,
+                    Some(column.name()),
+                );
+            } else if let Some(alias) = column.alias() {
+                let expr = self.data_source.expr(column.name(), vec![]);
+                self.data_source
+                    .add_select_column(&mut select, expr, Some(alias));
             } else {
-                match column.alias() {
-                    Some(alias) => select.add_expression(
-                        self.data_source.expr(column.name(), vec![]),
-                        Some(alias.to_string()),
-                    ),
-                    None => select.add_field(column.name()),
-                }
+                select.add_field(column.name());
             }
         }
 
@@ -41,7 +43,8 @@ where
         for (name, expr_fn) in &self.expressions {
             if !self.columns.contains_key(name) {
                 let expr = expr_fn(self);
-                select.add_expression(expr_any!("({})", (expr)), Some(name.clone()));
+                self.data_source
+                    .add_select_column(&mut select, expr, Some(name));
             }
         }
 

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -25,11 +25,8 @@ where
         for column in self.columns.values() {
             if let Some(expr_fn) = self.expressions.get(column.name()) {
                 let expr = expr_fn(self);
-                self.data_source.add_select_column(
-                    &mut select,
-                    expr,
-                    Some(column.name()),
-                );
+                self.data_source
+                    .add_select_column(&mut select, expr, Some(column.name()));
             } else if let Some(alias) = column.alias() {
                 let expr = self.data_source.expr(column.name(), vec![]);
                 self.data_source

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -1,6 +1,6 @@
 use vantage_core::Result;
 use vantage_expressions::traits::selectable::Selectable;
-use vantage_expressions::{Expression, Expressive, SelectableDataSource};
+use vantage_expressions::{Expression, Expressive, SelectableDataSource, expr_any};
 use vantage_types::Entity;
 
 use crate::{
@@ -25,8 +25,11 @@ where
         for column in self.columns.values() {
             if let Some(expr_fn) = self.expressions.get(column.name()) {
                 let expr = expr_fn(self);
-                self.data_source
-                    .add_select_column(&mut select, expr, Some(column.name()));
+                self.data_source.add_select_column(
+                    &mut select,
+                    expr_any!("({})", (expr)),
+                    Some(column.name()),
+                );
             } else if let Some(alias) = column.alias() {
                 let expr = self.data_source.expr(column.name(), vec![]);
                 self.data_source
@@ -40,8 +43,11 @@ where
         for (name, expr_fn) in &self.expressions {
             if !self.columns.contains_key(name) {
                 let expr = expr_fn(self);
-                self.data_source
-                    .add_select_column(&mut select, expr, Some(name));
+                self.data_source.add_select_column(
+                    &mut select,
+                    expr_any!("({})", (expr)),
+                    Some(name),
+                );
             }
         }
 


### PR DESCRIPTION
SQL `SELECT` columns now alias through a builder method on the expression itself, not a tacked-on `Option<String>` argument. Every call to `Selectable::with_expression` and `add_expression` breaks.

### Migration

`Selectable::with_expression` and `add_expression` no longer take an alias parameter. Use the new `AliasExt::as_alias()` extension trait instead — it works on anything `Expressive`:

```rust
use vantage_sql::primitives::alias::AliasExt;

// before
.with_expression(Fx::new("count", [...]), Some("cnt".into()))

// after
.with_expression(Fx::new("count", [...]).as_alias("cnt"))
```

The per-primitive `with_alias()` builder is gone from `Fx`, `Iif`, `Concat`, `GroupConcat`, `JsonExtract`, `DateFormat`, `Case`, and `Ternary` — `as_alias()` replaces it uniformly. (`Identifier::with_alias` is unaffected.)

### Why

The old shape stored `Option<String>` on every primitive and re-implemented the `expr AS "alias"` rendering inside each one's `Expressive::expr()`. Two consequences fell out: `Fx` and `Case` hardcoded `"` quoting, breaking MySQL backticks, and the `Selectable` trait carried an alias parameter every backend had to thread through (MongoDB faked it as a renamed projection field, ReDB ignored it).

`AliasExt` builds on `Identifier` so quoting follows the backend. The new `SelectableDataSource::add_select_column(select, expr, alias)` hook lets each backend decide what "alias" means: SQL backends wrap with `AS`, MongoDB pushes the alias as a field name, ReDB no-ops.