### PR TITLE
add RedbCache + JSONPlaceholder demo with condition pushdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,7 +3859,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-live"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4003,11 +4003,14 @@ dependencies = [
  "futures-util",
  "indexmap",
  "pretty_assertions",
+ "redb",
+ "serde_json",
  "tempfile",
  "tokio",
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "vantage-api-client",
  "vantage-core",
  "vantage-dataset",
  "vantage-expressions",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.2 — 2026-04-26
+
+- New `RestApi::builder(base_url)` builder for picking response shape and pagination conventions. The legacy `RestApi::new(url)` still works and matches the 0.1.x default (`{ "data": [...] }` wrapper).
+- New `ResponseShape` enum: `BareArray` (most public APIs), `Wrapped { array_key }` (legacy), `WrappedByTableName` (DummyJSON-style).
+- New `PaginationParams` with `page_limit` (1-based page index, the JSON Server / JSONPlaceholder convention `_page` / `_limit`) and `skip_limit` (0-based item offset, DummyJSON convention `skip` / `limit`) constructors. `RestApi` now appends pagination to the URL automatically when a `Pagination` is set on the wrapping `Table`.
+- New `eq_condition(field, value)` helper for building eq-conditions on `Table<RestApi, _>`. Required because Rust's orphan rule blocks `Expressive<serde_json::Value>` impls for primitive types in this crate. Conditions added via `add_condition` are pushed into the URL as query params (`?field=value`) on `list_values` — multiple conditions AND together. Non-eq conditions are silently skipped for now; gt/lt/like/etc. would need their own translators.
+- Adds `urlencoding` as a runtime dep so query params get encoded properly.
+
 ## 0.1.1 — 2026-04-19
 
 - Pinned dependency versions for crates.io publishing.

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST API backends"
@@ -12,6 +12,7 @@ indexmap = { version = "2", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+urlencoding = "2.1"
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }

--- a/vantage-api-client/src/api.rs
+++ b/vantage-api-client/src/api.rs
@@ -1,13 +1,83 @@
 use indexmap::IndexMap;
+use serde_json::Value;
 use vantage_core::error;
 use vantage_dataset::traits::Result;
+use vantage_expressions::Expression;
+use vantage_table::pagination::Pagination;
 use vantage_types::Record;
+
+/// How the API wraps its row array in the response body.
+///
+/// Most public APIs use one of these three shapes; the legacy vantage
+/// "wrapped under `data`" shape is `Wrapped { array_key: "data" }`.
+#[derive(Clone, Debug)]
+pub enum ResponseShape {
+    /// Body is a bare JSON array of records.
+    /// Example: `GET /users` → `[ {…}, {…} ]`. JSONPlaceholder, GitHub, etc.
+    BareArray,
+
+    /// Body is a JSON object with the array under a fixed key.
+    /// Example: `GET /users` → `{ "data": [ … ] }`.
+    Wrapped { array_key: String },
+
+    /// Body is a JSON object with the array under a key matching the
+    /// table name. Example (DummyJSON):
+    /// `GET /products` → `{ "products": [ … ], "total": …, "skip": …, "limit": … }`.
+    WrappedByTableName,
+}
+
+impl Default for ResponseShape {
+    /// Default matches the legacy 0.1.x shape: `{ "data": [...] }`.
+    fn default() -> Self {
+        ResponseShape::Wrapped {
+            array_key: "data".to_string(),
+        }
+    }
+}
+
+/// Names of the page/limit query parameters the API expects.
+///
+/// Defaults to `("_page", "_limit")` — the JSON Server convention used
+/// by JSONPlaceholder. DummyJSON uses `("skip", "limit")` (in items not
+/// pages). Customise via `RestApiBuilder::pagination_params`.
+#[derive(Clone, Debug)]
+pub struct PaginationParams {
+    pub page: String,
+    pub limit: String,
+    /// If true, the page parameter is sent as a *0-based item offset*
+    /// (`skip`) instead of a 1-based page index. DummyJSON-style.
+    pub skip_based: bool,
+}
+
+impl PaginationParams {
+    pub fn page_limit(page: impl Into<String>, limit: impl Into<String>) -> Self {
+        Self {
+            page: page.into(),
+            limit: limit.into(),
+            skip_based: false,
+        }
+    }
+
+    pub fn skip_limit(skip: impl Into<String>, limit: impl Into<String>) -> Self {
+        Self {
+            page: skip.into(),
+            limit: limit.into(),
+            skip_based: true,
+        }
+    }
+}
+
+impl Default for PaginationParams {
+    fn default() -> Self {
+        Self::page_limit("_page", "_limit")
+    }
+}
 
 /// REST API backend for Vantage — reads data from HTTP JSON endpoints.
 ///
 /// Each table maps to an API endpoint: `{base_url}/{table_name}`.
-/// The API returns paginated JSON: `{"data": [...], "pagination": {...}}`.
-/// Uses `serde_json::Value` as the native value type — no custom type system needed.
+/// Response shape is configurable via [`RestApi::builder`]; see
+/// [`ResponseShape`] for the supported variants.
 ///
 /// Currently read-only — write operations return errors.
 #[derive(Clone, Debug)]
@@ -15,39 +85,105 @@ pub struct RestApi {
     base_url: String,
     client: reqwest::Client,
     pub(crate) auth_header: Option<String>,
+    response_shape: ResponseShape,
+    pagination: PaginationParams,
 }
 
 impl RestApi {
-    /// Create a new REST API data source pointing at `base_url`.
+    /// Create a new REST API pointing at `base_url`. Uses the legacy
+    /// default response shape (`{ "data": [...] }`). For other shapes
+    /// (bare array, wrapped-by-table-name) use [`RestApi::builder`].
     pub fn new(base_url: impl Into<String>) -> Self {
-        Self {
-            base_url: base_url.into(),
-            client: reqwest::Client::new(),
-            auth_header: None,
-        }
+        RestApi::builder(base_url).build()
+    }
+
+    /// Start configuring a [`RestApi`] via the builder.
+    pub fn builder(base_url: impl Into<String>) -> RestApiBuilder {
+        RestApiBuilder::new(base_url.into())
     }
 
     /// Set the Authorization header value (e.g. "Bearer `<token>`").
+    /// Provided for backwards compatibility — prefer
+    /// `RestApi::builder(...).auth(...)`.
     pub fn with_auth(mut self, auth: impl Into<String>) -> Self {
         self.auth_header = Some(auth.into());
         self
     }
 
-    /// Build the endpoint URL for a given table name.
+    /// Build the endpoint URL for a given table name. No query string.
     fn endpoint_url(&self, table_name: &str) -> String {
         format!("{}/{}", self.base_url, table_name)
     }
 
+    /// Build the combined query-string from pagination + conditions.
+    /// Conditions that don't peel cleanly into eq pairs are skipped (we
+    /// could fail loudly here, but silently ignoring matches the v1
+    /// "best effort" stance — the caller still gets correct data, just
+    /// with less efficient filtering).
+    fn build_query_string<'a>(
+        &self,
+        pagination: Option<&Pagination>,
+        conditions: impl IntoIterator<Item = &'a Expression<Value>>,
+    ) -> String {
+        let mut params: Vec<(String, String)> = Vec::new();
+
+        // Pagination first — matches the order users see in the URL bar.
+        if let Some(p) = pagination {
+            let page_value = if self.pagination.skip_based {
+                p.skip().to_string()
+            } else {
+                p.get_page().to_string()
+            };
+            params.push((self.pagination.page.clone(), page_value));
+            params.push((self.pagination.limit.clone(), p.limit().to_string()));
+        }
+
+        // Conditions: each `eq` becomes `?field=value`. Multiple
+        // conditions AND together (JSON Server semantics).
+        for cond in conditions {
+            if let Some((field, value)) = crate::condition_to_query_param(cond) {
+                params.push((field, value));
+            }
+        }
+
+        if params.is_empty() {
+            return String::new();
+        }
+        let mut s = String::from("?");
+        for (i, (k, v)) in params.iter().enumerate() {
+            if i > 0 {
+                s.push('&');
+            }
+            // Minimal URL encoding — we encode `&` and `=` and spaces
+            // because those break the query format. Anything else
+            // passes through; the JSON Server convention is permissive.
+            s.push_str(&urlencode(k));
+            s.push('=');
+            s.push_str(&urlencode(v));
+        }
+        s
+    }
+
     /// Fetch data from the API endpoint and return parsed records.
     ///
-    /// The `id_field` parameter determines which JSON field to use as the record ID.
-    /// If None, row indices are used.
-    pub(crate) async fn fetch_records(
+    /// `id_field` selects which JSON field is treated as the record ID;
+    /// if `None`, row indices are used. `pagination` and `conditions`
+    /// are pushed into the URL query string — eq-conditions become
+    /// `?field=value`. Conditions that can't be peeled into a simple
+    /// eq are silently skipped (caller-side filtering still applies if
+    /// needed).
+    pub(crate) async fn fetch_records<'a>(
         &self,
         table_name: &str,
         id_field: Option<&str>,
+        pagination: Option<&Pagination>,
+        conditions: impl IntoIterator<Item = &'a Expression<Value>>,
     ) -> Result<IndexMap<String, Record<serde_json::Value>>> {
-        let url = self.endpoint_url(table_name);
+        let url = format!(
+            "{}{}",
+            self.endpoint_url(table_name),
+            self.build_query_string(pagination, conditions)
+        );
 
         let mut request = self.client.get(&url);
         if let Some(ref auth) = self.auth_header {
@@ -72,12 +208,9 @@ impl RestApi {
             .await
             .map_err(|e| error!("Failed to parse API response as JSON", detail = e))?;
 
-        let data = body["data"]
-            .as_array()
-            .ok_or_else(|| error!("API response missing 'data' array", url = url))?;
+        let data = self.extract_array(&body, table_name)?;
 
         let mut records = IndexMap::new();
-
         for (row_idx, item) in data.iter().enumerate() {
             let obj = item
                 .as_object()
@@ -100,5 +233,103 @@ impl RestApi {
         }
 
         Ok(records)
+    }
+}
+
+fn urlencode(s: &str) -> String {
+    urlencoding::encode(s).into_owned()
+}
+
+impl RestApi {
+    /// Pull the row array out of the response body, according to the
+    /// configured `ResponseShape`.
+    fn extract_array<'a>(
+        &self,
+        body: &'a serde_json::Value,
+        table_name: &str,
+    ) -> Result<&'a Vec<serde_json::Value>> {
+        match &self.response_shape {
+            ResponseShape::BareArray => body.as_array().ok_or_else(|| {
+                error!("Expected response body to be a JSON array (BareArray shape)")
+            }),
+            ResponseShape::Wrapped { array_key } => body[array_key].as_array().ok_or_else(|| {
+                error!(
+                    "Response missing array under wrapper key",
+                    array_key = array_key
+                )
+            }),
+            ResponseShape::WrappedByTableName => body[table_name].as_array().ok_or_else(|| {
+                error!(
+                    "Response missing array under table-name key",
+                    table_name = table_name
+                )
+            }),
+        }
+    }
+}
+
+/// Builder for [`RestApi`]. Lets callers pick a [`ResponseShape`] and
+/// override the pagination parameter names.
+///
+/// ```no_run
+/// use vantage_api_client::{RestApi, ResponseShape, PaginationParams};
+///
+/// // JSONPlaceholder: bare arrays, JSON-Server pagination conventions.
+/// let api = RestApi::builder("https://jsonplaceholder.typicode.com")
+///     .response_shape(ResponseShape::BareArray)
+///     .build();
+///
+/// // DummyJSON: wrapped-by-table-name, skip-based pagination.
+/// let api = RestApi::builder("https://dummyjson.com")
+///     .response_shape(ResponseShape::WrappedByTableName)
+///     .pagination_params(PaginationParams::skip_limit("skip", "limit"))
+///     .build();
+/// ```
+#[derive(Clone, Debug)]
+pub struct RestApiBuilder {
+    base_url: String,
+    auth_header: Option<String>,
+    response_shape: ResponseShape,
+    pagination: PaginationParams,
+}
+
+impl RestApiBuilder {
+    fn new(base_url: String) -> Self {
+        Self {
+            base_url,
+            auth_header: None,
+            response_shape: ResponseShape::default(),
+            pagination: PaginationParams::default(),
+        }
+    }
+
+    /// Set the Authorization header value (e.g. "Bearer `<token>`").
+    pub fn auth(mut self, auth: impl Into<String>) -> Self {
+        self.auth_header = Some(auth.into());
+        self
+    }
+
+    /// Choose how the API wraps its row array. Defaults to
+    /// `Wrapped { array_key: "data" }` for backwards compat.
+    pub fn response_shape(mut self, shape: ResponseShape) -> Self {
+        self.response_shape = shape;
+        self
+    }
+
+    /// Override the page/limit query parameter names. Default is
+    /// `("_page", "_limit")` (JSON Server convention).
+    pub fn pagination_params(mut self, pagination: PaginationParams) -> Self {
+        self.pagination = pagination;
+        self
+    }
+
+    pub fn build(self) -> RestApi {
+        RestApi {
+            base_url: self.base_url,
+            client: reqwest::Client::new(),
+            auth_header: self.auth_header,
+            response_shape: self.response_shape,
+            pagination: self.pagination,
+        }
     }
 }

