### PR TITLE
version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "csv",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-expressions"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3847,7 +3847,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "bson",
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "bakery_model3",
@@ -3919,7 +3919,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.4.0"
+version = "0.4.1"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"

--- a/vantage-expressions/Cargo.toml
+++ b/vantage-expressions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-expressions"
-version = "0.4.1"
+version = "0.4.2"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Database agnostic expressions"

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.4.0"
+version = "0.4.1"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"


### PR DESCRIPTION
Patch bump (`0.4.1`, `vantage-expressions` to `0.4.2`) to republish `vantage-csv`, `vantage-expressions`, `vantage-mongodb`, `vantage-sql`, `vantage-surrealdb`, and `vantage-table` so docs.rs picks up the expressions/traversal documentation from #197.