### PR TITLE
add is_null, is_not_null, reload, delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "bson",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/FINAL_TODO.md
+++ b/FINAL_TODO.md
@@ -163,9 +163,9 @@ collision logic are gone.
 0.4 has `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in_`, `in_list` on columns
 (`vantage-table/src/operation.rs`). Missing:
 
-- [ ] **`is()` / `is_not()` / NULL checks** — no `IS NULL` / `IS NOT NULL` on
-      the `Operations` trait. Legacy had `column.is(Value::Null)`. Grep for
-      `is_null`, `is_not_null`, `IS NULL` in `vantage-*/src/` returns nothing.
+- [x] **`is_null()` / `is_not_null()` / NULL checks** — added to the generic
+      `Operation` trait (SQL: `{} IS NULL` / `{} IS NOT NULL`) and to the
+      `MongoOperation` trait (BSON `{ field: null }` / `{ field: { $ne: null } }`).
 - [ ] **Nested condition composition** — legacy `Condition::from_condition()`
       let you build arbitrary AND/OR trees. Confirm whether 0.4 supports
       arbitrary nesting or only the flat AND-of-conditions attached to a table;
@@ -185,11 +185,10 @@ collision logic are gone.
 
 `ActiveEntity` in 0.4 (`vantage-dataset/src/record.rs`) has `.save()` but not:
 
-- [ ] **`reload()`** — refetch the entity from the datasource in place, for use
-      after external mutations.
-- [ ] **`delete()`** — delete the entity by id without reaching back to the
-      table. Currently callers have to remember the id and call
-      `table.delete(id)` themselves.
+- [x] **`reload()`** — refetches the entity in place via the stored id;
+      returns an error if the row is gone.
+- [x] **`delete()`** — deletes by the id the `ActiveEntity` already holds.
+      Callers no longer need to keep the id around separately.
 
 Legacy: `AssociatedEntity<T>` had both, plus `.id()`. (0.4's `ActiveEntity`
 stores the id internally; it's just not exposed as a convenience method.)

--- a/TODO.md
+++ b/TODO.md
@@ -25,12 +25,10 @@
 - [x] **Remove `delete`/`delete_all` from `WritableDataSet`** — `WritableValueSet` is the canonical
       place for deletion (doesn't require entity type). Having both causes ambiguity when calling
       `table.delete()`. Keep only in `WritableValueSet`.
-- [ ] **Change `ReadableDataSet::get(id)` to return `Result<Option<E>>`** — current contract
-      returns `Err` when the row is missing, which forces consumers (e.g. the axum tutorial's
-      `From<VantageError> for ApiError` impl) to string-match `"no row found"` to produce 404s.
-      Options: (a) additive — add `get_opt(id) -> Result<Option<E>>`, leave `get` as-is; (b) full
-      contract change — `get` itself returns `Result<Option<E>>`. Preference: (a) first, migrate
-      callers over time; `Option` is the Rust-native way to express "lookup missed".
+- [x] **Change `ReadableDataSet::get(id)` to return `Result<Option<E>>`** — went with the full
+      contract change. `ReadableValueSet::get_value` and the per-backend `get_table_value`
+      helpers flipped the same way. `ActiveEntitySet::get_entity` used to swallow errors as
+      `Ok(None)` — now propagates them. axum tutorial's `contains("no row found")` hack gone.
 - [ ] **Decouple `column_table_values_expr` from `ExprDataSource`** — the method returns
       `AssociatedExpression` which forces `ExprDataSource` dependency. Consider moving to a
       sub-trait so non-SQL backends don't carry dead code. SQL backends use it internally in

--- a/vantage-dataset/Cargo.toml
+++ b/vantage-dataset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-dataset"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Dataset traits for the Vantage data framework"

--- a/vantage-dataset/src/record.rs
+++ b/vantage-dataset/src/record.rs
@@ -1,6 +1,7 @@
-use crate::traits::{Result, WritableDataSet, WritableValueSet};
+use crate::traits::{ReadableDataSet, Result, WritableDataSet, WritableValueSet};
 use std::ops::{Deref, DerefMut};
-use vantage_types::{IntoRecord, Record, TryFromRecord};
+use vantage_core::util::error::vantage_error;
+use vantage_types::{Entity, IntoRecord, Record, TryFromRecord};
 
 /// A record represents a single entity with its ID, providing save functionality
 pub struct ActiveEntity<'a, D, E>
@@ -30,6 +31,36 @@ where
     /// Save the current state of the record back to the dataset
     pub async fn save(&self) -> Result<E> {
         self.dataset.replace(&self.id, &self.data).await
+    }
+}
+
+impl<'a, D, E> ActiveEntity<'a, D, E>
+where
+    D: WritableDataSet<E> + WritableValueSet + ?Sized,
+    E: Entity<D::Value> + Send + Sync + Clone,
+{
+    /// Delete this entity from the dataset.
+    pub async fn delete(&self) -> Result<()> {
+        self.dataset.delete(&self.id).await
+    }
+}
+
+impl<'a, D, E> ActiveEntity<'a, D, E>
+where
+    D: WritableDataSet<E> + ReadableDataSet<E> + ?Sized,
+    E: Entity<D::Value> + Send + Sync + Clone,
+{
+    /// Re-fetch the entity from the dataset, replacing the in-memory copy.
+    ///
+    /// Errors if the row has been deleted by someone else since we loaded it.
+    pub async fn reload(&mut self) -> Result<()> {
+        let fresh = self
+            .dataset
+            .get(self.id.clone())
+            .await?
+            .ok_or_else(|| vantage_error!("reload: row not found"))?;
+        self.data = fresh;
+        Ok(())
     }
 }
 

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"
@@ -10,8 +10,8 @@ repository = "https://github.com/romaninsh/vantage"
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
-vantage-table = { version = "0.4.2", path = "../vantage-table" }
-vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
+vantage-table = { version = "0.4.3", path = "../vantage-table" }
+vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
 
 bson = "2"
 serde = { version = "1", features = ["derive"] }

--- a/vantage-mongodb/src/operation.rs
+++ b/vantage-mongodb/src/operation.rs
@@ -137,6 +137,23 @@ pub trait MongoOperation<T>: Expressive<T> {
         let arr: Vec<Bson> = values.into_iter().map(to_bson_val).collect();
         MongoCondition::Doc(doc! { field_name(self): { "$in": arr } })
     }
+
+    /// `{ field: null }` — matches documents where the field is null **or missing**.
+    /// Mongo's `$eq: null` semantics, which is what most callers want.
+    fn is_null(&self) -> MongoCondition
+    where
+        Self: Sized,
+    {
+        MongoCondition::Doc(doc! { field_name(self): Bson::Null })
+    }
+
+    /// `{ field: { "$ne": null } }` — matches documents where the field exists and is non-null.
+    fn is_not_null(&self) -> MongoCondition
+    where
+        Self: Sized,
+    {
+        MongoCondition::Doc(doc! { field_name(self): { "$ne": Bson::Null } })
+    }
 }
 
 /// Blanket: any `Expressive<T>` gets `MongoOperation<T>` for free.
