### PR TITLE
add per-crate CHANGELOG.md

### DIFF
--- a/surreal-client/CHANGELOG.md
+++ b/surreal-client/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.4.0 — 2026-04-16
+
+- Initial 0.4 release. Standalone SurrealDB client over WebSocket with CBOR transport — used by `vantage-surrealdb` and usable on its own.

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.1 — 2026-04-19
+
+- Pinned dependency versions for crates.io publishing.

--- a/vantage-api-pool/CHANGELOG.md
+++ b/vantage-api-pool/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.1 — 2026-04-19
+
+- Pinned dependency versions for crates.io publishing.

--- a/vantage-cli-util/CHANGELOG.md
+++ b/vantage-cli-util/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.4.0 — 2026-04-16
+
+- Initial 0.4 release. Generic CLI helpers (`render_records`, `handle_commands`) for driving any vantage backend through a uniform command set.

--- a/vantage-core/CHANGELOG.md
+++ b/vantage-core/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.4.0 — 2026-04-16
+
+- Initial 0.4 release. `VantageError` with structured context, `Result` alias, and the unified error-handling foundation used by every other vantage crate.

--- a/vantage-csv/CHANGELOG.md
+++ b/vantage-csv/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.4.3 — 2026-04-25
+
+- `From`/`Into<ciborium::Value>` impls on `AnyCsvType` so CSV tables can be wrapped via `AnyTable::from_table`. Round-trips via `serde_json::Value` (same lossy bits as the existing JSON bridge — binary, NaN, etc.).
+- Pins `vantage-table = "0.4.4"` to keep the pair in lock-step.

--- a/vantage-dataset/CHANGELOG.md
+++ b/vantage-dataset/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.4.2 — 2026-04-19
+
+- `Operation::is_null()` / `is_not_null()` on the generic trait — SQL backends render `{} IS NULL` / `{} IS NOT NULL`; Mongo gets `{ field: null }` / `{ field: { $ne: null } }`.
+- `ActiveEntity::reload()` — refetches by stored id; errors if the row was deleted externally.
+- `ActiveEntity::delete()` — deletes by stored id.
+- `ReadableDataSet::get(id)` and `ReadableValueSet::get_value` now return `Result<Option<E>>` / `Result<Option<Record>>` instead of `Err("no row found")` on miss.

--- a/vantage-expressions/CHANGELOG.md
+++ b/vantage-expressions/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.4.2 — 2026-04-17
+
+- Patch bump in the 0.4 release line.

--- a/vantage-mongodb/CHANGELOG.md
+++ b/vantage-mongodb/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.4.4 — 2026-04-25
+
+- `From`/`Into<ciborium::Value>` impls on `AnyMongoType` so MongoDB tables can be wrapped via `AnyTable::from_table`. Round-trips via `serde_json::Value` (Bson and ciborium are both serde-friendly; same lossy bits as the existing JSON bridge).
+- Pins `vantage-table = "0.4.4"` to keep the pair in lock-step.
+
+## 0.4.3 — 2026-04-19
+
+- Reference traversal now bridges `ObjectId` and `String` id-field boundaries via `related_in_condition`'s dual push.
+- `impl From<MongoId> for AnyMongoType` so `c.id().eq(MongoId::parse(...))` dispatches to the right BSON type.

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.4.3 — 2026-04-19
+
+- SQL `is_null` / `is_not_null` operations rendered as `{} IS NULL` / `{} IS NOT NULL` for sqlite, postgres, mysql.
+- Doc fixes in `docs4`.

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.4.2 — 2026-04-19
+
+- Patch bump in the 0.4 release line.

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.4.4 — 2026-04-25
+
+- **Breaking**: `AnyTable` now carries `ciborium::Value` instead of `serde_json::Value`. Backends already store CBOR (surreal/sql) or BSON (mongo) internally; this drops the last lossy JSON hop at the type-erased boundary.
+- Renames the internal `JsonAdapter` to `CborAdapter`. Constructor signatures (`AnyTable::new` / `AnyTable::from_table`) unchanged at call sites.
+- New `CborValueExt` trait re-exported from `prelude` — adds `as_str()`, `as_i64()`, `as_u64()`, `as_f64()`, `get(&str)`, `get_mut(&str)` so consumer code stays one-liner-shaped on top of `Record<ciborium::Value>`.
+- Migration: AnyTable consumers that matched on JSON variants need to either match on `ciborium::Value` arms or call `serde_json::to_value(&record)?` at the consumer edge.

--- a/vantage-types/CHANGELOG.md
+++ b/vantage-types/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.4.1 — 2026-04-25
+
+- `TerminalRender` impl for `ciborium::Value` so generic CLI/UI rendering keeps working when records flow through `AnyTable`.
+- Blanket `From<ciborium::Value> for Record<ciborium::Value>` (and reverse), plus serde-blanket `IntoRecord<CborValue>` / `TryFromRecord<CborValue>` so any `Serialize + DeserializeOwned` entity auto-implements `Entity<CborValue>`.


### PR DESCRIPTION
crates.io has no native changelog, so each crate gets its own minimal `CHANGELOG.md` with just the most recent version. The repo `CHANGELOG.md` at workspace root is left alone (stale at 0.2.0; can be revived separately, perhaps wired up to `git-cliff` since `cliff.toml` is already there).

Coverage: all 13 published crates — `vantage-core`, `vantage-types`, `vantage-expressions`, `vantage-dataset`, `vantage-table`, `vantage-csv`, `vantage-mongodb`, `vantage-sql`, `vantage-surrealdb`, `vantage-cli-util`, `vantage-api-client`, `vantage-api-pool`, `surreal-client`. Each holds one entry for the version currently on crates.io.

Format is intentionally tiny:

```
# Changelog

## 0.4.X — YYYY-MM-DD

- one-line summary
```

Future bumps just prepend a new section above the previous one.