### PR TITLE
add log_stream and ecs models to vantage-aws

### DIFF
--- a/test-tf/.gitignore
+++ b/test-tf/.gitignore
@@ -1,0 +1,7 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfvars
+crash.log
+crash.*.log

--- a/test-tf/README.md
+++ b/test-tf/README.md
@@ -1,0 +1,67 @@
+# test-tf
+
+Throwaway Terraform stack to give `vantage-aws-cli` something to explore.
+
+## What it builds
+
+In `eu-west-2` by default:
+
+- VPC + 2 public subnets + IGW + security group (port 80 open).
+- ECS cluster `vantage-demo` (Fargate + Fargate Spot capacity providers).
+- Task definition `vantage-demo` — `nginx:stable-alpine`, 256 CPU / 512 MB.
+- ECS service `vantage-demo-svc`, `desired_count = 1`, runs on **Fargate Spot** by default.
+- CloudWatch log group `/ecs/vantage-demo` (7-day retention).
+- IAM task-execution role.
+
+## Cost
+
+`desired_count = 1` runs one Fargate **Spot** task continuously: roughly **$0.003/hr**, **$0.07/day**, **$2/month**. Spot tasks can be reclaimed by AWS with a 2-minute warning — fine for a throwaway demo, not for production. ECS clusters themselves cost nothing; only the running task is billable.
+
+Set `desired_count = 0` if you want everything provisioned without any running task at all.
+
+```sh
+terraform apply -var desired_count=0    # registered but quiet, cheap
+terraform apply -var desired_count=1    # one running task, billable
+```
+
+## Usage
+
+You'll need [`terraform`](https://developer.hashicorp.com/terraform/downloads) (or `tofu`):
+
+```sh
+brew install terraform     # or: brew install opentofu
+```
+
+Then:
+
+```sh
+cd test-tf
+terraform init
+terraform plan             # see what will be created
+terraform apply            # create everything
+# … explore with vantage-aws-cli, see outputs …
+terraform destroy          # tear it all down
+```
+
+## Explore with vantage-aws-cli
+
+`terraform apply` prints an `explore_with_vantage_aws_cli` output with copy-pasteable commands. The short version:
+
+```sh
+cd ../vantage-aws
+cargo run --example aws-cli -- --region eu-west-2 list-clusters
+cargo run --example aws-cli -- --region eu-west-2 list-services vantage-demo
+cargo run --example aws-cli -- --region eu-west-2 list-tasks vantage-demo
+cargo run --example aws-cli -- --region eu-west-2 list-task-defs --family-prefix vantage-demo
+cargo run --example aws-cli -- --region eu-west-2 list-streams /ecs/vantage-demo
+```
+
+Once a Fargate task has started and pulled an image, `list-streams` will show the per-task log streams; `list-events /ecs/vantage-demo` will show nginx startup output.
+
+## Customising
+
+```sh
+terraform apply -var region=us-east-1 -var name=my-demo -var desired_count=0
+```
+
+Variables (see `variables.tf`): `region`, `name`, `desired_count`, `cpu`, `memory`.

--- a/test-tf/ecs.tf
+++ b/test-tf/ecs.tf
@@ -1,0 +1,60 @@
+resource "aws_ecs_cluster" "main" {
+  name = var.name
+}
+
+resource "aws_ecs_cluster_capacity_providers" "main" {
+  cluster_name       = aws_ecs_cluster.main.name
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight            = 1
+  }
+}
+
+resource "aws_ecs_task_definition" "nginx" {
+  family                   = var.name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "nginx"
+      image     = "public.ecr.aws/nginx/nginx:stable-alpine"
+      essential = true
+      portMappings = [{
+        containerPort = 80
+        protocol      = "tcp"
+      }]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.main.name
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = "nginx"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "main" {
+  name            = "${var.name}-svc"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.nginx.arn
+  desired_count   = var.desired_count
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight            = 1
+  }
+
+  network_configuration {
+    subnets          = aws_subnet.public[*].id
+    security_groups  = [aws_security_group.task.id]
+    assign_public_ip = true
+  }
+}

--- a/test-tf/iam.tf
+++ b/test-tf/iam.tf
@@ -1,0 +1,22 @@
+# Fargate needs a task-execution role to pull images and ship logs.
+# Stack-scoped so it's torn down with `terraform destroy`.
+
+data "aws_iam_policy_document" "ecs_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${var.name}-task-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}

--- a/test-tf/logs.tf
+++ b/test-tf/logs.tf
@@ -1,0 +1,5 @@
+resource "aws_cloudwatch_log_group" "main" {
+  name              = "/ecs/${var.name}"
+  retention_in_days = 7
+  tags              = { Name = var.name }
+}

--- a/test-tf/main.tf
+++ b/test-tf/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/test-tf/outputs.tf
+++ b/test-tf/outputs.tf
@@ -1,0 +1,27 @@
+output "cluster_name" {
+  value = aws_ecs_cluster.main.name
+}
+
+output "cluster_arn" {
+  value = aws_ecs_cluster.main.arn
+}
+
+output "service_name" {
+  value = aws_ecs_service.main.name
+}
+
+output "task_definition_arn" {
+  value = aws_ecs_task_definition.nginx.arn
+}
+
+output "log_group_name" {
+  value = aws_cloudwatch_log_group.main.name
+}
+
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "subnet_ids" {
+  value = aws_subnet.public[*].id
+}

