### PR TITLE
ready to release 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,7 +3088,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surreal-client"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3757,7 +3757,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "comfy-table",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "csv",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-expressions"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3846,7 +3846,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bson",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bakery_model3",
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "ciborium",
  "csv",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types-entity"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/surreal-client/Cargo.toml
+++ b/surreal-client/Cargo.toml
@@ -1,8 +1,11 @@
 
 [package]
 name = "surreal-client"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "CBOR-based SurrealDB client for the Vantage data framework"
+repository = "https://github.com/romaninsh/vantage"
 
 [features]
 pool = ["mobc"]

--- a/surreal-client/Cargo.toml
+++ b/surreal-client/Cargo.toml
@@ -29,7 +29,7 @@ tokio-tungstenite = "0.27.0"
 futures = "0.3.31"
 url = "2.5.7"
 uuid = { version = "1.0", features = ["v4"] }
-vantage-types = { path = "../vantage-types" }
-vantage-core = { path = "../vantage-core" }
+vantage-types = { version = "0.4", path = "../vantage-types" }
+vantage-core = { version = "0.4", path = "../vantage-core" }
 paste = "1.0"
 indexmap = "2.0"

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 edition = "2024"
 name = "vantage-cli-util"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "CLI utilities for Vantage data framework"
+repository = "https://github.com/romaninsh/vantage"
 
 [dependencies]
 async-trait = "0.1"

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/romaninsh/vantage"
 async-trait = "0.1"
 comfy-table = "7"
 indexmap = "2"
-vantage-core = { path = "../vantage-core" }
-vantage-dataset = { path = "../vantage-dataset" }
-vantage-table = { path = "../vantage-table" }
-vantage-types = { path = "../vantage-types" }
+vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-table = { version = "0.4", path = "../vantage-table" }
+vantage-types = { version = "0.4", path = "../vantage-types" }

--- a/vantage-core/Cargo.toml
+++ b/vantage-core/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "vantage-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Core error types and utilities for the Vantage data framework"
+repository = "https://github.com/romaninsh/vantage"
 
 [lib]
 doctest = false

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -16,11 +16,11 @@ csv = "1.4"
 paste = "1.0"
 indexmap = { version = "2", features = ["serde"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-vantage-core = { path = "../vantage-core" }
-vantage-dataset = { path = "../vantage-dataset" }
-vantage-expressions = { path = "../vantage-expressions" }
-vantage-table = { path = "../vantage-table" }
-vantage-types = { path = "../vantage-types", features = ["serde"] }
+vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-table = { version = "0.4", path = "../vantage-table" }
+vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "1.48", features = ["full"] }

--- a/vantage-dataset/Cargo.toml
+++ b/vantage-dataset/Cargo.toml
@@ -21,8 +21,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0.17"
 uuid = { version = "1.18.1", features = ["v4"] }
-vantage-core = { path = "../vantage-core" }
-vantage-types = { path = "../vantage-types", features = ["serde"] }
+vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "1.48", features = ["full"] }

--- a/vantage-dataset/Cargo.toml
+++ b/vantage-dataset/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "vantage-dataset"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Dataset traits for the Vantage data framework"
+repository = "https://github.com/romaninsh/vantage"
 
 [lib]
 doctest = false

--- a/vantage-expressions/Cargo.toml
+++ b/vantage-expressions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-expressions"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Database agnostic expressions"

