### PR TITLE
bump versions for cbor swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bson",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ciborium",
  "csv",

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.4.2"
+version = "0.4.3"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"
@@ -18,7 +18,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
-vantage-table = { version = "0.4.2", path = "../vantage-table" }
+vantage-table = { version = "0.4.4", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
 
 [dev-dependencies]

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"
@@ -10,7 +10,7 @@ repository = "https://github.com/romaninsh/vantage"
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
-vantage-table = { version = "0.4.3", path = "../vantage-table" }
+vantage-table = { version = "0.4.4", path = "../vantage-table" }
 vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
 
 bson = "2"

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-types/Cargo.toml
+++ b/vantage-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-types"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Type system and Record types for the Vantage data framework"


### PR DESCRIPTION
Patch bumps for the four crates touched by the AnyTable CBOR swap (#204), and tightens the inter-crate `vantage-table` pin in `vantage-csv` / `vantage-mongodb` so users on the new patch versions can't pull a mismatched mid-stream `vantage-table`.

- `vantage-types`: 0.4.0 → 0.4.1 (additive: `TerminalRender for ciborium::Value`, blanket `From<ciborium::Value>` impls)
- `vantage-table`: 0.4.3 → 0.4.4 (breaking: `AnyTable` now carries `ciborium::Value` instead of `serde_json::Value`)
- `vantage-csv`: 0.4.2 → 0.4.3 (additive: `From/Into<CborValue>` on `AnyCsvType`; pins `vantage-table = "0.4.4"`)
- `vantage-mongodb`: 0.4.3 → 0.4.4 (additive: `From/Into<CborValue>` on `AnyMongoType`; pins `vantage-table = "0.4.4"`)

Skipped CHANGELOG.md — it hasn't been touched for any 0.4.x patch so a one-off entry would feel out of place. Worth picking up as a separate cleanup if you want to revive it.