--- a/test-tf/variables.tf
+++ b/test-tf/variables.tf
@@ -1,0 +1,32 @@
+variable "region" {
+  type        = string
+  default     = "eu-west-2"
+  description = "AWS region. Default matches the user's [default] profile."
+}
+
+variable "name" {
+  type        = string
+  default     = "vantage-demo"
+  description = "Prefix used for every resource name + tag in this stack."
+}
+
+variable "desired_count" {
+  type        = number
+  default     = 1
+  description = <<-EOT
+    ECS service desired task count. 1 = ~$0.01/hr while running.
+    Set to 0 if you want the cluster + service registered without
+    incurring Fargate cost — list-clusters / list-services /
+    list-task-defs will still have data, list-tasks will be empty.
+  EOT
+}
+
+variable "cpu" {
+  type    = string
+  default = "256"
+}
+
+variable "memory" {
+  type    = string
+  default = "512"
+}

--- a/test-tf/vpc.tf
+++ b/test-tf/vpc.tf
@@ -1,0 +1,65 @@
+# Self-contained VPC so the stack doesn't depend on whatever default
+# infra happens to be in the account. Public subnets with auto-assigned
+# public IPs are enough for Fargate to pull from public ECR.
+
+resource "aws_vpc" "main" {
+  cidr_block           = "10.42.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags                 = { Name = var.name }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = var.name }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.42.${count.index}.0/24"
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+  tags                    = { Name = "${var.name}-public-${count.index}" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+  tags = { Name = "${var.name}-public" }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_security_group" "task" {
+  name        = "${var.name}-task"
+  description = "Inbound HTTP for the demo nginx task"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.name}-task" }
+}

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## 0.4.1 — 2026-04-28
+
+More built-in models — CloudWatch `LogStream`, plus an ECS submodule covering clusters, services, tasks, and task definitions. The `parse_records` path now wraps scalar array elements (which is what AWS's ECS `List*` APIs return) so they look like ordinary single-field rows.
+
+- New `vantage_aws::models::log_stream` — `LogStream` + `log_streams_table` (`DescribeLogStreams`, requires `logGroupName`). `LogStream::ref_events` derives the log group from the stream's ARN; `ref_events_in` lets the caller pass it. Both narrow `FilterLogEvents` via `logStreamNamePrefix`.
+- `LogGroup` gains a `streams` `with_many` relation alongside the existing `events` one, plus a typed `LogGroup::ref_streams()`.
+- New `vantage_aws::models::ecs` submodule:
+  - `Cluster` + `clusters_table` (`ListClusters`). Methods: `name()` (parsed from ARN), `ref_services()`, `ref_tasks()`.
+  - `Service` + `services_table` (`ListServices`, requires `cluster` condition). `name()` helper.
+  - `Task` + `tasks_table` (`ListTasks`, requires `cluster` condition; supports `serviceName` / `family` / `desiredStatus` filters). `task_id()` helper. `ref_log_events(aws, log_group_name, prefix)` returns a `FilterLogEvents` table narrowed by `logStreamNamePrefix` — caller supplies the prefix because ECS streams put `taskId` at the *end* of the name (`<streamPrefix>/<container>/<taskId>`) and AWS only supports prefix matching.
+  - `TaskDefinition` + `task_definitions_table` (`ListTaskDefinitions`).
+- `parse_records` wraps scalar (string / number) array entries as `{<id_field>: value}` records — the ECS `List*` APIs return arrays of ARN strings rather than objects, so without this wrap the response would error.
+- `examples/aws-cli.rs` gains `list-streams`, `traverse-streams`, `list-clusters`, `list-services`, `list-tasks` (with `--service` / `--family` / `--status`), `list-task-defs` (with `--family-prefix`).
+
+## 0.4.0 — 2026-04-27
+
+First release — incubating. Read-only AWS JSON-1.1 RPC backend that exposes AWS APIs (CloudWatch Logs, ECS, DynamoDB control plane, KMS, …) as Vantage `TableSource`s. `AwsAccount` *is* the source; per-operation config lives in the table name (`array_key:service/target`).
+
+- `AwsAccount` with three credential entry points: `from_env()` (standard env vars), `from_credentials_file()` (`[default]` profile in `~/.aws/credentials`; region resolves through `AWS_REGION` → `AWS_DEFAULT_REGION` → `~/.aws/config` `[default]`), and `from_default()` (env first, file fallback). Named profiles, SSO, assume-role, IMDS — out of v0.
+- Hand-rolled SigV4 in `src/sign.rs`, no `aws-sdk-*` / `aws-sigv4` dep — just `hmac` / `sha2` / `hex`. Pinned to AWS's canonical-example fixture. Civil-time conversion is hand-rolled too (Hinnant's `days_from_civil`) so we stay off `chrono` / `time` for one function.
+- `AwsCondition` with `Eq` (folds into the JSON request body), `In` (literal set; must collapse to a single value at execute time), and `Deferred` (subquery, resolved at execute time). AWS APIs only accept exact-match filters, so multi-value conditions error loudly.
+- `AwsOperation` blanket trait so `column.eq(value)` / `column.in_(subquery)` works against any `Expressive<ciborium::Value>`.
+- `TableSource` impl: `list_table_values` with deferred-condition resolution, `column_table_values_expr` for relation traversal, `related_in_condition` so `with_one` / `with_many` traversal works without AWS-side joins. Writes (`insert` / `replace` / `patch` / `delete`) and aggregations (`sum` / `min` / `max`) intentionally error.
+- Built-in CloudWatch models in `vantage_aws::models`: `log_groups_table` / `log_events_table` (`DescribeLogGroups` / `FilterLogEvents`), with an `events` `with_many` relation between them and a typed `LogGroup::ref_events()` for the entity-in-hand case.
+- `examples/aws-cli.rs` — `list-groups`, `list-events`, `traverse`, `--region` override. Output via `vantage_cli_util::print_table`, so the demo exercises the same `Table` / `TableSource` machinery the rest of the framework uses.
+- CI workflow (`.github/workflows/aws.yaml`) runs the demo CLI against a live AWS account (`list-groups`, `list-groups --prefix /aws/lambda/`, `traverse`) on every PR — catches signature regressions and wire-format drift the offline tests miss.

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -9,7 +9,6 @@ documentation = "https://docs.rs/vantage-aws"
 homepage = "https://romaninsh.github.io/vantage"
 repository = "https://github.com/romaninsh/vantage"
 readme = "README.md"
