### PR TITLE
get returns Result<Option<E>>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3796,7 +3796,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3816,7 +3816,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-pool"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "csv",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "bson",
@@ -3952,7 +3952,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3975,7 +3975,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "bakery_model3",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/learn-3/src/vantage_axum.rs
+++ b/learn-3/src/vantage_axum.rs
@@ -37,14 +37,18 @@ impl IntoResponse for ApiError {
 
 impl From<VantageError> for ApiError {
     fn from(e: VantageError) -> Self {
-        let message = e.to_string();
-        let status = if message.contains("no row found") || message.contains("Document not found") {
-            StatusCode::NOT_FOUND
-        } else {
-            StatusCode::INTERNAL_SERVER_ERROR
-        };
         eprintln!("API error: {:?}", e);
-        Self { status, message }
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: e.to_string(),
+        }
+    }
+}
+
+fn not_found(id: &str) -> ApiError {
+    ApiError {
+        status: StatusCode::NOT_FOUND,
+        message: format!("not found: {}", id),
     }
 }
 
@@ -100,7 +104,10 @@ where
                 let f = f.clone();
                 move |Path(params): Path<Params>| async move {
                     let id = params["id"].clone();
-                    let entity = f(db(), &params).get(id).await?;
+                    let entity = f(db(), &params)
+                        .get(id.clone())
+                        .await?
+                        .ok_or_else(|| not_found(&id))?;
                     ApiResult::Ok(Json(entity))
                 }
             })

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -12,11 +12,11 @@ indexmap = { version = "2", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-vantage-core = { path = "../vantage-core" }
-vantage-dataset = { path = "../vantage-dataset" }
-vantage-expressions = { path = "../vantage-expressions" }
-vantage-table = { path = "../vantage-table" }
-vantage-types = { path = "../vantage-types", features = ["serde"] }
+vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
+vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-table = { version = "0.4.2", path = "../vantage-table" }
+vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST API backends"

--- a/vantage-api-client/examples/cities.rs
+++ b/vantage-api-client/examples/cities.rs
@@ -70,13 +70,19 @@ async fn main() -> anyhow::Result<()> {
     print_table(&countries).await?;
 
     // Load Argentina (on first page) → traverse to cities
-    let country: Country = countries.get("Argentina").await?;
+    let country: Country = countries
+        .get("Argentina")
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Argentina not found"))?;
     let cities = country.ref_cities();
     println!("\nCities in {}:", country.name);
     print_table(&cities).await?;
 
     // Load a specific city entity
-    let rosario: City = cities.get("Rosario").await?;
+    let rosario: City = cities
+        .get("Rosario")
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Rosario not found"))?;
     println!("\nRosario population: {}", rosario.population);
 
     Ok(())

--- a/vantage-api-client/src/table_source.rs
+++ b/vantage-api-client/src/table_source.rs
@@ -110,7 +110,7 @@ impl TableSource for RestApi {
         &self,
         table: &Table<Self, E>,
         id: &Self::Id,
-    ) -> Result<Record<Self::Value>>
+    ) -> Result<Option<Record<Self::Value>>>
     where
         E: Entity<Self::Value>,
         Self: Sized,
@@ -118,10 +118,7 @@ impl TableSource for RestApi {
         let records = self
             .fetch_records(table.table_name(), id_field_name(table).as_deref())
             .await?;
-        records
-            .get(id)
-            .cloned()
-            .ok_or_else(|| error!("Record not found", id = id))
+        Ok(records.get(id).cloned())
     }
 
     async fn get_table_some_value<E>(

--- a/vantage-api-pool/Cargo.toml
+++ b/vantage-api-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "vantage-api-pool"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT OR Apache-2.0"
 description = "Paginated REST API client pool for Vantage"
 

--- a/vantage-api-pool/Cargo.toml
+++ b/vantage-api-pool/Cargo.toml
@@ -18,11 +18,11 @@ tokio-stream = "0.1"
 async-trait = "0.1"
 indexmap = { version = "2", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
-vantage-core = { path = "../vantage-core" }
-vantage-dataset = { path = "../vantage-dataset" }
-vantage-expressions = { path = "../vantage-expressions" }
-vantage-table = { path = "../vantage-table" }
-vantage-types = { path = "../vantage-types", features = ["serde"] }
+vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
+vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-table = { version = "0.4.2", path = "../vantage-table" }
+vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/vantage-api-pool/examples/pool_cities.rs
+++ b/vantage-api-pool/examples/pool_cities.rs
@@ -94,13 +94,19 @@ async fn main() -> Result<()> {
     print_table(&countries).await?;
 
     // Load a country and traverse to its cities
-    let argentina: Country = countries.get("Argentina").await?;
+    let argentina: Country = countries
+        .get("Argentina")
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Argentina not found"))?;
     let cities = argentina.ref_cities();
     println!("\nCities in {}:", argentina.name);
     print_table(&cities).await?;
 
     // Load a specific city
-    let rosario: City = cities.get("Rosario").await?;
+    let rosario: City = cities
+        .get("Rosario")
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("Rosario not found"))?;
     println!("\nRosario population: {}", rosario.population);
 
     Ok(())

--- a/vantage-api-pool/src/pool_api.rs
+++ b/vantage-api-pool/src/pool_api.rs
@@ -172,17 +172,14 @@ impl TableSource for PoolApi {
         &self,
         table: &Table<Self, E>,
         id: &Self::Id,
-    ) -> Result<Record<Self::Value>>
+    ) -> Result<Option<Record<Self::Value>>>
     where
         E: Entity<Self::Value>,
         Self: Sized,
     {
         // Fetch all and find by id — could be optimized with a direct endpoint later
         let records = self.list_table_values(table).await?;
-        records
-            .get(id)
-            .cloned()
-            .ok_or_else(|| error!("Record not found", id = id))
+        Ok(records.get(id).cloned())
     }
 
     async fn get_table_some_value<E>(

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.4.1"
+version = "0.4.2"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"
@@ -15,9 +15,9 @@ paste = "1.0"
 indexmap = { version = "2", features = ["serde"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
-vantage-table = { version = "0.4", path = "../vantage-table" }
+vantage-table = { version = "0.4.2", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
 
 [dev-dependencies]

--- a/vantage-csv/src/table_source.rs
+++ b/vantage-csv/src/table_source.rs
@@ -88,16 +88,13 @@ impl TableSource for Csv {
         &self,
         table: &Table<Self, E>,
         id: &Self::Id,
-    ) -> Result<Record<Self::Value>>
+    ) -> Result<Option<Record<Self::Value>>>
     where
         E: Entity<Self::Value>,
         Self: Sized,
     {
         let records = self.read_csv(table.table_name(), table.columns())?;
-        records
-            .get(id)
-            .cloned()
-            .ok_or_else(|| error!("Record not found", id = id))
+        Ok(records.get(id).cloned())
     }
 
     async fn get_table_some_value<E>(
@@ -376,7 +373,11 @@ mod tests {
             .with_column_of::<String>("name")
             .with_column_of::<String>("email");
 
-        let record = table.get_value(&"doc".to_string()).await.unwrap();
+        let record = table
+            .get_value(&"doc".to_string())
+            .await
+            .unwrap()
+            .expect("doc exists");
         assert_eq!(record["name"].try_get::<String>().unwrap(), "Doc Brown");
         assert_eq!(
             record["email"].try_get::<String>().unwrap(),
@@ -389,8 +390,8 @@ mod tests {
         let csv = test_csv();
         let table = Table::<Csv, EmptyEntity>::new("client", csv);
 
-        let result = table.get_value(&"nonexistent".to_string()).await;
-        assert!(result.is_err());
+        let result = table.get_value(&"nonexistent".to_string()).await.unwrap();
+        assert!(result.is_none());
     }
 
     #[tokio::test]

--- a/vantage-dataset/Cargo.toml
+++ b/vantage-dataset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-dataset"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Dataset traits for the Vantage data framework"

--- a/vantage-dataset/src/im/dataset_readable.rs
+++ b/vantage-dataset/src/im/dataset_readable.rs
@@ -35,21 +35,20 @@ where
         Ok(records)
     }
 
-    async fn get(&self, id: impl Into<Self::Id> + Send) -> Result<E> {
+    async fn get(&self, id: impl Into<Self::Id> + Send) -> Result<Option<E>> {
         let id = id.into();
         let table = self.data_source.get_or_create_table(&self.table_name);
 
-        match table.get(&id) {
-            Some(record) => {
-                // Add the id field to the record for conversion
-                let mut record_with_id = record.clone();
-                record_with_id.insert("id".to_string(), serde_json::Value::String(id.clone()));
+        let Some(record) = table.get(&id) else {
+            return Ok(None);
+        };
 
-                E::try_from_record(&record_with_id)
-                    .map_err(|e| vantage_error!("Failed to convert record to entity: {:?}", e))
-            }
-            None => Err(vantage_error!("Record with id '{}' not found", id)),
-        }
+        let mut record_with_id = record.clone();
+        record_with_id.insert("id".to_string(), serde_json::Value::String(id.clone()));
+
+        let entity = E::try_from_record(&record_with_id)
+            .map_err(|e| vantage_error!("Failed to convert record to entity: {:?}", e))?;
+        Ok(Some(entity))
     }
 
     async fn get_some(&self) -> Result<Option<(Self::Id, E)>> {

--- a/vantage-dataset/src/im/valueset_readable.rs
+++ b/vantage-dataset/src/im/valueset_readable.rs
@@ -14,10 +14,7 @@ where
         Ok(table)
     }
 
-    async fn get_value(
-        &self,
-        id: &Self::Id,
-    ) -> crate::traits::Result<Option<Record<Self::Value>>> {
+    async fn get_value(&self, id: &Self::Id) -> crate::traits::Result<Option<Record<Self::Value>>> {
         let table = self.data_source.get_or_create_table(&self.table_name);
         Ok(table.get(id).cloned())
     }

--- a/vantage-dataset/src/im/valueset_readable.rs
+++ b/vantage-dataset/src/im/valueset_readable.rs
@@ -14,16 +14,12 @@ where
         Ok(table)
     }
 
-    async fn get_value(&self, id: &Self::Id) -> crate::traits::Result<Record<Self::Value>> {
+    async fn get_value(
+        &self,
+        id: &Self::Id,
+    ) -> crate::traits::Result<Option<Record<Self::Value>>> {
         let table = self.data_source.get_or_create_table(&self.table_name);
-
-        match table.get(id) {
-            Some(record) => Ok(record.clone()),
-            None => Err(vantage_core::util::error::vantage_error!(
-                "Record with id '{}' not found",
-                id
-            )),
-        }
+        Ok(table.get(id).cloned())
     }
 
     async fn get_some_value(
@@ -64,8 +60,8 @@ mod tests {
         let ds = ImDataSource::new();
         let table = ImTable::<User>::new(&ds, "users");
 
-        let result = table.get_value(&"nonexistent".to_string()).await;
-        assert!(result.is_err());
+        let result = table.get_value(&"nonexistent".to_string()).await.unwrap();
+        assert!(result.is_none());
     }
 
     #[tokio::test]

--- a/vantage-dataset/src/mocks/csv.rs
+++ b/vantage-dataset/src/mocks/csv.rs
@@ -148,12 +148,14 @@ where
         Ok(records)
     }
 
-    async fn get(&self, id: impl Into<Self::Id> + Send) -> Result<T> {
+    async fn get(&self, id: impl Into<Self::Id> + Send) -> Result<Option<T>> {
         let id = id.into();
-        let record = self.get_value(&id).await?;
+        let Some(record) = self.get_value(&id).await? else {
+            return Ok(None);
+        };
         let entity = T::try_from_record(&record)
             .map_err(|_| vantage_error!("Failed to convert record to entity"))?;
-        Ok(entity)
+        Ok(Some(entity))
     }
 
     async fn get_some(&self) -> Result<Option<(Self::Id, T)>> {
@@ -203,7 +205,7 @@ where
         Ok(records)
     }
 
-    async fn get_value(&self, id: &Self::Id) -> Result<Record<Self::Value>> {
+    async fn get_value(&self, id: &Self::Id) -> Result<Option<Record<Self::Value>>> {
         let content = self
             .csv_ds
             .get_file_content(&self.filename)
@@ -229,11 +231,11 @@ where
                     }
                 }
 
-                return Ok(csv_record_map);
+                return Ok(Some(csv_record_map));
             }
         }
 
-        Err(vantage_error!("Record with index {} not found", id))
+        Ok(None)
     }
 
     async fn get_some_value(&self) -> Result<Option<(Self::Id, Record<Self::Value>)>> {

--- a/vantage-dataset/src/traits/dataset.rs
+++ b/vantage-dataset/src/traits/dataset.rs
@@ -90,7 +90,7 @@ where
 ///
 /// // Type-safe entity access
 /// let all_users: IndexMap<String, User> = users.list().await?;
-/// let specific_user: User = users.get(&user_id).await?;
+/// let specific_user: Option<User> = users.get(&user_id).await?;
 ///
 /// // Sample data without loading everything
 /// if let Some((id, user)) = users.get_some().await? {
@@ -115,12 +115,14 @@ where
 
     /// Retrieve a specific entity by ID.
     ///
-    /// The storage value is automatically deserialized to the entity type.
+    /// Returns `Ok(None)` when no entity exists with the given ID. The storage
+    /// value is automatically deserialized to the entity type.
     ///
     /// # Errors
     ///
-    /// Returns an error if the entity doesn't exist or deserialization fails.
-    async fn get(&self, id: impl Into<Self::Id> + Send) -> Result<E>;
+    /// Returns an error only if the lookup itself fails (connection errors,
+    /// deserialization failures). A missing row is not an error.
+    async fn get(&self, id: impl Into<Self::Id> + Send) -> Result<Option<E>>;
 
     /// Retrieve one single entity from the set. If entities are ordered - return first entity.
     ///
@@ -331,10 +333,10 @@ where
     /// - `Ok(None)`: entity doesn't exist
     /// - `Err`: Storage or deserialization error
     async fn get_entity(&self, id: &Self::Id) -> Result<Option<ActiveEntity<'_, Self, E>>> {
-        match self.get(id.clone()).await {
-            Ok(data) => Ok(Some(ActiveEntity::new(id.clone(), data, self))),
-            Err(_) => Ok(None),
-        }
+        Ok(self
+            .get(id.clone())
+            .await?
+            .map(|data| ActiveEntity::new(id.clone(), data, self)))
     }
 
     /// Retrieve all entities wrapped for change tracking.

--- a/vantage-dataset/src/traits/valueset.rs
+++ b/vantage-dataset/src/traits/valueset.rs
@@ -87,7 +87,10 @@ pub trait ReadableValueSet: ValueSet {
     async fn list_values(&self) -> Result<IndexMap<Self::Id, Record<Self::Value>>>;
 
     /// Retrieve a specific record by ID as a structured record.
-    async fn get_value(&self, id: &Self::Id) -> Result<Record<Self::Value>>;
+    ///
+    /// Returns `Ok(None)` when no record exists with the given ID. Returns an
+    /// error only if the lookup itself fails.
+    async fn get_value(&self, id: &Self::Id) -> Result<Option<Record<Self::Value>>>;
 
     /// Retrieve one single record from the set. If records are ordered - return first record.
     /// will return Ok(None).
@@ -217,9 +220,10 @@ pub trait ActiveRecordSet: ReadableValueSet + WritableValueSet {
     ///
     /// # Returns
     ///
-    /// - `Ok(RecordValue)`: Record wrapper with change tracking
-    /// - `Err`: If record doesn't exist or cannot be loaded
-    async fn get_value_record(&self, id: &Self::Id) -> Result<ActiveRecord<'_, Self>>;
+    /// - `Ok(Some(RecordValue))`: Record wrapper with change tracking
+    /// - `Ok(None)`: No record with this ID
+    /// - `Err`: If the lookup itself fails
+    async fn get_value_record(&self, id: &Self::Id) -> Result<Option<ActiveRecord<'_, Self>>>;
 
     /// Retrieve all records wrapped for change tracking.
     ///
@@ -239,9 +243,11 @@ impl<T> ActiveRecordSet for T
 where
     T: ReadableValueSet + WritableValueSet + Sync,
 {
-    async fn get_value_record(&self, id: &Self::Id) -> Result<ActiveRecord<'_, Self>> {
-        let record = self.get_value(id).await?;
-        Ok(ActiveRecord::new(id.clone(), record, self))
+    async fn get_value_record(&self, id: &Self::Id) -> Result<Option<ActiveRecord<'_, Self>>> {
+        Ok(self
+            .get_value(id)
+            .await?
+            .map(|record| ActiveRecord::new(id.clone(), record, self)))
     }
 
     async fn list_value_records(&self) -> Result<Vec<ActiveRecord<'_, Self>>> {

--- a/vantage-dataset/tests/im_dataset.rs
+++ b/vantage-dataset/tests/im_dataset.rs
@@ -32,8 +32,8 @@ async fn test_readable_dataset() {
     assert_eq!(result.len(), 0);
 
     // Test get non-existent record
-    let result = table.get("nonexistent".to_string()).await;
-    assert!(result.is_err());
+    let result = table.get("nonexistent".to_string()).await.unwrap();
+    assert!(result.is_none());
 
     // Test get_some on empty dataset
     let result = table.get_some().await.unwrap();
@@ -133,8 +133,8 @@ async fn test_writable_dataset() {
 
     // Test delete
     table.delete(&"user-1".to_string()).await.unwrap();
-    let result = table.get("user-1".to_string()).await;
-    assert!(result.is_err());
+    let result = table.get("user-1".to_string()).await.unwrap();
+    assert!(result.is_none());
 
     // Test delete_all
     let _ = table.insert(&"user-2".to_string(), &user).await.unwrap();
@@ -161,7 +161,11 @@ async fn test_full_crud_cycle() {
     assert_eq!(result, product);
 
     // Read
-    let retrieved = table.get("prod-1".to_string()).await.unwrap();
+    let retrieved = table
+        .get("prod-1".to_string())
+        .await
+        .unwrap()
+        .expect("prod-1 exists");
     assert_eq!(retrieved, product);
 
     // Update
@@ -178,14 +182,18 @@ async fn test_full_crud_cycle() {
     assert_eq!(result, updated_product);
 
     // Verify update
-    let retrieved = table.get("prod-1".to_string()).await.unwrap();
+    let retrieved = table
+        .get("prod-1".to_string())
+        .await
+        .unwrap()
+        .expect("prod-1 exists");
     assert_eq!(retrieved.name, "Gaming Laptop");
     assert_eq!(retrieved.price, 1500);
 
     // Delete
     table.delete(&"prod-1".to_string()).await.unwrap();
-    let result = table.get("prod-1".to_string()).await;
-    assert!(result.is_err());
+    let result = table.get("prod-1".to_string()).await.unwrap();
+    assert!(result.is_none());
 }
 
 #[tokio::test]
@@ -205,7 +213,11 @@ async fn test_record_field_handling() {
     table.insert(&"test-user".to_string(), &user).await.unwrap();
 
     // Retrieve and verify ID is properly restored
-    let retrieved = table.get("test-user".to_string()).await.unwrap();
+    let retrieved = table
+        .get("test-user".to_string())
+        .await
+        .unwrap()
+        .expect("test-user exists");
     assert_eq!(retrieved.id, Some("test-user".to_string()));
     assert_eq!(retrieved.name, "Test User");
     assert_eq!(retrieved.age, 42);
@@ -242,8 +254,8 @@ async fn test_error_conditions() {
     assert!(result.is_err());
 
     // Test get on non-existent record
-    let result = table.get("nonexistent".to_string()).await;
-    assert!(result.is_err());
+    let result = table.get("nonexistent".to_string()).await.unwrap();
+    assert!(result.is_none());
 }
 
 #[tokio::test]

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"
@@ -10,8 +10,8 @@ repository = "https://github.com/romaninsh/vantage"
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
-vantage-table = { version = "0.4", path = "../vantage-table" }
-vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-table = { version = "0.4.2", path = "../vantage-table" }
+vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 
 bson = "2"
 serde = { version = "1", features = ["derive"] }

--- a/vantage-mongodb/src/mongodb/impls/table_source.rs
+++ b/vantage-mongodb/src/mongodb/impls/table_source.rs
@@ -179,20 +179,22 @@ impl TableSource for MongoDB {
         &self,
         table: &Table<Self, E>,
         id: &Self::Id,
-    ) -> Result<Record<Self::Value>>
+    ) -> Result<Option<Record<Self::Value>>>
     where
         E: Entity<Self::Value>,
     {
         let coll = self.doc_collection(table.table_name());
 
-        let d = coll
+        let Some(d) = coll
             .find_one(doc! { "_id": id })
             .await
             .map_err(|e| error!("MongoDB find_one failed", details = e.to_string()))?
-            .ok_or_else(|| error!("Document not found", id = id.to_string()))?;
+        else {
+            return Ok(None);
+        };
 
         let (_oid, record) = doc_to_record(d);
-        Ok(record)
+        Ok(Some(record))
     }
 
     async fn get_table_some_value<E>(
@@ -347,7 +349,9 @@ impl TableSource for MongoDB {
             .await
             .map_err(|e| error!("MongoDB insert_one failed", details = e.to_string()))?;
 
-        self.get_table_value(table, id).await
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Inserted row disappeared", id = id.to_string()))
     }
 
     async fn replace_table_value<E>(
@@ -371,7 +375,9 @@ impl TableSource for MongoDB {
             .await
             .map_err(|e| error!("MongoDB replace_one failed", details = e.to_string()))?;
 
-        self.get_table_value(table, id).await
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Replaced row disappeared", id = id.to_string()))
     }
 
     async fn patch_table_value<E>(
@@ -395,7 +401,9 @@ impl TableSource for MongoDB {
             .await
             .map_err(|e| error!("MongoDB update_one failed", details = e.to_string()))?;
 
-        self.get_table_value(table, id).await
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Record not found after patch", id = id.to_string()))
     }
 
     async fn delete_table_value<E>(&self, table: &Table<Self, E>, id: &Self::Id) -> Result<()>

--- a/vantage-mongodb/tests/1_table_source.rs
+++ b/vantage-mongodb/tests/1_table_source.rs
@@ -99,7 +99,7 @@ async fn test_get_value_by_id() {
     ]);
     table.insert_value(&id, &rec).await.unwrap();
 
-    let fetched = table.get_value(&id).await.unwrap();
+    let fetched = table.get_value(&id).await.unwrap().expect("row exists");
     assert_eq!(fetched["name"].try_get::<String>(), Some("Tart".into()));
 
     teardown(&db, &db_name).await;
@@ -199,7 +199,7 @@ async fn test_replace() {
     ]);
     table.replace_value(&id, &replacement).await.unwrap();
 
-    let fetched = table.get_value(&id).await.unwrap();
+    let fetched = table.get_value(&id).await.unwrap().expect("row exists");
     assert_eq!(fetched["name"].try_get::<String>(), Some("New".into()));
     assert_eq!(fetched["price"].try_get::<i64>(), Some(99));
 
@@ -223,7 +223,7 @@ async fn test_patch() {
     let patch = record(&[("price", AnyMongoType::new(75i64))]);
     table.patch_value(&id, &patch).await.unwrap();
 
-    let fetched = table.get_value(&id).await.unwrap();
+    let fetched = table.get_value(&id).await.unwrap().expect("row exists");
     assert_eq!(fetched["name"].try_get::<String>(), Some("Original".into()));
     assert_eq!(fetched["price"].try_get::<i64>(), Some(75));
     assert_eq!(fetched["calories"].try_get::<i64>(), Some(200));
@@ -278,7 +278,7 @@ async fn test_insert_return_id() {
     ]);
     let id = table.insert_return_id_value(&rec).await.unwrap();
 
-    let fetched = table.get_value(&id).await.unwrap();
+    let fetched = table.get_value(&id).await.unwrap().expect("row exists");
     assert_eq!(fetched["name"].try_get::<String>(), Some("Auto".into()));
 
     teardown(&db, &db_name).await;

--- a/vantage-mongodb/tests/4_editable_data_set.rs
+++ b/vantage-mongodb/tests/4_editable_data_set.rs
@@ -54,7 +54,7 @@ async fn test_insert() {
     assert_eq!(result["name"].try_get::<String>(), Some("Gamma".into()));
     assert_eq!(result["price"].try_get::<i64>(), Some(30));
 
-    let fetched = table.get_value(&MongoId::from("c")).await.unwrap();
+    let fetched = table.get_value(&MongoId::from("c")).await.unwrap().expect("row exists");
     assert_eq!(fetched["name"].try_get::<String>(), Some("Gamma".into()));
 }
 
@@ -71,7 +71,11 @@ async fn test_replace() {
         .await
         .unwrap();
 
-    let fetched = table.get_value(&MongoId::from("a")).await.unwrap();
+    let fetched = table
+        .get_value(&MongoId::from("a"))
+        .await
+        .unwrap()
+        .expect("row a exists");
     assert_eq!(
         fetched["name"].try_get::<String>(),
         Some("Alpha Replaced".into())
@@ -89,7 +93,11 @@ async fn test_patch() {
         .await
         .unwrap();
 
-    let fetched = table.get_value(&MongoId::from("a")).await.unwrap();
+    let fetched = table
+        .get_value(&MongoId::from("a"))
+        .await
+        .unwrap()
+        .expect("row a exists");
     assert_eq!(fetched["price"].try_get::<i64>(), Some(55));
     // name untouched
     assert_eq!(fetched["name"].try_get::<String>(), Some("Alpha".into()));
@@ -135,7 +143,7 @@ async fn test_insert_return_id() {
     let id = table.insert_return_id_value(&rec).await.unwrap();
     assert!(!id.to_string().is_empty());
 
-    let fetched = table.get_value(&id).await.unwrap();
+    let fetched = table.get_value(&id).await.unwrap().expect("row exists");
     assert_eq!(fetched["name"].try_get::<String>(), Some("Auto".into()));
     assert_eq!(fetched["price"].try_get::<i64>(), Some(42));
 }

--- a/vantage-mongodb/tests/4_editable_data_set.rs
+++ b/vantage-mongodb/tests/4_editable_data_set.rs
@@ -54,7 +54,11 @@ async fn test_insert() {
     assert_eq!(result["name"].try_get::<String>(), Some("Gamma".into()));
     assert_eq!(result["price"].try_get::<i64>(), Some(30));
 
-    let fetched = table.get_value(&MongoId::from("c")).await.unwrap().expect("row exists");
+    let fetched = table
+        .get_value(&MongoId::from("c"))
+        .await
+        .unwrap()
+        .expect("row exists");
     assert_eq!(fetched["name"].try_get::<String>(), Some("Gamma".into()));
 }
 

--- a/vantage-mongodb/tests/4_readable_data_set.rs
+++ b/vantage-mongodb/tests/4_readable_data_set.rs
@@ -52,7 +52,8 @@ async fn test_get_product() {
     let record = table
         .get_value(&MongoId::from("delorean_donut"))
         .await
-        .unwrap();
+        .unwrap()
+        .expect("delorean_donut exists");
     assert_eq!(
         record["name"].try_get::<String>(),
         Some("DeLorean Doughnut".into())

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -21,8 +21,8 @@ vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 paste = "1.0"
 
-vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
-vantage-table = { version = "0.4", path = "../vantage-table" }
+vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
+vantage-table = { version = "0.4.2", path = "../vantage-table" }
 async-trait = "0.1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "rust_decimal", "uuid", "chrono"] }
 rust_decimal = "1"

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -158,7 +158,7 @@ impl TableSource for MysqlDB {
         &self,
         table: &Table<Self, E>,
         id: &Self::Id,
-    ) -> Result<Record<Self::Value>>
+    ) -> Result<Option<Record<Self::Value>>>
     where
         E: Entity<Self::Value>,
     {
@@ -175,8 +175,7 @@ impl TableSource for MysqlDB {
         let result = self.execute(&select.expr()).await?;
 
         let mut rows = parse_rows(result, &id_field_name)?;
-        rows.swap_remove(id)
-            .ok_or_else(|| error!("get_table_value: no row found", id = id.clone()))
+        Ok(rows.swap_remove(id))
     }
 
     async fn get_table_some_value<E>(
@@ -265,7 +264,9 @@ impl TableSource for MysqlDB {
             .with_record(record);
         self.execute(&insert.expr()).await?;
 
-        self.get_table_value(table, id).await
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Inserted row disappeared", id = id.clone()))
     }
 
     async fn replace_table_value<E>(
@@ -304,7 +305,9 @@ impl TableSource for MysqlDB {
         let upsert = expr_any!("{} ON DUPLICATE KEY UPDATE {}", (base), (conflict));
         self.execute(&upsert).await?;
 
-        self.get_table_value(table, id).await
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Row missing after upsert", id = id.clone()))
     }
 
     async fn patch_table_value<E>(
@@ -330,7 +333,9 @@ impl TableSource for MysqlDB {
             .with_condition(id_condition);
         self.execute(&update.expr()).await?;
 
-        self.get_table_value(table, id).await
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Row not found after patch", id = id.clone()))
     }
 
     async fn delete_table_value<E>(&self, table: &Table<Self, E>, id: &Self::Id) -> Result<()>

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -161,7 +161,7 @@ impl TableSource for PostgresDB {
         &self,
         table: &Table<Self, E>,
         id: &Self::Id,
-    ) -> Result<Record<Self::Value>>
+    ) -> Result<Option<Record<Self::Value>>>
     where
         E: Entity<Self::Value>,
     {
@@ -178,8 +178,7 @@ impl TableSource for PostgresDB {
         let result = self.execute(&select.expr()).await?;
 
         let mut rows = parse_rows(result, &id_field_name)?;
-        rows.swap_remove(id)
-            .ok_or_else(|| error!("get_table_value: no row found", id = id.clone()))
+        Ok(rows.swap_remove(id))
     }
 
     async fn get_table_some_value<E>(
@@ -270,7 +269,9 @@ impl TableSource for PostgresDB {
             .with_record(record);
         self.execute(&insert.expr()).await?;
 
-        self.get_table_value(table, id).await
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Inserted row disappeared", id = id.clone()))
     }
 
     async fn replace_table_value<E>(
@@ -300,7 +301,10 @@ impl TableSource for PostgresDB {
                 (ident(&id_field_name))
             );
             self.execute(&upsert).await?;
-            return self.get_table_value(table, id).await;
+            return self
+                .get_table_value(table, id)
+                .await?
+                .ok_or_else(|| error!("Row missing after upsert", id = id.clone()));
         } else {
             record
                 .keys()
@@ -316,7 +320,9 @@ impl TableSource for PostgresDB {
         );
         self.execute(&upsert).await?;
 
-        self.get_table_value(table, id).await
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Row missing after upsert", id = id.clone()))
     }
 
     async fn patch_table_value<E>(
@@ -342,7 +348,9 @@ impl TableSource for PostgresDB {
             .with_condition(id_condition);
         self.execute(&update.expr()).await?;
 
-        self.get_table_value(table, id).await
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Row not found after patch", id = id.clone()))
     }
 
     async fn delete_table_value<E>(&self, table: &Table<Self, E>, id: &Self::Id) -> Result<()>

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -151,7 +151,7 @@ impl TableSource for SqliteDB {
         &self,
         table: &Table<Self, E>,
         id: &Self::Id,
-    ) -> Result<Record<Self::Value>>
+    ) -> Result<Option<Record<Self::Value>>>
     where
         E: Entity<Self::Value>,
     {
@@ -166,8 +166,7 @@ impl TableSource for SqliteDB {
         let result = self.execute(&select.expr()).await?;
 
         let mut rows = parse_rows(result, &id_field_name)?;
-        rows.swap_remove(id)
-            .ok_or_else(|| error!("get_table_value: no row found", id = id.clone()))
+        Ok(rows.swap_remove(id))
     }
 
     async fn get_table_some_value<E>(
@@ -256,7 +255,9 @@ impl TableSource for SqliteDB {
             .with_record(record);
         self.execute(&insert.expr()).await?;
 
-        self.get_table_value(table, id).await
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Inserted row disappeared", id = id.clone()))
     }
 
     async fn replace_table_value<E>(
@@ -286,7 +287,9 @@ impl TableSource for SqliteDB {
         );
         self.execute(&replace_expr).await?;
 
-        self.get_table_value(table, id).await
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Row missing after replace", id = id.clone()))
     }
 
     async fn patch_table_value<E>(
@@ -310,7 +313,9 @@ impl TableSource for SqliteDB {
             .with_condition(id_condition);
         self.execute(&update.expr()).await?;
 
-        self.get_table_value(table, id).await
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Row not found after patch", id = id.clone()))
     }
 
     async fn delete_table_value<E>(&self, table: &Table<Self, E>, id: &Self::Id) -> Result<()>

--- a/vantage-sql/tests/mysql/1_chrono.rs
+++ b/vantage-sql/tests/mysql/1_chrono.rs
@@ -107,7 +107,11 @@ where
         .replace(&id.to_string(), entity)
         .await
         .map_err(|e| e.to_string())?;
-    table.get(id).await.map_err(|e| e.to_string())
+    table
+        .get(id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "row missing after replace".to_string())
 }
 
 // ═════════════════════════════════════════════════════════════════════════

--- a/vantage-sql/tests/mysql/1_decimal.rs
+++ b/vantage-sql/tests/mysql/1_decimal.rs
@@ -46,7 +46,11 @@ async fn try_round_trip(
         .replace(&id.to_string(), entity)
         .await
         .map_err(|e| e.to_string())?;
-    table.get(id).await.map_err(|e| e.to_string())
+    table
+        .get(id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "row missing after replace".to_string())
 }
 
 fn dec(s: &str) -> Decimal {
@@ -246,7 +250,11 @@ async fn try_i64(
         .replace(&id.to_string(), entity)
         .await
         .map_err(|e| e.to_string())?;
-    table.get(id).await.map_err(|e| e.to_string())
+    table
+        .get(id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "row missing after replace".to_string())
 }
 
 #[tokio::test]
@@ -356,7 +364,11 @@ async fn try_f64(
         .replace(&id.to_string(), entity)
         .await
         .map_err(|e| e.to_string())?;
-    table.get(id).await.map_err(|e| e.to_string())
+    table
+        .get(id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "row missing after replace".to_string())
 }
 
 #[tokio::test]

--- a/vantage-sql/tests/mysql/4_editable_data_set.rs
+++ b/vantage-sql/tests/mysql/4_editable_data_set.rs
@@ -67,7 +67,7 @@ async fn test_insert() {
     assert_eq!(result.name, "Gamma");
     assert_eq!(result.price, 30);
 
-    let fetched = table.get("c").await.unwrap();
+    let fetched = table.get("c").await.unwrap().expect("row c");
     assert_eq!(fetched.name, "Gamma");
 }
 
@@ -81,7 +81,7 @@ async fn test_replace() {
     };
     table.replace(&"a".to_string(), &item).await.unwrap();
 
-    let fetched = table.get("a").await.unwrap();
+    let fetched = table.get("a").await.unwrap().expect("row a");
     assert_eq!(fetched.name, "Alpha Replaced");
     assert_eq!(fetched.price, 99);
 }
@@ -96,7 +96,7 @@ async fn test_patch() {
     };
     table.patch(&"a".to_string(), &partial).await.unwrap();
 
-    let fetched = table.get("a").await.unwrap();
+    let fetched = table.get("a").await.unwrap().expect("row a");
     assert_eq!(fetched.price, 55);
 }
 
@@ -151,7 +151,7 @@ async fn test_insert_return_id() {
     let id = table.insert_return_id(&item).await.unwrap();
     assert!(!id.is_empty());
 
-    let fetched = table.get(id).await.unwrap();
+    let fetched = table.get(id).await.unwrap().expect("inserted row");
     assert_eq!(fetched.name, "Auto");
     assert_eq!(fetched.price, 42);
 }

--- a/vantage-sql/tests/mysql/4_readable_data_set.rs
+++ b/vantage-sql/tests/mysql/4_readable_data_set.rs
@@ -62,7 +62,11 @@ async fn test_get_product() {
     let db = get_db().await;
     let table = Product::mysql_table(db);
 
-    let product = table.get("delorean_donut").await.unwrap();
+    let product = table
+        .get("delorean_donut")
+        .await
+        .unwrap()
+        .expect("delorean_donut exists");
     assert_eq!(product.name, "DeLorean Doughnut");
     assert_eq!(product.price, 135);
     assert_eq!(product.calories, 250);

--- a/vantage-sql/tests/postgres/1_chrono.rs
+++ b/vantage-sql/tests/postgres/1_chrono.rs
@@ -109,7 +109,11 @@ where
         .replace(&id.to_string(), entity)
         .await
         .map_err(|e| e.to_string())?;
-    table.get(id).await.map_err(|e| e.to_string())
+    table
+        .get(id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "row missing after replace".to_string())
 }
 
 // ═════════════════════════════════════════════════════════════════════════

--- a/vantage-sql/tests/postgres/1_decimal.rs
+++ b/vantage-sql/tests/postgres/1_decimal.rs
@@ -46,7 +46,11 @@ async fn try_round_trip(
         .replace(&id.to_string(), entity)
         .await
         .map_err(|e| e.to_string())?;
-    table.get(id).await.map_err(|e| e.to_string())
+    table
+        .get(id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "row missing after replace".to_string())
 }
 
 fn dec(s: &str) -> Decimal {

--- a/vantage-sql/tests/postgres/4_editable_data_set.rs
+++ b/vantage-sql/tests/postgres/4_editable_data_set.rs
@@ -67,7 +67,7 @@ async fn test_insert() {
     assert_eq!(result.name, "Gamma");
     assert_eq!(result.price, 30);
 
-    let fetched = table.get("c").await.unwrap();
+    let fetched = table.get("c").await.unwrap().expect("row c");
     assert_eq!(fetched.name, "Gamma");
 }
 
@@ -81,7 +81,7 @@ async fn test_replace() {
     };
     table.replace(&"a".to_string(), &item).await.unwrap();
 
-    let fetched = table.get("a").await.unwrap();
+    let fetched = table.get("a").await.unwrap().expect("row a");
     assert_eq!(fetched.name, "Alpha Replaced");
     assert_eq!(fetched.price, 99);
 }
@@ -96,7 +96,7 @@ async fn test_patch() {
     };
     table.patch(&"a".to_string(), &partial).await.unwrap();
 
-    let fetched = table.get("a").await.unwrap();
+    let fetched = table.get("a").await.unwrap().expect("row a");
     assert_eq!(fetched.price, 55);
 }
 
@@ -151,7 +151,7 @@ async fn test_insert_return_id() {
     let id = table.insert_return_id(&item).await.unwrap();
     assert!(!id.is_empty());
 
-    let fetched = table.get(id).await.unwrap();
+    let fetched = table.get(id).await.unwrap().expect("inserted row");
     assert_eq!(fetched.name, "Auto");
     assert_eq!(fetched.price, 42);
 }

--- a/vantage-sql/tests/postgres/4_readable_data_set.rs
+++ b/vantage-sql/tests/postgres/4_readable_data_set.rs
@@ -62,7 +62,11 @@ async fn test_get_product() {
     let db = get_db().await;
     let table = Product::postgres_table(db);
 
-    let product = table.get("delorean_donut").await.unwrap();
+    let product = table
+        .get("delorean_donut")
+        .await
+        .unwrap()
+        .expect("delorean_donut exists");
     assert_eq!(product.name, "DeLorean Doughnut");
     assert_eq!(product.price, 135);
     assert_eq!(product.calories, 250);

--- a/vantage-sql/tests/sqlite/1_chrono.rs
+++ b/vantage-sql/tests/sqlite/1_chrono.rs
@@ -75,7 +75,7 @@ async fn test_chrono_text_columns() {
     let inserted = table.insert(&"evt1".to_string(), &original).await.unwrap();
     assert_eq!(inserted, original);
 
-    let fetched = table.get("evt1").await.unwrap();
+    let fetched = table.get("evt1").await.unwrap().expect("row exists");
     assert_eq!(fetched, original);
 }
 
@@ -139,7 +139,7 @@ async fn test_chrono_text_fixed_offset() {
     let inserted = table.insert(&"fix1".to_string(), &original).await.unwrap();
     assert_eq!(inserted, original);
 
-    let fetched = table.get("fix1").await.unwrap();
+    let fetched = table.get("fix1").await.unwrap().expect("row exists");
     assert_eq!(fetched, original);
     // Offset preserved as +05:30
     assert_eq!(fetched.value.offset().local_minus_utc(), 5 * 3600 + 30 * 60);
@@ -177,6 +177,6 @@ async fn test_chrono_text_subsec() {
         .unwrap();
     assert_eq!(inserted, original);
 
-    let fetched = table.get("evt_sub").await.unwrap();
+    let fetched = table.get("evt_sub").await.unwrap().expect("row exists");
     assert_eq!(fetched, original);
 }

--- a/vantage-sql/tests/sqlite/1_decimal.rs
+++ b/vantage-sql/tests/sqlite/1_decimal.rs
@@ -74,7 +74,7 @@ async fn test_text_decimal() {
     };
     let inserted = t.insert(&"t1".to_string(), &orig).await.unwrap();
     assert_eq!(inserted, orig);
-    let fetched = t.get("t1").await.unwrap();
+    let fetched = t.get("t1").await.unwrap().expect("row exists");
     assert_eq!(fetched, orig);
 }
 
@@ -88,7 +88,7 @@ async fn test_text_high_precision() {
     };
     let inserted = t.insert(&"t2".to_string(), &orig).await.unwrap();
     assert_eq!(inserted, orig);
-    let fetched = t.get("t2").await.unwrap();
+    let fetched = t.get("t2").await.unwrap().expect("row exists");
     assert_eq!(fetched, orig);
 }
 
@@ -106,7 +106,7 @@ async fn test_numeric_decimal() {
     };
     let inserted = t.insert(&"n1".to_string(), &orig).await.unwrap();
     assert_eq!(inserted, orig);
-    let fetched = t.get("n1").await.unwrap();
+    let fetched = t.get("n1").await.unwrap().expect("row exists");
     assert_eq!(fetched, orig);
 }
 

--- a/vantage-sql/tests/sqlite/4_editable_data_set.rs
+++ b/vantage-sql/tests/sqlite/4_editable_data_set.rs
@@ -63,7 +63,7 @@ async fn test_insert() {
     assert_eq!(result.name, "Gamma");
     assert_eq!(result.price, 30);
 
-    let fetched = table.get("c").await.unwrap();
+    let fetched = table.get("c").await.unwrap().expect("row c");
     assert_eq!(fetched.name, "Gamma");
 }
 
@@ -77,7 +77,7 @@ async fn test_replace() {
     };
     table.replace(&"a".to_string(), &item).await.unwrap();
 
-    let fetched = table.get("a").await.unwrap();
+    let fetched = table.get("a").await.unwrap().expect("row a");
     assert_eq!(fetched.name, "Alpha Replaced");
     assert_eq!(fetched.price, 99);
 }
@@ -92,7 +92,7 @@ async fn test_patch() {
     };
     table.patch(&"a".to_string(), &partial).await.unwrap();
 
-    let fetched = table.get("a").await.unwrap();
+    let fetched = table.get("a").await.unwrap().expect("row a");
     assert_eq!(fetched.price, 55);
 }
 
@@ -144,7 +144,7 @@ async fn test_insert_return_id() {
     let id = table.insert_return_id(&item).await.unwrap();
     assert!(!id.is_empty());
 
-    let fetched = table.get(id).await.unwrap();
+    let fetched = table.get(id).await.unwrap().expect("inserted row");
     assert_eq!(fetched.name, "Auto");
     assert_eq!(fetched.price, 42);
 }

--- a/vantage-sql/tests/sqlite/4_editable_value_set.rs
+++ b/vantage-sql/tests/sqlite/4_editable_value_set.rs
@@ -55,7 +55,11 @@ async fn test_insert_value() {
     assert_eq!(result["name"].try_get::<String>().unwrap(), "Gamma");
 
     // Verify it's actually there
-    let fetched = table.get_value(&"c".to_string()).await.unwrap();
+    let fetched = table
+        .get_value(&"c".to_string())
+        .await
+        .unwrap()
+        .expect("c exists");
     assert_eq!(fetched["price"].try_get::<i64>().unwrap(), 30);
 }
 
@@ -66,7 +70,11 @@ async fn test_replace_value() {
     let rec = record(&[("name", "Alpha Replaced".into()), ("price", 99i64.into())]);
     table.replace_value(&"a".to_string(), &rec).await.unwrap();
 
-    let fetched = table.get_value(&"a".to_string()).await.unwrap();
+    let fetched = table
+        .get_value(&"a".to_string())
+        .await
+        .unwrap()
+        .expect("a exists");
     assert_eq!(
         fetched["name"].try_get::<String>().unwrap(),
         "Alpha Replaced"
@@ -82,7 +90,11 @@ async fn test_patch_value() {
     let partial = record(&[("price", 55i64.into())]);
     table.patch_value(&"a".to_string(), &partial).await.unwrap();
 
-    let fetched = table.get_value(&"a".to_string()).await.unwrap();
+    let fetched = table
+        .get_value(&"a".to_string())
+        .await
+        .unwrap()
+        .expect("a exists");
     assert_eq!(fetched["name"].try_get::<String>().unwrap(), "Alpha"); // unchanged
     assert_eq!(fetched["price"].try_get::<i64>().unwrap(), 55); // updated
 }
@@ -133,7 +145,7 @@ async fn test_insert_return_id_value() {
     let id = table.insert_return_id_value(&rec).await.unwrap();
     assert!(!id.is_empty());
 
-    let fetched = table.get_value(&id).await.unwrap();
+    let fetched = table.get_value(&id).await.unwrap().expect("inserted row");
     assert_eq!(
         fetched["message"].try_get::<String>().unwrap(),
         "hello world"

--- a/vantage-sql/tests/sqlite/4_readable_data_set.rs
+++ b/vantage-sql/tests/sqlite/4_readable_data_set.rs
@@ -62,7 +62,11 @@ async fn test_get_product() {
     let db = get_db().await;
     let table = Product::sqlite_table(db);
 
-    let product = table.get("delorean_donut").await.unwrap();
+    let product = table
+        .get("delorean_donut")
+        .await
+        .unwrap()
+        .expect("delorean_donut exists");
     assert_eq!(product.name, "DeLorean Doughnut");
     assert_eq!(product.price, 135);
     assert_eq!(product.calories, 250);

--- a/vantage-sql/tests/sqlite/4_readable_value_set.rs
+++ b/vantage-sql/tests/sqlite/4_readable_value_set.rs
@@ -69,7 +69,8 @@ async fn test_get_value_product() {
     let record = table
         .get_value(&"delorean_donut".to_string())
         .await
-        .unwrap();
+        .unwrap()
+        .expect("delorean_donut exists");
     assert_eq!(
         record["name"].try_get::<String>(),
         Some("DeLorean Doughnut".to_string())

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.4.1"
+version = "0.4.2"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"
@@ -17,8 +17,8 @@ decimal = ["surreal-client/decimal", "rust_decimal"]
 async-trait = "0.1"
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions", features = ["chrono"] }
-vantage-table = { version = "0.4", path = "../vantage-table" }
-vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-table = { version = "0.4.2", path = "../vantage-table" }
+vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
 surreal-client = { version = "0.4", path = "../surreal-client" }
 

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -170,14 +170,20 @@ impl TableSource for SurrealDB {
         &self,
         _table: &Table<Self, E>,
         id: &Self::Id,
-    ) -> Result<Record<Self::Value>>
+    ) -> Result<Option<Record<Self::Value>>>
     where
         E: Entity<Self::Value>,
     {
         let query = crate::surreal_expr!("SELECT * FROM ONLY {}", (id.clone()));
         let result = self.execute(&query).await?;
 
-        let map = result.into_value().into_map().map_err(|_| {
+        // `SELECT ... FROM ONLY` returns Null (in cbor) when no row matches.
+        let value = result.into_value();
+        if matches!(value, ciborium::Value::Null) {
+            return Ok(None);
+        }
+
+        let map = value.into_map().map_err(|_| {
             error!(
                 "get_table_value: expected map result",
                 id = format!("{:?}", id)
@@ -185,7 +191,7 @@ impl TableSource for SurrealDB {
         })?;
 
         let (_thing, record) = parse_cbor_row(map, "id");
-        Ok(record)
+        Ok(Some(record))
     }
 
     async fn get_table_some_value<E>(

--- a/vantage-surrealdb/tests/table_source_read.rs
+++ b/vantage-surrealdb/tests/table_source_read.rs
@@ -190,7 +190,11 @@ async fn test_get_table_value_product() {
     let table = Product::surreal_table(db.clone());
 
     let id = Thing::new("product", "delorean_donut");
-    let record = db.get_table_value(&table, &id).await.unwrap();
+    let record = db
+        .get_table_value(&table, &id)
+        .await
+        .unwrap()
+        .expect("product exists");
     let product = Product::from_record(record).unwrap();
     assert_eq!(product.name, "DeLorean Doughnut");
     assert_eq!(product.calories, 250);
@@ -203,7 +207,11 @@ async fn test_get_table_value_client() {
     let table = Client::surreal_table(db.clone());
 
     let id = Thing::new("client", "doc");
-    let record = db.get_table_value(&table, &id).await.unwrap();
+    let record = db
+        .get_table_value(&table, &id)
+        .await
+        .unwrap()
+        .expect("client exists");
     let client = Client::from_record(record).unwrap();
     assert_eq!(client.name, "Doc Brown");
     assert_eq!(client.email, "doc@brown.com");

--- a/vantage-surrealdb/tests/table_source_write.rs
+++ b/vantage-surrealdb/tests/table_source_write.rs
@@ -94,7 +94,8 @@ async fn test_insert_table_return_id() {
         .data_source()
         .get_table_value(&table, &id)
         .await
-        .expect("get_table_value failed");
+        .expect("get_table_value failed")
+        .expect("row exists");
 
     assert_eq!(
         fetched.get("name").and_then(|v| v.try_get::<String>()),
@@ -292,7 +293,8 @@ async fn test_full_crud_lifecycle() {
         .data_source()
         .get_table_value(&table, &id)
         .await
-        .unwrap();
+        .unwrap()
+        .expect("row exists");
     assert_eq!(
         fetched.get("name").and_then(|v| v.try_get::<String>()),
         Some("Lifecycle".to_string())
@@ -312,7 +314,8 @@ async fn test_full_crud_lifecycle() {
         .data_source()
         .get_table_value(&table, &id)
         .await
-        .unwrap();
+        .unwrap()
+        .expect("row exists");
     assert_eq!(
         updated.get("score").and_then(|v| v.try_get::<i64>()),
         Some(999)
@@ -334,7 +337,8 @@ async fn test_full_crud_lifecycle() {
         .data_source()
         .get_table_value(&table, &id)
         .await
-        .unwrap();
+        .unwrap()
+        .expect("row exists");
     assert_eq!(
         replaced.get("name").and_then(|v| v.try_get::<String>()),
         Some("Replaced".to_string())

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"
@@ -19,7 +19,7 @@ doctest = false
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
-vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 async-stream = "0.3"
 async-trait = "0.1"
 futures-core = "0.3"

--- a/vantage-table/src/any.rs
+++ b/vantage-table/src/any.rs
@@ -167,7 +167,7 @@ impl ReadableValueSet for AnyTable {
         self.inner.list_values().await
     }
 
-    async fn get_value(&self, id: &Self::Id) -> Result<Record<Self::Value>> {
+    async fn get_value(&self, id: &Self::Id) -> Result<Option<Record<Self::Value>>> {
         self.inner.get_value(id).await
     }
 
@@ -350,14 +350,14 @@ where
             .collect())
     }
 
-    async fn get_value(&self, id: &String) -> Result<Record<Value>> {
+    async fn get_value(&self, id: &String) -> Result<Option<Record<Value>>> {
         let native_id: T::Id = id.clone().into();
         let rec = self
             .inner
             .data_source()
             .get_table_value(&self.inner, &native_id)
             .await?;
-        Ok(Self::convert_record(rec))
+        Ok(rec.map(Self::convert_record))
     }
 
     async fn get_some_value(&self) -> Result<Option<(String, Record<Value>)>> {

--- a/vantage-table/src/mocks/mock_table_source.rs
+++ b/vantage-table/src/mocks/mock_table_source.rs
@@ -182,7 +182,7 @@ impl TableSource for MockTableSource {
         &self,
         table: &Table<Self, E>,
         id: &Self::Id,
-    ) -> Result<Record<Self::Value>>
+    ) -> Result<Option<Record<Self::Value>>>
     where
         E: Entity,
         Self: Sized,
@@ -270,7 +270,7 @@ impl TableSource for MockTableSource {
         let im_table = ImTable::<E>::new(&self.im_data_source, table.table_name());
 
         // Check if record already exists - fail if it does
-        if im_table.get_value(id).await.is_ok() {
+        if im_table.get_value(id).await?.is_some() {
             return Err(vantage_core::error!(
                 "Record with ID already exists",
                 id = id
@@ -325,7 +325,7 @@ impl TableSource for MockTableSource {
         let im_table = ImTable::<E>::new(&self.im_data_source, table.table_name());
 
         // Check if record exists - fail if it doesn't
-        if im_table.get_value(id).await.is_err() {
+        if im_table.get_value(id).await?.is_none() {
             return Err(vantage_core::error!("Record not found", id = id));
         }
 

--- a/vantage-table/src/table/sets/readable_dataset.rs
+++ b/vantage-table/src/table/sets/readable_dataset.rs
@@ -30,11 +30,14 @@ where
         Ok(entities)
     }
 
-    async fn get(&self, id: impl Into<Self::Id> + Send) -> Result<E> {
+    async fn get(&self, id: impl Into<Self::Id> + Send) -> Result<Option<E>> {
         let id = id.into();
-        let record = self.data_source().get_table_value(self, &id).await?;
-        E::try_from_record(&record)
-            .map_err(|_| vantage_core::error!("Failed to convert record to entity"))
+        let Some(record) = self.data_source().get_table_value(self, &id).await? else {
+            return Ok(None);
+        };
+        let entity = E::try_from_record(&record)
+            .map_err(|_| vantage_core::error!("Failed to convert record to entity"))?;
+        Ok(Some(entity))
     }
 
     async fn get_some(&self) -> Result<Option<(Self::Id, E)>> {
@@ -136,14 +139,14 @@ mod tests {
         assert_eq!(entity_1.age, 30);
 
         // Test get() with existing ID
-        let entity_2 = table.get("2".to_string()).await.unwrap();
+        let entity_2 = table.get("2".to_string()).await.unwrap().expect("row 2");
         assert_eq!(entity_2.id, Some("2".to_string()));
         assert_eq!(entity_2.name, "Bob");
         assert_eq!(entity_2.age, 25);
 
         // Test get() with non-existing ID
-        let result = table.get("999".to_string()).await;
-        assert!(result.is_err());
+        let result = table.get("999".to_string()).await.unwrap();
+        assert!(result.is_none());
 
         // Test get_some()
         let some_entity = table.get_some().await.unwrap();
@@ -179,6 +182,7 @@ mod tests {
         let result = table.list().await;
         assert!(result.is_err());
 
+        // Test get() with existing id but broken record — surfaces conversion error.
         let result = table.get("1".to_string()).await;
         assert!(result.is_err());
 

--- a/vantage-table/src/table/sets/readable_value_set.rs
+++ b/vantage-table/src/table/sets/readable_value_set.rs
@@ -16,7 +16,7 @@ impl<T: TableSource, E: Entity<T::Value>> ReadableValueSet for Table<T, E> {
         self.data_source().list_table_values(self).await
     }
 
-    async fn get_value(&self, id: &Self::Id) -> Result<Record<Self::Value>> {
+    async fn get_value(&self, id: &Self::Id) -> Result<Option<Record<Self::Value>>> {
         self.data_source().get_table_value(self, id).await
     }
 
@@ -67,13 +67,13 @@ mod tests {
         assert_eq!(record_1["age"], json!(30));
 
         // Test get_value with existing ID
-        let value_2 = table.get_value(&"2".to_string()).await.unwrap();
+        let value_2 = table.get_value(&"2".to_string()).await.unwrap().expect("row 2");
         assert_eq!(value_2["name"], json!("Bob"));
         assert_eq!(value_2["age"], json!(25));
 
         // Test get_value with non-existing ID
-        let result = table.get_value(&"999".to_string()).await;
-        assert!(result.is_err());
+        let result = table.get_value(&"999".to_string()).await.unwrap();
+        assert!(result.is_none());
 
         // Test get_some_value
         let some_value = table.get_some_value().await.unwrap();

--- a/vantage-table/src/table/sets/readable_value_set.rs
+++ b/vantage-table/src/table/sets/readable_value_set.rs
@@ -67,7 +67,11 @@ mod tests {
         assert_eq!(record_1["age"], json!(30));
 
         // Test get_value with existing ID
-        let value_2 = table.get_value(&"2".to_string()).await.unwrap().expect("row 2");
+        let value_2 = table
+            .get_value(&"2".to_string())
+            .await
+            .unwrap()
+            .expect("row 2");
         assert_eq!(value_2["name"], json!("Bob"));
         assert_eq!(value_2["age"], json!(25));
 

--- a/vantage-table/src/table/sets/writable_dataset.rs
+++ b/vantage-table/src/table/sets/writable_dataset.rs
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(replaced2.name, "Eve");
 
         // Test patch - create a partial update that only changes the name
-        let original = table.get("1".to_string()).await.unwrap();
+        let original = table.get("1".to_string()).await.unwrap().expect("row 1");
         assert_eq!(original.name, "Alice");
         assert_eq!(original.age, 30);
 
@@ -147,8 +147,8 @@ mod tests {
 
         // Test delete
         table.delete(&"2".to_string()).await.unwrap();
-        let result3 = table.get("2".to_string()).await;
-        assert!(result3.is_err()); // Should be deleted
+        let result3 = table.get("2".to_string()).await.unwrap();
+        assert!(result3.is_none()); // Should be deleted
 
         // Test delete non-existing ID should fail
         let result4 = table.delete(&"999".to_string()).await;

--- a/vantage-table/src/table/sets/writable_value_set.rs
+++ b/vantage-table/src/table/sets/writable_value_set.rs
@@ -117,8 +117,8 @@ mod tests {
 
         // Test delete
         table.delete(&"2".to_string()).await.unwrap();
-        let result3 = table.get_value(&"2".to_string()).await;
-        assert!(result3.is_err()); // Should be deleted
+        let result3 = table.get_value(&"2".to_string()).await.unwrap();
+        assert!(result3.is_none()); // Should be deleted
 
         // Test delete non-existing ID should fail
         let result4 = table.delete(&"999".to_string()).await;

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -79,12 +79,14 @@ pub trait TableSource: DataSource + Clone + 'static {
         E: Entity<Self::Value>,
         Self: Sized;
 
-    /// Get a single record by ID as Record value (for ReadableValueSet implementation)
+    /// Get a single record by ID as Record value (for ReadableValueSet implementation).
+    ///
+    /// Returns `Ok(None)` when no record exists with the given ID.
     async fn get_table_value<E>(
         &self,
         table: &Table<Self, E>,
         id: &Self::Id,
-    ) -> Result<Record<Self::Value>>
+    ) -> Result<Option<Record<Self::Value>>>
     where
         E: Entity<Self::Value>,
         Self: Sized;

--- a/vantage-table/tests/column_type_system.rs
+++ b/vantage-table/tests/column_type_system.rs
@@ -322,16 +322,12 @@ impl TableSource for Type3TableSource {
         &self,
         _table: &Table<Self, E>,
         id: &Self::Id,
-    ) -> Result<Record<Self::Value>>
+    ) -> Result<Option<Record<Self::Value>>>
     where
         E: Entity<Self::Value>,
         Self: Sized,
     {
-        if let Some(row) = self.data.get(*id) {
-            Ok(Record::from_indexmap(row.clone()))
-        } else {
-            Err(vantage_core::error!("Record not found", id = id))
-        }
+        Ok(self.data.get(*id).cloned().map(Record::from_indexmap))
     }
 
     async fn get_table_some_value<E>(


### PR DESCRIPTION
The old contract threw `Err("no row found")` on a missed lookup, forcing
callers to string-match the message to distinguish 404 from a real error
— the axum tutorial literally did that. Returning `Option` removes the
ambiguity:

    match users.get(id).await? {
        Some(u) => Ok(u),
        None    => Err(ApiError::NotFound),
    }

Same flip for `ReadableValueSet::get_value` and the per-backend
`get_table_value` helpers. `ActiveEntitySet::get_entity` used to swallow
real errors as `Ok(None)` because `get` always `Err`ed on miss — it now
propagates properly.

Ripples through sqlite / postgres / mysql / mongodb / surrealdb / csv /
api-client / api-pool / im / mocks plus ~40 test and example call sites.
The axum tutorial's `contains("no row found")` hack is gone.

pr 202 is for fixing 404  - niiice! 👍 