### PR TITLE
rewrite aws-cli around generic Factory + model_cli runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3961,6 +3961,7 @@ name = "vantage-cli-util"
 version = "0.4.0"
 dependencies = [
  "async-trait",
+ "ciborium",
  "comfy-table",
  "indexmap",
  "owo-colors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ciborium",
  "csv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-live"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.4.3 — 2026-04-30
+
+`vantage-aws` picks up a generic, type-erased model factory and the AWS-side machinery to back the new model-driven CLI in `vantage-cli-util`. ([#215](https://github.com/romaninsh/vantage/pull/215))
+
+- New `vantage_aws::models::Factory` — dotted-string lookup (`iam.user`, `log.group`, `ecs.cluster`, …) to `AnyTable` plus a single `Factory::from_arn` entry point. Singular forms drop into `FactoryMode::Single`, plural into `FactoryMode::List`. Models whose AWS API requires a parent filter aren't exposed top-level; they're reachable via traversal:
+  - `iam.user … :access_keys`        (`ListAccessKeys` needs `UserName`)
+  - `log.group … :streams`           (`DescribeLogStreams` needs `logGroupName`)
+  - `log.group … :events`            (`FilterLogEvents` needs `logGroupName`)
+  - `ecs.cluster … :services`        (`ListServices` needs `cluster`)
+  - `ecs.cluster … :tasks`           (`ListTasks` needs `cluster`)
+- New per-entity `from_arn(arn, aws) -> Option<Table<…>>` on `User`, `Group`, `Role`, `Policy`, `InstanceProfile`, `AccessKey`, `LogGroup`, `LogStream`, `Cluster`. Each parses its own ARN shape and returns a pre-conditioned table. `Factory::from_arn` walks them in order.
+- `ecs::clusters_table` gains the previously-missing `with_many("services", "cluster", services_table)` and `with_many("tasks", "cluster", tasks_table)` so cluster traversal hits the registered relations.
+- Existing IAM / Logs models pick up `with_title_column_of` for the columns worth showing in lists (`Path`, `CreateDate`, `UserName`, `Status`, `PolicyName`, `IsAttachable`, …). Long, noisy, or always-empty columns (`Arn`, `AssumeRolePolicyDocument`, `PasswordLastUsed`, log message body) stay hidden by default and surface when you drill into a single record.
+- New `TableSource::eq_condition` impl on `AwsAccount` — builds an `AwsCondition::Eq` from raw strings so the generic CLI's `add_condition_eq` works without reaching into the backend's expression type.
+- `AwsAccount::list_table_values` now post-filters records by any `Eq` condition whose field appears on the records. AWS APIs only push down their own request-param filters (`PathPrefix`, `logGroupNamePrefix`, `cluster`); eq conditions on actual record fields (`UserName`, `Path`, `clusterArn`) used to be silently dropped on the wire. Fields not on any record are assumed to be request params and skipped (no over-filtering on `PathPrefix` etc.). Also makes the deferred-subquery path under `:relation` resolve correctly when the source is narrowed in-memory.
+- `examples/aws-cli.rs` rewritten as a thin adapter around `vantage_cli_util::model_cli::run` — same end-to-end paths as before plus filters / index / column-overrides / ARN-as-first-argument. The previous clap subcommand surface is gone; everything goes through the generic argv parser.
+- Pins `vantage-table = "0.4.8"` for the new `TableLike` reflection methods + `with_title_column_of`.
+
 ## 0.4.2 — 2026-04-29
 
 AWS Query protocol (form-encoded request, XML response) lands alongside the existing JSON-1.1 transport, plus an IAM submodule that uses it. Same `AwsAccount` is the `TableSource` for both — relations span protocols freely. ([#212](https://github.com/romaninsh/vantage/pull/212))

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2109,6 +2109,7 @@ name = "vantage-cli-util"
 version = "0.4.0"
 dependencies = [
  "async-trait",
+ "ciborium",
  "comfy-table",
  "indexmap",
  "owo-colors",

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -14,7 +14,7 @@ readme = "README.md"
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
-vantage-table = { version = "0.4.6", path = "../vantage-table" }
+vantage-table = { version = "0.4.8", path = "../vantage-table" }
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
 
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
@@ -40,7 +40,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 
 [dev-dependencies]
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
-vantage-cli-util = { version = "0.4", path = "../vantage-cli-util" }
+vantage-cli-util = { version = "0.4.1", path = "../vantage-cli-util" }
 
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }

--- a/vantage-aws/examples/aws-cli.rs
+++ b/vantage-aws/examples/aws-cli.rs
@@ -1,165 +1,196 @@
-//! `vantage-aws-cli` — proof-of-concept CLI driving the CloudWatch
-//! Logs, ECS, and IAM models through `vantage-aws`. Renders results
-//! via `vantage_cli_util::print_table` so the output exercises the
-//! same `Table` / `TableSource` machinery the rest of the framework
-//! uses.
+//! `vantage-aws-cli` — generic, model-driven CLI over `vantage-aws`.
+//!
+//! Argument shape (everything after `--region`):
+//!
+//! ```text
+//! aws-cli <model | arn> [field=value ...] [[N]] [:relation [[N]] ...]
+//! ```
+//!
+//! - First positional is either a dotted model name (`iam.users`,
+//!   `log.group`, `ecs.task_definitions`, …) or an ARN (`arn:...`).
+//! - Singular forms (`iam.user`) drop into single-record mode and
+//!   render the first matching record. Plural forms (`iam.users`)
+//!   render a list.
+//! - Filters (`field=value` or `field="quoted value"`) AND together.
+//! - `[N]` selects the Nth record from a list and switches into
+//!   single-record mode.
+//! - `:relation` traverses a `with_many` / `with_one` registered on
+//!   the current table and switches into list mode for the child.
+//! - Glued forms work too: `users[0]`, `:members[0]`, `name=foo[0]`.
 //!
 //! Reads creds from the standard env vars (`AWS_ACCESS_KEY_ID`,
-//! `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, `AWS_REGION`),
-//! falling back to the `[default]` profile in `~/.aws/credentials`
-//! and `~/.aws/config`.
+//! `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`,
+//! `AWS_REGION`), falling back to the `[default]` profile in
+//! `~/.aws/credentials` and `~/.aws/config`.
 
 use anyhow::{Context, Result};
 use ciborium::Value as CborValue;
-use clap::{Parser, Subcommand};
+use clap::Parser;
 use indexmap::IndexMap;
-use vantage_aws::models::ecs::{
-    clusters_table, services_table, task_definitions_table, tasks_table,
-};
-use vantage_aws::models::iam::{
-    Role, User, access_keys_table, groups_table as iam_groups_table, instance_profiles_table,
-    policies_table, roles_table, users_table,
-};
-use vantage_aws::models::logs::{events_table, groups_table, streams_table};
-use vantage_aws::{AwsAccount, eq, typed_records, untyped_records};
-use vantage_cli_util::render_records_typed;
-use vantage_dataset::prelude::{ReadableDataSet, ReadableValueSet};
-use vantage_table::prelude::ColumnLike;
-use vantage_table::table::Table;
-use vantage_table::traits::table_source::TableSource;
-use vantage_types::{Entity, Record};
-
-/// Print an AWS table with rich rendering: ARNs and dates get
-/// multi-segment styling, booleans get green/red, etc. Reads column
-/// metadata to drive parsing of typed values from the raw response.
-async fn print_table<E>(t: &Table<AwsAccount, E>) -> Result<()>
-where
-    E: Entity<<AwsAccount as TableSource>::Value>,
-{
-    let id_field = t.id_field().map(|c| c.name().to_string());
-    let column_types: IndexMap<String, &'static str> = t
-        .columns()
-        .iter()
-        .map(|(name, col)| (name.clone(), col.get_type()))
-        .collect();
-    let records = t.list_values().await?;
-    let typed = typed_records(records, &column_types);
-    render_records_typed(&typed, id_field.as_deref(), &column_types);
-    Ok(())
-}
-
-/// Render ad-hoc records (e.g. from `AnyTable::list_values`) with
-/// detection-based ARN/datetime rendering — no column metadata
-/// available, so we sniff strings.
-fn render_any_records(records: IndexMap<String, Record<CborValue>>, id_field: Option<&str>) {
-    let typed = untyped_records(records);
-    render_records_typed(&typed, id_field, &IndexMap::new());
-}
-
-const TRAVERSE_GROUP: &str = "/ecs/ba-nginx";
+use vantage_aws::AwsAccount;
+use vantage_aws::models::{Factory, FactoryMode};
+use vantage_aws::types::{AnyAwsType, typed_records};
+use vantage_cli_util::model_cli::{self, Mode, ModelFactory, Renderer};
+use vantage_cli_util::{render_records_columns, render_records_typed};
+use vantage_table::any::AnyTable;
+use vantage_table::traits::table_like::TableLike;
+use vantage_types::{Record, TerminalRender};
 
 #[derive(Parser)]
 #[command(
     name = "vantage-aws-cli",
-    about = "vantage-aws CloudWatch + ECS + IAM demo"
+    about = "Generic CLI for vantage-aws models",
+    long_about = "Use a dotted model name (e.g. iam.users, log.group) or an ARN as the first arg, \
+                  then chain filters (field=value), index selectors ([0]), and relation \
+                  traversals (:relation). Example: aws-cli iam.user UserName=alice :groups."
 )]
 struct Cli {
     /// Override the AWS region (sets AWS_REGION before credential load).
     #[arg(long, global = true)]
     region: Option<String>,
 
-    #[command(subcommand)]
-    command: Command,
+    /// Positional tokens: model-or-ARN, filters, indices, traversals.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = false)]
+    args: Vec<String>,
 }
 
-#[derive(Subcommand)]
-enum Command {
-    /// CloudWatch: list log groups (optionally filtered by prefix).
-    LogGroups {
-        #[arg(long)]
-        prefix: Option<String>,
-    },
-    /// CloudWatch: list log streams in a group.
-    LogStreams { log_group_name: String },
-    /// CloudWatch: list log events in a group.
-    LogEvents { log_group_name: String },
-    /// CloudWatch: filter to one group, drill into its events via `with_many("events")`.
-    TraverseLogEvents,
-    /// CloudWatch: filter to one group, drill into its streams via `with_many("streams")`.
-    TraverseLogStreams,
+/// Adapts the standalone [`Factory`] (which lives in `vantage-aws`
+/// proper) to `vantage-cli-util`'s [`ModelFactory`] trait. Keeps
+/// `vantage-aws` itself free of a runtime dep on `vantage-cli-util`.
+struct AwsFactoryAdapter(Factory);
 
-    /// ECS: list clusters in the account.
-    ListClusters,
-    /// ECS: list services in a cluster (name or ARN).
-    ListServices { cluster: String },
-    /// ECS: list tasks in a cluster (name or ARN).
-    ListTasks {
-        cluster: String,
-        /// Filter by service name.
-        #[arg(long)]
-        service: Option<String>,
-        /// Filter by task definition family.
-        #[arg(long)]
-        family: Option<String>,
-        /// RUNNING / PENDING / STOPPED.
-        #[arg(long)]
-        status: Option<String>,
-    },
-    /// ECS: list active task definitions (optionally filtered by family prefix).
-    ListTaskDefs {
-        #[arg(long)]
-        family_prefix: Option<String>,
-    },
+impl ModelFactory for AwsFactoryAdapter {
+    fn for_name(&self, name: &str) -> Option<(AnyTable, Mode)> {
+        self.0.for_name(name).map(|(t, m)| {
+            (
+                t,
+                match m {
+                    FactoryMode::List => Mode::List,
+                    FactoryMode::Single => Mode::Single,
+                },
+            )
+        })
+    }
 
-    /// IAM: list users in the account.
-    ListUsers {
-        /// Filter by IAM path prefix.
-        #[arg(long)]
-        path_prefix: Option<String>,
-    },
-    /// IAM: list groups in the account.
-    ListGroups {
-        #[arg(long)]
-        path_prefix: Option<String>,
-    },
-    /// IAM: list roles in the account.
-    ListRoles {
-        /// Filter by IAM path prefix (e.g. "/service-role/").
-        #[arg(long)]
-        path_prefix: Option<String>,
-    },
-    /// IAM: list managed policies in the account.
-    ListPolicies {
-        /// AWS / Local / All — defaults to All on the AWS side.
-        #[arg(long)]
-        scope: Option<String>,
-        /// true to skip dormant policies.
-        #[arg(long)]
-        only_attached: Option<String>,
-        #[arg(long)]
-        path_prefix: Option<String>,
-    },
-    /// IAM: list access keys for a user (defaults to the caller).
-    ListAccessKeys {
-        #[arg(long)]
-        user: Option<String>,
-    },
-    /// IAM: list instance profiles in the account.
-    ListInstanceProfiles {
-        #[arg(long)]
-        path_prefix: Option<String>,
-    },
+    fn for_arn(&self, arn: &str) -> Option<AnyTable> {
+        self.0.from_arn(arn)
+    }
+}
 
-    /// IAM: filter to one user, drill into their groups via `with_many("groups")`.
-    TraverseUserGroups { user: String },
-    /// IAM: filter to one user, drill into their attached managed policies.
-    TraverseUserPolicies { user: String },
-    /// IAM: filter to one user, drill into their access keys.
-    TraverseUserAccessKeys { user: String },
-    /// IAM: filter to one role, drill into its attached managed policies.
-    TraverseRolePolicies { role: String },
-    /// IAM: filter to one role, drill into the instance profiles wrapping it.
-    TraverseRoleProfiles { role: String },
+/// AWS-aware renderer. Lists go through the existing typed table
+/// renderer (with non-title columns hidden); single records print
+/// `id` + title columns, then `----`, then the rest, and finally a
+/// list of traversable relations.
+struct AwsRenderer;
+
+impl Renderer for AwsRenderer {
+    fn render_list(
+        &self,
+        table: &AnyTable,
+        records: &IndexMap<String, Record<CborValue>>,
+        column_override: Option<&[String]>,
+    ) {
+        let id_field = table.id_field_name();
+        let column_types = table.column_types();
+        let title_fields = table.title_field_names();
+
+        let typed = typed_records(records.clone(), &column_types);
+
+        if let Some(cols) = column_override {
+            // Explicit override: only the spelled-out columns are
+            // shown. `id` resolves to the table's id field.
+            let resolved: Vec<String> = cols
+                .iter()
+                .map(|raw| {
+                    if raw == "id" {
+                        id_field.clone().unwrap_or_else(|| raw.clone())
+                    } else {
+                        raw.clone()
+                    }
+                })
+                .collect();
+            render_records_columns(&typed, &resolved, &column_types);
+            return;
+        }
+
+        // Default: show id + title columns. Tables with no title
+        // columns (single-column ARN tables in ECS) fall back to
+        // every non-id column so the listing isn't empty.
+        let visible: IndexMap<String, &'static str> = if title_fields.is_empty() {
+            column_types.clone()
+        } else {
+            let mut v = IndexMap::new();
+            for f in &title_fields {
+                if let Some(t) = column_types.get(f) {
+                    v.insert(f.clone(), *t);
+                }
+            }
+            v
+        };
+        render_records_typed(&typed, id_field.as_deref(), &visible);
+    }
+
+    fn render_record(
+        &self,
+        table: &AnyTable,
+        id: &str,
+        record: &Record<CborValue>,
+        relations: &[String],
+    ) {
+        let id_field = table.id_field_name();
+        let title_fields = table.title_field_names();
+        let column_types = table.column_types();
+
+        let typed_rec: Record<AnyAwsType> = record
+            .iter()
+            .map(|(k, v)| {
+                let declared = column_types.get(k).copied().unwrap_or("");
+                (k.clone(), AnyAwsType::from_cbor_typed(v.clone(), declared))
+            })
+            .collect();
+
+        // id leads, then title columns, then `--------`, then the rest.
+        if let Some(ref name) = id_field {
+            println!(
+                "{}: {}",
+                name,
+                format_field(&typed_rec, name).unwrap_or_else(|| id.to_string())
+            );
+        } else {
+            println!("id: {id}");
+        }
+        for tf in &title_fields {
+            if Some(tf.as_str()) == id_field.as_deref() {
+                continue;
+            }
+            if let Some(s) = format_field(&typed_rec, tf) {
+                println!("{tf}: {s}");
+            }
+        }
+
+        println!("--------");
+
+        for k in column_types.keys() {
+            if Some(k.as_str()) == id_field.as_deref() || title_fields.contains(k) {
+                continue;
+            }
+            if let Some(s) = format_field(&typed_rec, k) {
+                println!("{k}: {s}");
+            }
+        }
+
+        if !relations.is_empty() {
+            println!();
+            println!("Relations:");
+            for r in relations {
+                println!("  :{r}");
+            }
+        }
+    }
+}
+
+fn format_field(record: &Record<AnyAwsType>, key: &str) -> Option<String> {
+    record.get(key).map(|v| v.render().to_string())
 }
 
 #[tokio::main]
@@ -173,192 +204,17 @@ async fn main() -> Result<()> {
         "Set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_REGION, or configure ~/.aws/credentials [default]",
     )?;
 
-    match cli.command {
-        Command::LogGroups { prefix } => {
-            let mut t = groups_table(aws);
-            if let Some(p) = prefix {
-                t.add_condition(eq("logGroupNamePrefix", p));
-            }
-            print_table(&t).await?;
+    if cli.args.is_empty() {
+        eprintln!("usage: aws-cli <model | arn> [field=value ...] [[N]] [:relation ...]");
+        eprintln!("\nKnown models:");
+        for name in Factory::known_names() {
+            eprintln!("  {name}");
         }
-
-        Command::LogStreams { log_group_name } => {
-            let mut t = streams_table(aws);
-            t.add_condition(eq("logGroupName", log_group_name));
-            print_table(&t).await?;
-        }
-
-        Command::LogEvents { log_group_name } => {
-            let mut t = events_table(aws);
-            t.add_condition(eq("logGroupName", log_group_name));
-            print_table(&t).await?;
-        }
-
-        Command::TraverseLogEvents => {
-            let mut log_groups = groups_table(aws);
-            log_groups.add_condition(eq("logGroupNamePrefix", TRAVERSE_GROUP));
-            print_table(&log_groups).await?;
-
-            println!("\n→ events via with_many(\"events\"):\n");
-
-            let events_any = log_groups.get_ref("events")?;
-            let records = events_any.list_values().await?;
-            render_any_records(records, Some("eventId"));
-        }
-
-        Command::TraverseLogStreams => {
-            let mut log_groups = groups_table(aws);
-            log_groups.add_condition(eq("logGroupNamePrefix", TRAVERSE_GROUP));
-            print_table(&log_groups).await?;
-
-            println!("\n→ streams via with_many(\"streams\"):\n");
-
-            let streams_any = log_groups.get_ref("streams")?;
-            let records = streams_any.list_values().await?;
-            render_any_records(records, Some("logStreamName"));
-        }
-
-        Command::ListClusters => {
-            let t = clusters_table(aws);
-            print_table(&t).await?;
-        }
-
-        Command::ListServices { cluster } => {
-            let mut t = services_table(aws);
-            t.add_condition(eq("cluster", cluster));
-            print_table(&t).await?;
-        }
-
-        Command::ListTasks {
-            cluster,
-            service,
-            family,
-            status,
-        } => {
-            let mut t = tasks_table(aws);
-            t.add_condition(eq("cluster", cluster));
-            if let Some(s) = service {
-                t.add_condition(eq("serviceName", s));
-            }
-            if let Some(f) = family {
-                t.add_condition(eq("family", f));
-            }
-            if let Some(s) = status {
-                t.add_condition(eq("desiredStatus", s));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListTaskDefs { family_prefix } => {
-            let mut t = task_definitions_table(aws);
-            if let Some(p) = family_prefix {
-                t.add_condition(eq("familyPrefix", p));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListUsers { path_prefix } => {
-            let mut t = users_table(aws);
-            if let Some(p) = path_prefix {
-                t.add_condition(eq("PathPrefix", p));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListGroups { path_prefix } => {
-            let mut t = iam_groups_table(aws);
-            if let Some(p) = path_prefix {
-                t.add_condition(eq("PathPrefix", p));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListRoles { path_prefix } => {
-            let mut t = roles_table(aws);
-            if let Some(p) = path_prefix {
-                t.add_condition(eq("PathPrefix", p));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListPolicies {
-            scope,
-            only_attached,
-            path_prefix,
-        } => {
-            let mut t = policies_table(aws);
-            if let Some(s) = scope {
-                t.add_condition(eq("Scope", s));
-            }
-            if let Some(o) = only_attached {
-                t.add_condition(eq("OnlyAttached", o));
-            }
-            if let Some(p) = path_prefix {
-                t.add_condition(eq("PathPrefix", p));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListAccessKeys { user } => {
-            let mut t = access_keys_table(aws);
-            if let Some(u) = user {
-                t.add_condition(eq("UserName", u));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListInstanceProfiles { path_prefix } => {
-            let mut t = instance_profiles_table(aws);
-            if let Some(p) = path_prefix {
-                t.add_condition(eq("PathPrefix", p));
-            }
-            print_table(&t).await?;
-        }
-
-        // IAM ListUsers / ListRoles ignore unknown filters and return
-        // the whole account, so the parent table can't be narrowed
-        // API-side. The entity-method helpers (`User::ref_*`,
-        // `Role::ref_*`) are the right tool here — they take the
-        // already-loaded entity and pre-filter the child table.
-        Command::TraverseUserGroups { user } => {
-            let target = find_user(aws.clone(), &user).await?;
-            print_table(&target.ref_groups(aws)).await?;
-        }
-
-        Command::TraverseUserPolicies { user } => {
-            let target = find_user(aws.clone(), &user).await?;
-            print_table(&target.ref_attached_policies(aws)).await?;
-        }
-
-        Command::TraverseUserAccessKeys { user } => {
-            let target = find_user(aws.clone(), &user).await?;
-            print_table(&target.ref_access_keys(aws)).await?;
-        }
-
-        Command::TraverseRolePolicies { role } => {
-            let target = find_role(aws.clone(), &role).await?;
-            print_table(&target.ref_attached_policies(aws)).await?;
-        }
-
-        Command::TraverseRoleProfiles { role } => {
-            let target = find_role(aws.clone(), &role).await?;
-            print_table(&target.ref_instance_profiles(aws)).await?;
-        }
+        std::process::exit(2);
     }
 
+    let factory = AwsFactoryAdapter(Factory::new(aws));
+    let renderer = AwsRenderer;
+    model_cli::run(&factory, &renderer, &cli.args).await?;
     Ok(())
-}
-
-async fn find_user(aws: AwsAccount, name: &str) -> Result<User> {
-    users_table(aws)
-        .get(name.to_string())
-        .await?
-        .with_context(|| format!("IAM user {name:?} not found in this account"))
-}
-
-async fn find_role(aws: AwsAccount, name: &str) -> Result<Role> {
-    roles_table(aws)
-        .get(name.to_string())
-        .await?
-        .with_context(|| format!("IAM role {name:?} not found in this account"))
 }

--- a/vantage-aws/src/impls/table_source.rs
+++ b/vantage-aws/src/impls/table_source.rs
@@ -42,6 +42,10 @@ impl TableSource for AwsAccount {
     type Id = String;
     type Condition = AwsCondition;
 
+    fn eq_condition(field: &str, value: &str) -> DatasetResult<Self::Condition> {
+        Ok(AwsCondition::eq(field.to_string(), value.to_string()))
+    }
+
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         Column::new(name)
     }
@@ -93,7 +97,26 @@ impl TableSource for AwsAccount {
         let id_field = table.id_field().map(|c| c.name().to_string());
         let conditions: Vec<AwsCondition> = table.conditions().cloned().collect();
         let resp = self.execute_rpc(table.table_name(), &conditions).await?;
-        Ok(self.parse_records(table.table_name(), resp, id_field.as_deref())?)
+        let mut records = self.parse_records(table.table_name(), resp, id_field.as_deref())?;
+
+        // AWS APIs only push down their own request-param filters
+        // (e.g. `PathPrefix`, `logGroupNamePrefix`, `cluster`). Eq
+        // conditions naming actual record fields (`UserName`, `Path`,
+        // `clusterArn`) are still useful — apply them post-hoc so
+        // narrowing works regardless of what the API filters
+        // server-side. Field names that don't appear on any record are
+        // assumed to be request params and skipped.
+        records.retain(|_id, record| {
+            conditions.iter().all(|c| match c {
+                AwsCondition::Eq { field, value } => match record.get(field) {
+                    Some(rec_val) => rec_val == value,
+                    None => true,
+                },
+                _ => true,
+            })
+        });
+
+        Ok(records)
     }
 
     async fn get_table_value<E>(

--- a/vantage-aws/src/models/ecs/cluster.rs
+++ b/vantage-aws/src/models/ecs/cluster.rs
@@ -30,9 +30,23 @@ pub fn clusters_table(aws: AwsAccount) -> Table<AwsAccount, Cluster> {
         aws,
     )
     .with_id_column("clusterArn")
+    .with_many("services", "cluster", services_table)
+    .with_many("tasks", "cluster", tasks_table)
 }
 
 impl Cluster {
+    /// Build a [`clusters_table`] narrowed to the cluster identified
+    /// by `arn`. Accepts ARNs of the shape
+    /// `arn:aws:ecs:<region>:<account>:cluster/<name>`.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Cluster>> {
+        if !arn.contains(":cluster/") {
+            return None;
+        }
+        let mut t = clusters_table(aws);
+        t.add_condition(eq("clusterArn", arn.to_string()));
+        Some(t)
+    }
+
     /// The cluster's short name, parsed out of [`Self::cluster_arn`].
     /// Cluster ARNs have the shape
     /// `arn:aws:ecs:<region>:<account>:cluster/<name>`.

--- a/vantage-aws/src/models/iam/access_key.rs
+++ b/vantage-aws/src/models/iam/access_key.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
-use crate::AwsAccount;
+use crate::{AwsAccount, eq};
 
 /// One IAM access key from `ListAccessKeys`. Secret material is
 /// never returned by the API — only the metadata you can use to
@@ -26,7 +26,25 @@ pub struct AccessKey {
 pub fn access_keys_table(aws: AwsAccount) -> Table<AwsAccount, AccessKey> {
     Table::new("query/AccessKeyMetadata:iam/2010-05-08.ListAccessKeys", aws)
         .with_id_column("AccessKeyId")
-        .with_column_of::<String>("UserName")
-        .with_column_of::<String>("Status")
+        .with_title_column_of::<String>("UserName")
+        .with_title_column_of::<String>("Status")
         .with_column_of::<String>("CreateDate")
+}
+
+impl AccessKey {
+    /// Access keys don't have stable, addressable ARNs in IAM. The
+    /// closest thing is the user-scoped form
+    /// `arn:aws:iam::<account>:user/<name>/access-key/<id>` — accepted
+    /// here as a convenience: we filter by `UserName` since that's the
+    /// only condition `ListAccessKeys` accepts.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, AccessKey>> {
+        let after = arn.strip_prefix("arn:aws:iam::")?.split(":user/").nth(1)?;
+        let user_name = after.split("/access-key/").next()?;
+        if user_name.is_empty() {
+            return None;
+        }
+        let mut t = access_keys_table(aws);
+        t.add_condition(eq("UserName", user_name.to_string()));
+        Some(t)
+    }
 }

--- a/vantage-aws/src/models/iam/attached_policy.rs
+++ b/vantage-aws/src/models/iam/attached_policy.rs
@@ -28,7 +28,7 @@ pub fn attached_user_policies_table(aws: AwsAccount) -> Table<AwsAccount, Attach
         aws,
     )
     .with_id_column("PolicyArn")
-    .with_column_of::<String>("PolicyName")
+    .with_title_column_of::<String>("PolicyName")
 }
 
 /// `ListAttachedGroupPolicies` — requires `eq("GroupName", "...")`.
@@ -39,7 +39,7 @@ pub fn attached_group_policies_table(aws: AwsAccount) -> Table<AwsAccount, Attac
         aws,
     )
     .with_id_column("PolicyArn")
-    .with_column_of::<String>("PolicyName")
+    .with_title_column_of::<String>("PolicyName")
 }
 
 /// `ListAttachedRolePolicies` — requires `eq("RoleName", "...")`.
@@ -50,5 +50,5 @@ pub fn attached_role_policies_table(aws: AwsAccount) -> Table<AwsAccount, Attach
         aws,
     )
     .with_id_column("PolicyArn")
-    .with_column_of::<String>("PolicyName")
+    .with_title_column_of::<String>("PolicyName")
 }

--- a/vantage-aws/src/models/iam/group.rs
+++ b/vantage-aws/src/models/iam/group.rs
@@ -33,8 +33,8 @@ pub fn groups_table(aws: AwsAccount) -> Table<AwsAccount, Group> {
         .with_id_column("GroupName")
         .with_column_of::<String>("GroupId")
         .with_column_of::<Arn>("Arn")
-        .with_column_of::<String>("Path")
-        .with_column_of::<AwsDateTime>("CreateDate")
+        .with_title_column_of::<String>("Path")
+        .with_title_column_of::<AwsDateTime>("CreateDate")
         .with_many(
             "attached_policies",
             "GroupName",
@@ -55,6 +55,21 @@ pub(crate) fn groups_for_user_table(aws: AwsAccount) -> Table<AwsAccount, Group>
 }
 
 impl Group {
+    /// Build a [`groups_table`] narrowed to the group named in `arn`.
+    ///
+    /// Accepts ARNs of the shape
+    /// `arn:aws:iam::<account>:group/<name>`. Returns `None` if `arn`
+    /// isn't an IAM-group ARN.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Group>> {
+        let name = arn.strip_prefix("arn:aws:iam::")?.split(":group/").nth(1)?;
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = groups_table(aws);
+        t.add_condition(eq("GroupName", name.to_string()));
+        Some(t)
+    }
+
     /// Attached managed policies for *this* group.
     pub fn ref_attached_policies(&self, aws: AwsAccount) -> Table<AwsAccount, AttachedPolicy> {
         let mut t = attached_group_policies_table(aws);

--- a/vantage-aws/src/models/iam/instance_profile.rs
+++ b/vantage-aws/src/models/iam/instance_profile.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
-use crate::AwsAccount;
+use crate::{AwsAccount, eq};
 
 /// One IAM instance profile from `ListInstanceProfiles` /
 /// `ListInstanceProfilesForRole`. The nested `Roles` array isn't
@@ -31,7 +31,7 @@ pub fn instance_profiles_table(aws: AwsAccount) -> Table<AwsAccount, InstancePro
     .with_id_column("InstanceProfileName")
     .with_column_of::<String>("InstanceProfileId")
     .with_column_of::<String>("Arn")
-    .with_column_of::<String>("Path")
+    .with_title_column_of::<String>("Path")
     .with_column_of::<String>("CreateDate")
 }
 
@@ -50,4 +50,23 @@ pub(crate) fn instance_profiles_for_role_table(
     .with_column_of::<String>("Arn")
     .with_column_of::<String>("Path")
     .with_column_of::<String>("CreateDate")
+}
+
+impl InstanceProfile {
+    /// Build an [`instance_profiles_table`] narrowed to the profile
+    /// named in `arn`. Accepts ARNs of the shape
+    /// `arn:aws:iam::<account>:instance-profile/<path/>?<name>`.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, InstanceProfile>> {
+        let after = arn
+            .strip_prefix("arn:aws:iam::")?
+            .split(":instance-profile/")
+            .nth(1)?;
+        let name = after.rsplit('/').next()?;
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = instance_profiles_table(aws);
+        t.add_condition(eq("InstanceProfileName", name.to_string()));
+        Some(t)
+    }
 }

--- a/vantage-aws/src/models/iam/policy.rs
+++ b/vantage-aws/src/models/iam/policy.rs
@@ -67,7 +67,10 @@ impl Policy {
     /// `arn`. Accepts both AWS-managed (`arn:aws:iam::aws:policy/...`)
     /// and customer-managed (`arn:aws:iam::<account>:policy/...`) ARNs.
     pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Policy>> {
-        let after = arn.strip_prefix("arn:aws:iam::")?.split(":policy/").nth(1)?;
+        let after = arn
+            .strip_prefix("arn:aws:iam::")?
+            .split(":policy/")
+            .nth(1)?;
         // Customer-managed policies can sit under a path; managed
         // policies don't. Either way, the policy name is the last
         // path component.

--- a/vantage-aws/src/models/iam/policy.rs
+++ b/vantage-aws/src/models/iam/policy.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
-use crate::AwsAccount;
 use crate::types::{Arn, AwsDateTime};
+use crate::{AwsAccount, eq};
 
 /// One IAM managed policy from `ListPolicies`. Numeric fields stay as
 /// strings — the Query protocol's XML response is untyped, and we
@@ -52,12 +52,31 @@ pub fn policies_table(aws: AwsAccount) -> Table<AwsAccount, Policy> {
         .with_id_column("PolicyName")
         .with_column_of::<String>("PolicyId")
         .with_column_of::<Arn>("Arn")
-        .with_column_of::<String>("Path")
+        .with_title_column_of::<String>("Path")
         .with_column_of::<String>("DefaultVersionId")
-        .with_column_of::<i64>("AttachmentCount")
+        .with_title_column_of::<i64>("AttachmentCount")
         .with_column_of::<i64>("PermissionsBoundaryUsageCount")
-        .with_column_of::<bool>("IsAttachable")
+        .with_title_column_of::<bool>("IsAttachable")
         .with_column_of::<AwsDateTime>("CreateDate")
         .with_column_of::<AwsDateTime>("UpdateDate")
         .with_column_of::<String>("Description")
+}
+
+impl Policy {
+    /// Build a [`policies_table`] narrowed to the policy named in
+    /// `arn`. Accepts both AWS-managed (`arn:aws:iam::aws:policy/...`)
+    /// and customer-managed (`arn:aws:iam::<account>:policy/...`) ARNs.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Policy>> {
+        let after = arn.strip_prefix("arn:aws:iam::")?.split(":policy/").nth(1)?;
+        // Customer-managed policies can sit under a path; managed
+        // policies don't. Either way, the policy name is the last
+        // path component.
+        let name = after.rsplit('/').next()?;
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = policies_table(aws);
+        t.add_condition(eq("PolicyName", name.to_string()));
+        Some(t)
+    }
 }

--- a/vantage-aws/src/models/iam/role.rs
+++ b/vantage-aws/src/models/iam/role.rs
@@ -51,8 +51,8 @@ pub fn roles_table(aws: AwsAccount) -> Table<AwsAccount, Role> {
         .with_id_column("RoleName")
         .with_column_of::<String>("RoleId")
         .with_column_of::<Arn>("Arn")
-        .with_column_of::<String>("Path")
-        .with_column_of::<AwsDateTime>("CreateDate")
+        .with_title_column_of::<String>("Path")
+        .with_title_column_of::<AwsDateTime>("CreateDate")
         .with_column_of::<String>("Description")
         .with_column_of::<String>("AssumeRolePolicyDocument")
         .with_column_of::<String>("MaxSessionDuration")
@@ -69,6 +69,24 @@ pub fn roles_table(aws: AwsAccount) -> Table<AwsAccount, Role> {
 }
 
 impl Role {
+    /// Build a [`roles_table`] narrowed to the role named in `arn`.
+    ///
+    /// Accepts ARNs of the shape
+    /// `arn:aws:iam::<account>:role/<path/>?<name>`. Returns `None` if
+    /// `arn` isn't an IAM-role ARN.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Role>> {
+        // Role names can sit under a path: arn:aws:iam::123:role/some/path/MyRole
+        // — strip back to the trailing component for the IAM filter.
+        let after = arn.strip_prefix("arn:aws:iam::")?.split(":role/").nth(1)?;
+        let name = after.rsplit('/').next()?;
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = roles_table(aws);
+        t.add_condition(eq("RoleName", name.to_string()));
+        Some(t)
+    }
+
     /// Attached managed policies for *this* role.
     pub fn ref_attached_policies(&self, aws: AwsAccount) -> Table<AwsAccount, AttachedPolicy> {
         let mut t = attached_role_policies_table(aws);

--- a/vantage-aws/src/models/iam/user.rs
+++ b/vantage-aws/src/models/iam/user.rs
@@ -56,8 +56,8 @@ pub fn users_table(aws: AwsAccount) -> Table<AwsAccount, User> {
         .with_id_column("UserName")
         .with_column_of::<String>("UserId")
         .with_column_of::<Arn>("Arn")
-        .with_column_of::<String>("Path")
-        .with_column_of::<AwsDateTime>("CreateDate")
+        .with_title_column_of::<String>("Path")
+        .with_title_column_of::<AwsDateTime>("CreateDate")
         .with_column_of::<AwsDateTime>("PasswordLastUsed")
         .with_many("groups", "UserName", groups_for_user_table)
         .with_many("access_keys", "UserName", access_keys_table)
@@ -69,6 +69,21 @@ pub fn users_table(aws: AwsAccount) -> Table<AwsAccount, User> {
 }
 
 impl User {
+    /// Build a [`users_table`] narrowed to the user named in `arn`.
+    ///
+    /// Accepts ARNs of the shape
+    /// `arn:aws:iam::<account>:user/<name>`. Returns `None` if `arn`
+    /// isn't an IAM-user ARN.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, User>> {
+        let name = arn.strip_prefix("arn:aws:iam::")?.split(":user/").nth(1)?;
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = users_table(aws);
+        t.add_condition(eq("UserName", name.to_string()));
+        Some(t)
+    }
+
     /// Groups *this* user belongs to.
     pub fn ref_groups(&self, aws: AwsAccount) -> Table<AwsAccount, Group> {
         let mut t = groups_for_user_table(aws);

--- a/vantage-aws/src/models/logs/event.rs
+++ b/vantage-aws/src/models/logs/event.rs
@@ -33,7 +33,7 @@ pub struct LogEvent {
 pub fn events_table(aws: AwsAccount) -> Table<AwsAccount, LogEvent> {
     Table::new("json1/events:logs/Logs_20140328.FilterLogEvents", aws)
         .with_id_column("eventId")
-        .with_column_of::<String>("logStreamName")
-        .with_column_of::<i64>("timestamp")
+        .with_title_column_of::<String>("logStreamName")
+        .with_title_column_of::<i64>("timestamp")
         .with_column_of::<String>("message")
 }

--- a/vantage-aws/src/models/logs/group.rs
+++ b/vantage-aws/src/models/logs/group.rs
@@ -42,12 +42,34 @@ pub fn groups_table(aws: AwsAccount) -> Table<AwsAccount, LogGroup> {
     Table::new("json1/logGroups:logs/Logs_20140328.DescribeLogGroups", aws)
         .with_id_column("logGroupName")
         .with_column_of::<i64>("creationTime")
-        .with_column_of::<i64>("storedBytes")
+        .with_title_column_of::<i64>("storedBytes")
         .with_many("events", "logGroupName", events_table)
         .with_many("streams", "logGroupName", streams_table)
 }
 
 impl LogGroup {
+    /// Build a [`groups_table`] narrowed to the group named in `arn`.
+    ///
+    /// Accepts ARNs of the shape
+    /// `arn:aws:logs:<region>:<account>:log-group:<name>` with an
+    /// optional trailing `:*` (the form returned by IAM policy
+    /// resources). Returns `None` if the ARN isn't a log-group ARN.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, LogGroup>> {
+        let after = arn.split(":log-group:").nth(1)?;
+        // Strip the optional :log-stream:... or :* suffix.
+        let name = after
+            .split(":log-stream:")
+            .next()
+            .unwrap_or(after)
+            .trim_end_matches(":*");
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = groups_table(aws);
+        t.add_condition(eq("logGroupNamePrefix", name.to_string()));
+        Some(t)
+    }
+
     /// Events table pre-filtered to *this* group's name.
     pub fn ref_events(&self, aws: AwsAccount) -> Table<AwsAccount, LogEvent> {
         let mut t = events_table(aws);

--- a/vantage-aws/src/models/logs/stream.rs
+++ b/vantage-aws/src/models/logs/stream.rs
@@ -48,13 +48,30 @@ pub fn streams_table(aws: AwsAccount) -> Table<AwsAccount, LogStream> {
     .with_column_of::<String>("arn")
     .with_column_of::<i64>("creationTime")
     .with_column_of::<i64>("firstEventTimestamp")
-    .with_column_of::<i64>("lastEventTimestamp")
+    .with_title_column_of::<i64>("lastEventTimestamp")
     .with_column_of::<i64>("lastIngestionTime")
-    .with_column_of::<i64>("storedBytes")
+    .with_title_column_of::<i64>("storedBytes")
     .with_column_of::<String>("uploadSequenceToken")
 }
 
 impl LogStream {
+    /// Build a [`streams_table`] narrowed to the stream identified by
+    /// `arn`. Accepts ARNs of the shape
+    /// `arn:aws:logs:<region>:<account>:log-group:<group>:log-stream:<stream>`.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, LogStream>> {
+        let after_group = arn.split(":log-group:").nth(1)?;
+        let mut parts = after_group.splitn(2, ":log-stream:");
+        let group_name = parts.next()?;
+        let stream_name = parts.next()?;
+        if group_name.is_empty() || stream_name.is_empty() {
+            return None;
+        }
+        let mut t = streams_table(aws);
+        t.add_condition(eq("logGroupName", group_name.to_string()));
+        t.add_condition(eq("logStreamNamePrefix", stream_name.to_string()));
+        Some(t)
+    }
+
     /// The owning log group's name, parsed out of [`Self::arn`].
     /// Stream ARNs have the shape
     /// `arn:aws:logs:<region>:<account>:log-group:<group>:log-stream:<stream>`.

--- a/vantage-aws/src/models/logs/stream.rs
+++ b/vantage-aws/src/models/logs/stream.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
-use crate::{AwsAccount, eq};
+use crate::{eq, AwsAccount};
 
-use super::event::{LogEvent, events_table};
+use super::event::{events_table, LogEvent};
 
 /// One CloudWatch Logs stream from `DescribeLogStreams`. Field names
 /// match the wire shape.
@@ -60,9 +60,7 @@ impl LogStream {
     /// `arn:aws:logs:<region>:<account>:log-group:<group>:log-stream:<stream>`.
     pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, LogStream>> {
         let after_group = arn.split(":log-group:").nth(1)?;
-        let mut parts = after_group.splitn(2, ":log-stream:");
-        let group_name = parts.next()?;
-        let stream_name = parts.next()?;
+        let (group_name, stream_name) = after_group.split_once(":log-stream:")?;
         if group_name.is_empty() || stream_name.is_empty() {
             return None;
         }

--- a/vantage-aws/src/models/mod.rs
+++ b/vantage-aws/src/models/mod.rs
@@ -19,6 +19,15 @@
 //!   - [`iam::access_keys_table`]        — `ListAccessKeys`  (per user)
 //!   - [`iam::instance_profiles_table`]  — `ListInstanceProfiles`
 //!
+//! ## Generic factory ([`Factory`])
+//!
+//! Wraps every table above behind dotted-string names (`iam.users`,
+//! `log.group`, `ecs.task_definitions`, …) and a single
+//! [`Factory::from_arn`] entry point. Powers the `aws-cli` example
+//! (which adapts it to `vantage_cli_util`'s `ModelFactory` trait);
+//! anything else that needs a generic, type-erased AWS table by name
+//! can reuse it without dragging in a CLI rendering crate.
+//!
 //! ```no_run
 //! # use vantage_aws::{AwsAccount, eq};
 //! # use vantage_aws::models::logs::groups_table;
@@ -32,3 +41,156 @@
 pub mod ecs;
 pub mod iam;
 pub mod logs;
+
+use vantage_table::any::AnyTable;
+
+use crate::AwsAccount;
+
+/// Whether a [`Factory`] lookup should drop into list mode (returning
+/// every matching record) or single-record mode (returning just the
+/// first match).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FactoryMode {
+    List,
+    Single,
+}
+
+/// Generic, type-erased model factory.
+///
+/// The factory maps dotted string names to the typed `*_table`
+/// factories above and dispatches ARN parsing across each entity's
+/// `from_arn`. Singular forms (e.g. `iam.user`) drop into
+/// [`FactoryMode::Single`]; plural forms (`iam.users`) drop into
+/// [`FactoryMode::List`].
+#[derive(Debug, Clone)]
+pub struct Factory {
+    aws: AwsAccount,
+}
+
+impl Factory {
+    /// Build a factory bound to a specific AWS account.
+    pub fn new(aws: AwsAccount) -> Self {
+        Self { aws }
+    }
+
+    /// All known model names, in registration order.
+    ///
+    /// Models whose AWS API requires a parent filter aren't exposed
+    /// top-level — listing them standalone would either error
+    /// or quietly return only the caller's slice. Reach them via
+    /// traversal from their parent:
+    ///   - `iam.user ... :access_keys`        (ListAccessKeys needs UserName)
+    ///   - `log.group ... :streams`           (DescribeLogStreams needs logGroupName)
+    ///   - `log.group ... :events`            (FilterLogEvents needs logGroupName)
+    ///   - `ecs.cluster ... :services`        (ListServices needs cluster)
+    ///   - `ecs.cluster ... :tasks`           (ListTasks needs cluster)
+    ///
+    /// Per-resource ARNs still work as the first argument for any of
+    /// these — see [`Factory::from_arn`].
+    pub fn known_names() -> &'static [&'static str] {
+        &[
+            "iam.user",
+            "iam.users",
+            "iam.group",
+            "iam.groups",
+            "iam.role",
+            "iam.roles",
+            "iam.policy",
+            "iam.policies",
+            "iam.instance_profile",
+            "iam.instance_profiles",
+            "log.group",
+            "log.groups",
+            "ecs.cluster",
+            "ecs.clusters",
+            "ecs.task_definition",
+            "ecs.task_definitions",
+        ]
+    }
+
+    /// Resolve a model name to an `AnyTable` plus its mode.
+    pub fn for_name(&self, name: &str) -> Option<(AnyTable, FactoryMode)> {
+        let aws = self.aws.clone();
+        let (table, mode) = match name {
+            "iam.user" => (AnyTable::new(iam::users_table(aws)), FactoryMode::Single),
+            "iam.users" => (AnyTable::new(iam::users_table(aws)), FactoryMode::List),
+            "iam.group" => (AnyTable::new(iam::groups_table(aws)), FactoryMode::Single),
+            "iam.groups" => (AnyTable::new(iam::groups_table(aws)), FactoryMode::List),
+            "iam.role" => (AnyTable::new(iam::roles_table(aws)), FactoryMode::Single),
+            "iam.roles" => (AnyTable::new(iam::roles_table(aws)), FactoryMode::List),
+            "iam.policy" => (AnyTable::new(iam::policies_table(aws)), FactoryMode::Single),
+            "iam.policies" => (AnyTable::new(iam::policies_table(aws)), FactoryMode::List),
+            // iam.access_key / iam.access_keys intentionally omitted:
+            // listing them standalone returns just the caller's keys,
+            // which is rarely what people mean. Reach them via
+            // `iam.user ... :access_keys`.
+            "iam.instance_profile" => (
+                AnyTable::new(iam::instance_profiles_table(aws)),
+                FactoryMode::Single,
+            ),
+            "iam.instance_profiles" => (
+                AnyTable::new(iam::instance_profiles_table(aws)),
+                FactoryMode::List,
+            ),
+            "log.group" => (AnyTable::new(logs::groups_table(aws)), FactoryMode::Single),
+            "log.groups" => (AnyTable::new(logs::groups_table(aws)), FactoryMode::List),
+            // log.stream / log.event intentionally omitted: AWS
+            // requires `logGroupName`. Reach them via
+            // `log.group ... :streams` / `:events`.
+            "ecs.cluster" => (
+                AnyTable::new(ecs::clusters_table(aws)),
+                FactoryMode::Single,
+            ),
+            "ecs.clusters" => (AnyTable::new(ecs::clusters_table(aws)), FactoryMode::List),
+            // ecs.service / ecs.task intentionally omitted: AWS
+            // requires `cluster` as a filter, so listing them
+            // standalone returns nothing useful. Reach them via
+            // `ecs.cluster ... :services` / `:tasks`.
+            "ecs.task_definition" => (
+                AnyTable::new(ecs::task_definitions_table(aws)),
+                FactoryMode::Single,
+            ),
+            "ecs.task_definitions" => (
+                AnyTable::new(ecs::task_definitions_table(aws)),
+                FactoryMode::List,
+            ),
+            _ => return None,
+        };
+        Some((table, mode))
+    }
+
+    /// Resolve an ARN to a pre-conditioned single-record table by
+    /// dispatching to each entity's `from_arn`. Returns `None` if no
+    /// entity recognises the ARN's resource type.
+    pub fn from_arn(&self, arn: &str) -> Option<AnyTable> {
+        let aws = self.aws.clone();
+        if let Some(t) = iam::user::User::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = iam::group::Group::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = iam::role::Role::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = iam::policy::Policy::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = iam::instance_profile::InstanceProfile::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = iam::access_key::AccessKey::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = logs::stream::LogStream::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = logs::group::LogGroup::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = ecs::cluster::Cluster::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        None
+    }
+}

--- a/vantage-aws/src/models/mod.rs
+++ b/vantage-aws/src/models/mod.rs
@@ -137,10 +137,7 @@ impl Factory {
             // log.stream / log.event intentionally omitted: AWS
             // requires `logGroupName`. Reach them via
             // `log.group ... :streams` / `:events`.
-            "ecs.cluster" => (
-                AnyTable::new(ecs::clusters_table(aws)),
-                FactoryMode::Single,
-            ),
+            "ecs.cluster" => (AnyTable::new(ecs::clusters_table(aws)), FactoryMode::Single),
             "ecs.clusters" => (AnyTable::new(ecs::clusters_table(aws)), FactoryMode::List),
             // ecs.service / ecs.task intentionally omitted: AWS
             // requires `cluster` as a filter, so listing them

--- a/vantage-cli-util/CHANGELOG.md
+++ b/vantage-cli-util/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.1 — 2026-04-30
+
+- New `model_cli` module — generic, model-driven CLI runner over any `AnyTable`. Argv shape: `<model | arn> [field=value ...] [[N]] [:relation [[N]] ...] [=col1,col2 ...]`. Singular vs plural model names drive list/single mode; `id=value` is sugar that resolves to the table's id field and forces single-record mode; `[N]` selects the Nth record and switches into single-record mode by adding `eq(id_field, that_id)`; `:relation` traverses a registered `with_many` / `with_one`; `=col1,col2` overrides the visible columns in list mode. Glued forms (`users[0]`, `:members[0]`, `name=foo[0]`, `=msg,timestamp[0]`) split into a base token plus an index selector.
+- Two new traits the caller implements: `ModelFactory` (resolve a name or ARN to an `AnyTable`) and `Renderer` (render lists / single records). The crate stays UI-/backend-agnostic — actual record rendering is delegated to the caller.
+- New `render_records_columns` helper alongside the existing `render_records_typed`. Takes an explicit column list and does *not* auto-prepend an id column — for the case where the caller spelled out exactly what they want to see (e.g. the `=col1,col2` override path) and an extra id column would just be noise. Existing `render_records` / `render_records_typed` are unchanged.
+- New `ciborium` dep (used at the model_cli boundary, where records flow as `Record<CborValue>`).
+- Pins `vantage-table = "0.4.8"` for the new `TableLike` reflection methods (`id_field_name`, `title_field_names`, `column_types`, `get_ref_names`, `add_condition_eq`).
+
 ## 0.4.0 — 2026-04-16
 
 - Initial 0.4 release. Generic CLI helpers (`render_records`, `handle_commands`) for driving any vantage backend through a uniform command set.

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/romaninsh/vantage"
 
 [dependencies]
 async-trait = "0.1"
+ciborium = "0.2.2"
 comfy-table = { version = "7", features = ["custom_styling"] }
 indexmap = "2"
 owo-colors = "4"

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-cli-util"
-version = "0.4.0"
+version = "0.4.1"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "CLI utilities for Vantage data framework"
@@ -15,5 +15,5 @@ indexmap = "2"
 owo-colors = "4"
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
-vantage-table = { version = "0.4", path = "../vantage-table" }
+vantage-table = { version = "0.4.8", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types" }

--- a/vantage-cli-util/src/lib.rs
+++ b/vantage-cli-util/src/lib.rs
@@ -1,3 +1,7 @@
+pub mod model_cli;
 mod table_display;
 
-pub use table_display::{print_table, render_records, render_records_typed};
+pub use model_cli::{Mode, ModelFactory, Renderer};
+pub use table_display::{
+    print_table, render_records, render_records_columns, render_records_typed,
+};

--- a/vantage-cli-util/src/model_cli.rs
+++ b/vantage-cli-util/src/model_cli.rs
@@ -1,0 +1,395 @@
+//! Generic model-driven CLI runner.
+//!
+//! Drives an `AnyTable` from positional argv tokens — model name, ARN,
+//! `field=value` filters, `[N]` index selectors, and `:relation`
+//! traversals. Backend specifics (which names map to which tables, how
+//! ARNs are parsed, how records are rendered) are injected through the
+//! [`ModelFactory`] and [`Renderer`] traits.
+//!
+//! ## Token forms
+//!
+//! - `arn:...` — ARN; resolved via [`ModelFactory::for_arn`]; drops
+//!   straight into single-record mode.
+//! - `iam.user`, `iam.users` — model name (singular drops into single
+//!   mode, plural into list mode).
+//! - `field=value` or `field="quoted value"` — adds an equality
+//!   condition. Multiple are ANDed.
+//! - `[N]` — selects the Nth record from a list (zero-indexed) and
+//!   narrows the table to that record. Switches to single-record mode.
+//! - `:relation` — traverses a relation registered via `with_many` /
+//!   `with_one`. Only allowed in single-record mode (so the deferred
+//!   child query yields a single foreign-key value); switches to list
+//!   mode for the child table.
+//! - `=col1,col2,...` — overrides the visible columns in list mode.
+//!   Stays in effect for the rest of the run; later relation
+//!   traversals reset it. The literal `id` resolves to the table's id
+//!   field at render time.
+//!
+//! Glued forms are accepted: `users[0]`, `:members[0]`,
+//! `name=foo[0]`, and `=col1,col2[0]` all split into a base token plus
+//! an index selector.
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_table::any::AnyTable;
+use vantage_table::traits::table_like::TableLike;
+use vantage_types::Record;
+
+/// Whether the current state is a list of records or a single record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    List,
+    Single,
+}
+
+/// Resolves model identifiers (singular/plural names, ARNs) to
+/// `AnyTable`s. Implemented per-backend.
+pub trait ModelFactory {
+    /// Resolve a model name (e.g. `iam.user` or `iam.users`).
+    /// Singular names should return [`Mode::Single`], plural
+    /// [`Mode::List`]. Returns `None` for unknown names.
+    fn for_name(&self, name: &str) -> Option<(AnyTable, Mode)>;
+
+    /// Resolve an ARN to a single-record table with any required
+    /// conditions (e.g. resource-name eq) already applied.
+    fn for_arn(&self, arn: &str) -> Option<AnyTable>;
+}
+
+/// Backend hook for printing list and single-record results.
+pub trait Renderer {
+    fn render_list(
+        &self,
+        table: &AnyTable,
+        records: &IndexMap<String, Record<CborValue>>,
+        column_override: Option<&[String]>,
+    );
+    fn render_record(
+        &self,
+        table: &AnyTable,
+        id: &str,
+        record: &Record<CborValue>,
+        relations: &[String],
+    );
+}
+
+#[derive(Debug)]
+enum Token {
+    ModelName(String, Option<usize>),
+    Arn(String),
+    Condition(String, String, Option<usize>),
+    Relation(String, Option<usize>),
+    Index(usize),
+    Columns(Vec<String>, Option<usize>),
+}
+
+fn split_index_suffix(s: &str) -> (&str, Option<usize>) {
+    if let Some(stripped) = s.strip_suffix(']') {
+        if let Some(open) = stripped.rfind('[') {
+            let inner = &stripped[open + 1..];
+            if !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit()) {
+                if let Ok(n) = inner.parse::<usize>() {
+                    return (&stripped[..open], Some(n));
+                }
+            }
+        }
+    }
+    (s, None)
+}
+
+fn parse_token(arg: &str) -> Result<Token> {
+    if arg.is_empty() {
+        return Err(error!("Empty argument"));
+    }
+    if arg.starts_with("arn:") {
+        return Ok(Token::Arn(arg.to_string()));
+    }
+    if let Some(rest) = arg.strip_prefix(':') {
+        let (rel, idx) = split_index_suffix(rest);
+        if rel.is_empty() {
+            return Err(error!(format!("Empty relation name in token `{arg}`")));
+        }
+        return Ok(Token::Relation(rel.to_string(), idx));
+    }
+    if arg.starts_with('[') {
+        let (_, idx) = split_index_suffix(arg);
+        let idx = idx.ok_or_else(|| error!(format!("Invalid index token `{arg}`")))?;
+        return Ok(Token::Index(idx));
+    }
+    if let Some(rest) = arg.strip_prefix('=') {
+        let (cols_part, idx) = split_index_suffix(rest);
+        if cols_part.is_empty() {
+            return Err(error!(format!(
+                "Empty column list in token `{arg}` — write `=col1,col2`"
+            )));
+        }
+        let cols: Vec<String> = cols_part
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if cols.is_empty() {
+            return Err(error!(format!("Empty column list in token `{arg}`")));
+        }
+        return Ok(Token::Columns(cols, idx));
+    }
+    if let Some(eq_pos) = arg.find('=') {
+        let field = arg[..eq_pos].to_string();
+        if field.is_empty() {
+            return Err(error!(format!("Empty field name in token `{arg}`")));
+        }
+        let value_part = &arg[eq_pos + 1..];
+        let (value, idx) = if value_part.starts_with('"') && value_part.ends_with('"') && value_part.len() >= 2 {
+            (value_part[1..value_part.len() - 1].to_string(), None)
+        } else {
+            let (v, i) = split_index_suffix(value_part);
+            (v.to_string(), i)
+        };
+        return Ok(Token::Condition(field, value, idx));
+    }
+    let (name, idx) = split_index_suffix(arg);
+    Ok(Token::ModelName(name.to_string(), idx))
+}
+
+/// Run a model-driven CLI.
+///
+/// `args` is the list of positional arguments after any global flags
+/// (region, profile, etc.) have been stripped out.
+pub async fn run<F: ModelFactory, R: Renderer>(
+    factory: &F,
+    renderer: &R,
+    args: &[String],
+) -> Result<()> {
+    if args.is_empty() {
+        return Err(error!(
+            "No model specified — pass a model name (e.g. `iam.users`) or an ARN"
+        ));
+    }
+
+    let mut tokens: Vec<Token> = args.iter().map(|s| parse_token(s)).collect::<Result<_>>()?;
+    let first = tokens.remove(0);
+    let mut column_override: Option<Vec<String>> = None;
+
+    let (mut table, mut mode) = match first {
+        Token::ModelName(name, idx) => {
+            let (t, m) = factory
+                .for_name(&name)
+                .ok_or_else(|| error!(format!("Unknown model `{name}`")))?;
+            if let Some(i) = idx {
+                apply_index(t, i).await?
+            } else {
+                (t, m)
+            }
+        }
+        Token::Arn(arn) => {
+            let t = factory
+                .for_arn(&arn)
+                .ok_or_else(|| error!(format!("Cannot resolve ARN `{arn}`")))?;
+            (t, Mode::Single)
+        }
+        Token::Condition(_, _, _)
+        | Token::Relation(_, _)
+        | Token::Index(_)
+        | Token::Columns(_, _) => {
+            return Err(error!(format!(
+                "First argument must be a model name or ARN, got `{}`",
+                args[0]
+            )));
+        }
+    };
+
+    for token in tokens {
+        match token {
+            Token::Condition(field, value, idx) => {
+                // `id=value` is a sugared "fetch this specific record":
+                // resolve to the actual id field and force single-record
+                // mode. Anything else is just a regular eq filter.
+                let is_id_alias = field == "id";
+                let resolved_field = if is_id_alias {
+                    table.id_field_name().ok_or_else(|| {
+                        error!(format!(
+                            "`id=` used but table `{}` has no id field",
+                            table.table_name()
+                        ))
+                    })?
+                } else {
+                    field.clone()
+                };
+                table.add_condition_eq(&resolved_field, &value)?;
+                if is_id_alias {
+                    mode = Mode::Single;
+                }
+                if let Some(i) = idx {
+                    let (t, m) = apply_index(table, i).await?;
+                    table = t;
+                    mode = m;
+                }
+            }
+            Token::Index(i) => {
+                let (t, m) = apply_index(table, i).await?;
+                table = t;
+                mode = m;
+            }
+            Token::Relation(rel, idx) => {
+                if mode != Mode::Single {
+                    return Err(error!(format!(
+                        "Cannot traverse `:{rel}` from list mode — narrow to a single record first (add a filter or `[N]`)"
+                    )));
+                }
+                table = table.get_ref(&rel)?;
+                mode = Mode::List;
+                // A new table means the column override no longer
+                // applies — drop it so the child renders with its own
+                // default columns until a new override appears.
+                column_override = None;
+                if let Some(i) = idx {
+                    let (t, m) = apply_index(table, i).await?;
+                    table = t;
+                    mode = m;
+                }
+            }
+            Token::Columns(cols, idx) => {
+                column_override = Some(cols);
+                if let Some(i) = idx {
+                    let (t, m) = apply_index(table, i).await?;
+                    table = t;
+                    mode = m;
+                }
+            }
+            Token::ModelName(_, _) | Token::Arn(_) => {
+                return Err(error!(
+                    "Model name or ARN may only appear as the first argument"
+                ));
+            }
+        }
+    }
+
+    match mode {
+        Mode::List => {
+            let records = table.list_values().await?;
+            renderer.render_list(&table, &records, column_override.as_deref());
+        }
+        Mode::Single => {
+            let (id, record) = table
+                .get_some_value()
+                .await?
+                .ok_or_else(|| error!("No record found"))?;
+            let relations = table.get_ref_names();
+            renderer.render_record(&table, &id, &record, &relations);
+        }
+    }
+
+    Ok(())
+}
+
+/// List the table, take the Nth row, narrow the table to that row by
+/// adding `eq(id_field, that_id)`. Returns the narrowed table in
+/// single-record mode so subsequent traversals see one parent.
+async fn apply_index(mut table: AnyTable, index: usize) -> Result<(AnyTable, Mode)> {
+    let records = table.list_values().await?;
+    let total = records.len();
+    let (id, _record) = records.into_iter().nth(index).ok_or_else(|| {
+        error!(format!(
+            "Index [{index}] out of bounds — only {total} record(s) match"
+        ))
+    })?;
+    let id_field = table.id_field_name().ok_or_else(|| {
+        error!(format!(
+            "Cannot apply index — table `{}` has no id field",
+            table.table_name()
+        ))
+    })?;
+    table.add_condition_eq(&id_field, &id)?;
+    Ok((table, Mode::Single))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_split_index_suffix() {
+        assert_eq!(split_index_suffix("users"), ("users", None));
+        assert_eq!(split_index_suffix("users[0]"), ("users", Some(0)));
+        assert_eq!(split_index_suffix("users[42]"), ("users", Some(42)));
+        assert_eq!(split_index_suffix("[3]"), ("", Some(3)));
+        assert_eq!(split_index_suffix("foo[bar]"), ("foo[bar]", None));
+        assert_eq!(split_index_suffix("foo[]"), ("foo[]", None));
+    }
+
+    #[test]
+    fn token_parse_kinds() {
+        match parse_token("iam.users").unwrap() {
+            Token::ModelName(n, i) => {
+                assert_eq!(n, "iam.users");
+                assert_eq!(i, None);
+            }
+            t => panic!("expected ModelName, got {t:?}"),
+        }
+        match parse_token("iam.users[0]").unwrap() {
+            Token::ModelName(n, i) => {
+                assert_eq!(n, "iam.users");
+                assert_eq!(i, Some(0));
+            }
+            t => panic!("expected ModelName with index, got {t:?}"),
+        }
+        match parse_token(":members[2]").unwrap() {
+            Token::Relation(r, i) => {
+                assert_eq!(r, "members");
+                assert_eq!(i, Some(2));
+            }
+            t => panic!("expected Relation, got {t:?}"),
+        }
+        match parse_token("name=alice").unwrap() {
+            Token::Condition(f, v, i) => {
+                assert_eq!(f, "name");
+                assert_eq!(v, "alice");
+                assert_eq!(i, None);
+            }
+            t => panic!("expected Condition, got {t:?}"),
+        }
+        match parse_token("name=\"john doe\"").unwrap() {
+            Token::Condition(f, v, i) => {
+                assert_eq!(f, "name");
+                assert_eq!(v, "john doe");
+                assert_eq!(i, None);
+            }
+            t => panic!("expected Condition, got {t:?}"),
+        }
+        match parse_token("name=alice[0]").unwrap() {
+            Token::Condition(f, v, i) => {
+                assert_eq!(f, "name");
+                assert_eq!(v, "alice");
+                assert_eq!(i, Some(0));
+            }
+            t => panic!("expected Condition with index, got {t:?}"),
+        }
+        match parse_token("[7]").unwrap() {
+            Token::Index(i) => assert_eq!(i, 7),
+            t => panic!("expected Index, got {t:?}"),
+        }
+        match parse_token("arn:aws:iam::123:user/alice").unwrap() {
+            Token::Arn(s) => assert_eq!(s, "arn:aws:iam::123:user/alice"),
+            t => panic!("expected Arn, got {t:?}"),
+        }
+        match parse_token("=timestamp,message").unwrap() {
+            Token::Columns(cols, idx) => {
+                assert_eq!(cols, vec!["timestamp".to_string(), "message".to_string()]);
+                assert_eq!(idx, None);
+            }
+            t => panic!("expected Columns, got {t:?}"),
+        }
+        match parse_token("=id, name [0]").unwrap_or_else(|_| {
+            // trim handles the spaces, but split on `[0]` requires no
+            // intervening space — skip that variant.
+            parse_token("=id,name[0]").unwrap()
+        }) {
+            Token::Columns(cols, idx) => {
+                assert_eq!(cols, vec!["id".to_string(), "name".to_string()]);
+                assert_eq!(idx, Some(0));
+            }
+            t => panic!("expected Columns with index, got {t:?}"),
+        }
+    }
+}

--- a/vantage-cli-util/src/model_cli.rs
+++ b/vantage-cli-util/src/model_cli.rs
@@ -85,14 +85,15 @@ enum Token {
 }
 
 fn split_index_suffix(s: &str) -> (&str, Option<usize>) {
-    if let Some(stripped) = s.strip_suffix(']') {
-        if let Some(open) = stripped.rfind('[') {
-            let inner = &stripped[open + 1..];
-            if !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit()) {
-                if let Ok(n) = inner.parse::<usize>() {
-                    return (&stripped[..open], Some(n));
-                }
-            }
+    if let Some(stripped) = s.strip_suffix(']')
+        && let Some(open) = stripped.rfind('[')
+    {
+        let inner = &stripped[open + 1..];
+        if !inner.is_empty()
+            && inner.chars().all(|c| c.is_ascii_digit())
+            && let Ok(n) = inner.parse::<usize>()
+        {
+            return (&stripped[..open], Some(n));
         }
     }
     (s, None)
@@ -140,12 +141,13 @@ fn parse_token(arg: &str) -> Result<Token> {
             return Err(error!(format!("Empty field name in token `{arg}`")));
         }
         let value_part = &arg[eq_pos + 1..];
-        let (value, idx) = if value_part.starts_with('"') && value_part.ends_with('"') && value_part.len() >= 2 {
-            (value_part[1..value_part.len() - 1].to_string(), None)
-        } else {
-            let (v, i) = split_index_suffix(value_part);
-            (v.to_string(), i)
-        };
+        let (value, idx) =
+            if value_part.starts_with('"') && value_part.ends_with('"') && value_part.len() >= 2 {
+                (value_part[1..value_part.len() - 1].to_string(), None)
+            } else {
+                let (v, i) = split_index_suffix(value_part);
+                (v.to_string(), i)
+            };
         return Ok(Token::Condition(field, value, idx));
     }
     let (name, idx) = split_index_suffix(arg);

--- a/vantage-cli-util/src/table_display.rs
+++ b/vantage-cli-util/src/table_display.rs
@@ -98,6 +98,64 @@ where
     render_records_typed(records, id_field, &IndexMap::new());
 }
 
+/// Render records with an explicit column list — no auto-prepended
+/// id column. `column_types` is consulted for per-column alignment but
+/// doesn't drive which columns appear; `columns` does.
+///
+/// Used by the model-driven CLI when the caller passes `=col1,col2`:
+/// the user spelled out exactly what they want to see, and an extra
+/// id column would just be noise.
+pub fn render_records_columns<Id, V>(
+    records: &IndexMap<Id, Record<V>>,
+    columns: &[String],
+    column_types: &IndexMap<String, &'static str>,
+) where
+    Id: std::fmt::Display,
+    V: TerminalRender,
+{
+    if records.is_empty() {
+        println!("{}", "No records.".dimmed());
+        return;
+    }
+
+    let mut table = ComfyTable::new();
+    table
+        .load_preset(presets::UTF8_HORIZONTAL_ONLY)
+        .remove_style(TableComponent::HorizontalLines)
+        .remove_style(TableComponent::MiddleIntersections)
+        .remove_style(TableComponent::LeftBorderIntersections)
+        .remove_style(TableComponent::RightBorderIntersections)
+        .set_content_arrangement(ContentArrangement::Disabled);
+
+    let header: Vec<Cell> = columns.iter().map(|c| header_cell(c)).collect();
+    table.set_header(header);
+
+    for (idx, name) in columns.iter().enumerate() {
+        if let Some(type_name) = column_types.get(name) {
+            let align = alignment_for(type_name);
+            if let Some(col) = table.column_mut(idx) {
+                col.set_cell_alignment(align);
+            }
+        }
+    }
+
+    for (_id, record) in records {
+        let row: Vec<Cell> = columns
+            .iter()
+            .map(|col| match record.get(col.as_str()) {
+                Some(value) => Cell::new(rich_to_ansi(&value.render())),
+                None => Cell::new("—".bright_black().to_string()),
+            })
+            .collect();
+        table.add_row(row);
+    }
+
+    println!("{table}");
+    let n = records.len();
+    let label = if n == 1 { "record" } else { "records" };
+    println!("{}", format!("{n} {label}").dimmed());
+}
+
 /// Render records as a styled table.
 ///
 /// `id_field` names the column used as the record key — printed as the

--- a/vantage-live/CHANGELOG.md
+++ b/vantage-live/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.3 — 2026-04-30
+
+- `LiveTable` forwards the four new `TableLike` reflection methods (`id_field_name`, `title_field_names`, `column_types`, `get_ref_names`) through to the master `AnyTable`, so generic UIs that drive a `LiveTable` see the same metadata they would see on the underlying table.
+- Pins `vantage-table = "0.4.8"` for those new trait surfaces.
+
 ## 0.4.2 — 2026-04-29
 
 - `LiveTable::get_ref(relation)` now forwards through to the master `AnyTable`, so reference traversal works on a `LiveTable` the same way it does on the underlying table — `live.get_ref("orders")` returns an `AnyTable` you can keep wrapping.

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-live"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -15,7 +15,7 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
-vantage-table = { version = "0.4.7", path = "../vantage-table" }
+vantage-table = { version = "0.4.8", path = "../vantage-table" }
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-live/src/live_table/impls/table_like.rs
+++ b/vantage-live/src/live_table/impls/table_like.rs
@@ -5,6 +5,7 @@
 
 use async_trait::async_trait;
 use ciborium::Value as CborValue;
+use indexmap::IndexMap;
 use tracing::warn;
 use vantage_core::{Result, error};
 use vantage_expressions::AnyExpression;
@@ -27,6 +28,22 @@ impl TableLike for LiveTable {
 
     fn column_names(&self) -> Vec<String> {
         self.master.column_names()
+    }
+
+    fn id_field_name(&self) -> Option<String> {
+        self.master.id_field_name()
+    }
+
+    fn title_field_names(&self) -> Vec<String> {
+        self.master.title_field_names()
+    }
+
+    fn column_types(&self) -> IndexMap<String, &'static str> {
+        self.master.column_types()
+    }
+
+    fn get_ref_names(&self) -> Vec<String> {
+        self.master.get_ref_names()
     }
 
     fn add_condition(&mut self, _condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()> {

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.8 — 2026-04-30
+
+- `TableLike` gains five reflection / mutation methods so type-erased callers (the new model-driven CLI in `vantage-cli-util`, anything else holding an `AnyTable`) can reach metadata that previously only existed on the typed side. All have default impls so existing implementors compile unchanged.
+  - `id_field_name() -> Option<String>`
+  - `title_field_names() -> Vec<String>`
+  - `column_types() -> IndexMap<String, &'static str>`
+  - `get_ref_names() -> Vec<String>`
+  - `add_condition_eq(field, value) -> Result<()>`
+- New `TableSource::eq_condition(field, value) -> Result<Self::Condition>` (default: error). Backends that support textual eq filtering override; `add_condition_eq` dispatches through it.
+- New `Table::with_title_column_of::<Type>(name)` builder — adds a typed column and records its name in an ordered `title_fields: Vec<String>` on the table. `title_field_names()` returns that vec, then unions in any columns that carry `ColumnFlag::TitleField` directly.
+- `AnyTable` and the internal `CborAdapter` forward all five new methods through to the wrapped table.
+
 ## 0.4.7 — 2026-04-29
 
 - New `AnyTable::get_ref(relation) -> Result<AnyTable>`. Lets reference traversal continue on the type-erased side — previously `get_ref` only existed on the typed `Table<T, E>`, so once you wrapped a table into `AnyTable` the relation graph was unreachable.

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/any.rs
+++ b/vantage-table/src/any.rs
@@ -257,8 +257,28 @@ impl TableLike for AnyTable {
         self.inner.column_names()
     }
 
+    fn id_field_name(&self) -> Option<String> {
+        self.inner.id_field_name()
+    }
+
+    fn title_field_names(&self) -> Vec<String> {
+        self.inner.title_field_names()
+    }
+
+    fn column_types(&self) -> IndexMap<String, &'static str> {
+        self.inner.column_types()
+    }
+
+    fn get_ref_names(&self) -> Vec<String> {
+        self.inner.get_ref_names()
+    }
+
     fn add_condition(&mut self, condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()> {
         self.inner.add_condition(condition)
+    }
+
+    fn add_condition_eq(&mut self, field: &str, value: &str) -> Result<()> {
+        self.inner.add_condition_eq(field, value)
     }
 
     fn temp_add_condition(
@@ -500,8 +520,28 @@ where
         self.inner.columns().keys().cloned().collect()
     }
 
+    fn id_field_name(&self) -> Option<String> {
+        TableLike::id_field_name(&self.inner)
+    }
+
+    fn title_field_names(&self) -> Vec<String> {
+        TableLike::title_field_names(&self.inner)
+    }
+
+    fn column_types(&self) -> IndexMap<String, &'static str> {
+        TableLike::column_types(&self.inner)
+    }
+
+    fn get_ref_names(&self) -> Vec<String> {
+        TableLike::get_ref_names(&self.inner)
+    }
+
     fn add_condition(&mut self, _condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()> {
         Err(error!("add_condition not supported through CborAdapter"))
+    }
+
+    fn add_condition_eq(&mut self, field: &str, value: &str) -> Result<()> {
+        TableLike::add_condition_eq(&mut self.inner, field, value)
     }
 
     fn temp_add_condition(

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -32,6 +32,7 @@ where
     pub(super) expressions: IndexMap<String, ExpressionFn<T, E>>,
     pub(super) pagination: Option<Pagination>,
     pub(super) title_field: Option<String>,
+    pub(super) title_fields: Vec<String>,
     pub(super) id_field: Option<String>,
 }
 
@@ -51,6 +52,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             expressions: IndexMap::new(),
             pagination: None,
             title_field: None,
+            title_fields: Vec::new(),
             id_field: None,
         }
     }
@@ -70,6 +72,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             expressions: IndexMap::new(),
             pagination: self.pagination,
             title_field: self.title_field,
+            title_fields: self.title_fields,
             id_field: self.id_field,
         }
     }
@@ -108,6 +111,13 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
         self.title_field
             .as_ref()
             .and_then(|name| self.columns.get(name))
+    }
+
+    /// Names of columns marked as display titles (set via
+    /// [`Self::with_title_column_of`]). These show alongside the id in
+    /// list views and on the leading lines of single-record displays.
+    pub fn title_fields(&self) -> &[String] {
+        &self.title_fields
     }
 
     /// Get the id field column if set

--- a/vantage-table/src/table/impls/columns.rs
+++ b/vantage-table/src/table/impls/columns.rs
@@ -55,6 +55,27 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
         self
     }
 
+    /// Add a typed column AND mark it as a display title.
+    ///
+    /// Title columns show alongside the id in generic list views and
+    /// lead the body of single-record displays. Multiple title columns
+    /// are allowed; their order matches the order of these calls.
+    pub fn with_title_column_of<NewColumnType>(mut self, name: impl Into<String>) -> Self
+    where
+        NewColumnType: ColumnType,
+    {
+        let name = name.into();
+        if !self.title_fields.contains(&name) {
+            self.title_fields.push(name.clone());
+        }
+        if self.title_field.is_none() {
+            self.title_field = Some(name.clone());
+        }
+        let column = self.data_source.create_column::<NewColumnType>(&name);
+        self.add_column(column);
+        self
+    }
+
     /// Add a typed column to the table (builder pattern)
     pub fn with_column_of<NewColumnType>(self, name: impl Into<String>) -> Self
     where

--- a/vantage-table/src/table/impls/table_like.rs
+++ b/vantage-table/src/table/impls/table_like.rs
@@ -1,14 +1,16 @@
 use async_trait::async_trait;
+use indexmap::IndexMap;
 use vantage_core::{Result, error};
 use vantage_expressions::AnyExpression;
 use vantage_types::Entity;
 
 use crate::{
     any::AnyTable,
+    column::flags::ColumnFlag,
     conditions::ConditionHandle,
     pagination::Pagination,
     table::Table,
-    traits::{table_like::TableLike, table_source::TableSource},
+    traits::{column_like::ColumnLike, table_like::TableLike, table_source::TableSource},
 };
 
 #[async_trait]
@@ -29,6 +31,35 @@ where
         self.columns.keys().cloned().collect()
     }
 
+    fn id_field_name(&self) -> Option<String> {
+        self.id_field().map(|c| c.name().to_string())
+    }
+
+    fn title_field_names(&self) -> Vec<String> {
+        // Two paths: the explicit `with_title_column_of` ordered list,
+        // and any columns that have `TitleField` flagged on them
+        // directly. The flagged path covers backends whose column type
+        // sets flags during construction (e.g. SQL).
+        let mut out: Vec<String> = self.title_fields.clone();
+        for (name, col) in &self.columns {
+            if col.flags().contains(&ColumnFlag::TitleField) && !out.contains(name) {
+                out.push(name.clone());
+            }
+        }
+        out
+    }
+
+    fn column_types(&self) -> IndexMap<String, &'static str> {
+        self.columns
+            .iter()
+            .map(|(name, col)| (name.clone(), col.get_type()))
+            .collect()
+    }
+
+    fn get_ref_names(&self) -> Vec<String> {
+        self.references()
+    }
+
     fn add_condition(&mut self, condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()> {
         // Downcast the boxed Any to T::Condition
         let cond = condition
@@ -40,6 +71,15 @@ where
         let id = -next_id;
         *self.next_condition_id_mut() = next_id + 1;
         self.conditions_mut().insert(id, *cond);
+        Ok(())
+    }
+
+    fn add_condition_eq(&mut self, field: &str, value: &str) -> Result<()> {
+        let cond = T::eq_condition(field, value)?;
+        let next_id = *self.next_condition_id_mut();
+        let id = -next_id;
+        *self.next_condition_id_mut() = next_id + 1;
+        self.conditions_mut().insert(id, cond);
         Ok(())
     }
 

--- a/vantage-table/src/traits/table_like.rs
+++ b/vantage-table/src/traits/table_like.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use indexmap::IndexMap;
 use vantage_core::Result;
 use vantage_dataset::prelude::{ReadableValueSet, WritableValueSet};
 use vantage_expressions::AnyExpression;
@@ -12,9 +13,45 @@ pub trait TableLike: ReadableValueSet + WritableValueSet + Send + Sync {
     fn table_alias(&self) -> &str;
     fn column_names(&self) -> Vec<String>;
 
+    /// Name of the column flagged as the id field, if any.
+    fn id_field_name(&self) -> Option<String> {
+        None
+    }
+
+    /// Names of columns flagged as `TitleField`.
+    fn title_field_names(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    /// Map of column name -> original Rust type name. Backends that
+    /// preserve type metadata (e.g. `Column::get_type()`) override this
+    /// so generic UIs can drive type-aware rendering without poking at
+    /// concrete column types.
+    fn column_types(&self) -> IndexMap<String, &'static str> {
+        IndexMap::new()
+    }
+
+    /// Names of relations traversable via [`get_ref`].
+    fn get_ref_names(&self) -> Vec<String> {
+        Vec::new()
+    }
+
     /// Add a condition to this table using a type-erased expression
     /// The expression must be of type T::Expr for the underlying table's TableSource
     fn add_condition(&mut self, condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()>;
+
+    /// Add a permanent equality condition expressed as raw strings.
+    ///
+    /// Generic CLIs (and other type-erased callers) work with
+    /// `field=value` text and cannot reach into `T::Condition`. Each
+    /// backend that supports textual eq filtering overrides this; the
+    /// default returns an error.
+    fn add_condition_eq(&mut self, field: &str, value: &str) -> Result<()> {
+        let _ = (field, value);
+        Err(vantage_core::error!(
+            "add_condition_eq not supported on this TableLike"
+        ))
+    }
 
     /// Add a temporary condition using AnyExpression that can be removed later
     fn temp_add_condition(&mut self, condition: AnyExpression) -> Result<ConditionHandle>;

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -31,6 +31,20 @@ pub trait TableSource: DataSource + Clone + 'static {
     /// can use a native filter type (e.g. `bson::Document`).
     type Condition: Clone + Send + Sync + 'static;
 
+    /// Build a textual `field == value` condition.
+    ///
+    /// Generic UIs (e.g. CLI argument parsers) only have strings on
+    /// hand, so they need a way to construct a `Self::Condition` without
+    /// knowing the backend's native expression type. Backends that
+    /// don't support raw text filtering can leave the default, which
+    /// returns an error.
+    fn eq_condition(field: &str, value: &str) -> Result<Self::Condition> {
+        let _ = (field, value);
+        Err(vantage_core::error!(
+            "eq_condition not implemented for this TableSource"
+        ))
+    }
+
     /// Create a new column with the given name
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type>;
 

--- a/vantage-types/CHANGELOG.md
+++ b/vantage-types/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.2 — 2026-04-30
+
+Catches up the crates.io release with the additions that landed locally in [#214](https://github.com/romaninsh/vantage/pull/214) but never got their own version bump.
+
+- New `RichText` / `Span` / `Style` types and a refactored `TerminalRender` trait — `render() -> RichText` instead of `render() -> String` plus a separate `color_hint()`. `Style` is semantic (`Default`, `Dim`, `Muted`, `Strong`, `Success`, `Error`, `Warning`, `Info`) — UI layers map to native presentation. `RichText` impls `Display` (writes the plain text), so existing string-shaped consumers keep compiling without code changes.
+- Default `TerminalRender` impls migrated for `String`, `&str`, `i32` / `i64` / `f64`, `bool`, `Option<T>`, `serde_json::Value`, and `ciborium::Value`. Booleans render as `Style::Success` / `Style::Error`; nulls render as a dim em-dash.
+
 ## 0.4.1 — 2026-04-25
 
 - `TerminalRender` impl for `ciborium::Value` so generic CLI/UI rendering keeps working when records flow through `AnyTable`.

--- a/vantage-types/Cargo.toml
+++ b/vantage-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-types"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Type system and Record types for the Vantage data framework"


### PR DESCRIPTION
The old `aws-cli` was a clap subcommand tree that grew one arm per AWS resource. Every new entity meant a new `list-foo` / `traverse-foo` pair and the handler-side argument parsing to go with it — by the time #211 landed, the file was 500 lines of subcommand boilerplate. This PR throws that away and replaces it with one positional grammar:

```
$ aws-cli iam.user UserName=github :access_keys
──────────────────────────────────────────
 ID                     USERNAME   STATUS
══════════════════════════════════════════
 AKIAYNLZTOELWQ6VU54C   github     Active
```

Or feed it a raw ARN and skip the filter dance entirely:

```
$ aws-cli arn:aws:iam::578465001751:user/github
UserName: github
Path: /
CreateDate: 2026-04-27 21:59
--------
UserId: AIDAYNLZTOEL6N7DW33RO
Arn: arn:aws:iam::578465001751:user/github

Relations:
  :groups
  :access_keys
  :attached_policies
```

The renderer prints which `:relations` exist on this record, so you discover the next hop without leaving the terminal. `[N]` picks a record from a list (`iam.users[0]` ≡ "first user, drop into single-record mode"). `=col1,col2` overrides which columns a list view shows.

### How an argv reaches a query

The dispatch logic lives in a new `vantage-cli-util::model_cli` module. Each positional becomes one of six tokens:

```rust
enum Token {
    ModelName(String, Option<usize>),  // iam.users, iam.users[0]
    Arn(String),                       // arn:aws:...
    Condition(String, String, _),      // UserName=github
    Relation(String, _),               // :groups
    Index(usize),                      // [3]
    Columns(Vec<String>, _),           // =id,Path
}
```

The first token must be `ModelName` or `Arn` and produces an `AnyTable` plus a `Mode` (`List` or `Single`) via the injected `ModelFactory`. After that, the runner walks the remaining tokens against a single mutable `AnyTable`:

- `Condition` calls `table.add_condition_eq(field, value)` — a new method on `TableLike` that backends override to translate a string pair into their native condition type. The sugared `id=…` resolves to whichever column was flagged with `with_id_column` and forces `Single` mode.
- `Relation` calls `table.get_ref(name)` — also new on `TableLike`, lifted up so `AnyTable` can traverse without unwrapping its concrete type. Only legal in `Single` mode (otherwise the deferred child query would fan out to a multi-value parent key, which most AWS APIs reject).
- `Index(N)` lists the table, picks the Nth id, then narrows by `id_field = that_id`. Same shape as condition, just preceded by a fetch — costs an extra round-trip vs `id=…`, so prefer the latter when you know the value.
- `Columns` is a render-time hint that survives until the next `:relation` resets it.

End state: one `AnyTable` with conditions stacked, plus `Mode`. The runner calls `list_values()` or `get_some_value()` and hands the records to your `Renderer`.

The grammar is positional rather than a clap subcommand-per-resource because subcommands don't compose: with subcommands, "list a user's access keys" needs its own handler that knows to pre-filter; here, `iam.user UserName=github :access_keys` falls out of two general-purpose tokens. That, in turn, is what makes the runner backend-agnostic — `model_cli` knows nothing about AWS.

### Plugging in another backend

Anything that implements `TableLike` can drive `model_cli::run` directly. Two pieces wire it up:

1. A `ModelFactory` impl with `for_name(&str) -> Option<(AnyTable, Mode)>` and `for_arn(&str) -> Option<AnyTable>`. For `vantage-aws`, this is the new `Factory` in `vantage-aws/src/models/mod.rs` — a flat match per dotted name, plus a chain of per-entity `from_arn` calls. ~100 lines for the IAM/Logs/ECS surface.
2. A `Renderer` impl that decides how a single record and a list look. The AWS one prints id + title columns first, divider, then the rest, then a `Relations:` footer.

That's it — no proc-macros, no derive, no command tree to maintain. Adding a new resource means adding `with_id_column` / `with_title_column_of` / `with_many` to its `Table` definition and one match arm in the factory. S3, Lambda and DynamoDB landed in #216 right after this and slotted in without a single change to `model_cli`.

The natural next extensions all sit at the parser or trait edge: range/inequality filters (`field>value`) are a parser-only change in `model_cli.rs` plus new methods on `TableLike` (`add_condition_gt`, etc.); a `--json` flag is a second `Renderer` impl wrapping `serde_json`; and any backend already implementing `TableLike` (SurrealDB, SQLite, the in-memory `vantage-csv`) gets a CLI for free.

### Worth knowing

- `iam.access_keys`, `log.streams`, `ecs.services`, `ecs.tasks` deliberately aren't top-level: the underlying AWS calls require a parent filter (`UserName`, `logGroupName`, `cluster`), and listing them standalone would either error or silently return only the caller's slice. Reach them via `:traversal` from the parent, or pass the resource ARN.
- `add_condition_eq`, `get_ref`, `id_field_name`, `title_field_names`, `column_types` and `get_ref_names` are all new on `TableLike`. `vantage-live`'s `LiveTable` and `vantage-table`'s `AnyTable` got matching forwarding impls so the runner works through any wrapper.