-publish = false
 
 [dependencies]
 vantage-core = { version = "0.4", path = "../vantage-core" }

--- a/vantage-aws/README.md
+++ b/vantage-aws/README.md
@@ -61,10 +61,13 @@ parsed into `Record<CborValue>` rows.
 You only have to write this once per resource — usually you wrap it in
 a model factory and forget about the encoding (see below).
 
-## Built-in CloudWatch models
+## Built-in models
 
-`vantage_aws::models` ships two CloudWatch tables ready-made so you
-don't have to memorise the table-name format:
+`vantage_aws::models` ships ready-made tables so you don't have to
+memorise the table-name format:
+
+- CloudWatch Logs: `log_groups_table`, `log_streams_table`, `log_events_table`.
+- ECS (under `models::ecs`): `clusters_table`, `services_table`, `tasks_table`, `task_definitions_table`.
 
 ```rust
 use vantage_aws::models::{log_groups_table, log_events_table};
@@ -79,10 +82,16 @@ events.add_condition(eq("logGroupName", "/aws/lambda/foo"));
 let logs = events.list_values().await?;
 ```
 
-`log_groups_table` registers `events` as a `with_many` relation that
-traverses to the group's log events. AWS doesn't accept multi-value
-filters, so the source has to narrow to a single group before
-traversal — otherwise the call errors at execute time.
+`log_groups_table` registers two `with_many` relations — `events` and
+`streams` — that traverse to the group's log events / streams. AWS
+doesn't accept multi-value filters, so the source has to narrow to a
+single group before traversal — otherwise the call errors at execute
+time.
+
+ECS APIs split into a `List*` step (returns ARNs only) and a `Describe*`
+step (full objects). v0 exposes the `List*` side; rows hold the ARN
+plus parsed-out short-name helpers (`Cluster::name()`,
+`Task::task_id()`, etc.).
 
 ## Conditions
 
@@ -134,7 +143,8 @@ something else, you probably want a different crate.
 
 v0 covers: `AwsAccount` + JSON-1.1 transport, hand-rolled SigV4,
 `Eq` / `In` / `Deferred` conditions, `with_one` / `with_many`
-traversal, two CloudWatch models (`LogGroup`, `LogEvent`), env-var and
+traversal, CloudWatch (`LogGroup`, `LogStream`, `LogEvent`) and ECS
+(`Cluster`, `Service`, `Task`, `TaskDefinition`) models, env-var and
 `~/.aws/credentials` `[default]` credential loading.
 
 Out of scope for v0:

--- a/vantage-aws/examples/aws-cli.rs
+++ b/vantage-aws/examples/aws-cli.rs
@@ -1,5 +1,5 @@
 //! `vantage-aws-cli` — proof-of-concept CLI driving the CloudWatch
-//! models through `vantage-aws`. Renders results via
+//! and ECS models through `vantage-aws`. Renders results via
 //! `vantage_cli_util::print_table` so the output exercises the same
 //! `Table` / `TableSource` machinery the rest of the framework uses.
 //!
@@ -7,15 +7,13 @@
 //! `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, `AWS_REGION`),
 //! falling back to the `[default]` profile in `~/.aws/credentials`
 //! and `~/.aws/config`.