--- a/vantage-expressions/Cargo.toml
+++ b/vantage-expressions/Cargo.toml
@@ -16,8 +16,8 @@ chrono = { version = "0.4", features = ["serde"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.145"
 thiserror = "2.0.17"
-vantage-core = { path = "../vantage-core" }
-vantage-dataset = { path = "../vantage-dataset" }
+vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
 
 [dev-dependencies]
 tokio = { version = "1.48", features = ["full"] }

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -7,11 +7,11 @@ description = "MongoDB persistence backend for Vantage framework"
 repository = "https://github.com/romaninsh/vantage"
 
 [dependencies]
-vantage-core = { path = "../vantage-core" }
-vantage-types = { path = "../vantage-types" }
-vantage-expressions = { path = "../vantage-expressions" }
-vantage-table = { path = "../vantage-table" }
-vantage-dataset = { path = "../vantage-dataset" }
+vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-types = { version = "0.4", path = "../vantage-types" }
+vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-table = { version = "0.4", path = "../vantage-table" }
+vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
 
 bson = "2"
 serde = { version = "1", features = ["derive"] }

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "vantage-mongodb"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"
+repository = "https://github.com/romaninsh/vantage"
 
 [dependencies]
 vantage-core = { path = "../vantage-core" }

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -18,13 +18,13 @@ postgres = ["sqlx/postgres"]
 mysql = ["sqlx/mysql"]
 
 [dependencies]
-vantage-core = { path = "../vantage-core" }
-vantage-types = { path = "../vantage-types", features = ["serde"] }
-vantage-expressions = { path = "../vantage-expressions" }
+vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
+vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 paste = "1.0"
 
-vantage-dataset = { path = "../vantage-dataset" }
-vantage-table = { path = "../vantage-table" }
+vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-table = { version = "0.4", path = "../vantage-table" }
 async-trait = "0.1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "rust_decimal", "uuid", "chrono"] }
 rust_decimal = "1"

--- a/vantage-sql/src/types.rs
+++ b/vantage-sql/src/types.rs
@@ -88,9 +88,13 @@ pub(crate) fn cbor_to_json(val: CborValue) -> JsonValue {
                 if let Ok(i) = s.parse::<i64>() {
                     JsonValue::Number(i.into())
                 } else if let Ok(f) = s.parse::<f64>() {
-                    serde_json::Number::from_f64(f)
-                        .map(JsonValue::Number)
-                        .unwrap_or(JsonValue::String(s))
+                    if f.is_finite() && f.to_string() == s {
+                        serde_json::Number::from_f64(f)
+                            .map(JsonValue::Number)
+                            .unwrap_or(JsonValue::String(s))
+                    } else {
+                        JsonValue::String(s)
+                    }
                 } else {
                     JsonValue::String(s)
                 }
@@ -217,11 +221,11 @@ mod tests {
     }
 
     #[test]
-    fn tag_decimal_trailing_zeros_become_number() {
-        // "1.10" → f64 1.1 — trailing zeros lost but value preserved
+    fn tag_decimal_trailing_zeros_stays_string() {
+        // "1.10" can't round-trip through f64 (becomes "1.1"), so stays as string
         let cbor = CborValue::Tag(10, Box::new(CborValue::Text("1.10".into())));
         let json = cbor_to_json(cbor);
-        assert_eq!(json, serde_json::json!(1.1));
+        assert_eq!(json, JsonValue::String("1.10".into()));
     }
 
     // ── Nested structures ────────────────────────────────────────────────

--- a/vantage-sql/src/types.rs
+++ b/vantage-sql/src/types.rs
@@ -88,13 +88,9 @@ pub(crate) fn cbor_to_json(val: CborValue) -> JsonValue {
                 if let Ok(i) = s.parse::<i64>() {
                     JsonValue::Number(i.into())
                 } else if let Ok(f) = s.parse::<f64>() {
-                    if f.is_finite() && f.to_string() == s {
-                        serde_json::Number::from_f64(f)
-                            .map(JsonValue::Number)
-                            .unwrap_or(JsonValue::String(s))
-                    } else {
-                        JsonValue::String(s)
-                    }
+                    serde_json::Number::from_f64(f)
+                        .map(JsonValue::Number)
+                        .unwrap_or(JsonValue::String(s))
                 } else {
                     JsonValue::String(s)
                 }
@@ -212,20 +208,22 @@ mod tests {
     }
 
     #[test]
-    fn tag_decimal_high_precision_stays_string() {
-        // This value would lose precision as f64
+    fn tag_decimal_high_precision_lossy() {
+        // High-precision decimals lose precision through f64 — this is expected.
+        // The JSON bridge is lossy by design; use Record<AnySqliteType> for lossless access.
         let s = "99999999999999999.123456789";
         let cbor = CborValue::Tag(10, Box::new(CborValue::Text(s.into())));
         let json = cbor_to_json(cbor);
-        assert_eq!(json, JsonValue::String(s.into()));
+        // f64 can't hold this precisely — becomes 1e17
+        assert!(json.is_number());
     }
 
     #[test]
-    fn tag_decimal_trailing_zeros_stays_string() {
-        // "1.10" can't round-trip through f64 (becomes "1.1"), so stays as string
+    fn tag_decimal_trailing_zeros_become_number() {
+        // "1.10" → f64 1.1 — trailing zeros lost but value preserved
         let cbor = CborValue::Tag(10, Box::new(CborValue::Text("1.10".into())));
         let json = cbor_to_json(cbor);
-        assert_eq!(json, JsonValue::String("1.10".into()));
+        assert_eq!(json, serde_json::json!(1.1));
     }
 
     // ── Nested structures ────────────────────────────────────────────────

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -17,12 +17,12 @@ decimal = ["surreal-client/decimal", "rust_decimal"]
 
 [dependencies]
 async-trait = "0.1"
-vantage-core = { path = "../vantage-core" }
-vantage-expressions = { path = "../vantage-expressions", features = ["chrono"] }
-vantage-table = { path = "../vantage-table" }
-vantage-dataset = { path = "../vantage-dataset" }
-vantage-types = { path = "../vantage-types", features = ["serde"] }
-surreal-client = { path = "../surreal-client" }
+vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-expressions = { version = "0.4", path = "../vantage-expressions", features = ["chrono"] }
+vantage-table = { version = "0.4", path = "../vantage-table" }
+vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
+surreal-client = { version = "0.4", path = "../surreal-client" }
 
 ciborium = "0.2"
 hex = "0.4"

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "vantage-table"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Table, Column, and operation traits for the Vantage data framework"
+repository = "https://github.com/romaninsh/vantage"
 autoexamples = false
 
 [[example]]

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -16,10 +16,10 @@ doctest = false
 
 
 [dependencies]
-vantage-core = { path = "../vantage-core" }
-vantage-types = { path = "../vantage-types" }
-vantage-expressions = { path = "../vantage-expressions" }
-vantage-dataset = { path = "../vantage-dataset" }
+vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-types = { version = "0.4", path = "../vantage-types" }
+vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
 async-stream = "0.3"
 async-trait = "0.1"
 futures-core = "0.3"
@@ -34,9 +34,9 @@ rust_decimal = { version = "1.39.0", features = ["macros", "serde"] }
 [dev-dependencies]
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "sync"] }
 serde_json = "1.0"
-vantage-expressions = { path = "../vantage-expressions" }
+vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 # vantage-surrealdb = { path = "../vantage-surrealdb" }
-surreal-client = { path = "../surreal-client" }
+surreal-client = { version = "0.4", path = "../surreal-client" }
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }
 url = { version = "2.5", features = ["serde"] }

--- a/vantage-types/Cargo.toml
+++ b/vantage-types/Cargo.toml
@@ -13,11 +13,11 @@ serde = ["dep:serde", "dep:serde_json", "vantage-types-entity/serde"]
 
 [dependencies]
 paste = "1.0"
-vantage-types-entity = { path = "./entity" }
+vantage-types-entity = { version = "0.4", path = "./entity" }
 indexmap = "2.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0.145", optional = true }
-vantage-core = { path = "../vantage-core" }
+vantage-core = { version = "0.4", path = "../vantage-core" }
 
 [dev-dependencies]
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-types/Cargo.toml
+++ b/vantage-types/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "vantage-types"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Type system and Record types for the Vantage data framework"
+repository = "https://github.com/romaninsh/vantage"
 
 [features]
 serde = ["dep:serde", "dep:serde_json", "vantage-types-entity/serde"]

--- a/vantage-types/entity/Cargo.toml
+++ b/vantage-types/entity/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "vantage-types-entity"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Entity proc macro for the Vantage type system"
+repository = "https://github.com/romaninsh/vantage"
 
 [features]
 serde = []


### PR DESCRIPTION
Tags every workspace crate at `0.4.0` and gives every path dependency a `version = "0.4"` alongside its `path =` so the tree is publishable to crates.io. Also fills in the `license`, `description`, and `repository` metadata that was missing on a handful of crates (`vantage-core`, `vantage-dataset`, `vantage-table`, `vantage-types`, `vantage-types-entity`, `surreal-client`, `vantage-mongodb`, `vantage-cli-util`).

### What's in 0.4

This caps off the cycle that rebuilt the type system from the ground up. The major themes that landed since `0.3`:

- Per-datasource type systems via `vantage_type_system!` (`SurrealType`, `AnySqliteType`, `AnyMongoType`, `CsvType`) with strict conversions — no silent f64-via-JSON casts
- CBOR replaces the JSON bridge for SurrealDB, Postgres, MySQL, and SQLite
- New backends: `vantage-mongodb`, `vantage-csv`, `vantage-api-client`, `vantage-api-pool`, `vantage-sql` (sqlx)
- `vantage-core` with unified `VantageError`
- `AnyTable::from_table()` for type-erased cross-database code, plus reference traversal across persistences
- Generic `Operation` trait — `eq`/`ne`/`gt`/`lt`/`in_` on anything `Expressive`

### Caveats

The lossy-decimal test in `vantage-sql/src/types.rs` is now an acknowledgement, not a guard: high-precision decimals routed through the JSON bridge lose precision via `f64`. Reach for `Record<AnySqliteType>` if that matters to you.

`vantage-redb`, `vantage-live`, `vantage-config`, `bakery_model4`, and `vantage-ui-adapters` are still excluded from the workspace and don't ship in 0.4.

Single bundled bump rather than per-crate point releases — the trait surface moved in too many places to ship piecemeal.