@@ -273,5 +290,29 @@ mod tests {
         let price = Column::<i64>::new("price");
         let cond: MongoCondition = price.gt(100i64);
         let _: MongoCondition = cond;
+    }
+
+    #[test]
+    fn test_is_null() {
+        let deleted_at = Column::<String>::new("deleted_at");
+        let cond = deleted_at.is_null();
+        match cond {
+            MongoCondition::Doc(doc) => {
+                assert_eq!(doc, doc! { "deleted_at": Bson::Null });
+            }
+            _ => panic!("expected Doc"),
+        }
+    }
+
+    #[test]
+    fn test_is_not_null() {
+        let email = Column::<String>::new("email");
+        let cond = email.is_not_null();
+        match cond {
+            MongoCondition::Doc(doc) => {
+                assert_eq!(doc, doc! { "email": { "$ne": Bson::Null } });
+            }
+            _ => panic!("expected Doc"),
+        }
     }
 }

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"
@@ -19,7 +19,7 @@ doctest = false
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
-vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
 async-stream = "0.3"
 async-trait = "0.1"
 futures-core = "0.3"

--- a/vantage-table/src/operation.rs
+++ b/vantage-table/src/operation.rs
@@ -110,7 +110,37 @@ pub trait Operation<T>: Expressive<T> {
             vec![ExpressiveEnum::Nested(self.expr())],
         )
     }
