### PR TITLE
bump book to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-expressions"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ additions:
 - **vantage-core** - Unified error handling with `VantageError`
 - **Cross-database integration** - `AnyTable::from_table()` wraps any datasource for generic code
 - **References** - Traverse between `Table<Client>` into `Table<Order>`, even across databases
-- **Generic Operation trait** - Blanket `eq`/`ne`/`gt`/`lt`/`in_` for all `Expressive` types
+- **Backend-specific Operation traits** - Each backend provides `eq`/`ne`/`gt`/`lt`/`in_` for all `Expressive` types
 - **Multi-source CLI** - Same `handle_commands` function works with CSV, SQLite, and SurrealDB
 
 Features planned for next release:
@@ -663,12 +663,24 @@ features are still missing:
 
 ## Installation
 
-For 0.4, clone this repository and specify path to a crate in your `Cargo.toml`:
+Vantage 0.4 crates are published on [crates.io](https://crates.io). Add the crates you need:
 
 ```toml
-vantage-table = { path = "../vantage/vantage-table" }
-vantage-surrealdb = { path = "../vantage/vantage-surrealdb" }
+# Core crates
+vantage-core = "0.4"
+vantage-types = "0.4"
+vantage-expressions = "0.4"
+vantage-dataset = "0.4"
+vantage-table = "0.4"
+
+# Backend crates — pick the ones you need
+vantage-sql = { version = "0.4", features = ["sqlite"] }  # also: "postgres", "mysql"
+vantage-surrealdb = "0.4"
+vantage-mongodb = "0.4"
+vantage-csv = "0.4"
 ```
+
+For the tutorial, see the [Vantage Book](https://romaninsh.github.io/vantage/).
 
 If you like what you see so far - reach out to me on BlueSky:
 [nearly.guru](https://bsky.app/profile/nearly.guru)

--- a/docs4/src/intro/step1-first-query.md
+++ b/docs4/src/intro/step1-first-query.md
@@ -38,23 +38,18 @@ By the end of this page you'll be able to:
 
 ## Set up
 
-```admonish note title="Pre-release"
-Vantage 0.4 crates aren't on crates.io yet. For now, clone the repo
-(`git clone https://github.com/romaninsh/vantage.git`) and work inside it as shown below.
-```
-
-Create a new project inside the Vantage workspace:
+Create a new project:
 
 ```sh
-cd vantage
-mkdir learn-1 && cd learn-1
-cargo init
-cargo add vantage-sql --path ../vantage-sql --features sqlite
+cargo init learn-1 && cd learn-1
+cargo add vantage-sql --features sqlite
+cargo add vantage-expressions
 cargo add tokio --features full
 ```
 
-Two dependencies — `vantage-sql` gives us the SQLite query builder and connection pool, `tokio`
-provides the async runtime because all database operations are async.
+Three dependencies — `vantage-sql` gives us the SQLite query builder and connection pool,
+`vantage-expressions` is needed by the `sqlite_expr!` macro, and `tokio` provides the async
+runtime because all database operations are async.
 
 ## Create and populate a database
 
@@ -372,7 +367,7 @@ with column names as keys. It lives in the `vantage-types` crate, so add that de
 its prelude:
 
 ```sh
-cargo add vantage-types --path ../vantage-types --features serde
+cargo add vantage-types --features serde
 ```
 
 ```rust
@@ -459,7 +454,7 @@ The macro needs `vantage-core` as a direct dependency (it's already a transitive
 `vantage-sql`, but the generated code references it in your crate):
 
 ```sh
-cargo add vantage-core --path ../vantage-core
+cargo add vantage-core
 ```
 
 The macro also supports multiple type systems in one attribute —

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"
-documentation = "https://docs.rs/vantage"
 homepage = "https://romaninsh.github.io/vantage"
 repository = "https://github.com/romaninsh/vantage"
 readme = "../README.md"

--- a/vantage-expressions/Cargo.toml
+++ b/vantage-expressions/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 edition = "2024"
 name = "vantage-expressions"
-version = "0.4.0"
+version = "0.4.1"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Database agnostic expressions"
-documentation = "https://docs.rs/vantage"
 homepage = "https://romaninsh.github.io/vantage"
 repository = "https://github.com/romaninsh/vantage"
 readme = "../README.md"

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SQL databases (Postgres, MySQL, SQLite)"
-documentation = "https://docs.rs/vantage"
 homepage = "https://romaninsh.github.io/vantage"
 repository = "https://github.com/romaninsh/vantage"
 readme = "../README.md"

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"
-documentation = "https://docs.rs/vantage"
 homepage = "https://romaninsh.github.io/vantage"
 repository = "https://github.com/romaninsh/vantage"
 readme = "../README.md"


### PR DESCRIPTION
Bumps install instructions in the `README` and book to use crates.io instead of `path =` deps now that 0.4 is published, and drops the stale top-level `documentation = "https://docs.rs/vantage"` from per-crate `Cargo.toml`s (each crate has its own `docs.rs` page) — `vantage-expressions` ticks to 0.4.1 to republish.