--- a/vantage-api-client/src/lib.rs
+++ b/vantage-api-client/src/lib.rs
@@ -1,4 +1,7 @@
 mod api;
+mod operation;
 mod table_source;
 
-pub use api::RestApi;
+pub use api::{PaginationParams, ResponseShape, RestApi, RestApiBuilder};
+pub(crate) use operation::condition_to_query_param;
+pub use operation::eq_condition;

--- a/vantage-api-client/src/operation.rs
+++ b/vantage-api-client/src/operation.rs
@@ -1,0 +1,132 @@
+//! Condition helpers — build eq-conditions for `Table<RestApi, _>` and
+//! peel them apart at the `list_values` boundary into URL query params.
+//!
+//! Why not the standard `Operation::eq` from `vantage-table`? That trait
+//! is blanket-implemented for all `Expressive<T>`, but we can't provide
+//! the *value-side* `Expressive<serde_json::Value>` impls for primitive
+//! types — orphan rule (both `Expressive` and `serde_json::Value` are
+//! foreign to this crate). A future refactor wrapping the value type in
+//! a local newtype would unlock the full `Operation` surface; for now
+//! we provide an `eq_condition(field, value)` free function that builds
+//! the same expression shape directly.
+
+use serde_json::Value;
+use vantage_expressions::Expression;
+use vantage_expressions::traits::expressive::ExpressiveEnum;
+
+/// Build an `eq` condition `field = value` for use with `Table<RestApi,
+/// _>::add_condition`. Produces the same shape as
+/// `vantage_table::operation::Operation::eq` would for backends that
+/// support it.
+///
+/// ```ignore
+/// use vantage_api_client::eq_condition;
+/// use serde_json::json;
+///
+/// let mut comments = Table::<RestApi, EmptyEntity>::new("comments", api);
+/// comments.add_condition(eq_condition("postId", json!(1)));
+/// ```
+pub fn eq_condition(field: &str, value: Value) -> Expression<Value> {
+    Expression::new(
+        "{} = {}",
+        vec![
+            // Field side: bare identifier expression.
+            ExpressiveEnum::Nested(Expression::new(field.to_string(), vec![])),
+            // Value side: scalar wrapped in a `{}` expression so it
+            // matches the layout `Operation::eq` produces.
+            ExpressiveEnum::Nested(Expression::new("{}", vec![ExpressiveEnum::Scalar(value)])),
+        ],
+    )
+}
+
+/// Try to peel an `eq`-shaped condition into `(field_name, value_string)`
+/// suitable for a URL query parameter.
+///
+/// Recognised shape — same one `eq_condition` (and
+/// `vantage_table::Operation::eq` for compatible value types) produces:
+///
+/// ```text
+/// Expression {
+///     template: "{} = {}",
+///     parameters: [
+///         Nested(Expression { template: <field_name>, parameters: [] }),
+///         Nested(Expression { template: "{}", parameters: [Scalar(value)] }),
+///     ],
+/// }
+/// ```
+///
+/// Returns `None` for anything that doesn't match — non-eq operators,
+/// nested column-on-column comparisons, deferred values, etc. The caller
+/// decides what to do (skip silently is the v1 stance).
+pub(crate) fn condition_to_query_param(cond: &Expression<Value>) -> Option<(String, String)> {
+    if cond.template != "{} = {}" || cond.parameters.len() != 2 {
+        return None;
+    }
+
+    let field = match &cond.parameters[0] {
+        ExpressiveEnum::Nested(e) if e.parameters.is_empty() => e.template.clone(),
+        _ => return None,
+    };
+
+    let value = match &cond.parameters[1] {
+        ExpressiveEnum::Nested(e) if e.template == "{}" && e.parameters.len() == 1 => {
+            match &e.parameters[0] {
+                ExpressiveEnum::Scalar(v) => json_to_query_string(v)?,
+                _ => return None,
+            }
+        }
+        ExpressiveEnum::Scalar(v) => json_to_query_string(v)?,
+        _ => return None,
+    };
+
+    Some((field, value))
+}
+
+fn json_to_query_string(v: &Value) -> Option<String> {
+    match v {
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::String(s) => Some(s.clone()),
+        Value::Null | Value::Array(_) | Value::Object(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn eq_condition_round_trips_int() {
+        let cond = eq_condition("userId", json!(1));
+        let pair = condition_to_query_param(&cond).expect("eq parses");
+        assert_eq!(pair, ("userId".into(), "1".into()));
+    }
+
+    #[test]
+    fn eq_condition_round_trips_string() {
+        let cond = eq_condition("name", json!("Alice"));
+        let pair = condition_to_query_param(&cond).expect("eq parses");
+        assert_eq!(pair, ("name".into(), "Alice".into()));
+    }
+
+    #[test]
+    fn eq_condition_round_trips_bool() {
+        let cond = eq_condition("completed", json!(true));
+        let pair = condition_to_query_param(&cond).expect("eq parses");
+        assert_eq!(pair, ("completed".into(), "true".into()));
+    }
+
+    #[test]
+    fn raw_expression_with_unknown_template_returns_none() {
+        let cond = Expression::<Value>::new("CUSTOM SQL", vec![]);
+        assert!(condition_to_query_param(&cond).is_none());
+    }
+
+    #[test]
+    fn array_value_returns_none() {
+        let cond = eq_condition("tags", json!(["a", "b"]));
+        // Arrays don't map to a single query-param string.
+        assert!(condition_to_query_param(&cond).is_none());
+    }
+}

--- a/vantage-api-client/src/table_source.rs
+++ b/vantage-api-client/src/table_source.rs
@@ -102,8 +102,13 @@ impl TableSource for RestApi {
         E: Entity<Self::Value>,
         Self: Sized,
     {
-        self.fetch_records(table.table_name(), id_field_name(table).as_deref())
-            .await
+        self.fetch_records(
+            table.table_name(),
+            id_field_name(table).as_deref(),
+            table.pagination(),
+            table.conditions(),
+        )
+        .await
     }
 
     async fn get_table_value<E>(
@@ -116,7 +121,12 @@ impl TableSource for RestApi {
         Self: Sized,
     {
         let records = self
-            .fetch_records(table.table_name(), id_field_name(table).as_deref())
+            .fetch_records(
+                table.table_name(),
+                id_field_name(table).as_deref(),
+                table.pagination(),
+                table.conditions(),
+            )
             .await?;
         Ok(records.get(id).cloned())
     }
@@ -130,7 +140,12 @@ impl TableSource for RestApi {
         Self: Sized,
     {
         let records = self
-            .fetch_records(table.table_name(), id_field_name(table).as_deref())
+            .fetch_records(
+                table.table_name(),
+                id_field_name(table).as_deref(),
+                table.pagination(),
+                table.conditions(),
+            )
             .await?;
         Ok(records.into_iter().next())
     }
@@ -141,7 +156,12 @@ impl TableSource for RestApi {
         Self: Sized,
     {
         let records = self
-            .fetch_records(table.table_name(), id_field_name(table).as_deref())
+            .fetch_records(
+                table.table_name(),
+                id_field_name(table).as_deref(),
+                table.pagination(),
+                table.conditions(),
+            )
             .await?;
         Ok(records.len() as i64)
     }

--- a/vantage-api-client/tests/builder.rs
+++ b/vantage-api-client/tests/builder.rs
@@ -1,0 +1,68 @@
+//! Unit tests for `RestApi::builder`. No network — verifies that the
+//! builder records what was set, and that the `Default` shape stays
+//! backwards-compatible with the legacy `{ "data": [...] }` format.
+
+use vantage_api_client::{PaginationParams, ResponseShape, RestApi};
+
+#[test]
+fn default_response_shape_is_data_wrapper() {
+    let _api = RestApi::new("https://example.com");
+    // Default shape is `Wrapped { array_key: "data" }` — no public
+    // accessor, so behaviour is verified by the legacy doc / fixture
+    // tests below.
+    let shape = ResponseShape::default();
+    match shape {
+        ResponseShape::Wrapped { array_key } => assert_eq!(array_key, "data"),
+        _ => panic!("default shape should be Wrapped {{ array_key: \"data\" }}"),
+    }
+}
+
+#[test]
+fn default_pagination_params_match_jsonserver() {
+    let p = PaginationParams::default();
+    assert_eq!(p.page, "_page");
+    assert_eq!(p.limit, "_limit");
+    assert!(!p.skip_based);
+}
+
+#[test]
+fn pagination_params_skip_limit_constructor() {
+    let p = PaginationParams::skip_limit("skip", "limit");
+    assert_eq!(p.page, "skip");
+    assert_eq!(p.limit, "limit");
+    assert!(p.skip_based);
+}
+
+#[test]
+fn pagination_params_page_limit_constructor() {
+    let p = PaginationParams::page_limit("page", "size");
+    assert_eq!(p.page, "page");
+    assert_eq!(p.limit, "size");
+    assert!(!p.skip_based);
+}
+
+#[test]
+fn builder_compiles_with_all_options() {
+    // Smoke test — the builder threads through without panic.
+    let _api = RestApi::builder("https://api.example.com")
+        .auth("Bearer xyz")
+        .response_shape(ResponseShape::BareArray)
+        .pagination_params(PaginationParams::skip_limit("skip", "limit"))
+        .build();
+}
+
+#[test]
+fn builder_response_shape_variants() {
+    // Each variant constructs without trouble.
+    let _bare = RestApi::builder("https://x")
+        .response_shape(ResponseShape::BareArray)
+        .build();
+    let _wrapped = RestApi::builder("https://x")
+        .response_shape(ResponseShape::Wrapped {
+            array_key: "items".into(),
+        })
+        .build();
+    let _by_table = RestApi::builder("https://x")
+        .response_shape(ResponseShape::WrappedByTableName)
+        .build();
+}

--- a/vantage-live/CHANGELOG.md
+++ b/vantage-live/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.1 — 2026-04-26
+
+- New `RedbCache::open(folder)` cache backend. Persists cached rows on disk so cache state survives process restarts. One redb file inside the folder, one redb table per `cache_key` (namespaced `__vlive__{cache_key}`) so the hot `invalidate_prefix(cache_key)` path is just a `delete_table` call — O(1)-ish, no scan. Sub-prefix invalidation falls back to scan-and-delete inside the table.
+- `examples/live_demo.rs` reworked into two master modes: `local` (redb-backed master, full read/write/event cycle, same as 0.4.0) and `api <users|posts|comments|…>` (read-only JSONPlaceholder master, demonstrates the cache benefit dramatically — first call ~300ms over the network, second call sub-millisecond from the cache). Pagination is pushed into the API URL via `--page` / `--limit` flags, each page caches under its own key. `--filter field=value` adds an eq-condition that becomes a URL query param and folds into the cache_key — different filters cache under different keys, matching the caller-owned-cache-key contract.
+- `--cache <PATH>` now uses `RedbCache` for real (was falling back to `MemCache` in 0.4.0). Combined with `api`, runs survive process restarts: `cargo run --example live_demo -- --cache ./vlive-cache api users list` — second invocation is microseconds-fast even though it's a fresh process.
+- `vantage-redb` and `vantage-api-client` moved from runtime deps to dev-deps — runtime never needed either (the `RedbCache` impl uses raw `redb` directly; vantage-api-client is only used by the demo).
+
 ## 0.4.0 — 2026-04-26
 
 First 0.4-line release. The crate was commented out of the workspace through the 0.4 type-system rewrite; this version replaces the 0.3 `RecordEdit` / `RwValueSet` design with a focused write-through cache around `AnyTable`. **Public API and storage shape are not compatible with 0.3** — there is no in-place upgrade.

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-live"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -16,12 +16,12 @@ vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
 vantage-table = { version = "0.4.6", path = "../vantage-table" }
-vantage-redb = { version = "0.4", path = "../vantage-redb" }
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }
 indexmap = "2"
 futures-util = "0.3"
+redb = "2.6"
 tokio = { version = "1", features = ["sync", "rt", "macros", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
@@ -32,6 +32,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tempfile = "3"
 pretty_assertions = "1"
 clap = { version = "4", features = ["derive"] }
+serde_json = "1"
+# vantage-redb only used in tests for the master fixture and the demo CLI.
+vantage-redb = { version = "0.4", path = "../vantage-redb" }
+vantage-api-client = { version = "0.1.2", path = "../vantage-api-client" }
 
 [[example]]
 name = "live_demo"

--- a/vantage-live/DESIGN.md
+++ b/vantage-live/DESIGN.md
@@ -142,7 +142,12 @@ pub struct CachedRows {
 
 Three impls in v1:
 
-- `RedbCache` — disk-backed, opens a redb file. Production fit.
+- `RedbCache` — disk-backed, takes a folder. Inside, one redb file
+  (`vlive.redb`) with one redb table per `cache_key`, namespaced
+  `__vlive__{cache_key}`. Sub-keys (`page_n`, `id/foo`) are `&str`
+  inside that table; values are CBOR-encoded `CachedRows`.
+  `invalidate_prefix(cache_key)` drops the whole redb table — O(1)-ish.
+  redb's exclusive file lock means one process per cache folder.
 - `MemCache` — `Arc<RwLock<HashMap<String, CachedRows>>>`. Fast, fine for
   tests and short-lived processes.
 - `NoCache` — every method is a no-op / returns `None`. Equivalent to

--- a/vantage-live/README.md
+++ b/vantage-live/README.md
@@ -16,48 +16,82 @@ For the architectural rationale see [`DESIGN.md`](./DESIGN.md).
 
 ## Demo
 
-The crate ships a self-contained CLI that exercises every feature
-without needing an external server. A redb file plays the role of "the
-remote database"; `LiveTable` wraps it.
+The crate ships a CLI with two master modes — `local` (redb file
+pretending to be a remote database, full read/write/event cycle) and
+`api` (JSONPlaceholder over the public internet, read-only but the
+cache benefit is dramatic).
+
+### Local mode — full cycle
 
 ```sh
-# 1. Populate the master with sample data.
-cargo run --example live_demo -- seed
+# Populate the master.
+cargo run --example live_demo -- local seed
 
-# 2. Read everything. Run twice — first is a miss, second a hit
-#    (you'll see ~80x speedup in the "wall time" line).
-cargo run --example live_demo -- list
-cargo run --example live_demo -- list
+# Read everything. Run twice — first is a miss, second a hit
+# (~80x speedup in the "wall time" line).
+cargo run --example live_demo -- local list
+cargo run --example live_demo -- local list
 
-# 3. Insert through the LiveTable. Cache is invalidated; next read
-#    repopulates from master.
-cargo run --example live_demo -- add d Donut 5
-cargo run --example live_demo -- list
+# Insert through the LiveTable. Cache is invalidated; next read
+# repopulates from master.
+cargo run --example live_demo -- local add d Donut 5
+cargo run --example live_demo -- local list
 
-# 4. Look up one row.
-cargo run --example live_demo -- get a
+# Push a fake "remote change" event and watch the cache invalidate.
+cargo run --example live_demo -- local event-then-list
+cargo run --example live_demo -- local event-then-list --id a   # targeted
 
-# 5. Push a fake "remote change" event and watch the cache invalidate.
-#    The demo prints first list (miss), second list (hit), then the
-#    event lands and the next list misses again.
-cargo run --example live_demo -- event-then-list
-
-# 6. Targeted event for one id.
-cargo run --example live_demo -- event-then-list --id a
-
-# 7. Show the LiveTable's wiring.
-cargo run --example live_demo -- info
-
-# 8. Watch every cache hit/miss and queue event in tracing output.
-cargo run --example live_demo -- --debug list
-RUST_LOG=vantage_live=trace cargo run --example live_demo -- --debug add e Eclair 9
+# Watch the dance in tracing output.
+cargo run --example live_demo -- --debug local list
+RUST_LOG=vantage_live=trace cargo run --example live_demo -- --debug local add e Eclair 9
 ```
 
-Useful flags:
+### API mode — JSONPlaceholder
 
-- `--master <PATH>` — point at a different redb file (default
+`https://jsonplaceholder.typicode.com` over the public internet. First
+fetch hits the network (50–500ms), subsequent fetches are
+microseconds-fast.
+
+```sh
+# Pick a resource. JSONPlaceholder offers users / posts / comments / albums / todos.
+cargo run --example live_demo -- api users list
+cargo run --example live_demo -- api posts list
+cargo run --example live_demo -- api comments list
+
+# Fetch by id.
+cargo run --example live_demo -- api users get 1
+
+# Pagination is pushed into the URL — each page caches under its own key.
+cargo run --example live_demo -- api users list --page 1 --limit 3
+cargo run --example live_demo -- api users list --page 2 --limit 3
+
+# Filter with --filter field=value (eq-condition). The filter becomes
+# part of the URL (?postId=1) and part of the cache_key, so different
+# filters cache under different slots — postId=1 and postId=2 don't
+# trample each other.
+cargo run --example live_demo -- api comments list --filter postId=1 --limit 5
+cargo run --example live_demo -- api todos    list --filter completed=true --limit 10
+```
+
+### Persistent disk cache
+
+A folder path becomes a `RedbCache` — cache survives process restarts.
+With API mode this gives a network-call → microseconds speedup *across
+runs*, which is the closest the demo gets to a real "mobile UI cached
+on disk" scenario.
+
+```sh
+cargo run --example live_demo -- --cache ./vlive-cache api users list   # cold network
+cargo run --example live_demo -- --cache ./vlive-cache api users list   # warm disk
+```
+
+### Flags
+
+- `--master <PATH>` — redb file for the `local` master (default
   `./demo-master.redb`).
-- `--cache mem|none|<PATH>` — pick a cache backend.
+- `--cache mem|none|<FOLDER>` — pick a cache backend. A folder path
+  becomes a `RedbCache`, persisting cache state across process
+  restarts.
 - `--debug` — emit tracing spans (cache hit/miss, queue events,
   invalidations).
 
@@ -92,8 +126,8 @@ keeps working.
 v1 covers: read-side cache keyed by caller-supplied `cache_key` plus
 page number, write-queue worker that doesn't block callers, sloppy
 invalidation on every write or live event, pluggable cache backends
-(`MemCache`, `NoCache`, `RedbCache` is on the roadmap), pluggable
-event source via `LiveStream`.
+(`MemCache`, `NoCache`, `RedbCache`), pluggable event source via
+`LiveStream`.
 
 Out of scope for v1 — see `DESIGN.md`:
 

--- a/vantage-live/examples/live_demo.rs
+++ b/vantage-live/examples/live_demo.rs
@@ -1,56 +1,63 @@
 //! `cargo run --example live_demo -- --help`
 //!
-//! A self-contained tour of vantage-live. Plays the role of a remote
-//! database with a redb file ("master.redb"), wraps it in a LiveTable
-//! with a configurable cache, and exposes commands that exercise every
-//! feature: cache hit/miss, pagination, write-through, custom write
-//! target, and live-stream invalidation.
+//! Self-contained tour of vantage-live with two master modes:
 //!
-//! No external server needed — redb-as-master stands in for "remote"
-//! storage, which happens to make the demo self-contained but does
-//! understate how much faster a hot cache is in real life. The
-//! "Wall time" column still shows the cache effect because the master
-//! deserialises CBOR rows on every read.
+//! - **`local`** — a redb file pretending to be a remote database.
+//!   Self-contained, supports the full read/write/event cycle.
+//! - **`api <users|posts|comments>`** — JSONPlaceholder
+//!   (https://jsonplaceholder.typicode.com), a free public REST API.
+//!   Read-only; the cache benefit is far more dramatic here because
+//!   network round-trips dwarf local CBOR decoding.
 //!
 //! Examples:
 //!
-//!   # Populate the master with sample data.
-//!   cargo run --example live_demo -- seed
+//!   # Local redb master, full cycle.
+//!   cargo run --example live_demo -- local seed
+//!   cargo run --example live_demo -- local list           # cache miss
+//!   cargo run --example live_demo -- local list           # cache hit
+//!   cargo run --example live_demo -- local add d Donut 5
+//!   cargo run --example live_demo -- local event-then-list
 //!
-//!   # Read everything twice — first is a miss, second a hit.
-//!   cargo run --example live_demo -- list
-//!   cargo run --example live_demo -- list
+//!   # JSONPlaceholder master. First call hits the network (~50–300ms);
+//!   # subsequent calls are microseconds-fast.
+//!   cargo run --example live_demo -- api users list
+//!   cargo run --example live_demo -- api users get 1
+//!   cargo run --example live_demo -- api posts list
 //!
-//!   # Insert through the LiveTable. Cache is invalidated; next read
-//!   # repopulates from master.
-//!   cargo run --example live_demo -- add d Delta 40
-//!   cargo run --example live_demo -- list
+//!   # Disk-persistent cache: state survives process restarts.
+//!   cargo run --example live_demo -- --cache ./vlive-cache api users list
+//!   cargo run --example live_demo -- --cache ./vlive-cache api users list
 //!
-//!   # Push a fake "remote change" event and watch the cache invalidate.
-//!   cargo run --example live_demo -- event-then-list
+//!   # Pagination: each page caches separately.
+//!   cargo run --example live_demo -- api users list --page 1 --limit 3
+//!   cargo run --example live_demo -- api users list --page 2 --limit 3
 //!
-//!   # Persist the cache to disk too — runs survive process restarts.
-//!   cargo run --example live_demo -- --cache ./demo-cache.redb list
+//!   # Tracing.
+//!   cargo run --example live_demo -- --debug api users list
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
 use clap::{Parser, Subcommand};
 
 use ciborium::Value as CborValue;
+use vantage_api_client::{ResponseShape, RestApi};
 use vantage_dataset::traits::{ReadableValueSet, WritableValueSet};
-use vantage_live::cache::{Cache, MemCache, NoCache};
+use vantage_live::cache::{Cache, MemCache, NoCache, RedbCache};
 use vantage_live::{LiveEvent, LiveTable, ManualLiveStream};
 use vantage_redb::{AnyRedbType, Redb};
 use vantage_table::any::AnyTable;
+use vantage_table::pagination::Pagination;
 use vantage_table::table::Table;
+use vantage_table::traits::table_like::TableLike;
 use vantage_types::{EmptyEntity, Record};
 
-const TABLE: &str = "products";
-const CACHE_KEY: &str = "products";
+const LOCAL_TABLE: &str = "products";
+const LOCAL_CACHE_KEY: &str = "products";
+const JSONPLACEHOLDER: &str = "https://jsonplaceholder.typicode.com";
 
-// ── ANSI colour helpers (no `colored` crate to keep deps tight) ──────────
+// ── ANSI colour helpers ──────────────────────────────────────────────────
 
 const RESET: &str = "\x1b[0m";
 const BOLD: &str = "\x1b[1m";
@@ -80,10 +87,21 @@ fn warn(text: &str) {
 fn timed<T>(name: &str, t: Instant, value: T) -> T {
     let elapsed = t.elapsed();
     let micros = elapsed.as_micros();
-    let colour = if micros < 200 { CYAN } else { MAGENTA };
+    let secs = micros / 1_000_000;
+    let millis = (micros / 1_000) % 1_000;
+    // Sub-ms cache hits show as 00.000 — still tells the story when the
+    // miss right above it is e.g. 00.446. Colour bands kick in once
+    // we're above 1ms.
+    let colour = if micros < 1_000 {
+        CYAN
+    } else if micros < 10_000 {
+        YELLOW
+    } else {
+        MAGENTA
+    };
     println!(
-        "  {}{}{}: {}{:>7}µs{}",
-        DIM, name, RESET, colour, micros, RESET
+        "  {}{}{}: {}{:>2}.{:03}{} s",
+        DIM, name, RESET, colour, secs, millis, RESET
     );
     value
 }
@@ -93,99 +111,362 @@ fn timed<T>(name: &str, t: Instant, value: T) -> T {
 #[derive(Parser, Debug)]
 #[command(name = "live_demo", about = "A guided tour of vantage-live.")]
 struct Cli {
-    /// Path to the redb file pretending to be a remote database.
+    /// Path to the redb file pretending to be a remote database
+    /// (used by the `local` subcommand).
     #[arg(long, default_value = "./demo-master.redb", global = true)]
     master: PathBuf,
 
-    /// Cache backend: `mem`, `none`, or a path to a redb file.
-    /// Path-based caching survives process restarts.
+    /// Cache backend: `mem`, `none`, or a path to a folder. The folder
+    /// becomes a RedbCache (one redb file inside, persisting across
+    /// process restarts).
     #[arg(long, default_value = "mem", global = true)]
     cache: String,
 
     /// Show vantage-live tracing spans (cache hit/miss, queue events,
-    /// invalidations). Set RUST_LOG to override.
+    /// invalidations). Set `RUST_LOG` to override the filter.
     #[arg(long, global = true)]
     debug: bool,
 
     #[command(subcommand)]
-    cmd: Cmd,
+    cmd: TopCmd,
 }
 
 #[derive(Subcommand, Debug)]
-enum Cmd {
-    /// Drop and repopulate the master with three sample rows. Run this
-    /// first; everything else assumes seeded data.
+enum TopCmd {
+    /// Local redb master — full read / write / live-event cycle.
+    Local {
+        #[command(subcommand)]
+        cmd: LocalCmd,
+    },
+    /// JSONPlaceholder API master — read-only, but the cache effect is
+    /// dramatic (network → microseconds).
+    Api {
+        /// Resource: `users`, `posts`, or `comments`. (Any
+        /// JSONPlaceholder collection works, but these three are the
+        /// ones the demo formats nicely.)
+        #[arg(value_parser = ["users", "posts", "comments", "albums", "todos"])]
+        resource: String,
+
+        #[command(subcommand)]
+        cmd: ApiCmd,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum LocalCmd {
+    /// Drop and repopulate the master with three sample rows.
     Seed,
-
-    /// List rows. Run twice to see the cache hit/miss timing difference.
+    /// List rows. Run twice to see the cache hit/miss timing.
     List,
-
     /// Look up one row by id.
     Get { id: String },
-
-    /// Insert a row through the LiveTable (queue → master → cache invalidated).
+    /// Insert a row through the LiveTable.
     Add {
         id: String,
         name: String,
         price: i64,
     },
-
     /// Delete a row through the LiveTable.
     Delete { id: String },
-
-    /// Push a manual `LiveEvent::Updated{id}` into a ManualLiveStream
-    /// attached to the LiveTable. Watch the cache get blown, then list
-    /// again to confirm the next read repopulates from master.
+    /// Push a manual `LiveEvent` and watch the cache invalidate.
     EventThenList { id: Option<String> },
-
-    /// Show the LiveTable's wiring (master, cache backend, queue capacity).
+    /// Show the LiveTable's wiring.
     Info,
 }
 
-// ── Master + cache construction ───────────────────────────────────────────
+#[derive(Subcommand, Debug)]
+enum ApiCmd {
+    /// List rows from the resource. Run twice for cache hit/miss
+    /// timing — the difference is on the order of 1000x.
+    List {
+        /// 1-based page number. JSONPlaceholder uses `?_page=N&_limit=M`.
+        #[arg(long)]
+        page: Option<i64>,
+        /// Items per page.
+        #[arg(long)]
+        limit: Option<i64>,
+        /// Filter rows by an `eq` condition, e.g. `--filter postId=1`
+        /// or `--filter completed=true`. The condition is pushed into
+        /// the URL query string by vantage-api-client and folded into
+        /// the cache key — different filters cache under different
+        /// keys, which is what the caller-owned-cache-key contract
+        /// requires.
+        #[arg(long, value_parser = parse_filter)]
+        filter: Option<(String, String)>,
+    },
+    /// Fetch one record by id (e.g. `1`).
+    Get { id: String },
+    /// Show the LiveTable's wiring for this API resource.
+    Info,
+}
 
-fn open_master(path: &PathBuf) -> AnyTable {
-    // Re-create the file if it doesn't exist so the demo is one-step.
+/// Parse a `field=value` flag value into a tuple. Used by `--filter`.
+fn parse_filter(s: &str) -> std::result::Result<(String, String), String> {
+    let (k, v) = s
+        .split_once('=')
+        .ok_or_else(|| format!("expected `field=value`, got `{s}`"))?;
+    if k.is_empty() {
+        return Err("empty field name".into());
+    }
+    Ok((k.to_string(), v.to_string()))
+}
+
+// ── Local master + cache ──────────────────────────────────────────────────
+
+fn open_local_master(path: &Path) -> AnyTable {
     let db = Redb::create(path).expect("open or create master redb");
-    let typed = Table::<Redb, EmptyEntity>::new(TABLE, db)
+    let typed = Table::<Redb, EmptyEntity>::new(LOCAL_TABLE, db)
         .with_id_column("id")
         .with_column_of::<String>("name")
         .with_column_of::<i64>("price");
     AnyTable::from_table(typed)
 }
 
-/// Build a typed Table directly — used by `seed` (which needs to write
-/// through the redb-typed path, not through the LiveTable wrapper).
-fn open_typed(path: &PathBuf) -> Table<Redb, EmptyEntity> {
+fn open_local_typed(path: &Path) -> Table<Redb, EmptyEntity> {
     let db = Redb::create(path).expect("open or create master redb");
-    Table::<Redb, EmptyEntity>::new(TABLE, db)
+    Table::<Redb, EmptyEntity>::new(LOCAL_TABLE, db)
         .with_id_column("id")
         .with_column_of::<String>("name")
         .with_column_of::<i64>("price")
 }
 
-fn build_cache(spec: &str) -> (Arc<dyn Cache>, &'static str) {
-    if spec == "mem" {
-        (Arc::new(MemCache::new()), "MemCache")
-    } else if spec == "none" {
-        (Arc::new(NoCache), "NoCache")
-    } else {
-        // Path → use vantage-redb as the cache backing store too. We're
-        // wrapping a Redb-backed table as a Cache via a thin shim — for
-        // the demo we use a MemCache and document that "real" RedbCache
-        // is on the roadmap (see DESIGN.md).
-        warn(&format!(
-            "path-based cache requested ({spec}) — RedbCache impl is on the roadmap; falling back to MemCache for now"
-        ));
-        (Arc::new(MemCache::new()), "MemCache (fallback)")
+// ── API master ────────────────────────────────────────────────────────────
+//
+// `RestApi::Value = serde_json::Value`, but `AnyTable` carries
+// `ciborium::Value`. There's no `Into<CborValue> + From<CborValue>` impl
+// for `serde_json::Value` (both are foreign types), so `from_table` rejects
+// `Table<RestApi, _>` directly. Wrap in a tiny adapter that implements
+// `TableLike<Value = CborValue, Id = String>` and converts on the fly via
+// serde round-trip. This is demo code — vantage-api-client could grow a
+// proper bridge as a follow-up.
+
+fn open_api_master(resource: &str, filter: Option<&(String, String)>) -> AnyTable {
+    use vantage_api_client::eq_condition;
+
+    let api = RestApi::builder(JSONPLACEHOLDER)
+        .response_shape(ResponseShape::BareArray)
+        .build();
+    let mut typed = Table::<RestApi, EmptyEntity>::new(resource, api).with_id_column("id");
+
+    if let Some((field, value)) = filter {
+        // Try the value as a number first, then bool, otherwise pass as
+        // a string. JSON Server is type-permissive in URL params, so
+        // this mostly works regardless, but `?completed=true` for a
+        // boolean field is more conventional than `?completed="true"`.
+        let json_value = if let Ok(n) = value.parse::<i64>() {
+            serde_json::Value::Number(n.into())
+        } else if value == "true" {
+            serde_json::Value::Bool(true)
+        } else if value == "false" {
+            serde_json::Value::Bool(false)
+        } else {
+            serde_json::Value::String(value.clone())
+        };
+        typed.add_condition(eq_condition(field, json_value));
+    }
+
+    AnyTable::from_table_like(api_master::JsonToCborAdapter::new(typed))
+}
+
+/// Build a cache key that varies with the filter. With no filter,
+/// `users`. With `--filter postId=1`, `comments?postId=1`. Caller
+/// ownership of cache_key is the design rule (DESIGN.md) — different
+/// conditions need different keys, otherwise the cache would serve
+/// stale-shape data when filters change.
+fn api_cache_key(resource: &str, filter: Option<&(String, String)>) -> String {
+    match filter {
+        Some((f, v)) => format!("{resource}?{f}={v}"),
+        None => resource.to_string(),
     }
 }
 
-// ── Commands ──────────────────────────────────────────────────────────────
+mod api_master {
+    use async_trait::async_trait;
+    use ciborium::Value as CborValue;
+    use indexmap::IndexMap;
+    use vantage_api_client::RestApi;
+    use vantage_core::{Result, error};
+    use vantage_dataset::traits::{ReadableValueSet, ValueSet, WritableValueSet};
+    use vantage_expressions::AnyExpression;
+    use vantage_table::conditions::ConditionHandle;
+    use vantage_table::pagination::Pagination;
+    use vantage_table::table::Table;
+    use vantage_table::traits::table_like::TableLike;
+    use vantage_types::{EmptyEntity, Record};
 
-async fn cmd_seed(typed: Table<Redb, EmptyEntity>) {
-    header("seed");
-    // Wipe whatever was there and lay down three rows.
+    /// Demo-only TableLike adapter. Wraps `Table<RestApi, EmptyEntity>`
+    /// and converts each row's `serde_json::Value` fields to/from
+    /// `ciborium::Value` so the master fits AnyTable's CBOR-shaped slot.
+    #[derive(Clone)]
+    pub struct JsonToCborAdapter {
+        inner: Table<RestApi, EmptyEntity>,
+    }
+
+    impl JsonToCborAdapter {
+        pub fn new(inner: Table<RestApi, EmptyEntity>) -> Self {
+            Self { inner }
+        }
+    }
+
+    fn json_to_cbor(v: serde_json::Value) -> CborValue {
+        // serde round-trip — same lossy bits as elsewhere (NaN, binary
+        // → string), but JSONPlaceholder responses are vanilla JSON so
+        // this is fine.
+        ciborium::Value::serialized(&v).unwrap_or(CborValue::Null)
+    }
+
+    fn cbor_to_json(v: CborValue) -> serde_json::Value {
+        serde_json::to_value(v).unwrap_or(serde_json::Value::Null)
+    }
+
+    fn record_j2c(r: Record<serde_json::Value>) -> Record<CborValue> {
+        r.into_iter().map(|(k, v)| (k, json_to_cbor(v))).collect()
+    }
+
+    fn record_c2j(r: Record<CborValue>) -> Record<serde_json::Value> {
+        r.into_iter().map(|(k, v)| (k, cbor_to_json(v))).collect()
+    }
+
+    impl ValueSet for JsonToCborAdapter {
+        type Id = String;
+        type Value = CborValue;
+    }
+
+    #[async_trait]
+    impl ReadableValueSet for JsonToCborAdapter {
+        async fn list_values(&self) -> Result<IndexMap<String, Record<CborValue>>> {
+            let rows = self.inner.list_values().await?;
+            Ok(rows.into_iter().map(|(k, v)| (k, record_j2c(v))).collect())
+        }
+
+        async fn get_value(&self, id: &String) -> Result<Option<Record<CborValue>>> {
+            Ok(self.inner.get_value(id).await?.map(record_j2c))
+        }
+
+        async fn get_some_value(&self) -> Result<Option<(String, Record<CborValue>)>> {
+            Ok(self
+                .inner
+                .get_some_value()
+                .await?
+                .map(|(k, v)| (k, record_j2c(v))))
+        }
+    }
+
+    #[async_trait]
+    impl WritableValueSet for JsonToCborAdapter {
+        async fn insert_value(
+            &self,
+            id: &String,
+            record: &Record<CborValue>,
+        ) -> Result<Record<CborValue>> {
+            // Round-trip through inner write path so existing semantics
+            // (read-only error) propagate naturally.
+            let json_record = record_c2j(record.clone());
+            let result = self.inner.insert_value(id, &json_record).await?;
+            Ok(record_j2c(result))
+        }
+
+        async fn replace_value(
+            &self,
+            id: &String,
+            record: &Record<CborValue>,
+        ) -> Result<Record<CborValue>> {
+            let json_record = record_c2j(record.clone());
+            let result = self.inner.replace_value(id, &json_record).await?;
+            Ok(record_j2c(result))
+        }
+
+        async fn patch_value(
+            &self,
+            id: &String,
+            partial: &Record<CborValue>,
+        ) -> Result<Record<CborValue>> {
+            let json_partial = record_c2j(partial.clone());
+            let result = self.inner.patch_value(id, &json_partial).await?;
+            Ok(record_j2c(result))
+        }
+
+        async fn delete(&self, id: &String) -> Result<()> {
+            self.inner.delete(id).await
+        }
+
+        async fn delete_all(&self) -> Result<()> {
+            self.inner.delete_all().await
+        }
+    }
+
+    #[async_trait]
+    impl TableLike for JsonToCborAdapter {
+        fn table_name(&self) -> &str {
+            self.inner.table_name()
+        }
+        fn table_alias(&self) -> &str {
+            self.inner.table_alias()
+        }
+        fn column_names(&self) -> Vec<String> {
+            self.inner.column_names()
+        }
+        fn add_condition(
+            &mut self,
+            _condition: Box<dyn std::any::Any + Send + Sync>,
+        ) -> Result<()> {
+            Err(error!(
+                "JsonToCborAdapter (demo): condition pushdown not implemented"
+            ))
+        }
+        fn temp_add_condition(&mut self, _c: AnyExpression) -> Result<ConditionHandle> {
+            Err(error!(
+                "JsonToCborAdapter (demo): temp_add_condition not implemented"
+            ))
+        }
+        fn temp_remove_condition(&mut self, _h: ConditionHandle) -> Result<()> {
+            Err(error!(
+                "JsonToCborAdapter (demo): temp_remove_condition not implemented"
+            ))
+        }
+        fn search_expression(&self, _: &str) -> Result<AnyExpression> {
+            Err(error!(
+                "JsonToCborAdapter (demo): search_expression not implemented"
+            ))
+        }
+        fn clone_box(&self) -> Box<dyn TableLike<Value = CborValue, Id = String>> {
+            Box::new(self.clone())
+        }
+        fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+            self
+        }
+        fn as_any_ref(&self) -> &dyn std::any::Any {
+            self
+        }
+        fn set_pagination(&mut self, p: Option<Pagination>) {
+            self.inner.set_pagination(p);
+        }
+        fn get_pagination(&self) -> Option<&Pagination> {
+            self.inner.get_pagination()
+        }
+        async fn get_count(&self) -> Result<i64> {
+            self.inner.get_count().await
+        }
+    }
+}
+
+// ── Cache builder ────────────────────────────────────────────────────────
+
+fn build_cache(spec: &str) -> (Arc<dyn Cache>, String) {
+    if spec == "mem" {
+        (Arc::new(MemCache::new()), "MemCache".into())
+    } else if spec == "none" {
+        (Arc::new(NoCache), "NoCache".into())
+    } else {
+        let cache = RedbCache::open(spec).expect("open or create RedbCache folder");
+        (Arc::new(cache), format!("RedbCache({spec})"))
+    }
+}
+
+// ── Local commands ───────────────────────────────────────────────────────
+
+async fn cmd_local_seed(typed: Table<Redb, EmptyEntity>) {
+    header("local: seed");
     let _ = WritableValueSet::delete_all(&typed).await;
 
     for (id, name, price) in [
@@ -201,14 +482,14 @@ async fn cmd_seed(typed: Table<Redb, EmptyEntity>) {
     }
 }
 
-async fn cmd_list(live: &LiveTable) {
-    header("list");
+async fn cmd_local_list(live: &LiveTable) {
+    header("local: list");
     let t = Instant::now();
     let rows = live.list_values().await.unwrap();
     timed("wall time", t, ());
 
     if rows.is_empty() {
-        warn("no rows — run `seed` first");
+        warn("no rows — run `local seed` first");
         return;
     }
 
@@ -227,8 +508,8 @@ async fn cmd_list(live: &LiveTable) {
     note("rows", &rows.len().to_string());
 }
 
-async fn cmd_get(live: &LiveTable, id: &str) {
-    header("get");
+async fn cmd_local_get(live: &LiveTable, id: &str) {
+    header("local: get");
     let t = Instant::now();
     let row = live.get_value(&id.to_string()).await.unwrap();
     timed("wall time", t, ());
@@ -243,8 +524,8 @@ async fn cmd_get(live: &LiveTable, id: &str) {
     }
 }
 
-async fn cmd_add(live: &LiveTable, id: String, name: String, price: i64) {
-    header("add");
+async fn cmd_local_add(live: &LiveTable, id: String, name: String, price: i64) {
+    header("local: add");
     let mut rec: Record<CborValue> = Record::new();
     rec.insert("name".into(), CborValue::Text(name.clone()));
     rec.insert("price".into(), CborValue::Integer(price.into()));
@@ -257,26 +538,24 @@ async fn cmd_add(live: &LiveTable, id: String, name: String, price: i64) {
     note("cache", "invalidated for cache_key prefix");
 }
 
-async fn cmd_delete(live: &LiveTable, id: String) {
-    header("delete");
+async fn cmd_local_delete(live: &LiveTable, id: String) {
+    header("local: delete");
     let t = Instant::now();
     WritableValueSet::delete(live, &id).await.unwrap();
     timed("wall time", t, ());
     ok(&format!("queued delete: {id}"));
 }
 
-async fn cmd_event_then_list(target_id: Option<String>) {
-    header("event-then-list");
+async fn cmd_local_event_then_list(target_id: Option<String>, master_path: &Path) {
+    header("local: event-then-list");
 
-    let typed = open_typed(&PathBuf::from("./demo-master.redb"));
-    let master = AnyTable::from_table(typed);
+    let master = open_local_master(master_path);
     let cache = MemCache::new();
     let stream = ManualLiveStream::default();
 
-    let live = LiveTable::new(master, CACHE_KEY, Arc::new(cache.clone()))
+    let live = LiveTable::new(master, LOCAL_CACHE_KEY, Arc::new(cache.clone()))
         .with_live_stream(Arc::new(stream.clone()));
 
-    // Warm cache.
     println!();
     println!("  {}1) prime cache{}", BOLD, RESET);
     let t = Instant::now();
@@ -287,7 +566,6 @@ async fn cmd_event_then_list(target_id: Option<String>) {
     let _ = live.list_values().await.unwrap();
     timed("second list (hit)", t, ());
 
-    // Push event.
     println!();
     println!("  {}2) external event{}", BOLD, RESET);
     let event = match target_id {
@@ -295,14 +573,12 @@ async fn cmd_event_then_list(target_id: Option<String>) {
         None => LiveEvent::Changed,
     };
     let kind = format!("{:?}", event);
-    tokio::task::yield_now().await; // let consumer subscribe
+    tokio::task::yield_now().await;
     let n = stream.push(event);
     note("pushed", &format!("{kind} → {n} subscriber(s)"));
 
-    // Give the consumer a moment to process.
     tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
-    // List again — should be a miss.
     println!();
     println!("  {}3) post-event list{}", BOLD, RESET);
     let t = Instant::now();
@@ -314,11 +590,145 @@ async fn cmd_event_then_list(target_id: Option<String>) {
     timed("next list (hit again)", t, ());
 }
 
-fn cmd_info(live: &LiveTable, master_path: &std::path::Path, cache_label: &str) {
-    header("info");
+// ── API commands ─────────────────────────────────────────────────────────
+
+async fn cmd_api_list(
+    resource: &str,
+    page: Option<i64>,
+    limit: Option<i64>,
+    filter: Option<&(String, String)>,
+    cache_spec: &str,
+) {
+    header(&format!("api: {resource} list"));
+    let master = open_api_master(resource, filter);
+    let cache_key = api_cache_key(resource, filter);
+    let (cache, _) = build_cache(cache_spec);
+    let mut live = LiveTable::new(master, &cache_key, cache);
+
+    if let (Some(p), Some(l)) = (page, limit) {
+        live.set_pagination(Some(Pagination::new(p, l)));
+        note("pagination", &format!("page {p}, {l} per page"));
+    }
+    if let Some((f, v)) = filter {
+        note("filter", &format!("{f} = {v}"));
+    }
+
+    let t = Instant::now();
+    let rows = live.list_values().await.unwrap();
+    timed("wall time", t, ());
+
+    if rows.is_empty() {
+        warn("no rows returned");
+        return;
+    }
+
+    let columns = pretty_columns_for(resource);
+    print_api_table(&columns, &rows);
+    println!();
+    note("rows", &rows.len().to_string());
+    note(
+        "cache key",
+        &live.page_cache_key(live.get_pagination().map(|p| p.get_page()).unwrap_or(1)),
+    );
+}
+
+async fn cmd_api_get(resource: &str, id: &str, cache_spec: &str) {
+    header(&format!("api: {resource} get {id}"));
+    let master = open_api_master(resource, None);
+    let (cache, _) = build_cache(cache_spec);
+    let live = LiveTable::new(master, resource, cache);
+
+    let t = Instant::now();
+    let row = live.get_value(&id.to_string()).await.unwrap();
+    timed("wall time", t, ());
+
+    match row {
+        Some(r) => {
+            for (k, v) in r.iter() {
+                println!("  {}{}{} = {}", DIM, k, RESET, fmt_json(v));
+            }
+        }
+        None => warn(&format!("no row with id `{id}`")),
+    }
+}
+
+fn cmd_api_info(resource: &str, cache_label: &str) {
+    header(&format!("api: {resource} info"));
+    note("base url", JSONPLACEHOLDER);
+    note("resource", resource);
+    note("response shape", "BareArray");
+    note("cache backend", cache_label);
+    println!();
+    println!("  {}┌─ LiveTable wiring{}", DIM, RESET);
+    println!(
+        "  {}│{}  master  → AnyTable<RestApi, EmptyEntity> → {}/{}",
+        DIM, RESET, JSONPLACEHOLDER, resource
+    );
+    println!("  {}│{}  cache   → {}", DIM, RESET, cache_label);
+    println!("  {}│{}  writes  → master is read-only", DIM, RESET);
+    println!("  {}└─ all reads consult cache first{}", DIM, RESET);
+}
+
+// ── Pretty-print columns per resource ─────────────────────────────────────
+
+struct Columns {
+    headers: &'static [(&'static str, usize)],
+}
+
+fn pretty_columns_for(resource: &str) -> Columns {
+    match resource {
+        "users" => Columns {
+            headers: &[("id", 4), ("name", 24), ("username", 16), ("email", 28)],
+        },
+        "posts" => Columns {
+            headers: &[("id", 4), ("userId", 8), ("title", 60)],
+        },
+        "comments" => Columns {
+            headers: &[("id", 4), ("postId", 8), ("name", 30), ("email", 28)],
+        },
+        _ => Columns {
+            headers: &[("id", 4), ("title", 50)],
+        },
+    }
+}
+
+fn print_api_table(cols: &Columns, rows: &indexmap::IndexMap<String, Record<CborValue>>) {
+    println!();
+    print!("  ");
+    for (h, w) in cols.headers {
+        print!("{}{:<width$}{} ", BOLD, h, RESET, width = w);
+    }
+    println!();
+    let total_width: usize = cols.headers.iter().map(|(_, w)| w + 1).sum();
+    println!("  {}", "─".repeat(total_width));
+
+    for row in rows.values() {
+        print!("  ");
+        for (h, w) in cols.headers {
+            let val = row.get(*h).map(fmt_json).unwrap_or_else(|| "—".into());
+            let truncated = truncate(&val, *w);
+            print!("{:<width$} ", truncated, width = w);
+        }
+        println!();
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let head: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{head}…")
+    }
+}
+
+// ── Local info ────────────────────────────────────────────────────────────
+
+fn cmd_local_info(live: &LiveTable, master_path: &Path, cache_label: &str) {
+    header("local: info");
     note("master file", &master_path.display().to_string());
     note("cache backend", cache_label);
-    note("cache_key", CACHE_KEY);
+    note("cache_key", LOCAL_CACHE_KEY);
     note("debug formatted", &format!("{:?}", live));
     println!();
     println!("  {}┌─ LiveTable wiring{}", DIM, RESET);
@@ -356,6 +766,23 @@ fn fmt_cbor(v: &CborValue) -> String {
     }
 }
 
+/// Pretty-print a CBOR value the way a JSON-shaped API would. Numbers
+/// and booleans unquoted, strings with no quotes (table cell already
+/// has the column for context), other shapes via Debug.
+fn fmt_json(v: &CborValue) -> String {
+    match v {
+        CborValue::Null => "null".into(),
+        CborValue::Bool(b) => b.to_string(),
+        CborValue::Integer(i) => match i64::try_from(*i) {
+            Ok(n) => n.to_string(),
+            Err(_) => format!("{:?}", i),
+        },
+        CborValue::Float(f) => format!("{f}"),
+        CborValue::Text(s) => s.clone(),
+        other => format!("{:?}", other),
+    }
+}
+
 // ── main ──────────────────────────────────────────────────────────────────
 
 #[tokio::main]
@@ -374,42 +801,60 @@ async fn main() {
     }
 
     match &cli.cmd {
-        Cmd::Seed => {
-            let typed = open_typed(&cli.master);
-            cmd_seed(typed).await;
-        }
-        Cmd::List => {
-            let master = open_master(&cli.master);
-            let (cache, _) = build_cache(&cli.cache);
-            let live = LiveTable::new(master, CACHE_KEY, cache);
-            cmd_list(&live).await;
-        }
-        Cmd::Get { id } => {
-            let master = open_master(&cli.master);
-            let (cache, _) = build_cache(&cli.cache);
-            let live = LiveTable::new(master, CACHE_KEY, cache);
-            cmd_get(&live, id).await;
-        }
-        Cmd::Add { id, name, price } => {
-            let master = open_master(&cli.master);
-            let (cache, _) = build_cache(&cli.cache);
-            let live = LiveTable::new(master, CACHE_KEY, cache);
-            cmd_add(&live, id.clone(), name.clone(), *price).await;
-        }
-        Cmd::Delete { id } => {
-            let master = open_master(&cli.master);
-            let (cache, _) = build_cache(&cli.cache);
-            let live = LiveTable::new(master, CACHE_KEY, cache);
-            cmd_delete(&live, id.clone()).await;
-        }
-        Cmd::EventThenList { id } => {
-            cmd_event_then_list(id.clone()).await;
-        }
-        Cmd::Info => {
-            let master = open_master(&cli.master);
-            let (cache, label) = build_cache(&cli.cache);
-            let live = LiveTable::new(master, CACHE_KEY, cache);
-            cmd_info(&live, &cli.master, label);
-        }
+        TopCmd::Local { cmd } => match cmd {
+            LocalCmd::Seed => {
+                let typed = open_local_typed(&cli.master);
+                cmd_local_seed(typed).await;
+            }
+            LocalCmd::List => {
+                let master = open_local_master(&cli.master);
+                let (cache, _) = build_cache(&cli.cache);
+                let live = LiveTable::new(master, LOCAL_CACHE_KEY, cache);
+                cmd_local_list(&live).await;
+            }
+            LocalCmd::Get { id } => {
+                let master = open_local_master(&cli.master);
+                let (cache, _) = build_cache(&cli.cache);
+                let live = LiveTable::new(master, LOCAL_CACHE_KEY, cache);
+                cmd_local_get(&live, id).await;
+            }
+            LocalCmd::Add { id, name, price } => {
+                let master = open_local_master(&cli.master);
+                let (cache, _) = build_cache(&cli.cache);
+                let live = LiveTable::new(master, LOCAL_CACHE_KEY, cache);
+                cmd_local_add(&live, id.clone(), name.clone(), *price).await;
+            }
+            LocalCmd::Delete { id } => {
+                let master = open_local_master(&cli.master);
+                let (cache, _) = build_cache(&cli.cache);
+                let live = LiveTable::new(master, LOCAL_CACHE_KEY, cache);
+                cmd_local_delete(&live, id.clone()).await;
+            }
+            LocalCmd::EventThenList { id } => {
+                cmd_local_event_then_list(id.clone(), &cli.master).await;
+            }
+            LocalCmd::Info => {
+                let master = open_local_master(&cli.master);
+                let (cache, label) = build_cache(&cli.cache);
+                let live = LiveTable::new(master, LOCAL_CACHE_KEY, cache);
+                cmd_local_info(&live, &cli.master, &label);
+            }
+        },
+        TopCmd::Api { resource, cmd } => match cmd {
+            ApiCmd::List {
+                page,
+                limit,
+                filter,
+            } => {
+                cmd_api_list(resource, *page, *limit, filter.as_ref(), &cli.cache).await;
+            }
+            ApiCmd::Get { id } => {
+                cmd_api_get(resource, id, &cli.cache).await;
+            }
+            ApiCmd::Info => {
+                let (_, label) = build_cache(&cli.cache);
+                cmd_api_info(resource, &label);
+            }
+        },
     }
 }

--- a/vantage-live/src/cache/mod.rs
+++ b/vantage-live/src/cache/mod.rs
@@ -14,9 +14,11 @@ use vantage_types::Record;
 
 mod mem;
 mod noop;
+mod redb;
 
 pub use mem::MemCache;
 pub use noop::NoCache;
+pub use redb::RedbCache;
 
 /// A row set as stored in the cache, with the wall-clock instant the master
 /// fetch completed. Fetch time isn't used in v1 (no TTL), but we keep it

--- a/vantage-live/src/cache/redb.rs
+++ b/vantage-live/src/cache/redb.rs
@@ -1,0 +1,317 @@
+//! redb-backed cache. Persists `CachedRows` on disk so cache state
+//! survives process restarts.
+//!
+//! ## Layout
+//!
+//! One redb file (`vlive.redb`) inside the caller-supplied folder.
+//! Inside the file, **one redb table per `cache_key`**, namespaced as
+//! `__vlive__{cache_key}` so cache tables can't collide with whatever
+//! else the user keeps in the same folder. Sub-keys inside that table
+//! are the part after the first `/` of the cache key (`page_1`,
+//! `id/foo`, etc.). Values are CBOR-encoded `CachedRows`.
+//!
+//! Per-table layout makes the hot invalidation path cheap:
+//! `invalidate_prefix("clients")` matches the whole cache_key →
+//! `delete_table("__vlive__clients")` is O(1)-ish (just unlinks the
+//! tree root). Sub-prefix invalidates fall back to scan + delete inside
+//! the table, but v1 of LiveTable always passes the bare cache_key.
+//!
+//! ## Concurrency
+//!
+//! redb takes an OS-level exclusive lock on its file — only one
+//! process can open the cache folder at a time. Trying to open the
+//! same folder from a second process returns
+//! `redb::DatabaseError::DatabaseAlreadyOpen`. If you need cross-process
+//! cache sharing, this isn't the layer for it (network cache: Redis).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use redb::{Database, ReadableTable, ReadableTableMetadata, TableDefinition};
+use std::time::SystemTime;
+use vantage_core::{Result, error};
+use vantage_types::Record;
+
+use super::{Cache, CachedRows};
+
+const CACHE_FILE: &str = "vlive.redb";
+const TABLE_PREFIX: &str = "__vlive__";
+
+/// Redb-backed cache. Cheap to clone — the inner `Arc<Database>` is
+/// shared.
+#[derive(Clone)]
+pub struct RedbCache {
+    db: Arc<Database>,
+    folder: PathBuf,
+}
+
+impl std::fmt::Debug for RedbCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RedbCache")
+            .field("folder", &self.folder)
+            .finish()
+    }
+}
+
+impl RedbCache {
+    /// Open or create a cache in `folder`. Creates the folder if it
+    /// doesn't exist; opens (or creates) `vlive.redb` inside.
+    ///
+    /// Returns an error if another process already has the cache open
+    /// (redb's exclusive file lock — see module docs).
+    pub fn open(folder: impl AsRef<Path>) -> Result<Self> {
+        let folder = folder.as_ref().to_path_buf();
+        std::fs::create_dir_all(&folder)
+            .map_err(|e| error!("Failed to create cache folder", details = e.to_string()))?;
+        let path = folder.join(CACHE_FILE);
+        let db = Database::create(&path)
+            .map_err(|e| error!("Failed to open cache redb", details = e.to_string()))?;
+        Ok(Self {
+            db: Arc::new(db),
+            folder,
+        })
+    }
+
+    /// Folder this cache lives in. Useful for diagnostics; do not use
+    /// to open a second handle while this one is alive.
+    pub fn folder(&self) -> &Path {
+        &self.folder
+    }
+}
+
+/// Split a cache key like `clients/page_1` into `("clients", "page_1")`.
+/// If there's no `/`, the whole key is treated as the root and the
+/// sub-key is empty (the `__root__` sentinel is used internally so
+/// every entry has a non-empty redb sub-key).
+fn split_key(key: &str) -> (&str, String) {
+    match key.find('/') {
+        Some(i) => (&key[..i], key[i + 1..].to_string()),
+        None => (key, String::from("__root__")),
+    }
+}
+
+fn redb_table_name(root: &str) -> String {
+    format!("{}{}", TABLE_PREFIX, root)
+}
+
+fn cache_table_def(name: &str) -> TableDefinition<'_, &'static str, &'static [u8]> {
+    TableDefinition::new(name)
+}
+
+fn encode_rows(rows: &CachedRows) -> Result<Vec<u8>> {
+    // CachedRows isn't directly Serialize, so encode field-by-field as a
+    // CBOR map. fetched_at is stored as seconds-since-epoch so the
+    // representation is portable / compact.
+    let secs = rows
+        .fetched_at
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+
+    let row_pairs: Vec<(CborValue, CborValue)> = rows
+        .rows
+        .iter()
+        .map(|(id, rec)| {
+            let entries: Vec<(CborValue, CborValue)> = rec
+                .iter()
+                .map(|(k, v)| (CborValue::Text(k.clone()), v.clone()))
+                .collect();
+            (CborValue::Text(id.clone()), CborValue::Map(entries))
+        })
+        .collect();
+
+    let envelope = CborValue::Map(vec![
+        (
+            CborValue::Text("fetched_at".into()),
+            CborValue::Integer(secs.into()),
+        ),
+        (CborValue::Text("rows".into()), CborValue::Map(row_pairs)),
+    ]);
+
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(&envelope, &mut bytes)
+        .map_err(|e| error!("CBOR encode failed", details = e.to_string()))?;
+    Ok(bytes)
+}
+
+fn decode_rows(bytes: &[u8]) -> Result<CachedRows> {
+    let parsed: CborValue = ciborium::de::from_reader(bytes)
+        .map_err(|e| error!("CBOR decode failed", details = e.to_string()))?;
+    let mut secs: i64 = 0;
+    let mut rows: IndexMap<String, Record<CborValue>> = IndexMap::new();
+
+    let pairs = match parsed {
+        CborValue::Map(p) => p,
+        _ => return Err(error!("RedbCache: expected envelope to be a map")),
+    };
+    for (k, v) in pairs {
+        let key = match k {
+            CborValue::Text(s) => s,
+            _ => continue,
+        };
+        match (key.as_str(), v) {
+            ("fetched_at", CborValue::Integer(i)) => {
+                secs = i64::try_from(i).unwrap_or(0);
+            }
+            ("rows", CborValue::Map(row_pairs)) => {
+                for (rk, rv) in row_pairs {
+                    let id = match rk {
+                        CborValue::Text(s) => s,
+                        _ => continue,
+                    };
+                    let mut rec: Record<CborValue> = Record::new();
+                    if let CborValue::Map(field_pairs) = rv {
+                        for (fk, fv) in field_pairs {
+                            if let CborValue::Text(name) = fk {
+                                rec.insert(name, fv);
+                            }
+                        }
+                    }
+                    rows.insert(id, rec);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let fetched_at =
+        SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(secs.try_into().unwrap_or(0));
+    Ok(CachedRows { rows, fetched_at })
+}
+
+#[async_trait]
+impl Cache for RedbCache {
+    async fn get(&self, key: &str) -> Result<Option<CachedRows>> {
+        let (root, sub) = split_key(key);
+        let table_name = redb_table_name(root);
+
+        let txn = self
+            .db
+            .begin_read()
+            .map_err(|e| error!("redb begin_read failed", details = e.to_string()))?;
+        let table = match txn.open_table(cache_table_def(&table_name)) {
+            Ok(t) => t,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => {
+                return Err(error!(
+                    "Failed to open cache table",
+                    table = table_name,
+                    details = e.to_string()
+                ));
+            }
+        };
+        let bytes = table
+            .get(sub.as_str())
+            .map_err(|e| error!("redb cache get failed", details = e.to_string()))?;
+        match bytes {
+            Some(b) => Ok(Some(decode_rows(b.value())?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn put(&self, key: &str, rows: CachedRows) -> Result<()> {
+        let (root, sub) = split_key(key);
+        let table_name = redb_table_name(root);
+        let bytes = encode_rows(&rows)?;
+
+        let txn = self
+            .db
+            .begin_write()
+            .map_err(|e| error!("redb begin_write failed", details = e.to_string()))?;
+        {
+            let mut table = txn.open_table(cache_table_def(&table_name)).map_err(|e| {
+                error!(
+                    "Failed to open cache table for write",
+                    table = table_name,
+                    details = e.to_string()
+                )
+            })?;
+            table
+                .insert(sub.as_str(), bytes.as_slice())
+                .map_err(|e| error!("redb cache insert failed", details = e.to_string()))?;
+        }
+        txn.commit()
+            .map_err(|e| error!("redb cache commit failed", details = e.to_string()))?;
+        Ok(())
+    }
+
+    async fn invalidate_prefix(&self, prefix: &str) -> Result<()> {
+        // The fast path: prefix is exactly a cache_key (no '/') →
+        // drop the whole table.
+        if !prefix.contains('/') {
+            let table_name = redb_table_name(prefix);
+            let txn = self
+                .db
+                .begin_write()
+                .map_err(|e| error!("redb begin_write failed", details = e.to_string()))?;
+            // delete_table returns Ok(false) if the table didn't exist,
+            // Ok(true) if it was dropped. Either way, swallow.
+            let _ = txn
+                .delete_table(cache_table_def(&table_name))
+                .map_err(|e| error!("delete_table failed", details = e.to_string()))?;
+            txn.commit()
+                .map_err(|e| error!("redb cache commit failed", details = e.to_string()))?;
+            return Ok(());
+        }
+
+        // Sub-prefix: scan inside the appropriate table and delete the
+        // matching sub-keys. Used by future surgical-invalidation paths;
+        // v1 LiveTable doesn't currently call this.
+        let (root, sub_prefix) = split_key(prefix);
+        let table_name = redb_table_name(root);
+
+        let txn = self
+            .db
+            .begin_write()
+            .map_err(|e| error!("redb begin_write failed", details = e.to_string()))?;
+        {
+            let mut table = match txn.open_table(cache_table_def(&table_name)) {
+                Ok(t) => t,
+                Err(redb::TableError::TableDoesNotExist(_)) => return Ok(()),
+                Err(e) => {
+                    return Err(error!(
+                        "Failed to open cache table for invalidate",
+                        table = table_name,
+                        details = e.to_string()
+                    ));
+                }
+            };
+            // Collect keys matching prefix first (can't mutate during iter).
+            let mut to_delete: Vec<String> = Vec::new();
+            {
+                let iter = table
+                    .iter()
+                    .map_err(|e| error!("redb cache iter failed", details = e.to_string()))?;
+                for entry in iter {
+                    let (k, _) = entry.map_err(|e| {
+                        error!("redb cache iter entry failed", details = e.to_string())
+                    })?;
+                    if k.value().starts_with(&sub_prefix) {
+                        to_delete.push(k.value().to_string());
+                    }
+                }
+            }
+            for k in to_delete {
+                table
+                    .remove(k.as_str())
+                    .map_err(|e| error!("redb cache remove failed", details = e.to_string()))?;
+            }
+            // If the table is now empty, drop it so we don't leak empties.
+            if ReadableTableMetadata::len(&table).map_err(|e: redb::StorageError| {
+                error!("redb cache len failed", details = e.to_string())
+            })? == 0
+            {
+                drop(table);
+                let _ = txn
+                    .delete_table(cache_table_def(&table_name))
+                    .map_err(|e| error!("delete_table failed", details = e.to_string()))?;
+            }
+        }
+        txn.commit()
+            .map_err(|e| error!("redb cache commit failed", details = e.to_string()))?;
+        Ok(())
+    }
+}

--- a/vantage-live/tests/1_cache_trait.rs
+++ b/vantage-live/tests/1_cache_trait.rs
@@ -5,7 +5,7 @@
 //! prefix and only those keys.
 
 use indexmap::IndexMap;
-use vantage_live::cache::{Cache, CachedRows, MemCache, NoCache};
+use vantage_live::cache::{Cache, CachedRows, MemCache, NoCache, RedbCache};
 use vantage_types::Record;
 
 fn empty_rows() -> CachedRows {
@@ -117,4 +117,174 @@ async fn cache_can_be_used_as_dyn_trait() {
     cache.put("k", rows_with_one("Alice")).await.unwrap();
     let v = cache.get("k").await.unwrap();
     assert!(v.is_some());
+}
+
+// ── RedbCache ────────────────────────────────────────────────────────────
+//
+// Each test gets its own tempdir so they don't fight for the redb file
+// lock. The RedbCache is dropped at end of scope; that releases the
+// lock, which lets us re-open the same folder in the persistence test
+// to verify state survived.
+
+fn fresh_dir() -> tempfile::TempDir {
+    tempfile::tempdir().unwrap()
+}
+
+#[tokio::test]
+async fn redbcache_miss_returns_none() {
+    let dir = fresh_dir();
+    let c = RedbCache::open(dir.path()).unwrap();
+    assert!(c.get("clients/page_1").await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn redbcache_put_then_get_round_trip() {
+    let dir = fresh_dir();
+    let c = RedbCache::open(dir.path()).unwrap();
+
+    c.put("clients/page_1", rows_with_one("Alice"))
+        .await
+        .unwrap();
+    let back = c.get("clients/page_1").await.unwrap().expect("hit");
+    assert_eq!(back.rows.len(), 1);
+    assert_eq!(
+        back.rows["id1"]["name"],
+        ciborium::Value::Text("Alice".into())
+    );
+}
+
+#[tokio::test]
+async fn redbcache_put_overwrites() {
+    let dir = fresh_dir();
+    let c = RedbCache::open(dir.path()).unwrap();
+
+    c.put("k/page_1", rows_with_one("Alice")).await.unwrap();
+    c.put("k/page_1", rows_with_one("Bob")).await.unwrap();
+    let back = c.get("k/page_1").await.unwrap().expect("hit");
+    assert_eq!(
+        back.rows["id1"]["name"],
+        ciborium::Value::Text("Bob".into())
+    );
+}
+
+#[tokio::test]
+async fn redbcache_invalidate_root_drops_all_subkeys() {
+    let dir = fresh_dir();
+    let c = RedbCache::open(dir.path()).unwrap();
+
+    c.put("clients/page_1", rows_with_one("A")).await.unwrap();
+    c.put("clients/page_2", rows_with_one("B")).await.unwrap();
+    c.put("clients/id/marty", rows_with_one("M")).await.unwrap();
+    c.put("orders/page_1", rows_with_one("O")).await.unwrap();
+
+    // Drop the whole "clients" cache_key.
+    c.invalidate_prefix("clients").await.unwrap();
+
+    assert!(c.get("clients/page_1").await.unwrap().is_none());
+    assert!(c.get("clients/page_2").await.unwrap().is_none());
+    assert!(c.get("clients/id/marty").await.unwrap().is_none());
+    // Other cache_keys untouched.
+    assert!(c.get("orders/page_1").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn redbcache_invalidate_subprefix_inside_a_table() {
+    // The fast path is "prefix == cache_key → drop table". The slow
+    // path matches sub-prefixes within a table. Test the slow path too.
+    let dir = fresh_dir();
+    let c = RedbCache::open(dir.path()).unwrap();
+
+    c.put("clients/page_1", rows_with_one("A")).await.unwrap();
+    c.put("clients/page_2", rows_with_one("B")).await.unwrap();
+    c.put("clients/id/marty", rows_with_one("M")).await.unwrap();
+
+    // Sub-prefix: invalidate only the page_* entries, leave id/marty.
+    c.invalidate_prefix("clients/page_").await.unwrap();
+
+    assert!(c.get("clients/page_1").await.unwrap().is_none());
+    assert!(c.get("clients/page_2").await.unwrap().is_none());
+    assert!(c.get("clients/id/marty").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn redbcache_persists_across_handles() {
+    // Drop the cache → release file lock → open it again at the same
+    // path. State should still be there.
+    let dir = fresh_dir();
+    {
+        let c = RedbCache::open(dir.path()).unwrap();
+        c.put("clients/page_1", rows_with_one("Alice"))
+            .await
+            .unwrap();
+        // c drops here, releasing the lock.
+    }
+
+    let c2 = RedbCache::open(dir.path()).unwrap();
+    let back = c2
+        .get("clients/page_1")
+        .await
+        .unwrap()
+        .expect("data persisted");
+    assert_eq!(
+        back.rows["id1"]["name"],
+        ciborium::Value::Text("Alice".into())
+    );
+}
+
+#[tokio::test]
+async fn redbcache_clone_shares_state() {
+    let dir = fresh_dir();
+    let a = RedbCache::open(dir.path()).unwrap();
+    let b = a.clone();
+
+    a.put("clients/page_1", rows_with_one("Alice"))
+        .await
+        .unwrap();
+    assert!(b.get("clients/page_1").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn redbcache_creates_folder_if_missing() {
+    // The point of taking a folder rather than a file path: missing
+    // directory is created, no fuss.
+    let parent = tempfile::tempdir().unwrap();
+    let nested = parent.path().join("nested/cache");
+    assert!(!nested.exists());
+    let c = RedbCache::open(&nested).unwrap();
+    assert!(nested.exists());
+
+    // And it actually works.
+    c.put("k/page_1", rows_with_one("Alice")).await.unwrap();
+    assert!(c.get("k/page_1").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn redbcache_no_cross_root_collisions() {
+    // Two cache_keys with similar names ("client" / "clients") must not
+    // see each other. The namespace prefix should keep them apart.
+    let dir = fresh_dir();
+    let c = RedbCache::open(dir.path()).unwrap();
+
+    c.put("client/page_1", rows_with_one("Singular"))
+        .await
+        .unwrap();
+    c.put("clients/page_1", rows_with_one("Plural"))
+        .await
+        .unwrap();
+
+    let s = c.get("client/page_1").await.unwrap().expect("hit");
+    let p = c.get("clients/page_1").await.unwrap().expect("hit");
+    assert_eq!(
+        s.rows["id1"]["name"],
+        ciborium::Value::Text("Singular".into())
+    );
+    assert_eq!(
+        p.rows["id1"]["name"],
+        ciborium::Value::Text("Plural".into())
+    );
+
+    // Invalidating "client" should not affect "clients".
+    c.invalidate_prefix("client").await.unwrap();
+    assert!(c.get("client/page_1").await.unwrap().is_none());
+    assert!(c.get("clients/page_1").await.unwrap().is_some());
 }


### PR DESCRIPTION
Three threads of work for vantage-live 0.4.1, all centered on making the demo CLI a more honest tour of the cache benefit:

1. **`RedbCache`** — disk-persistent cache backend. Cache state survives process restarts.
2. **JSONPlaceholder API master** in the demo CLI. Real network round-trips → cache hits go from ~300ms to sub-millisecond, which is what the live-table story is actually about.
3. **`eq` condition pushdown** in `vantage-api-client`, plus a `--filter` flag on the demo. Conditions become URL query params; cache keys fold the filter in so different filters cache under different slots.

### `RedbCache`

```rust
let cache = RedbCache::open("./cache-folder")?;   // creates folder if missing
let live = LiveTable::new(master, "clients", Arc::new(cache));
```

One redb file (`vlive.redb`) inside the folder. Inside the file, **one redb table per `cache_key`**, namespaced `__vlive__{cache_key}` so cache tables can't collide with the user's own tables in the same folder. `invalidate_prefix("clients")` is `delete_table("__vlive__clients")` — O(1)-ish, no scan. Sub-prefix invalidation (future surgical use) falls back to scan + delete inside the table.

redb takes an OS-level exclusive lock on its file, so the cache folder is one-process-only. Documented as "if you need cross-process sharing, you don't want redb here — go for a network cache."

9 new tests under `tests/1_cache_trait.rs` covering round-trip, persistence-across-handles, root-vs-sub-prefix invalidation, namespacing, and folder auto-creation.

### Demo: two master modes

A folder cache (`--cache <PATH>`) is used in every example below — `mem` doesn't persist between CLI invocations, which makes most of these examples uninteresting.

```sh
# Local redb master (existing 0.4.0 behaviour, scoped under `local`).
cargo run --example live_demo -- --cache ./vlive-cache local seed
cargo run --example live_demo -- --cache ./vlive-cache local list           # cache miss
cargo run --example live_demo -- --cache ./vlive-cache local list           # cache hit
cargo run --example live_demo -- --cache ./vlive-cache local event-then-list

# JSONPlaceholder master.
cargo run --example live_demo -- --cache ./vlive-cache api users list
cargo run --example live_demo -- --cache ./vlive-cache api posts list
cargo run --example live_demo -- --cache ./vlive-cache api comments list

# Pagination pushes into the URL (?_page=N&_limit=M).
cargo run --example live_demo -- --cache ./vlive-cache api users list --page 2 --limit 3

# Filter pushes into the URL (?postId=1) AND folds into the cache_key.
# Different filters cache under different slots — postId=1 and postId=2
# don't trample each other.
cargo run --example live_demo -- --cache ./vlive-cache api comments list --filter postId=1
cargo run --example live_demo -- --cache ./vlive-cache api todos    list --filter completed=true
```

### `vantage-api-client` 0.1.1 → 0.1.2

Backwards-compat additions, no breaking changes. Builder configures the response shape and pagination convention:

```rust
use vantage_api_client::{RestApi, ResponseShape, PaginationParams, eq_condition};

// JSONPlaceholder: bare-array responses, JSON-Server-style pagination.
let api = RestApi::builder("https://jsonplaceholder.typicode.com")
    .response_shape(ResponseShape::BareArray)
    .pagination_params(PaginationParams::page_limit("_page", "_limit"))
    .build();

// DummyJSON: response wrapped under a key matching the table name,
// skip-based pagination.
let api = RestApi::builder("https://dummyjson.com")
    .response_shape(ResponseShape::WrappedByTableName)
    .pagination_params(PaginationParams::skip_limit("skip", "limit"))
    .build();

// Authed legacy API: original 0.1.x default shape `{ "data": [...] }`.
let api = RestApi::builder("https://my-api.example.com")
    .response_shape(ResponseShape::Wrapped { array_key: "data".into() })
    .auth("Bearer …")
    .build();
```

Conditions added to a `Table<RestApi, _>` get pushed into the URL as query params:

```rust
let mut comments = Table::<RestApi, EmptyEntity>::new("comments", api);
comments.add_condition(eq_condition("postId", json!(1)));

// list_values fetches: GET /comments?postId=1
let rows = comments.list_values().await?;
```

`RestApi::new(url)` and the existing `with_auth` method still work — defaults match 0.1.x behaviour, so existing code doesn't need to change.

`urlencoding` joins the runtime deps so query params are encoded properly.