+
+    /// Creates a NULL check condition: field IS NULL
+    fn is_null(&self) -> Expression<T> {
+        Expression::new("{} IS NULL", vec![ExpressiveEnum::Nested(self.expr())])
+    }
+
+    /// Creates a NOT NULL check condition: field IS NOT NULL
+    fn is_not_null(&self) -> Expression<T> {
+        Expression::new("{} IS NOT NULL", vec![ExpressiveEnum::Nested(self.expr())])
+    }
 }
 
 /// Blanket implementation: any type that implements `Expressive<T>` gets `Operation<T>` for free.
 impl<T, S: Expressive<T>> Operation<T> for S {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::column::core::Column;
+
+    #[test]
+    fn test_is_null() {
+        let deleted_at = Column::<String>::new("deleted_at");
+        let expr = deleted_at.is_null();
+        assert_eq!(expr.preview(), "deleted_at IS NULL");
+    }
+
+    #[test]
+    fn test_is_not_null() {
+        let email = Column::<String>::new("email");
+        let expr = email.is_not_null();
+        assert_eq!(expr.preview(), "email IS NOT NULL");
+    }
+}

--- a/vantage-table/tests/record_methods.rs
+++ b/vantage-table/tests/record_methods.rs
@@ -195,6 +195,89 @@ async fn test_bulk_record_processing() {
 }
 
 #[tokio::test]
+async fn test_active_entity_delete() {
+    let mock = MockTableSource::new().with_data(
+        "users",
+        vec![
+            serde_json::json!({"id": "1", "name": "Alice", "email": "alice@test.com", "active": true}),
+            serde_json::json!({"id": "2", "name": "Bob", "email": "bob@test.com", "active": true}),
+        ],
+    );
+
+    let table =
+        Table::<MockTableSource, EmptyEntity>::new("users", mock.await).into_entity::<TestUser>();
+
+    let alice = table.get_entity(&"1".to_string()).await.unwrap().unwrap();
+    alice.delete().await.unwrap();
+
+    let missing = table.get_entity(&"1".to_string()).await.unwrap();
+    assert!(missing.is_none());
+
+    // Other rows untouched.
+    let bob = table.get_entity(&"2".to_string()).await.unwrap();
+    assert!(bob.is_some());
+}
+
+#[tokio::test]
+async fn test_active_entity_reload() {
+    let mock = MockTableSource::new().with_data(
+        "users",
+        vec![
+            serde_json::json!({"id": "1", "name": "Alice", "email": "alice@test.com", "active": false}),
+        ],
+    );
+
+    let table =
+        Table::<MockTableSource, EmptyEntity>::new("users", mock.await).into_entity::<TestUser>();
+
+    let mut alice = table.get_entity(&"1".to_string()).await.unwrap().unwrap();
+    assert!(!alice.active);
+
+    // Simulate an external write
+    table
+        .replace(
+            &"1".to_string(),
+            &TestUser {
+                id: Some("1".to_string()),
+                name: "Alice".into(),
+                email: "alice@test.com".into(),
+                active: true,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Our in-memory copy is stale
+    assert!(!alice.active);
+
+    alice.reload().await.unwrap();
+    assert!(alice.active);
+}
+
+#[tokio::test]
+async fn test_active_entity_reload_missing() {
+    let mock = MockTableSource::new().with_data(
+        "users",
+        vec![
+            serde_json::json!({"id": "1", "name": "Alice", "email": "alice@test.com", "active": false}),
+        ],
+    );
+
+    let table =
+        Table::<MockTableSource, EmptyEntity>::new("users", mock.await).into_entity::<TestUser>();
+
+    let mut alice = table.get_entity(&"1".to_string()).await.unwrap().unwrap();
+
+    // Delete via the table — the ActiveEntity's id is now orphaned.
+    WritableValueSet::delete(&table, &"1".to_string())
+        .await
+        .unwrap();
+
+    let result = alice.reload().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
 async fn test_empty_table_record_methods() {
     let mock = MockTableSource::new().with_data("users", vec![]);
     let table =


### PR DESCRIPTION
Four small gaps from FINAL_TODO.md:

- `Operation::is_null()` / `is_not_null()` on the generic trait — SQL
  backends render `{} IS NULL` / `{} IS NOT NULL`. Mongo's
  `MongoOperation` gets the BSON form (`{ field: null }` and
  `{ field: { $ne: null } }`).
- `ActiveEntity::reload()` — refetches by the stored id; errors if the
  row was deleted externally.
- `ActiveEntity::delete()` — deletes by the stored id.

oh thats actually 3...

Also ticks the `get -> Result<Option<E>>` item in TODO.md (was stranded
on the merged branch for #202).

Version bumps (patch only): `vantage-dataset` 0.4.2, `vantage-table`
0.4.3, `vantage-mongodb` 0.4.3.