### PR TITLE
add get_ref to anytable; bump vantage-{table,live,aws}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3995,7 +3995,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-live"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.4.2 — 2026-04-29
+
+AWS Query protocol (form-encoded request, XML response) lands alongside the existing JSON-1.1 transport, plus an IAM submodule that uses it. Same `AwsAccount` is the `TableSource` for both — relations span protocols freely. ([#212](https://github.com/romaninsh/vantage/pull/212))
+
+- The protocol is encoded as a prefix in the table name. Existing tables get `json1/` (e.g. `json1/logGroups:logs/Logs_20140328.DescribeLogGroups`); new IAM tables use `query/` (e.g. `query/Users:iam/2010-05-08.ListUsers`). `AwsAccount::execute_rpc` and `parse_records` match on the prefix and dispatch.
+- New `src/query/` mirrors `src/json1/` — `transport.rs` for the signed POST, `mod.rs` with `execute` + `parse_records`. Same hand-rolled SigV4 signer powers both protocols. Responses are XML; `query/xml.rs` normalises them to `serde_json::Value` by stripping `{Action}Response` / `{Action}Result` wrappers and hoisting `<member>` collections into JSON arrays.
+- Global services (IAM today, STS later) get a one-line override in `query/transport.rs`: served from `iam.amazonaws.com` (no region in the host) and signed with `us-east-1` regardless of the configured region.
+- New `vantage_aws::models::iam` submodule with six top-level tables: `users_table`, `groups_table`, `roles_table`, `policies_table`, `access_keys_table`, `instance_profiles_table`. One `AttachedPolicy` struct shared across `ListAttachedUserPolicies` / `ListAttachedGroupPolicies` / `ListAttachedRolePolicies` (same response shape, different action per source).
+- IAM relations on entity factories: `User` → `groups`, `access_keys`, `attached_policies`; `Group` → `attached_policies`; `Role` → `attached_policies`, `instance_profiles`. Both `with_many` traversal and `User::ref_*` / `Group::ref_*` / `Role::ref_*` entity-in-hand forms work — the ref-* form is the right tool for IAM since `ListUsers` / `ListRoles` ignore name filters and return the whole account.
+- **Reorganised**: `models::log_*` collapses into `models::logs::*` — `log_groups_table` becomes `logs::groups_table`, etc. Lets the IAM `groups_table` live cleanly under `models::iam::` without a name clash, and matches the `models::ecs::*` shape from 0.4.1. Existing call sites need to update imports.
+- `query::parse_records` treats an empty string at the array key as an empty array. `<Foo/>` (self-closing) is what IAM returns for an empty list and the XML normaliser surfaces that as `""` — `list-groups` on an account with no IAM groups now returns "No records found." instead of an obscure decode failure.
+- `examples/aws-cli.rs` picks up `list-users`, `list-policies` (`--scope`), `list-roles` (`--path-prefix`), `list-access-keys` (`--user`), `traverse-user-policies`, `traverse-user-access-keys`, `traverse-role-policies`, `traverse-role-profiles`. Log commands renamed to free up `list-groups` for IAM.
+
 ## 0.4.1 — 2026-04-28
 
 More built-in models — CloudWatch `LogStream`, plus an ECS submodule covering clusters, services, tasks, and task definitions. The `parse_records` path now wraps scalar array elements (which is what AWS's ECS `List*` APIs return) so they look like ordinary single-field rows.

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-live/CHANGELOG.md
+++ b/vantage-live/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.2 — 2026-04-29
+
+- `LiveTable::get_ref(relation)` now forwards through to the master `AnyTable`, so reference traversal works on a `LiveTable` the same way it does on the underlying table — `live.get_ref("orders")` returns an `AnyTable` you can keep wrapping.
+- Pins `vantage-table = "0.4.7"` for the new `AnyTable::get_ref` / `TableLike::get_ref` surface.
+
 ## 0.4.1 — 2026-04-26
 
 - New `RedbCache::open(folder)` cache backend. Persists cached rows on disk so cache state survives process restarts. One redb file inside the folder, one redb table per `cache_key` (namespaced `__vlive__{cache_key}`) so the hot `invalidate_prefix(cache_key)` path is just a `delete_table` call — O(1)-ish, no scan. Sub-prefix invalidation falls back to scan-and-delete inside the table.

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-live"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -15,7 +15,7 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
-vantage-table = { version = "0.4.6", path = "../vantage-table" }
+vantage-table = { version = "0.4.7", path = "../vantage-table" }
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-live/src/live_table/impls/table_like.rs
+++ b/vantage-live/src/live_table/impls/table_like.rs
@@ -8,6 +8,7 @@ use ciborium::Value as CborValue;
 use tracing::warn;
 use vantage_core::{Result, error};
 use vantage_expressions::AnyExpression;
+use vantage_table::any::AnyTable;
 use vantage_table::conditions::ConditionHandle;
 use vantage_table::pagination::Pagination;
 use vantage_table::traits::table_like::TableLike;
@@ -87,6 +88,10 @@ impl TableLike for LiveTable {
         let mut master = self.master.clone();
         master.set_pagination(self.pagination);
         master.get_count().await
+    }
+
+    fn get_ref(&self, relation: &str) -> Result<AnyTable> {
+        self.master.get_ref(relation)
     }
 }
 

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.7 — 2026-04-29
+
+- New `AnyTable::get_ref(relation) -> Result<AnyTable>`. Lets reference traversal continue on the type-erased side — previously `get_ref` only existed on the typed `Table<T, E>`, so once you wrapped a table into `AnyTable` the relation graph was unreachable.
+- `TableLike` gains a `get_ref` method with a default impl that errors out (`"get_ref not supported on this TableLike"`). `Table<T, E>` overrides to delegate to the inherent; `AnyTable` and the internal `CborAdapter` forward to the wrapped table; downstream wrappers like `vantage_live::LiveTable` override to forward through to their master.
+- The trait method is sync — `Reference::resolve_as_any` is sync (no IO), so callers don't need an `.await`.
+
 ## 0.4.6 — 2026-04-26
 
 - New `AnyTable::from_table_like<T: TableLike<…>>` constructor. Wraps any table-like type that already speaks `Value = CborValue, Id = String` — needed by `vantage-live::LiveTable`, which is `TableLike` but not a `Table<T, E>` instance.

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/any.rs
+++ b/vantage-table/src/any.rs
@@ -299,9 +299,20 @@ impl TableLike for AnyTable {
     async fn get_count(&self) -> vantage_core::Result<i64> {
         self.inner.get_count().await
     }
+
+    fn get_ref(&self, relation: &str) -> Result<AnyTable> {
+        self.inner.get_ref(relation)
+    }
 }
 
 impl AnyTable {
+    /// Traverse a named reference and return the related table as `AnyTable`.
+    ///
+    /// Inherent wrapper so callers don't need `use TableLike` in scope.
+    pub fn get_ref(&self, relation: &str) -> Result<AnyTable> {
+        TableLike::get_ref(self, relation)
+    }
+
     /// Configure pagination using a callback
     pub fn with_pagination<F>(&mut self, func: F)
     where
@@ -536,6 +547,10 @@ where
 
     async fn get_count(&self) -> Result<i64> {
         self.inner.data_source().get_table_count(&self.inner).await
+    }
+
+    fn get_ref(&self, relation: &str) -> Result<AnyTable> {
+        self.inner.get_ref(relation)
     }
 }
 

--- a/vantage-table/src/table/impls/table_like.rs
+++ b/vantage-table/src/table/impls/table_like.rs
@@ -4,6 +4,7 @@ use vantage_expressions::AnyExpression;
 use vantage_types::Entity;
 
 use crate::{
+    any::AnyTable,
     conditions::ConditionHandle,
     pagination::Pagination,
     table::Table,
@@ -92,5 +93,9 @@ where
 
     async fn get_count(&self) -> Result<i64> {
         self.data_source().get_table_count(self).await
+    }
+
+    fn get_ref(&self, relation: &str) -> Result<AnyTable> {
+        Table::<T, E>::get_ref(self, relation)
     }
 }

--- a/vantage-table/src/traits/table_like.rs
+++ b/vantage-table/src/traits/table_like.rs
@@ -3,7 +3,7 @@ use vantage_core::Result;
 use vantage_dataset::prelude::{ReadableValueSet, WritableValueSet};
 use vantage_expressions::AnyExpression;
 
-use crate::{conditions::ConditionHandle, pagination::Pagination};
+use crate::{any::AnyTable, conditions::ConditionHandle, pagination::Pagination};
 
 /// Dyn-safe trait for table operations.
 #[async_trait]
@@ -40,4 +40,16 @@ pub trait TableLike: ReadableValueSet + WritableValueSet + Send + Sync {
 
     /// Get count of records in the table
     async fn get_count(&self) -> Result<i64>;
+
+    /// Traverse a named reference and return the related table as `AnyTable`.
+    ///
+    /// Default impl returns an error so wrappers without ref support compile
+    /// unchanged. `Table<T, E>` overrides this to delegate to its inherent
+    /// `get_ref`; `AnyTable`, `CborAdapter` and `LiveTable` override to forward
+    /// through to the underlying table that holds the refs.
+    fn get_ref(&self, _relation: &str) -> Result<AnyTable> {
+        Err(vantage_core::error!(
+            "get_ref not supported on this TableLike"
+        ))
+    }
 }


### PR DESCRIPTION
Two bundled threads. The first is the actual feature: `get_ref` traversal on the type-erased side. The second is a forgotten release for `vantage-aws` — #212 merged without bumping the patch or updating the changelog, so this PR catches it up.

### `get_ref` on `AnyTable`

Once a `Table<T, E>` was wrapped into an `AnyTable`, the relation graph became unreachable — `get_ref` only existed on the typed side. New surface:

```rust
let any_clients: AnyTable = AnyTable::from_table(clients_table);
let any_orders: AnyTable = any_clients.get_ref("orders")?;     // walks `with_many`
let any_bakery: AnyTable = any_clients.get_ref("bakery")?;     // walks `with_one`
```

`TableLike` gains a `get_ref` method with a default impl that errors out, so no existing implementor had to change. The four impls that *can* answer override:

- `Table<T, E>` — delegates to the existing inherent `Table::get_ref` (UFCS to disambiguate).
- `AnyTable` — virtual-dispatches through `self.inner`.
- `CborAdapter<T, E>` (internal, used by `from_table`) — forwards to the wrapped `Table`.
- `LiveTable` — forwards to the master `AnyTable`.

The trait method is sync — `Reference::resolve_as_any` is sync, no IO. There's also an inherent `AnyTable::get_ref` wrapper so callers don't need `use TableLike` at the call site.