-//!
-//! Subcommands:
-//!   list-groups [--prefix <p>]   → DescribeLogGroups
-//!   list-events <group>           → FilterLogEvents
-//!   traverse                      → filter to one group, drill into its events
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use vantage_aws::models::{log_events_table, log_groups_table};
+use vantage_aws::models::ecs::{
+    clusters_table, services_table, task_definitions_table, tasks_table,
+};
+use vantage_aws::models::{log_events_table, log_groups_table, log_streams_table};
 use vantage_aws::{AwsAccount, eq};
 use vantage_cli_util::{print_table, render_records};
 use vantage_dataset::prelude::ReadableValueSet;
@@ -23,7 +21,7 @@ use vantage_dataset::prelude::ReadableValueSet;
 const TRAVERSE_GROUP: &str = "/ecs/ba-nginx";
 
 #[derive(Parser)]
-#[command(name = "vantage-aws-cli", about = "vantage-aws CloudWatch demo")]
+#[command(name = "vantage-aws-cli", about = "vantage-aws CloudWatch + ECS demo")]
 struct Cli {
     /// Override the AWS region (sets AWS_REGION before credential load).
     #[arg(long, global = true)]
@@ -35,15 +33,42 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// List CloudWatch log groups (optionally filtered by prefix).
+    /// CloudWatch: list log groups (optionally filtered by prefix).
     ListGroups {
         #[arg(long)]
         prefix: Option<String>,
     },
-    /// List log events for a specific log group.
+    /// CloudWatch: list log streams in a group.
+    ListStreams { log_group_name: String },
+    /// CloudWatch: list log events in a group.
     ListEvents { log_group_name: String },
-    /// Demo the relation: filter to a specific log group, then list its events.
+    /// CloudWatch: filter to one group, drill into its events via the `events` relation.
     Traverse,
+    /// CloudWatch: filter to one group, drill into its streams via the `streams` relation.
+    TraverseStreams,
+
+    /// ECS: list clusters in the account.
+    ListClusters,
+    /// ECS: list services in a cluster (name or ARN).
+    ListServices { cluster: String },
+    /// ECS: list tasks in a cluster (name or ARN).
+    ListTasks {
+        cluster: String,
+        /// Filter by service name.
+        #[arg(long)]
+        service: Option<String>,
+        /// Filter by task definition family.
+        #[arg(long)]
+        family: Option<String>,
+        /// RUNNING / PENDING / STOPPED.
+        #[arg(long)]
+        status: Option<String>,
+    },
+    /// ECS: list active task definitions (optionally filtered by family prefix).
+    ListTaskDefs {
+        #[arg(long)]
+        family_prefix: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -66,6 +91,12 @@ async fn main() -> Result<()> {
             print_table(&t).await?;
         }
 
+        Command::ListStreams { log_group_name } => {
+            let mut t = log_streams_table(aws);
+            t.add_condition(eq("logGroupName", log_group_name));
+            print_table(&t).await?;
+        }
+
         Command::ListEvents { log_group_name } => {
             let mut t = log_events_table(aws);
             t.add_condition(eq("logGroupName", log_group_name));
@@ -73,20 +104,66 @@ async fn main() -> Result<()> {
         }
 
         Command::Traverse => {
-            // Narrow the source table to the target group (DescribeLogGroups
-            // takes `logGroupNamePrefix`, and the full name is a prefix of
-            // itself). The `with_foreign("events", ...)` closure registered
-            // in log_groups_table picks this up and pre-conditions the
-            // events table with the same group.
             let mut groups_table = log_groups_table(aws);
             groups_table.add_condition(eq("logGroupNamePrefix", TRAVERSE_GROUP));
             print_table(&groups_table).await?;
 
-            println!("\n→ events via with_foreign(\"events\"):\n");
+            println!("\n→ events via with_many(\"events\"):\n");
 
             let events_any = groups_table.get_ref("events")?;
             let records = events_any.list_values().await?;
             render_records(&records, Some("eventId"));
+        }
+
+        Command::TraverseStreams => {
+            let mut groups_table = log_groups_table(aws);
+            groups_table.add_condition(eq("logGroupNamePrefix", TRAVERSE_GROUP));
+            print_table(&groups_table).await?;
+
+            println!("\n→ streams via with_many(\"streams\"):\n");
+
+            let streams_any = groups_table.get_ref("streams")?;
+            let records = streams_any.list_values().await?;
+            render_records(&records, Some("logStreamName"));
+        }
+
+        Command::ListClusters => {
+            let t = clusters_table(aws);
+            print_table(&t).await?;
+        }
+
+        Command::ListServices { cluster } => {
+            let mut t = services_table(aws);
+            t.add_condition(eq("cluster", cluster));
+            print_table(&t).await?;
+        }
+
+        Command::ListTasks {
+            cluster,
+            service,
+            family,
+            status,
+        } => {
+            let mut t = tasks_table(aws);
+            t.add_condition(eq("cluster", cluster));
+            if let Some(s) = service {
+                t.add_condition(eq("serviceName", s));
+            }
+            if let Some(f) = family {
+                t.add_condition(eq("family", f));
+            }
+            if let Some(s) = status {
+                t.add_condition(eq("desiredStatus", s));
+            }
+            print_table(&t).await?;
+        }
+
+        Command::ListTaskDefs { family_prefix } => {
+            let mut t = task_definitions_table(aws);
+            if let Some(p) = family_prefix {
+                t.add_condition(eq("familyPrefix", p));
+            }
+            print_table(&t).await?;
         }
     }
 

--- a/vantage-aws/src/json1/mod.rs
+++ b/vantage-aws/src/json1/mod.rs
@@ -50,6 +50,10 @@ impl AwsAccount {
     /// Pull the configured array out of a successful response and build
     /// records keyed by `id_field`. Each value is converted from
     /// `serde_json::Value` to `ciborium::Value` via the serde bridge.
+    ///
+    /// Scalar array elements (strings/numbers) get wrapped as
+    /// `{<id_field>: value}` — this is what the ECS List* APIs return
+    /// (`clusterArns: ["arn:…", …]` instead of objects).
     pub(crate) fn parse_records(
         &self,
         table_name: &str,
@@ -69,13 +73,20 @@ impl AwsAccount {
             })?
             .clone();
 
+        let scalar_field = id_field.unwrap_or("value");
+
         let mut out = IndexMap::with_capacity(array.len());
         for (idx, item) in array.into_iter().enumerate() {
             let obj = match item {
                 JsonValue::Object(map) => map,
+                JsonValue::String(_) | JsonValue::Number(_) => {
+                    let mut m = serde_json::Map::new();
+                    m.insert(scalar_field.to_string(), item);
+                    m
+                }
                 other => {
                     return Err(error!(
-                        "AWS response array entry is not an object",
+                        "AWS response array entry is not an object or scalar",
                         index = idx,
                         got = format!("{:?}", other)
                     ));

--- a/vantage-aws/src/models/ecs/cluster.rs
+++ b/vantage-aws/src/models/ecs/cluster.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+use vantage_table::table::Table;
+
+use crate::{AwsAccount, eq};
+
+use super::service::{Service, services_table};
+use super::task::{Task, tasks_table};
+
+/// One ECS cluster — `ListClusters` returns just an ARN per row, so
+/// that's all you get without a follow-up `DescribeClusters` call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Cluster {
+    #[serde(rename = "clusterArn")]
+    pub cluster_arn: String,
+}
+
+/// `ListClusters` table — every cluster in the account / region.
+///
+/// ```no_run
+/// # use vantage_aws::AwsAccount;
+/// # use vantage_aws::models::ecs::clusters_table;
+/// # async fn run() -> vantage_core::Result<()> {
+/// # let aws = AwsAccount::from_default()?;
+/// let clusters = clusters_table(aws);
+/// # Ok(()) }
+/// ```
+pub fn clusters_table(aws: AwsAccount) -> Table<AwsAccount, Cluster> {
+    Table::new(
+        "clusterArns:ecs/AmazonEC2ContainerServiceV20141113.ListClusters",
+        aws,
+    )
+    .with_id_column("clusterArn")
+}
+
+impl Cluster {
+    /// The cluster's short name, parsed out of [`Self::cluster_arn`].
+    /// Cluster ARNs have the shape
+    /// `arn:aws:ecs:<region>:<account>:cluster/<name>`.
+    pub fn name(&self) -> Option<&str> {
+        self.cluster_arn.rsplit('/').next()
+    }
+
+    /// Services table pre-filtered to *this* cluster.
+    pub fn ref_services(&self, aws: AwsAccount) -> Table<AwsAccount, Service> {
+        let mut t = services_table(aws);
+        t.add_condition(eq("cluster", self.cluster_arn.clone()));
+        t
+    }
+
+    /// Tasks table pre-filtered to *this* cluster.
+    pub fn ref_tasks(&self, aws: AwsAccount) -> Table<AwsAccount, Task> {
+        let mut t = tasks_table(aws);
+        t.add_condition(eq("cluster", self.cluster_arn.clone()));
+        t
+    }
+}

--- a/vantage-aws/src/models/ecs/mod.rs
+++ b/vantage-aws/src/models/ecs/mod.rs
@@ -1,0 +1,29 @@
+//! Ready-made ECS tables — clusters, services, tasks, task definitions.
+//!
+//! AWS's ECS APIs split into a `List*` step (returns ARNs only) and a
+//! `Describe*` step (takes those ARNs, returns full objects). v0
+//! exposes the `List*` side: rows hold the ARN plus a parsed-out
+//! short name where it's useful.
+//!
+//! ```no_run
+//! # use vantage_aws::AwsAccount;
+//! # use vantage_aws::models::ecs::clusters_table;
+//! # use vantage_dataset::prelude::ReadableValueSet;
+//! # async fn run() -> vantage_core::Result<()> {
+//! # let aws = AwsAccount::from_default()?;
+//! let clusters = clusters_table(aws.clone());
+//! for cluster in clusters.list_values().await? {
+//!     // …
+//! }
+//! # Ok(()) }
+//! ```
+
+pub mod cluster;
+pub mod service;
+pub mod task;
+pub mod task_definition;
+
+pub use cluster::{Cluster, clusters_table};
+pub use service::{Service, services_table};
+pub use task::{Task, tasks_table};
+pub use task_definition::{TaskDefinition, task_definitions_table};

--- a/vantage-aws/src/models/ecs/service.rs
+++ b/vantage-aws/src/models/ecs/service.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+use vantage_table::table::Table;
+
+use crate::AwsAccount;
+
+/// One ECS service — `ListServices` returns just an ARN per row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Service {
+    #[serde(rename = "serviceArn")]
+    pub service_arn: String,
+}
+
+/// `ListServices` table. AWS requires `cluster` (a name or ARN) before
+/// it will list anything, so add `eq("cluster", "...")` first or
+/// traverse from a [`Cluster`](super::cluster::Cluster).
+pub fn services_table(aws: AwsAccount) -> Table<AwsAccount, Service> {
+    Table::new(
+        "serviceArns:ecs/AmazonEC2ContainerServiceV20141113.ListServices",
+        aws,
+    )
+    .with_id_column("serviceArn")
+}
+
+impl Service {
+    /// The service's short name, parsed out of [`Self::service_arn`].
+    pub fn name(&self) -> Option<&str> {
+        self.service_arn.rsplit('/').next()
+    }
+}

--- a/vantage-aws/src/models/ecs/task.rs
+++ b/vantage-aws/src/models/ecs/task.rs
@@ -1,0 +1,59 @@
+use serde::{Deserialize, Serialize};
+use vantage_table::table::Table;
+
+use crate::{AwsAccount, eq};
+
+use crate::models::log_event::{LogEvent, log_events_table};
+
+/// One ECS task — `ListTasks` returns just an ARN per row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Task {
+    #[serde(rename = "taskArn")]
+    pub task_arn: String,
+}
+
+/// `ListTasks` table. AWS requires `cluster` (a name or ARN) before it
+/// will list anything, so add `eq("cluster", "...")` first or traverse
+/// from a [`Cluster`](super::cluster::Cluster).
+///
+/// Also accepts the optional filters AWS supports as conditions:
+/// `serviceName`, `family`, `desiredStatus` (`RUNNING` / `PENDING` /
+/// `STOPPED`), `launchType`, `containerInstance`.
+pub fn tasks_table(aws: AwsAccount) -> Table<AwsAccount, Task> {
+    Table::new(
+        "taskArns:ecs/AmazonEC2ContainerServiceV20141113.ListTasks",
+        aws,
+    )
+    .with_id_column("taskArn")
+}
+
+impl Task {
+    /// The task's id, parsed out of [`Self::task_arn`]. ECS task ARNs
+    /// have the shape `arn:aws:ecs:<region>:<account>:task/<cluster>/<id>`.
+    pub fn task_id(&self) -> Option<&str> {
+        self.task_arn.rsplit('/').next()
+    }
+
+    /// Log events from the given log group, with `logStreamNamePrefix`
+    /// set to this task's id.
+    ///
+    /// ECS log streams typically follow the pattern
+    /// `<streamPrefix>/<containerName>/<taskId>` — task id is at the
+    /// END, so this prefix-match doesn't directly find a task's
+    /// streams. Use it instead to point at a known prefix and combine
+    /// with a `filterPattern` that includes the task id.
+    ///
+    /// Most callers will already know the streamPrefix from the task
+    /// definition; pass that as `prefix` instead of the raw task id.
+    pub fn ref_log_events(
+        &self,
+        aws: AwsAccount,
+        log_group_name: &str,
+        prefix: &str,
+    ) -> Table<AwsAccount, LogEvent> {
+        let mut t = log_events_table(aws);
+        t.add_condition(eq("logGroupName", log_group_name));
+        t.add_condition(eq("logStreamNamePrefix", prefix));
+        t
+    }
+}

--- a/vantage-aws/src/models/ecs/task_definition.rs
+++ b/vantage-aws/src/models/ecs/task_definition.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+use vantage_table::table::Table;
+
+use crate::AwsAccount;
+
+/// One ECS task definition revision — `ListTaskDefinitions` returns
+/// just an ARN per row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskDefinition {
+    #[serde(rename = "taskDefinitionArn")]
+    pub task_definition_arn: String,
+}
+
+/// `ListTaskDefinitions` table — every active task definition in the
+/// account. Optional filters: `familyPrefix`, `status` (`ACTIVE` /
+/// `INACTIVE`), `sort` (`ASC` / `DESC`).
+pub fn task_definitions_table(aws: AwsAccount) -> Table<AwsAccount, TaskDefinition> {
+    Table::new(
+        "taskDefinitionArns:ecs/AmazonEC2ContainerServiceV20141113.ListTaskDefinitions",
+        aws,
+    )
+    .with_id_column("taskDefinitionArn")
+}
+
+impl TaskDefinition {
+    /// The `family:revision` part of the ARN — the form most ECS APIs
+    /// will accept as input.
+    pub fn family_revision(&self) -> Option<&str> {
+        self.task_definition_arn.rsplit('/').next()
+    }
+}

--- a/vantage-aws/src/models/log_group.rs
+++ b/vantage-aws/src/models/log_group.rs
@@ -4,6 +4,7 @@ use vantage_table::table::Table;
 use crate::{AwsAccount, eq};
 
 use super::log_event::{LogEvent, log_events_table};
+use super::log_stream::{LogStream, log_streams_table};
 
 /// One CloudWatch Logs group. Field names match the wire shape —
 /// these are exactly what `DescribeLogGroups` returns.
@@ -20,10 +21,13 @@ pub struct LogGroup {
 /// `DescribeLogGroups` table — every log group in the account. Filter
 /// by adding `eq("logGroupNamePrefix", "...")`.
 ///
-/// Comes with an `events` relation that traverses to the group's
-/// log events. AWS doesn't accept multi-value filters, so the source
-/// has to narrow to a single group before traversal — otherwise the
-/// traversal errors at execute time.
+/// Two relations:
+///   - `events` → `FilterLogEvents` for this group
+///   - `streams` → `DescribeLogStreams` for this group
+///
+/// AWS doesn't accept multi-value filters, so the source has to narrow
+/// to a single group before traversal — otherwise the call errors at
+/// execute time.
 ///
 /// ```no_run
 /// # use vantage_aws::{AwsAccount, eq};
@@ -40,14 +44,20 @@ pub fn log_groups_table(aws: AwsAccount) -> Table<AwsAccount, LogGroup> {
         .with_column_of::<i64>("creationTime")
         .with_column_of::<i64>("storedBytes")
         .with_many("events", "logGroupName", log_events_table)
+        .with_many("streams", "logGroupName", log_streams_table)
 }
 
 impl LogGroup {
-    /// Events table pre-filtered to *this* group's name. Use when
-    /// you already have a resolved `LogGroup` in hand and don't need
-    /// to go through the table-level relation traversal.
+    /// Events table pre-filtered to *this* group's name.
     pub fn ref_events(&self, aws: AwsAccount) -> Table<AwsAccount, LogEvent> {
         let mut t = log_events_table(aws);
+        t.add_condition(eq("logGroupName", self.log_group_name.clone()));
+        t
+    }
+
+    /// Streams table pre-filtered to *this* group's name.
+    pub fn ref_streams(&self, aws: AwsAccount) -> Table<AwsAccount, LogStream> {
+        let mut t = log_streams_table(aws);
         t.add_condition(eq("logGroupName", self.log_group_name.clone()));
         t
     }

--- a/vantage-aws/src/models/log_stream.rs
+++ b/vantage-aws/src/models/log_stream.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+use vantage_table::table::Table;
+
+use crate::{AwsAccount, eq};
+
+use super::log_event::{LogEvent, log_events_table};
+
+/// One CloudWatch Logs stream from `DescribeLogStreams`. Field names
+/// match the wire shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogStream {
+    #[serde(rename = "logStreamName")]
+    pub log_stream_name: String,
+    #[serde(default)]
+    pub arn: String,
+    #[serde(rename = "creationTime", default)]
+    pub creation_time: i64,
+    #[serde(rename = "firstEventTimestamp", default)]
+    pub first_event_timestamp: i64,
+    #[serde(rename = "lastEventTimestamp", default)]
+    pub last_event_timestamp: i64,
+    #[serde(rename = "lastIngestionTime", default)]
+    pub last_ingestion_time: i64,
+    #[serde(rename = "storedBytes", default)]
+    pub stored_bytes: i64,
+    #[serde(rename = "uploadSequenceToken", default)]
+    pub upload_sequence_token: String,
+}
+
+/// `DescribeLogStreams` table. AWS requires `logGroupName` before it
+/// will list anything, so add `eq("logGroupName", "...")` first.
+///
+/// ```no_run
+/// # use vantage_aws::{AwsAccount, eq};
+/// # use vantage_aws::models::log_streams_table;
+/// # async fn run() -> vantage_core::Result<()> {
+/// # let aws = AwsAccount::from_default()?;
+/// let mut streams = log_streams_table(aws);
+/// streams.add_condition(eq("logGroupName", "/aws/lambda/foo"));
+/// # Ok(()) }
+/// ```
+pub fn log_streams_table(aws: AwsAccount) -> Table<AwsAccount, LogStream> {
+    Table::new("logStreams:logs/Logs_20140328.DescribeLogStreams", aws)
+        .with_id_column("logStreamName")
+        .with_column_of::<String>("arn")
+        .with_column_of::<i64>("creationTime")
+        .with_column_of::<i64>("firstEventTimestamp")
+        .with_column_of::<i64>("lastEventTimestamp")
+        .with_column_of::<i64>("lastIngestionTime")
+        .with_column_of::<i64>("storedBytes")
+        .with_column_of::<String>("uploadSequenceToken")
+}
+
+impl LogStream {
+    /// The owning log group's name, parsed out of [`Self::arn`].
+    /// Stream ARNs have the shape
+    /// `arn:aws:logs:<region>:<account>:log-group:<group>:log-stream:<stream>`.
+    pub fn log_group_name(&self) -> Option<&str> {
+        let after = self.arn.split(":log-group:").nth(1)?;
+        after.split(":log-stream:").next()
+    }
+
+    /// Events table pre-filtered to *this* stream. The log group is
+    /// pulled from this stream's ARN; if the ARN is empty, pass it
+    /// in via [`Self::ref_events_in`] instead.
+    pub fn ref_events(&self, aws: AwsAccount) -> Option<Table<AwsAccount, LogEvent>> {
+        let group = self.log_group_name()?;
+        Some(self.ref_events_in(aws, group))
+    }
+
+    /// Events table pre-filtered to *this* stream within the given
+    /// log group. Use when the stream ARN isn't populated (e.g.
+    /// streams synthesised by hand).
+    pub fn ref_events_in(
+        &self,
+        aws: AwsAccount,
+        log_group_name: &str,
+    ) -> Table<AwsAccount, LogEvent> {
+        let mut t = log_events_table(aws);
+        t.add_condition(eq("logGroupName", log_group_name));
+        t.add_condition(eq("logStreamNamePrefix", self.log_stream_name.clone()));
+        t
+    }
+}

--- a/vantage-aws/src/models/mod.rs
+++ b/vantage-aws/src/models/mod.rs
@@ -1,7 +1,15 @@
-//! Two ready-made CloudWatch tables to skip the table-name dance.
+//! Ready-made tables to skip the table-name dance.
 //!
-//! - [`log_groups_table`] — `DescribeLogGroups`
-//! - [`log_events_table`] — `FilterLogEvents`
+//! CloudWatch Logs:
+//!   - [`log_groups_table`]  — `DescribeLogGroups`
+//!   - [`log_streams_table`] — `DescribeLogStreams`
+//!   - [`log_events_table`]  — `FilterLogEvents`
+//!
+//! ECS (under [`ecs`]):
+//!   - [`ecs::clusters_table`]
+//!   - [`ecs::services_table`]
+//!   - [`ecs::tasks_table`]
+//!   - [`ecs::task_definitions_table`]
 //!
 //! ```no_run
 //! # use vantage_aws::{AwsAccount, eq};
@@ -13,8 +21,11 @@
 //! # Ok(()) }
 //! ```
 
+pub mod ecs;
 pub mod log_event;
 pub mod log_group;
+pub mod log_stream;
 
 pub use log_event::{LogEvent, log_events_table};
 pub use log_group::{LogGroup, log_groups_table};
+pub use log_stream::{LogStream, log_streams_table};


### PR DESCRIPTION
vantage-aws 0.4.1, picking up where #210 leaves off. Adds the missing CloudWatch `LogStream` model and a fresh ECS submodule (clusters, services, tasks, task definitions). Also a small `parse_records` change so the ECS `List*` APIs (which return arrays of bare ARN strings, not objects) decode cleanly.

### CloudWatch: LogStream

`DescribeLogStreams` returns full objects, so it slots in the same way `LogGroup` did:

```rust
use vantage_aws::{eq, models::log_streams_table};

let mut streams = log_streams_table(aws);
streams.add_condition(eq("logGroupName", "/ecs/vantage-demo"));
let rows = streams.list_values().await?;
```

`LogGroup` picks up a `streams` `with_many` relation alongside the existing `events` one, plus a typed `LogGroup::ref_streams()`. `LogStream::ref_events` derives the log group from the stream's ARN; `ref_events_in` lets you pass it explicitly when the ARN field isn't populated.

### ECS

ECS APIs split into a `List*` step (returns ARNs) and a `Describe*` step (full objects). v0 ships the `List*` side — rows hold the ARN, plus parsed-out short-name helpers (`Cluster::name()`, `Task::task_id()`, etc.).

```rust
use vantage_aws::models::ecs::{clusters_table, tasks_table};

let clusters = clusters_table(aws.clone());
for cluster in clusters.list_values().await? {
    let tasks = cluster.ref_tasks(aws.clone());
    for task in tasks.list_values().await? {
        // …
    }
}
```

Four resources covered: `Cluster`, `Service`, `Task`, `TaskDefinition`. Cross-resource navigation:

- `Cluster::ref_services()`, `Cluster::ref_tasks()` — typed methods that pre-filter by this cluster's ARN.
- `Task::ref_log_events(group, prefix)` — narrows `FilterLogEvents` by `logStreamNamePrefix`. The caller passes the prefix because ECS streams put `taskId` at the *end* of the name (`<streamPrefix>/<container>/<taskId>`) and AWS only does prefix matching. Once `Describe*` arrives we can chain through the task definition automatically.

### parse_records: scalar wrap

ECS `List*` responses look like `{ "clusterArns": ["arn:...", ...] }` — array elements are bare strings, not objects. `parse_records` now wraps them as `{ <id_field>: value }` so the row machinery doesn't trip on them. No change for object-shaped responses; this is purely additive.

### aws-cli demo

`examples/aws-cli.rs` gets six new subcommands so you can drive the new models from the shell:

```sh
cargo run --example aws-cli -- list-streams /ecs/vantage-demo
cargo run --example aws-cli -- traverse-streams
cargo run --example aws-cli -- list-clusters
cargo run --example aws-cli -- list-services vantage-demo
cargo run --example aws-cli -- list-tasks vantage-demo --status RUNNING
cargo run --example aws-cli -- list-task-defs --family-prefix vantage-demo
```
