### PR TITLE
add Arn + AwsDateTime types; richtext rendering for cli + gpui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d"
+dependencies = [
+ "ansitok",
+]
+
+[[package]]
+name = "ansitok"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
+dependencies = [
+ "nom",
+ "vte",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +535,8 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
+ "ansi-str",
+ "console",
  "crossterm",
  "unicode-segmentation",
  "unicode-width",
@@ -528,6 +549,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -877,6 +910,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1877,6 +1916,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2086,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3908,6 +3963,7 @@ dependencies = [
  "async-trait",
  "comfy-table",
  "indexmap",
+ "owo-colors",
  "vantage-core",
  "vantage-dataset",
  "vantage-table",
@@ -4174,6 +4230,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "want"

--- a/bakery_model3/src/animal.rs
+++ b/bakery_model3/src/animal.rs
@@ -6,7 +6,7 @@ use vantage_sql::postgres::{PostgresType, types::PostgresTypeTextMarker};
 use vantage_sql::sqlite::{SqliteType, types::SqliteTypeTextMarker};
 use vantage_surrealdb::types::SurrealTypeStringMarker;
 use vantage_surrealdb::{CborValue, SurrealType};
-use vantage_types::TerminalRender;
+use vantage_types::{RichText, TerminalRender};
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum Animal {
@@ -46,14 +46,15 @@ impl Animal {
 }
 
 impl TerminalRender for Animal {
-    fn render(&self) -> String {
-        match self {
-            Animal::Cat => "🐱".to_string(),
-            Animal::Dog => "🐶".to_string(),
-            Animal::Pig => "🐷".to_string(),
-            Animal::Cow => "🐮".to_string(),
-            Animal::Chicken => "🐔".to_string(),
-        }
+    fn render(&self) -> RichText {
+        let glyph = match self {
+            Animal::Cat => "🐱",
+            Animal::Dog => "🐶",
+            Animal::Pig => "🐷",
+            Animal::Cow => "🐮",
+            Animal::Chicken => "🐔",
+        };
+        RichText::plain(glyph.to_string())
     }
 }
 

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -14,6 +14,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ansi-str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d"
+dependencies = [
+ "ansitok",
+]
+
+[[package]]
+name = "ansitok"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
+dependencies = [
+ "nom",
+ "vte",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,6 +273,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,10 +363,30 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
+ "ansi-str",
+ "console",
  "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -433,6 +493,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -733,6 +799,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +1047,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1088,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1978,6 +2084,7 @@ version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "ciborium",
  "clap",
  "hex",
@@ -2004,6 +2111,7 @@ dependencies = [
  "async-trait",
  "comfy-table",
  "indexmap",
+ "owo-colors",
  "vantage-core",
  "vantage-dataset",
  "vantage-table",
@@ -2100,6 +2208,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "want"
@@ -2276,10 +2394,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -35,6 +35,9 @@ ciborium = "0.2"
 # AWS Query protocol responses are XML (IAM, STS, EC2, …).
 quick-xml = "0.36"
 
+# Date parsing for AWS timestamps.
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+
 [dev-dependencies]
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
 vantage-cli-util = { version = "0.4", path = "../vantage-cli-util" }

--- a/vantage-aws/examples/aws-cli.rs
+++ b/vantage-aws/examples/aws-cli.rs
@@ -10,7 +10,9 @@
 //! and `~/.aws/config`.
 
 use anyhow::{Context, Result};
+use ciborium::Value as CborValue;
 use clap::{Parser, Subcommand};
+use indexmap::IndexMap;
 use vantage_aws::models::ecs::{
     clusters_table, services_table, task_definitions_table, tasks_table,
 };
@@ -19,9 +21,40 @@ use vantage_aws::models::iam::{
     policies_table, roles_table, users_table,
 };
 use vantage_aws::models::logs::{events_table, groups_table, streams_table};
-use vantage_aws::{AwsAccount, eq};
-use vantage_cli_util::{print_table, render_records};
+use vantage_aws::{AwsAccount, eq, typed_records, untyped_records};
+use vantage_cli_util::render_records_typed;
 use vantage_dataset::prelude::{ReadableDataSet, ReadableValueSet};
+use vantage_table::prelude::ColumnLike;
+use vantage_table::table::Table;
+use vantage_table::traits::table_source::TableSource;
+use vantage_types::{Entity, Record};
+
+/// Print an AWS table with rich rendering: ARNs and dates get
+/// multi-segment styling, booleans get green/red, etc. Reads column
+/// metadata to drive parsing of typed values from the raw response.
+async fn print_table<E>(t: &Table<AwsAccount, E>) -> Result<()>
+where
+    E: Entity<<AwsAccount as TableSource>::Value>,
+{
+    let id_field = t.id_field().map(|c| c.name().to_string());
+    let column_types: IndexMap<String, &'static str> = t
+        .columns()
+        .iter()
+        .map(|(name, col)| (name.clone(), col.get_type()))
+        .collect();
+    let records = t.list_values().await?;
+    let typed = typed_records(records, &column_types);
+    render_records_typed(&typed, id_field.as_deref(), &column_types);
+    Ok(())
+}
+
+/// Render ad-hoc records (e.g. from `AnyTable::list_values`) with
+/// detection-based ARN/datetime rendering — no column metadata
+/// available, so we sniff strings.
+fn render_any_records(records: IndexMap<String, Record<CborValue>>, id_field: Option<&str>) {
+    let typed = untyped_records(records);
+    render_records_typed(&typed, id_field, &IndexMap::new());
+}
 
 const TRAVERSE_GROUP: &str = "/ecs/ba-nginx";
 
@@ -170,7 +203,7 @@ async fn main() -> Result<()> {
 
             let events_any = log_groups.get_ref("events")?;
             let records = events_any.list_values().await?;
-            render_records(&records, Some("eventId"));
+            render_any_records(records, Some("eventId"));
         }
 
         Command::TraverseLogStreams => {
@@ -182,7 +215,7 @@ async fn main() -> Result<()> {
 
             let streams_any = log_groups.get_ref("streams")?;
             let records = streams_any.list_values().await?;
-            render_records(&records, Some("logStreamName"));
+            render_any_records(records, Some("logStreamName"));
         }
 
         Command::ListClusters => {

--- a/vantage-aws/src/lib.rs
+++ b/vantage-aws/src/lib.rs
@@ -57,10 +57,12 @@ mod query;
 mod sign;
 
 pub mod models;
+pub mod types;
 
 pub use account::AwsAccount;
 pub use condition::{AwsCondition, eq, in_};
 pub use operation::AwsOperation;
+pub use types::{AnyAwsType, Arn, AwsDateTime, typed_records, untyped_records};
 
 #[doc(hidden)]
 pub mod __test_support {

--- a/vantage-aws/src/models/iam/group.rs
+++ b/vantage-aws/src/models/iam/group.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
+use crate::types::{Arn, AwsDateTime};
 use crate::{AwsAccount, eq};
 
 use super::attached_policy::{AttachedPolicy, attached_group_policies_table};
@@ -31,9 +32,9 @@ pub fn groups_table(aws: AwsAccount) -> Table<AwsAccount, Group> {
     Table::new("query/Groups:iam/2010-05-08.ListGroups", aws)
         .with_id_column("GroupName")
         .with_column_of::<String>("GroupId")
-        .with_column_of::<String>("Arn")
+        .with_column_of::<Arn>("Arn")
         .with_column_of::<String>("Path")
-        .with_column_of::<String>("CreateDate")
+        .with_column_of::<AwsDateTime>("CreateDate")
         .with_many(
             "attached_policies",
             "GroupName",
@@ -48,9 +49,9 @@ pub(crate) fn groups_for_user_table(aws: AwsAccount) -> Table<AwsAccount, Group>
     Table::new("query/Groups:iam/2010-05-08.ListGroupsForUser", aws)
         .with_id_column("GroupName")
         .with_column_of::<String>("GroupId")
-        .with_column_of::<String>("Arn")
+        .with_column_of::<Arn>("Arn")
         .with_column_of::<String>("Path")
-        .with_column_of::<String>("CreateDate")
+        .with_column_of::<AwsDateTime>("CreateDate")
 }
 
 impl Group {

--- a/vantage-aws/src/models/iam/policy.rs
+++ b/vantage-aws/src/models/iam/policy.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
 use crate::AwsAccount;
+use crate::types::{Arn, AwsDateTime};
 
 /// One IAM managed policy from `ListPolicies`. Numeric fields stay as
 /// strings — the Query protocol's XML response is untyped, and we
@@ -50,13 +51,13 @@ pub fn policies_table(aws: AwsAccount) -> Table<AwsAccount, Policy> {
     Table::new("query/Policies:iam/2010-05-08.ListPolicies", aws)
         .with_id_column("PolicyName")
         .with_column_of::<String>("PolicyId")
-        .with_column_of::<String>("Arn")
+        .with_column_of::<Arn>("Arn")
         .with_column_of::<String>("Path")
         .with_column_of::<String>("DefaultVersionId")
-        .with_column_of::<String>("AttachmentCount")
-        .with_column_of::<String>("PermissionsBoundaryUsageCount")
-        .with_column_of::<String>("IsAttachable")
-        .with_column_of::<String>("CreateDate")
-        .with_column_of::<String>("UpdateDate")
+        .with_column_of::<i64>("AttachmentCount")
+        .with_column_of::<i64>("PermissionsBoundaryUsageCount")
+        .with_column_of::<bool>("IsAttachable")
+        .with_column_of::<AwsDateTime>("CreateDate")
+        .with_column_of::<AwsDateTime>("UpdateDate")
         .with_column_of::<String>("Description")
 }

--- a/vantage-aws/src/models/iam/role.rs
+++ b/vantage-aws/src/models/iam/role.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
+use crate::types::{Arn, AwsDateTime};
 use crate::{AwsAccount, eq};
 
 use super::attached_policy::{AttachedPolicy, attached_role_policies_table};
@@ -49,9 +50,9 @@ pub fn roles_table(aws: AwsAccount) -> Table<AwsAccount, Role> {
     Table::new("query/Roles:iam/2010-05-08.ListRoles", aws)
         .with_id_column("RoleName")
         .with_column_of::<String>("RoleId")
-        .with_column_of::<String>("Arn")
+        .with_column_of::<Arn>("Arn")
         .with_column_of::<String>("Path")
-        .with_column_of::<String>("CreateDate")
+        .with_column_of::<AwsDateTime>("CreateDate")
         .with_column_of::<String>("Description")
         .with_column_of::<String>("AssumeRolePolicyDocument")
         .with_column_of::<String>("MaxSessionDuration")

--- a/vantage-aws/src/models/iam/user.rs
+++ b/vantage-aws/src/models/iam/user.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
+use crate::types::{Arn, AwsDateTime};
 use crate::{AwsAccount, eq};
 
 use super::access_key::{AccessKey, access_keys_table};
@@ -54,10 +55,10 @@ pub fn users_table(aws: AwsAccount) -> Table<AwsAccount, User> {
     Table::new("query/Users:iam/2010-05-08.ListUsers", aws)
         .with_id_column("UserName")
         .with_column_of::<String>("UserId")
-        .with_column_of::<String>("Arn")
+        .with_column_of::<Arn>("Arn")
         .with_column_of::<String>("Path")
-        .with_column_of::<String>("CreateDate")
-        .with_column_of::<String>("PasswordLastUsed")
+        .with_column_of::<AwsDateTime>("CreateDate")
+        .with_column_of::<AwsDateTime>("PasswordLastUsed")
         .with_many("groups", "UserName", groups_for_user_table)
         .with_many("access_keys", "UserName", access_keys_table)
         .with_many(

--- a/vantage-aws/src/types/any.rs
+++ b/vantage-aws/src/types/any.rs
@@ -97,10 +97,14 @@ impl AnyAwsType {
             CborValue::Null => AnyAwsType::Null,
             CborValue::Bool(b) => AnyAwsType::Bool(b),
             CborValue::Text(s) => {
-                if s.starts_with("arn:") && let Ok(arn) = Arn::try_parse(&s) {
+                if s.starts_with("arn:")
+                    && let Ok(arn) = Arn::try_parse(&s)
+                {
                     return AnyAwsType::Arn(arn);
                 }
-                if looks_like_iso_timestamp(&s) && let Ok(dt) = AwsDateTime::try_parse(&s) {
+                if looks_like_iso_timestamp(&s)
+                    && let Ok(dt) = AwsDateTime::try_parse(&s)
+                {
                     return AnyAwsType::DateTime(dt);
                 }
                 AnyAwsType::Text(s)

--- a/vantage-aws/src/types/any.rs
+++ b/vantage-aws/src/types/any.rs
@@ -1,0 +1,237 @@
+//! `AnyAwsType` — the polymorphic value type held by AWS records.
+//!
+//! Mirrors the shape of `AnyCsvType` / `AnySurrealType`. Records flow
+//! through the system as `Record<AnyAwsType>` so the rendering layer
+//! can dispatch on a parsed variant (e.g. [`Arn`]) instead of a raw
+//! [`ciborium::Value`]. The variant choice is driven by the column's
+//! declared Rust type: `with_column_of::<Arn>(...)` becomes
+//! `AnyAwsType::Arn(...)` here.
+
+use ciborium::Value as CborValue;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use vantage_types::{RichText, Style, TerminalRender};
+
+use super::arn::Arn;
+use super::datetime::AwsDateTime;
+
+/// One value in an AWS record. Variants carry parsed types when the
+/// declared column type asked for them; otherwise we fall back to
+/// representation-friendly variants ([`AnyAwsType::Text`],
+/// [`AnyAwsType::Int`], …) and finally to the lossless
+/// [`AnyAwsType::Other`] escape hatch.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AnyAwsType {
+    Arn(Arn),
+    DateTime(AwsDateTime),
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Text(String),
+    Null,
+    /// Lossless fallback for shapes we don't have a typed variant for
+    /// (nested objects, byte strings, etc.).
+    Other(CborValue),
+}
+
+impl AnyAwsType {
+    /// Build a typed variant from a CBOR value, given the column's
+    /// declared Rust type name (from [`vantage_table::traits::column_like::ColumnLike::get_type`]).
+    ///
+    /// The type name is matched against a small set of known suffixes —
+    /// e.g. `"vantage_aws::types::arn::Arn"` ends in `"::arn::Arn"`,
+    /// `"vantage_aws::types::datetime::AwsDateTime"` ends in
+    /// `"::datetime::AwsDateTime"`. This avoids hard-coding full module
+    /// paths that change with reorganisations.
+    ///
+    /// On parse failure of a domain type (e.g. malformed ARN string)
+    /// we fall back to [`AnyAwsType::Text`] rather than panic, keeping
+    /// the data visible.
+    pub fn from_cbor_typed(value: CborValue, declared_type: &str) -> Self {
+        if is_arn_type(declared_type)
+            && let CborValue::Text(s) = &value
+            && let Ok(arn) = Arn::try_parse(s)
+        {
+            return AnyAwsType::Arn(arn);
+        }
+        if is_datetime_type(declared_type)
+            && let CborValue::Text(s) = &value
+            && let Ok(dt) = AwsDateTime::try_parse(s)
+        {
+            return AnyAwsType::DateTime(dt);
+        }
+        // AWS Query (XML) returns booleans/numbers as text. If the
+        // column declared a primitive type, parse the string into it
+        // so rendering picks up the typed treatment.
+        if is_bool_type(declared_type)
+            && let CborValue::Text(s) = &value
+        {
+            match s.as_str() {
+                "true" => return AnyAwsType::Bool(true),
+                "false" => return AnyAwsType::Bool(false),
+                _ => {}
+            }
+        }
+        if is_int_type(declared_type)
+            && let CborValue::Text(s) = &value
+            && let Ok(n) = s.parse::<i64>()
+        {
+            return AnyAwsType::Int(n);
+        }
+        if is_float_type(declared_type)
+            && let CborValue::Text(s) = &value
+            && let Ok(n) = s.parse::<f64>()
+        {
+            return AnyAwsType::Float(n);
+        }
+        Self::from_cbor_untyped(value)
+    }
+
+    /// Build a variant by inspecting the CBOR shape, with light
+    /// content sniffing for strings: anything starting with `"arn:"`
+    /// is tried as an ARN; anything matching ISO 8601 / epoch
+    /// timestamps is tried as an [`AwsDateTime`]. Used when the
+    /// column has no domain-specific declared type (e.g. records
+    /// returned via `AnyTable::list_values`).
+    pub fn from_cbor_untyped(value: CborValue) -> Self {
+        match value {
+            CborValue::Null => AnyAwsType::Null,
+            CborValue::Bool(b) => AnyAwsType::Bool(b),
+            CborValue::Text(s) => {
+                if s.starts_with("arn:") && let Ok(arn) = Arn::try_parse(&s) {
+                    return AnyAwsType::Arn(arn);
+                }
+                if looks_like_iso_timestamp(&s) && let Ok(dt) = AwsDateTime::try_parse(&s) {
+                    return AnyAwsType::DateTime(dt);
+                }
+                AnyAwsType::Text(s)
+            }
+            CborValue::Integer(i) => {
+                let n: i128 = i.into();
+                if let Ok(n64) = i64::try_from(n) {
+                    AnyAwsType::Int(n64)
+                } else {
+                    AnyAwsType::Other(CborValue::Integer(i))
+                }
+            }
+            CborValue::Float(f) => AnyAwsType::Float(f),
+            CborValue::Tag(_, inner) => Self::from_cbor_untyped(*inner),
+            other => AnyAwsType::Other(other),
+        }
+    }
+
+    /// Borrow as a plain CBOR value when downstream code (conditions,
+    /// expressions) needs the lossless representation.
+    pub fn to_cbor(&self) -> CborValue {
+        match self {
+            AnyAwsType::Arn(a) => CborValue::Text(a.to_string()),
+            AnyAwsType::DateTime(d) => CborValue::Text(d.to_string()),
+            AnyAwsType::Bool(b) => CborValue::Bool(*b),
+            AnyAwsType::Int(i) => CborValue::Integer((*i).into()),
+            AnyAwsType::Float(f) => CborValue::Float(*f),
+            AnyAwsType::Text(s) => CborValue::Text(s.clone()),
+            AnyAwsType::Null => CborValue::Null,
+            AnyAwsType::Other(v) => v.clone(),
+        }
+    }
+}
+
+fn is_arn_type(name: &str) -> bool {
+    name.ends_with("::Arn") || name == "Arn"
+}
+
+fn is_datetime_type(name: &str) -> bool {
+    name.ends_with("::AwsDateTime") || name == "AwsDateTime"
+}
+
+fn is_bool_type(name: &str) -> bool {
+    name == "bool"
+}
+
+fn is_int_type(name: &str) -> bool {
+    matches!(
+        name,
+        "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64" | "u128"
+    )
+}
+
+fn is_float_type(name: &str) -> bool {
+    matches!(name, "f32" | "f64")
+}
+
+/// Cheap pre-filter for ISO 8601 timestamps before reaching for chrono.
+/// Looks for `YYYY-MM-DDTHH:MM…` shape — enough to avoid running the
+/// parser on every random string.
+fn looks_like_iso_timestamp(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    if bytes.len() < 16 {
+        return false;
+    }
+    // `YYYY-MM-DDT…`
+    bytes[..4].iter().all(|b| b.is_ascii_digit())
+        && bytes[4] == b'-'
+        && bytes[5..7].iter().all(|b| b.is_ascii_digit())
+        && bytes[7] == b'-'
+        && bytes[8..10].iter().all(|b| b.is_ascii_digit())
+        && (bytes[10] == b'T' || bytes[10] == b' ')
+        && bytes[11..13].iter().all(|b| b.is_ascii_digit())
+        && bytes[13] == b':'
+}
+
+impl TerminalRender for AnyAwsType {
+    fn render(&self) -> RichText {
+        match self {
+            AnyAwsType::Arn(a) => a.render(),
+            AnyAwsType::DateTime(d) => d.render(),
+            AnyAwsType::Bool(b) => b.render(),
+            AnyAwsType::Int(i) => RichText::plain(i.to_string()),
+            AnyAwsType::Float(f) => RichText::plain(f.to_string()),
+            AnyAwsType::Text(s) => RichText::plain(s.clone()),
+            AnyAwsType::Null => RichText::styled("—", Style::Muted),
+            AnyAwsType::Other(v) => v.render(),
+        }
+    }
+}
+
+// Serde for AnyAwsType — preserves the typed variants by going through
+// CBOR. Used by AssociatedExpression / `serde_json::Value` interop in
+// downstream code that may serialise/deserialise records.
+impl Serialize for AnyAwsType {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        self.to_cbor().serialize(ser)
+    }
+}
+
+impl<'de> Deserialize<'de> for AnyAwsType {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let v = CborValue::deserialize(de)?;
+        Ok(AnyAwsType::from_cbor_untyped(v))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_arn_when_column_declared_as_arn() {
+        let v = CborValue::Text("arn:aws:iam::123:user/alice".to_string());
+        let t = AnyAwsType::from_cbor_typed(v, "vantage_aws::types::arn::Arn");
+        matches!(t, AnyAwsType::Arn(_))
+            .then_some(())
+            .expect("expected Arn variant");
+    }
+
+    #[test]
+    fn falls_back_to_text_when_column_is_string() {
+        let v = CborValue::Text("hello".to_string());
+        let t = AnyAwsType::from_cbor_typed(v, "alloc::string::String");
+        matches!(t, AnyAwsType::Text(_))
+            .then_some(())
+            .expect("expected Text variant");
+    }
+
+    #[test]
+    fn null_variant_renders_as_dash() {
+        assert_eq!(AnyAwsType::Null.render().to_plain(), "—");
+    }
+}

--- a/vantage-aws/src/types/arn.rs
+++ b/vantage-aws/src/types/arn.rs
@@ -1,0 +1,185 @@
+//! AWS [`Arn`] — parsed Amazon Resource Name.
+//!
+//! Wire format: `arn:partition:service:region:account-id:resource`. The
+//! `region` and `account-id` segments are commonly empty (global
+//! services like IAM have no region; STS responses sometimes elide
+//! account). The `resource` segment may itself contain colons or
+//! slashes — we keep it as a single string and don't try to parse
+//! `resource-type/resource-id` further (callers can split if needed).
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+
+use vantage_types::{RichText, Style, TerminalRender};
+
+/// Parsed AWS ARN.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Arn {
+    pub partition: String,
+    pub service: String,
+    pub region: String,
+    pub account_id: String,
+    pub resource: String,
+}
+
+impl Arn {
+    /// Parse an ARN. Panics on malformed input — this is a hard
+    /// invariant violation: AWS only ever returns well-formed ARNs, so
+    /// a panic here means something upstream broke.
+    ///
+    /// Use [`Arn::try_parse`] when the input might genuinely be a
+    /// non-ARN string.
+    pub fn parse(s: &str) -> Self {
+        Self::try_parse(s).unwrap_or_else(|e| panic!("invalid ARN {s:?}: {e}"))
+    }
+
+    /// Non-panicking parser. Returns `Err` with a short reason on
+    /// malformed input.
+    pub fn try_parse(s: &str) -> Result<Self, &'static str> {
+        // ARN has exactly 6 colon-separated parts: arn:partition:service:region:account:resource
+        // The resource part may itself contain colons, so split with limit.
+        let mut parts = s.splitn(6, ':');
+        let prefix = parts.next().ok_or("empty input")?;
+        if prefix != "arn" {
+            return Err("must start with \"arn:\"");
+        }
+        let partition = parts.next().ok_or("missing partition")?;
+        let service = parts.next().ok_or("missing service")?;
+        let region = parts.next().ok_or("missing region")?;
+        let account_id = parts.next().ok_or("missing account-id")?;
+        let resource = parts.next().ok_or("missing resource")?;
+
+        if partition.is_empty() {
+            return Err("partition must not be empty");
+        }
+        if service.is_empty() {
+            return Err("service must not be empty");
+        }
+        if resource.is_empty() {
+            return Err("resource must not be empty");
+        }
+
+        Ok(Arn {
+            partition: partition.to_string(),
+            service: service.to_string(),
+            region: region.to_string(),
+            account_id: account_id.to_string(),
+            resource: resource.to_string(),
+        })
+    }
+}
+
+impl fmt::Display for Arn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "arn:{}:{}:{}:{}:{}",
+            self.partition, self.service, self.region, self.account_id, self.resource
+        )
+    }
+}
+
+impl FromStr for Arn {
+    type Err = &'static str;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Arn::try_parse(s)
+    }
+}
+
+impl Serialize for Arn {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for Arn {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        Arn::try_parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl TerminalRender for Arn {
+    fn render(&self) -> RichText {
+        // arn : partition : service : region : account : resource
+        // dim   dim         info      dim      muted     default
+        let mut rt = RichText::new()
+            .push("arn", Style::Dim)
+            .push(":", Style::Muted)
+            .push(&self.partition, Style::Dim)
+            .push(":", Style::Muted)
+            .push(&self.service, Style::Info)
+            .push(":", Style::Muted);
+
+        if self.region.is_empty() {
+            rt = rt.push(":", Style::Muted);
+        } else {
+            rt = rt.push(&self.region, Style::Dim).push(":", Style::Muted);
+        }
+
+        if self.account_id.is_empty() {
+            rt = rt.push(":", Style::Muted);
+        } else {
+            rt = rt
+                .push(&self.account_id, Style::Muted)
+                .push(":", Style::Muted);
+        }
+
+        rt.push(&self.resource, Style::Default)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_iam_user_arn() {
+        let a = Arn::parse("arn:aws:iam::123456789012:user/alice");
+        assert_eq!(a.partition, "aws");
+        assert_eq!(a.service, "iam");
+        assert_eq!(a.region, "");
+        assert_eq!(a.account_id, "123456789012");
+        assert_eq!(a.resource, "user/alice");
+    }
+
+    #[test]
+    fn parses_resource_with_colons() {
+        // Lambda layer ARNs have version after a colon in the resource.
+        let a = Arn::parse("arn:aws:lambda:us-east-1:123456789012:layer:my-layer:3");
+        assert_eq!(a.service, "lambda");
+        assert_eq!(a.region, "us-east-1");
+        assert_eq!(a.resource, "layer:my-layer:3");
+    }
+
+    #[test]
+    fn round_trips_through_display() {
+        let s = "arn:aws:s3:::my-bucket/key/with/slashes";
+        let a = Arn::parse(s);
+        assert_eq!(a.to_string(), s);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid ARN")]
+    fn panics_on_malformed_input() {
+        let _ = Arn::parse("not-an-arn");
+    }
+
+    #[test]
+    fn try_parse_returns_err_for_garbage() {
+        assert!(Arn::try_parse("").is_err());
+        assert!(Arn::try_parse("foo:bar").is_err());
+        assert!(Arn::try_parse("arn:aws:iam::123:").is_err()); // empty resource
+    }
+
+    #[test]
+    fn renders_with_styled_segments() {
+        let a = Arn::parse("arn:aws:iam::123:user/alice");
+        let rt = a.render();
+        // Should produce more than one span.
+        assert!(rt.spans.len() > 3);
+        // Concatenated text round-trips.
+        assert_eq!(rt.to_plain(), "arn:aws:iam::123:user/alice");
+    }
+}

--- a/vantage-aws/src/types/datetime.rs
+++ b/vantage-aws/src/types/datetime.rs
@@ -1,0 +1,137 @@
+//! AWS timestamp wrapper.
+//!
+//! AWS Query and JSON-1.1 protocols return timestamps in a few shapes:
+//! ISO 8601 with `Z` suffix (`2024-03-15T10:30:00Z`), ISO 8601 with
+//! fractional seconds (`2024-03-15T10:30:00.123Z`), and Unix epoch
+//! seconds (less common, mostly JSON-1.1). We accept all three on
+//! parse and render as `YYYY-MM-DD HH:MM` for display — minute
+//! granularity is what's useful in a list view; full precision is one
+//! `.into_inner()` away if a caller needs it.
+
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+
+use vantage_types::{RichText, Style, TerminalRender};
+
+/// Owned timestamp parsed from an AWS response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AwsDateTime(pub DateTime<Utc>);
+
+impl AwsDateTime {
+    /// Parse a timestamp. Panics on malformed input.
+    pub fn parse(s: &str) -> Self {
+        Self::try_parse(s).unwrap_or_else(|e| panic!("invalid AWS timestamp {s:?}: {e}"))
+    }
+
+    /// Non-panicking parser. Accepts ISO 8601 with optional fractional
+    /// seconds, or a numeric string of Unix epoch seconds (with or
+    /// without fractional part).
+    pub fn try_parse(s: &str) -> Result<Self, String> {
+        if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+            return Ok(AwsDateTime(dt.with_timezone(&Utc)));
+        }
+        // Some AWS responses elide the timezone; treat naive as UTC.
+        if let Ok(naive) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f") {
+            return Ok(AwsDateTime(Utc.from_utc_datetime(&naive)));
+        }
+        if let Ok(naive) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
+            return Ok(AwsDateTime(Utc.from_utc_datetime(&naive)));
+        }
+        // Epoch seconds (possibly fractional).
+        if let Ok(secs) = s.parse::<f64>() {
+            let whole = secs.trunc() as i64;
+            let nanos = ((secs.fract()) * 1_000_000_000.0).round() as u32;
+            if let Some(dt) = DateTime::<Utc>::from_timestamp(whole, nanos) {
+                return Ok(AwsDateTime(dt));
+            }
+        }
+        Err(format!("unrecognised timestamp shape: {s}"))
+    }
+
+    pub fn into_inner(self) -> DateTime<Utc> {
+        self.0
+    }
+}
+
+impl fmt::Display for AwsDateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // RFC 3339 — the format AWS itself emits.
+        write!(f, "{}", self.0.to_rfc3339())
+    }
+}
+
+impl FromStr for AwsDateTime {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        AwsDateTime::try_parse(s)
+    }
+}
+
+impl Serialize for AwsDateTime {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for AwsDateTime {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        AwsDateTime::try_parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl TerminalRender for AwsDateTime {
+    fn render(&self) -> RichText {
+        // YYYY-MM-DD HH:MM with date in default and time dim.
+        let date = self.0.format("%Y-%m-%d").to_string();
+        let time = self.0.format("%H:%M").to_string();
+        RichText::new()
+            .push(date, Style::Default)
+            .push(" ", Style::Default)
+            .push(time, Style::Dim)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_iso_zulu() {
+        let d = AwsDateTime::parse("2024-03-15T10:30:00Z");
+        assert_eq!(
+            d.0.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2024-03-15 10:30:00"
+        );
+    }
+
+    #[test]
+    fn parses_iso_with_fractional_seconds() {
+        let d = AwsDateTime::parse("2024-03-15T10:30:00.123Z");
+        assert_eq!(
+            d.0.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2024-03-15 10:30:00"
+        );
+    }
+
+    #[test]
+    fn parses_epoch_seconds() {
+        // 2024-03-15T10:30:00Z -> 1710498600
+        let d = AwsDateTime::parse("1710498600");
+        assert_eq!(d.0.format("%Y-%m-%d %H:%M").to_string(), "2024-03-15 10:30");
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid AWS timestamp")]
+    fn panics_on_garbage() {
+        let _ = AwsDateTime::parse("not-a-date");
+    }
+
+    #[test]
+    fn renders_minute_granularity() {
+        let d = AwsDateTime::parse("2024-03-15T10:30:45.789Z");
+        assert_eq!(d.render().to_plain(), "2024-03-15 10:30");
+    }
+}

--- a/vantage-aws/src/types/mod.rs
+++ b/vantage-aws/src/types/mod.rs
@@ -1,0 +1,77 @@
+//! Custom value types for AWS records.
+//!
+//! - [`Arn`] — parsed Amazon Resource Name with multi-segment styled
+//!   rendering.
+//! - [`AwsDateTime`] — parsed AWS timestamp.
+//! - [`AnyAwsType`] — polymorphic value enum used at the rendering
+//!   boundary; built from a raw CBOR value plus the column's declared
+//!   Rust type, so `with_column_of::<Arn>(...)` actually drives parsing.
+//!
+//! `AnyAwsType` is a presentation-layer concern — internal flow
+//! (conditions, expressions, deferred resolution) keeps using
+//! [`ciborium::Value`]. Convert at the boundary with
+//! [`typed_records`] when you want rich rendering.
+
+mod any;
+mod arn;
+mod datetime;
+
+pub use any::AnyAwsType;
+pub use arn::Arn;
+pub use datetime::AwsDateTime;
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use std::hash::Hash;
+use vantage_types::Record;
+
+/// Convert raw `Record<CborValue>`s into `Record<AnyAwsType>` using the
+/// declared column types from `column_types` (column name → Rust type
+/// name from `column.get_type()`).
+///
+/// Columns whose declared type matches a known wrapper (`Arn`,
+/// `AwsDateTime`) get parsed into the typed variant; others fall back
+/// to shape-based variants (`Text`, `Int`, …). Returns the records in
+/// the same iteration order as the input.
+pub fn typed_records<I>(
+    records: IndexMap<I, Record<CborValue>>,
+    column_types: &IndexMap<String, &'static str>,
+) -> IndexMap<I, Record<AnyAwsType>>
+where
+    I: Eq + Hash,
+{
+    records
+        .into_iter()
+        .map(|(id, record)| {
+            let typed: Record<AnyAwsType> = record
+                .into_iter()
+                .map(|(k, v)| {
+                    let declared = column_types.get(&k).copied().unwrap_or("");
+                    (k, AnyAwsType::from_cbor_typed(v, declared))
+                })
+                .collect();
+            (id, typed)
+        })
+        .collect()
+}
+
+/// Untyped variant — useful when column type metadata isn't available
+/// (e.g. records produced via `AnyTable::list_values`). Each value
+/// gets shape-based variant selection; ARNs and dates aren't parsed.
+pub fn untyped_records<I>(
+    records: IndexMap<I, Record<CborValue>>,
+) -> IndexMap<I, Record<AnyAwsType>>
+where
+    I: Eq + Hash,
+{
+    records
+        .into_iter()
+        .map(|(id, record)| {
+            let typed: Record<AnyAwsType> = record
+                .into_iter()
+                .map(|(k, v)| (k, AnyAwsType::from_cbor_untyped(v)))
+                .collect();
+            (id, typed)
+        })
+        .collect()
+}

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -9,8 +9,9 @@ repository = "https://github.com/romaninsh/vantage"
 
 [dependencies]
 async-trait = "0.1"
-comfy-table = "7"
+comfy-table = { version = "7", features = ["custom_styling"] }
 indexmap = "2"
+owo-colors = "4"
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
 vantage-table = { version = "0.4", path = "../vantage-table" }

--- a/vantage-cli-util/src/lib.rs
+++ b/vantage-cli-util/src/lib.rs
@@ -1,4 +1,3 @@
 mod table_display;
 
-pub use table_display::print_table;
-pub use table_display::render_records;
+pub use table_display::{print_table, render_records, render_records_typed};

--- a/vantage-cli-util/src/table_display.rs
+++ b/vantage-cli-util/src/table_display.rs
@@ -1,44 +1,71 @@
-use comfy_table::{Attribute, Cell, Color, Table as ComfyTable};
+use comfy_table::{
+    Attribute, Cell, CellAlignment, ContentArrangement, Table as ComfyTable, TableComponent,
+    presets,
+};
 use indexmap::IndexMap;
+use owo_colors::OwoColorize;
 use vantage_dataset::prelude::ReadableValueSet;
 use vantage_table::prelude::ColumnLike;
 use vantage_table::table::Table;
 use vantage_table::traits::table_source::TableSource;
-use vantage_types::{Entity, Record, TerminalRender};
+use vantage_types::{Entity, Record, RichText, Span, Style, TerminalRender};
 
-/// Map a color hint string to a comfy-table Color.
-fn hint_to_color(hint: &str) -> Option<Color> {
-    match hint {
-        "green" => Some(Color::Green),
-        "red" => Some(Color::Red),
-        "blue" => Some(Color::Blue),
-        "yellow" => Some(Color::Yellow),
-        "cyan" => Some(Color::Cyan),
-        "magenta" => Some(Color::Magenta),
-        _ => None,
-    }
-}
-
-/// Create a styled Cell from a TerminalRender value.
-fn render_cell<V: TerminalRender>(value: &V) -> Cell {
-    let text = value.render();
-    let mut cell = Cell::new(&text);
-
-    if let Some(hint) = value.color_hint() {
-        if hint == "dim" {
-            cell = cell.add_attribute(Attribute::Dim);
-        } else if let Some(color) = hint_to_color(hint) {
-            cell = cell.fg(color);
-        }
-    }
-
-    cell
-}
-
-/// Fetch records from a table and print them as a formatted ASCII table.
+/// Convert a [`RichText`] to an ANSI-styled string.
 ///
-/// Reads the id field from the table's column flags to avoid duplicating
-/// the id column in the output.
+/// `owo-colors` honors `NO_COLOR` and auto-detects whether stdout is
+/// a TTY, so this is safe to embed in cells regardless of context.
+fn rich_to_ansi(rich: &RichText) -> String {
+    let mut out = String::with_capacity(rich.spans.iter().map(|s| s.text.len()).sum::<usize>() + 8);
+    for span in &rich.spans {
+        out.push_str(&span_to_ansi(span));
+    }
+    out
+}
+
+fn span_to_ansi(span: &Span) -> String {
+    let t = span.text.as_str();
+    match span.style {
+        Style::Default => t.to_string(),
+        Style::Dim => t.dimmed().to_string(),
+        Style::Muted => t.bright_black().to_string(),
+        Style::Strong => t.bold().to_string(),
+        Style::Success => t.green().to_string(),
+        Style::Error => t.red().to_string(),
+        Style::Warning => t.yellow().to_string(),
+        Style::Info => t.cyan().to_string(),
+    }
+}
+
+/// Pick alignment from the column's declared Rust type name.
+fn alignment_for(type_name: &str) -> CellAlignment {
+    let last = type_name.rsplit("::").next().unwrap_or(type_name);
+    if matches!(
+        last,
+        "i8" | "i16"
+            | "i32"
+            | "i64"
+            | "i128"
+            | "isize"
+            | "u8"
+            | "u16"
+            | "u32"
+            | "u64"
+            | "u128"
+            | "usize"
+            | "f32"
+            | "f64"
+    ) {
+        CellAlignment::Right
+    } else {
+        CellAlignment::Left
+    }
+}
+
+fn header_cell(name: &str) -> Cell {
+    Cell::new(name.to_uppercase().cyan().bold().to_string())
+}
+
+/// Fetch records from a table and print them as a styled table.
 pub async fn print_table<T, E>(table: &Table<T, E>) -> vantage_core::Result<()>
 where
     T: TableSource,
@@ -46,53 +73,110 @@ where
     T::Id: std::fmt::Display,
     E: Entity<T::Value>,
 {
-    let id_field = table.id_field().map(|col| col.name().to_string());
+    let id_field = table.id_field().map(|c| c.name().to_string());
+
+    let column_types: IndexMap<String, &'static str> = table
+        .columns()
+        .iter()
+        .map(|(name, col)| (name.clone(), col.get_type()))
+        .collect();
+
     let records = table.list_values().await?;
-    render_records(&records, id_field.as_deref());
+    render_records_typed(&records, id_field.as_deref(), &column_types);
     Ok(())
 }
 
-/// Render records as a formatted ASCII table.
+/// Render records as a styled table without per-column type metadata.
 ///
-/// `id_field` names the column used as the record key. That column is
-/// skipped in the data columns to avoid duplication.
-pub fn render_records<Id: std::fmt::Display, V: TerminalRender>(
+/// Convenience wrapper around [`render_records_typed`] for ad-hoc maps
+/// where column types aren't available.
+pub fn render_records<Id, V>(records: &IndexMap<Id, Record<V>>, id_field: Option<&str>)
+where
+    Id: std::fmt::Display,
+    V: TerminalRender,
+{
+    render_records_typed(records, id_field, &IndexMap::new());
+}
+
+/// Render records as a styled table.
+///
+/// `id_field` names the column used as the record key — printed as the
+/// leftmost column and skipped from the data section.
+///
+/// `column_types` maps column name → declared Rust type name (from
+/// `column.get_type()`). Drives per-column alignment and column order.
+pub fn render_records_typed<Id, V>(
     records: &IndexMap<Id, Record<V>>,
     id_field: Option<&str>,
-) {
+    column_types: &IndexMap<String, &'static str>,
+) where
+    Id: std::fmt::Display,
+    V: TerminalRender,
+{
     if records.is_empty() {
-        println!("No records found.");
+        println!("{}", "No records.".dimmed());
         return;
     }
 
-    let first_record = records.values().next().unwrap();
-    let columns: Vec<&String> = first_record
-        .keys()
-        .filter(|k| k.as_str() != "id" && Some(k.as_str()) != id_field)
-        .collect();
+    let columns: Vec<String> = if !column_types.is_empty() {
+        column_types
+            .keys()
+            .filter(|k| Some(k.as_str()) != id_field)
+            .cloned()
+            .collect()
+    } else {
+        records
+            .values()
+            .next()
+            .unwrap()
+            .keys()
+            .filter(|k| k.as_str() != "id" && Some(k.as_str()) != id_field)
+            .cloned()
+            .collect()
+    };
 
     let mut table = ComfyTable::new();
+    table
+        .load_preset(presets::UTF8_HORIZONTAL_ONLY)
+        // Drop inter-row separators — keep only top, header, and bottom rules.
+        .remove_style(TableComponent::HorizontalLines)
+        .remove_style(TableComponent::MiddleIntersections)
+        .remove_style(TableComponent::LeftBorderIntersections)
+        .remove_style(TableComponent::RightBorderIntersections)
+        // Size columns to their content. `Dynamic` stretches to fill
+        // terminal width, which looks bad when piped or when the
+        // terminal can't be detected.
+        .set_content_arrangement(ContentArrangement::Disabled);
 
-    let mut header = vec![Cell::new("id").add_attribute(Attribute::Bold)];
-    header.extend(
-        columns
-            .iter()
-            .map(|c| Cell::new(c).add_attribute(Attribute::Bold)),
-    );
+    let mut header = vec![header_cell("id")];
+    header.extend(columns.iter().map(|c| header_cell(c)));
     table.set_header(header);
 
-    for (id, record) in records {
-        let mut row = vec![Cell::new(id)];
-        for col in &columns {
-            if let Some(value) = record.get(col.as_str()) {
-                row.push(render_cell(value));
-            } else {
-                row.push(Cell::new(""));
+    for (idx, name) in columns.iter().enumerate() {
+        if let Some(type_name) = column_types.get(name) {
+            let align = alignment_for(type_name);
+            if let Some(col) = table.column_mut(idx + 1) {
+                col.set_cell_alignment(align);
             }
+        }
+    }
+
+    for (id, record) in records {
+        let id_cell = Cell::new(id.to_string()).add_attribute(Attribute::Bold);
+        let mut row = vec![id_cell];
+        for col in &columns {
+            let cell = match record.get(col.as_str()) {
+                Some(value) => Cell::new(rich_to_ansi(&value.render())),
+                None => Cell::new("—".bright_black().to_string()),
+            };
+            row.push(cell);
         }
         table.add_row(row);
     }
 
     println!("{table}");
-    println!("Found {} records", records.len());
+
+    let n = records.len();
+    let label = if n == 1 { "record" } else { "records" };
+    println!("{}", format!("{n} {label}").dimmed());
 }

--- a/vantage-csv/src/type_system.rs
+++ b/vantage-csv/src/type_system.rs
@@ -357,38 +357,33 @@ impl From<AnyCsvType> for ciborium::Value {
     }
 }
 
-use vantage_types::TerminalRender;
+use vantage_types::{RichText, Style, TerminalRender};
 
 impl TerminalRender for AnyCsvType {
-    fn render(&self) -> String {
+    fn render(&self) -> RichText {
         match self.type_variant() {
             // HACK: Animal is domain-specific, hardcoded here for now.
             // TODO: Make custom type rendering extensible at compile time.
-            Some(CsvTypeVariants::Animal) => match self.value().as_str() {
-                "cat" => "🐱",
-                "dog" => "🐶",
-                "pig" => "🐷",
-                "cow" => "🐮",
-                "chicken" => "🐔",
-                other => return other.to_string(),
+            Some(CsvTypeVariants::Animal) => {
+                let glyph = match self.value().as_str() {
+                    "cat" => "🐱",
+                    "dog" => "🐶",
+                    "pig" => "🐷",
+                    "cow" => "🐮",
+                    "chicken" => "🐔",
+                    other => return RichText::plain(other.to_string()),
+                };
+                RichText::plain(glyph.to_string())
             }
-            .to_string(),
-            None if self.value().is_empty() => "-".to_string(),
-            _ => self.value().clone(),
-        }
-    }
-
-    fn color_hint(&self) -> Option<&'static str> {
-        match self.type_variant() {
             Some(CsvTypeVariants::Bool) => {
                 if self.value() == "true" {
-                    Some("green")
+                    RichText::styled("true", Style::Success)
                 } else {
-                    Some("red")
+                    RichText::styled("false", Style::Error)
                 }
             }
-            None if self.value().is_empty() => Some("dim"),
-            _ => None,
+            None if self.value().is_empty() => RichText::styled("—", Style::Muted),
+            _ => RichText::plain(self.value().clone()),
         }
     }
 }

--- a/vantage-sql/src/mysql/types/value.rs
+++ b/vantage-sql/src/mysql/types/value.rs
@@ -331,35 +331,24 @@ impl TryFrom<AnyMysqlType> for vantage_types::Record<serde_json::Value> {
 }
 
 impl vantage_types::TerminalRender for AnyMysqlType {
-    fn render(&self) -> String {
+    fn render(&self) -> vantage_types::RichText {
+        use vantage_types::{RichText, Style};
         match self.value() {
-            CborValue::Null => "-".to_string(),
-            CborValue::Text(s) => s.clone(),
-            CborValue::Bool(b) => b.to_string(),
-            CborValue::Tag(10, inner) => {
+            CborValue::Null => RichText::styled("—", Style::Muted),
+            CborValue::Text(s) => RichText::plain(s.clone()),
+            CborValue::Bool(true) => RichText::styled("true", Style::Success),
+            CborValue::Bool(false) => RichText::styled("false", Style::Error),
+            CborValue::Tag(10, inner)
+            | CborValue::Tag(0, inner)
+            | CborValue::Tag(100, inner)
+            | CborValue::Tag(101, inner) => {
                 if let CborValue::Text(s) = inner.as_ref() {
-                    s.clone()
+                    RichText::plain(s.clone())
                 } else {
-                    format!("{}", self)
+                    RichText::plain(format!("{}", self))
                 }
             }
-            CborValue::Tag(0, inner) | CborValue::Tag(100, inner) | CborValue::Tag(101, inner) => {
-                if let CborValue::Text(s) = inner.as_ref() {
-                    s.clone()
-                } else {
-                    format!("{}", self)
-                }
-            }
-            _ => format!("{}", self),
-        }
-    }
-
-    fn color_hint(&self) -> Option<&'static str> {
-        match self.value() {
-            CborValue::Bool(true) => Some("green"),
-            CborValue::Bool(false) => Some("red"),
-            CborValue::Null => Some("dim"),
-            _ => None,
+            _ => RichText::plain(format!("{}", self)),
         }
     }
 }

--- a/vantage-sql/src/postgres/types/value.rs
+++ b/vantage-sql/src/postgres/types/value.rs
@@ -338,42 +338,25 @@ impl TryFrom<AnyPostgresType> for vantage_types::Record<serde_json::Value> {
 }
 
 impl vantage_types::TerminalRender for AnyPostgresType {
-    fn render(&self) -> String {
+    fn render(&self) -> vantage_types::RichText {
+        use vantage_types::{RichText, Style};
         match self.value() {
-            CborValue::Null => "-".to_string(),
-            CborValue::Text(s) => s.clone(),
-            CborValue::Bool(b) => b.to_string(),
-            CborValue::Tag(10, inner) => {
+            CborValue::Null => RichText::styled("—", Style::Muted),
+            CborValue::Text(s) => RichText::plain(s.clone()),
+            CborValue::Bool(true) => RichText::styled("true", Style::Success),
+            CborValue::Bool(false) => RichText::styled("false", Style::Error),
+            CborValue::Tag(10, inner)
+            | CborValue::Tag(0, inner)
+            | CborValue::Tag(100, inner)
+            | CborValue::Tag(101, inner)
+            | CborValue::Tag(9, inner) => {
                 if let CborValue::Text(s) = inner.as_ref() {
-                    s.clone()
+                    RichText::plain(s.clone())
                 } else {
-                    format!("{}", self)
+                    RichText::plain(format!("{}", self))
                 }
             }
-            CborValue::Tag(0, inner) | CborValue::Tag(100, inner) | CborValue::Tag(101, inner) => {
-                if let CborValue::Text(s) = inner.as_ref() {
-                    s.clone()
-                } else {
-                    format!("{}", self)
-                }
-            }
-            CborValue::Tag(9, inner) => {
-                if let CborValue::Text(s) = inner.as_ref() {
-                    s.clone()
-                } else {
-                    format!("{}", self)
-                }
-            }
-            _ => format!("{}", self),
-        }
-    }
-
-    fn color_hint(&self) -> Option<&'static str> {
-        match self.value() {
-            CborValue::Bool(true) => Some("green"),
-            CborValue::Bool(false) => Some("red"),
-            CborValue::Null => Some("dim"),
-            _ => None,
+            _ => RichText::plain(format!("{}", self)),
         }
     }
 }

--- a/vantage-sql/src/sqlite/types/value.rs
+++ b/vantage-sql/src/sqlite/types/value.rs
@@ -338,35 +338,24 @@ impl TryFrom<AnySqliteType> for vantage_types::Record<serde_json::Value> {
 }
 
 impl vantage_types::TerminalRender for AnySqliteType {
-    fn render(&self) -> String {
+    fn render(&self) -> vantage_types::RichText {
+        use vantage_types::{RichText, Style};
         match self.value() {
-            CborValue::Null => "-".to_string(),
-            CborValue::Text(s) => s.clone(),
-            CborValue::Bool(b) => b.to_string(),
-            CborValue::Tag(10, inner) => {
+            CborValue::Null => RichText::styled("—", Style::Muted),
+            CborValue::Text(s) => RichText::plain(s.clone()),
+            CborValue::Bool(true) => RichText::styled("true", Style::Success),
+            CborValue::Bool(false) => RichText::styled("false", Style::Error),
+            CborValue::Tag(10, inner)
+            | CborValue::Tag(0, inner)
+            | CborValue::Tag(100, inner)
+            | CborValue::Tag(101, inner) => {
                 if let CborValue::Text(s) = inner.as_ref() {
-                    s.clone()
+                    RichText::plain(s.clone())
                 } else {
-                    format!("{}", self)
+                    RichText::plain(format!("{}", self))
                 }
             }
-            CborValue::Tag(0, inner) | CborValue::Tag(100, inner) | CborValue::Tag(101, inner) => {
-                if let CborValue::Text(s) = inner.as_ref() {
-                    s.clone()
-                } else {
-                    format!("{}", self)
-                }
-            }
-            _ => format!("{}", self),
-        }
-    }
-
-    fn color_hint(&self) -> Option<&'static str> {
-        match self.value() {
-            CborValue::Bool(true) => Some("green"),
-            CborValue::Bool(false) => Some("red"),
-            CborValue::Null => Some("dim"),
-            _ => None,
+            _ => RichText::plain(format!("{}", self)),
         }
     }
 }

--- a/vantage-surrealdb/src/types/mod.rs
+++ b/vantage-surrealdb/src/types/mod.rs
@@ -238,23 +238,15 @@ impl std::fmt::Display for AnySurrealType {
 }
 
 impl TerminalRender for AnySurrealType {
-    fn render(&self) -> String {
+    fn render(&self) -> vantage_types::RichText {
         use ciborium::Value;
+        use vantage_types::{RichText, Style};
         match &self.value {
-            Value::Null | Value::Tag(6, _) => "-".to_string(),
-            Value::Text(s) => s.clone(),
-            Value::Bool(b) => b.to_string(),
-            _ => format!("{}", self),
-        }
-    }
-
-    fn color_hint(&self) -> Option<&'static str> {
-        use ciborium::Value;
-        match &self.value {
-            Value::Bool(true) => Some("green"),
-            Value::Bool(false) => Some("red"),
-            Value::Null | Value::Tag(6, _) => Some("dim"),
-            _ => None,
+            Value::Null | Value::Tag(6, _) => RichText::styled("—", Style::Muted),
+            Value::Text(s) => RichText::plain(s.clone()),
+            Value::Bool(true) => RichText::styled("true", Style::Success),
+            Value::Bool(false) => RichText::styled("false", Style::Error),
+            _ => RichText::plain(format!("{}", self)),
         }
     }
 }

--- a/vantage-types/src/lib.rs
+++ b/vantage-types/src/lib.rs
@@ -8,7 +8,7 @@ pub mod terminal_render;
 pub mod type_system;
 
 pub use record::{IntoRecord, Record, TryFromRecord};
-pub use terminal_render::TerminalRender;
+pub use terminal_render::{RichText, Span, Style, TerminalRender};
 
 /// Empty entity type for testing and dynamic table scenarios
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/vantage-types/src/prelude.rs
+++ b/vantage-types/src/prelude.rs
@@ -9,6 +9,7 @@
 
 // Re-export core types
 pub use crate::record::{IntoRecord, Record, TryFromRecord};
+pub use crate::terminal_render::{RichText, Span, Style, TerminalRender};
 
 // Re-export macros
 pub use crate::vantage_type_system;

--- a/vantage-types/src/terminal_render.rs
+++ b/vantage-types/src/terminal_render.rs
@@ -1,111 +1,200 @@
-/// Trait for rendering a value as a string for terminal output.
-///
-/// Returns plain text — styling (colors, bold, etc.) is applied by
-/// the rendering layer (e.g. `vantage-cli-util`) based on type information.
-pub trait TerminalRender {
-    /// The plain text representation of this value.
-    fn render(&self) -> String;
+//! UI-agnostic value rendering.
+//!
+//! [`TerminalRender`] returns a [`RichText`] — an ordered list of
+//! [`Span`]s, each carrying text plus a semantic [`Style`]. UI layers
+//! (CLI, GPUI, web) translate styles into their native presentation:
+//! `vantage-cli-util` emits ANSI; a GPUI adapter would emit styled
+//! `div`s; a web layer could emit CSS classes. The trait itself never
+//! references any specific output medium.
 
-    /// Optional hint for terminal styling. Return a color name like
-    /// "green", "red", "dim", or None for default.
-    fn color_hint(&self) -> Option<&'static str> {
-        None
+/// One styled run of text inside a [`RichText`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Span {
+    pub text: String,
+    pub style: Style,
+}
+
+impl Span {
+    pub fn new(text: impl Into<String>, style: Style) -> Self {
+        Self {
+            text: text.into(),
+            style,
+        }
     }
+
+    pub fn plain(text: impl Into<String>) -> Self {
+        Self::new(text, Style::Default)
+    }
+}
+
+/// Semantic styles. UI layers map these to colors / weights / etc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Style {
+    /// Default foreground — no special styling.
+    #[default]
+    Default,
+    /// Subdued. Use for separators and secondary information.
+    Dim,
+    /// Very subdued. Use for placeholders (null / missing values).
+    Muted,
+    /// Emphasized. Use for primary identifiers in mixed content.
+    Strong,
+    /// Positive state — true booleans, healthy status, etc.
+    Success,
+    /// Negative state — false booleans, errors, deletions, etc.
+    Error,
+    /// Cautionary state — warnings, deprecated, pending, etc.
+    Warning,
+    /// Informational highlight — service names, links, etc.
+    Info,
+}
+
+/// A sequence of styled text spans. The natural unit a rendering
+/// implementation produces and a UI layer consumes.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RichText {
+    pub spans: Vec<Span>,
+}
+
+impl RichText {
+    pub fn new() -> Self {
+        Self { spans: Vec::new() }
+    }
+
+    /// Single span with [`Style::Default`].
+    pub fn plain(text: impl Into<String>) -> Self {
+        Self {
+            spans: vec![Span::plain(text)],
+        }
+    }
+
+    /// Single span with the given style.
+    pub fn styled(text: impl Into<String>, style: Style) -> Self {
+        Self {
+            spans: vec![Span::new(text, style)],
+        }
+    }
+
+    /// Builder-style append.
+    pub fn push(mut self, text: impl Into<String>, style: Style) -> Self {
+        self.spans.push(Span::new(text, style));
+        self
+    }
+
+    /// Concatenate all span texts, dropping styles.
+    pub fn to_plain(&self) -> String {
+        let mut out = String::new();
+        for s in &self.spans {
+            out.push_str(&s.text);
+        }
+        out
+    }
+}
+
+impl std::fmt::Display for RichText {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for span in &self.spans {
+            f.write_str(&span.text)?;
+        }
+        Ok(())
+    }
+}
+
+impl From<&str> for RichText {
+    fn from(s: &str) -> Self {
+        RichText::plain(s)
+    }
+}
+
+impl From<String> for RichText {
+    fn from(s: String) -> Self {
+        RichText::plain(s)
+    }
+}
+
+/// Render a value as styled text. UI-agnostic — the returned
+/// [`RichText`] is translated into ANSI / GPUI / etc. by the consuming
+/// layer.
+pub trait TerminalRender {
+    fn render(&self) -> RichText;
 }
 
 // Standard type implementations
 
 impl TerminalRender for String {
-    fn render(&self) -> String {
-        self.clone()
+    fn render(&self) -> RichText {
+        RichText::plain(self.clone())
+    }
+}
+
+impl TerminalRender for &str {
+    fn render(&self) -> RichText {
+        RichText::plain(self.to_string())
     }
 }
 
 impl TerminalRender for i64 {
-    fn render(&self) -> String {
-        self.to_string()
+    fn render(&self) -> RichText {
+        RichText::plain(self.to_string())
     }
 }
 
 impl TerminalRender for i32 {
-    fn render(&self) -> String {
-        self.to_string()
+    fn render(&self) -> RichText {
+        RichText::plain(self.to_string())
     }
 }
 
 impl TerminalRender for f64 {
-    fn render(&self) -> String {
-        self.to_string()
+    fn render(&self) -> RichText {
+        RichText::plain(self.to_string())
     }
 }
 
 impl TerminalRender for bool {
-    fn render(&self) -> String {
-        self.to_string()
-    }
-
-    fn color_hint(&self) -> Option<&'static str> {
-        if *self { Some("green") } else { Some("red") }
+    fn render(&self) -> RichText {
+        if *self {
+            RichText::styled("true", Style::Success)
+        } else {
+            RichText::styled("false", Style::Error)
+        }
     }
 }
 
 impl<T: TerminalRender> TerminalRender for Option<T> {
-    fn render(&self) -> String {
+    fn render(&self) -> RichText {
         match self {
             Some(v) => v.render(),
-            None => "-".to_string(),
-        }
-    }
-
-    fn color_hint(&self) -> Option<&'static str> {
-        match self {
-            Some(v) => v.color_hint(),
-            None => Some("dim"),
+            None => RichText::styled("—", Style::Muted),
         }
     }
 }
 
 #[cfg(feature = "serde")]
 impl TerminalRender for serde_json::Value {
-    fn render(&self) -> String {
+    fn render(&self) -> RichText {
         match self {
-            serde_json::Value::String(s) => s.clone(),
-            serde_json::Value::Null => "-".to_string(),
-            serde_json::Value::Bool(b) => b.to_string(),
-            other => other.to_string(),
-        }
-    }
-
-    fn color_hint(&self) -> Option<&'static str> {
-        match self {
-            serde_json::Value::Bool(true) => Some("green"),
-            serde_json::Value::Bool(false) => Some("red"),
-            serde_json::Value::Null => Some("dim"),
-            _ => None,
+            serde_json::Value::String(s) => RichText::plain(s.clone()),
+            serde_json::Value::Null => RichText::styled("—", Style::Muted),
+            serde_json::Value::Bool(b) => b.render(),
+            other => RichText::plain(other.to_string()),
         }
     }
 }
 
 impl TerminalRender for ciborium::Value {
-    fn render(&self) -> String {
+    fn render(&self) -> RichText {
         match self {
-            ciborium::Value::Text(s) => s.clone(),
-            ciborium::Value::Null => "-".to_string(),
-            ciborium::Value::Bool(b) => b.to_string(),
-            ciborium::Value::Integer(i) => i128::from(*i).to_string(),
-            ciborium::Value::Float(f) => f.to_string(),
-            ciborium::Value::Bytes(b) => format!("[{} bytes]", b.len()),
+            ciborium::Value::Text(s) => RichText::plain(s.clone()),
+            ciborium::Value::Null => RichText::styled("—", Style::Muted),
+            ciborium::Value::Bool(b) => b.render(),
+            ciborium::Value::Integer(i) => RichText::plain(i128::from(*i).to_string()),
+            ciborium::Value::Float(f) => RichText::plain(f.to_string()),
+            ciborium::Value::Bytes(b) => {
+                RichText::styled(format!("[{} bytes]", b.len()), Style::Muted)
+            }
             ciborium::Value::Tag(_, inner) => inner.render(),
-            other => format!("{:?}", other),
-        }
-    }
-
-    fn color_hint(&self) -> Option<&'static str> {
-        match self {
-            ciborium::Value::Bool(true) => Some("green"),
-            ciborium::Value::Bool(false) => Some("red"),
-            ciborium::Value::Null => Some("dim"),
-            _ => None,
+            other => RichText::plain(format!("{:?}", other)),
         }
     }
 }


### PR DESCRIPTION
List an IAM role table from the CLI and you now get a styled table back: the
`Arn` column splits into coloured segments (service in info, region dim,
resource default), `CreateDate` collapses to `YYYY-MM-DD HH:MM` with the time
dimmed, booleans are green or red. The trait that drives it lives in
`vantage-types` and is medium-agnostic — the CLI maps spans to ANSI today; a
GPUI adapter or a web layer maps the same spans to text runs or CSS classes
without re-implementing per-type formatting.

The AWS surface in vantage has been growing fast:

- #210 — `vantage-aws` incubation: `AwsAccount` + JSON-1.1 transport,
  hand-rolled SigV4, CloudWatch Logs models.
- #211 — log streams + ECS (`Cluster`, `Service`, `Task`, `TaskDefinition`).
- #212 — IAM models + the form-encoded Query protocol that drives them.
- #213 — `get_ref` on `AnyTable`, so traversal works from a type-erased parent.

Up to #213 every ARN was just a 90-character string sliding off the right edge
of the terminal. A user list looked less like a table, more like a barcode.

### Parsed `Arn` and `AwsDateTime`

Two new value types you can attach to columns:

```rust
groups_table.with_column_of::<Arn>("Arn")
            .with_column_of::<AwsDateTime>("CreateDate");
```

What that buys you in user code: ARNs come back parsed — `arn.service`,
`arn.region`, `arn.resource` are fields, not substring math you wrote
yourself. Timestamps come back as `DateTime<Utc>`, accepting the three shapes
AWS actually returns (RFC 3339 with and without fractional seconds, plus epoch
seconds for the JSON-1.1 surface). `Arn::parse` panics on malformed input on
the assumption that AWS emits well-formed ARNs; reach for `Arn::try_parse` if
you're feeding it user input.

### `RichText` rendering

A new `TerminalRender` trait in `vantage-types` returns a `RichText` — a list
of styled spans with semantic styles (`Dim`, `Info`, `Success`, `Error`, …).
Implement it on a domain enum and that's how the value shows up everywhere
the CLI renders. The `bakery_model3` `Animal` enum renders as
`🐱` / `🐶` / `🐷` in the same line of code that drives every other column.
Good, bad, and overdue news for anyone whose `Status::Healthy` was previously
indistinguishable from `Status::OnFire`.

`AnySqliteType`, `AnyPostgresType`, `AnyMysqlType`, `AnyCsvType`, and
`AnySurrealType` all implement `TerminalRender` now too, so generic CLI tools
like `print_table` work across every backend without per-database glue.