### PR TITLE
add s3, lambda, dynamodb to vantage-aws + restxml/restjson/json10 protocols

### DIFF
--- a/.github/workflows/aws.yaml
+++ b/.github/workflows/aws.yaml
@@ -48,8 +48,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: eu-west-2
         run: |
-          cargo run --example aws-cli -- log-groups
-          cargo run --example aws-cli -- log-groups --prefix /aws/lambda/
-          cargo run --example aws-cli -- traverse-log-events
-          cargo run --example aws-cli -- list-users
-          cargo run --example aws-cli -- list-roles --path-prefix /aws-service-role/
+          cargo run --example aws-cli -- log.groups
+          cargo run --example aws-cli -- log.groups logGroupNamePrefix=/aws/lambda/
+          cargo run --example aws-cli -- iam.users
+          cargo run --example aws-cli -- iam.roles PathPrefix=/aws-service-role/
+          cargo run --example aws-cli -- s3.buckets
+          cargo run --example aws-cli -- lambda.functions
+          cargo run --example aws-cli -- dynamodb.tables

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3961,6 +3961,7 @@ name = "vantage-cli-util"
 version = "0.4.0"
 dependencies = [
  "async-trait",
+ "ciborium",
  "comfy-table",
  "indexmap",
  "owo-colors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ciborium",
  "csv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-live"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.4.3 — 2026-04-30
+
+`vantage-aws` picks up a generic, type-erased model factory and the AWS-side machinery to back the new model-driven CLI in `vantage-cli-util`. ([#215](https://github.com/romaninsh/vantage/pull/215))
+
+- New `vantage_aws::models::Factory` — dotted-string lookup (`iam.user`, `log.group`, `ecs.cluster`, …) to `AnyTable` plus a single `Factory::from_arn` entry point. Singular forms drop into `FactoryMode::Single`, plural into `FactoryMode::List`. Models whose AWS API requires a parent filter aren't exposed top-level; they're reachable via traversal:
+  - `iam.user … :access_keys`        (`ListAccessKeys` needs `UserName`)
+  - `log.group … :streams`           (`DescribeLogStreams` needs `logGroupName`)
+  - `log.group … :events`            (`FilterLogEvents` needs `logGroupName`)
+  - `ecs.cluster … :services`        (`ListServices` needs `cluster`)
+  - `ecs.cluster … :tasks`           (`ListTasks` needs `cluster`)
+- New per-entity `from_arn(arn, aws) -> Option<Table<…>>` on `User`, `Group`, `Role`, `Policy`, `InstanceProfile`, `AccessKey`, `LogGroup`, `LogStream`, `Cluster`. Each parses its own ARN shape and returns a pre-conditioned table. `Factory::from_arn` walks them in order.
+- `ecs::clusters_table` gains the previously-missing `with_many("services", "cluster", services_table)` and `with_many("tasks", "cluster", tasks_table)` so cluster traversal hits the registered relations.
+- Existing IAM / Logs models pick up `with_title_column_of` for the columns worth showing in lists (`Path`, `CreateDate`, `UserName`, `Status`, `PolicyName`, `IsAttachable`, …). Long, noisy, or always-empty columns (`Arn`, `AssumeRolePolicyDocument`, `PasswordLastUsed`, log message body) stay hidden by default and surface when you drill into a single record.
+- New `TableSource::eq_condition` impl on `AwsAccount` — builds an `AwsCondition::Eq` from raw strings so the generic CLI's `add_condition_eq` works without reaching into the backend's expression type.
+- `AwsAccount::list_table_values` now post-filters records by any `Eq` condition whose field appears on the records. AWS APIs only push down their own request-param filters (`PathPrefix`, `logGroupNamePrefix`, `cluster`); eq conditions on actual record fields (`UserName`, `Path`, `clusterArn`) used to be silently dropped on the wire. Fields not on any record are assumed to be request params and skipped (no over-filtering on `PathPrefix` etc.). Also makes the deferred-subquery path under `:relation` resolve correctly when the source is narrowed in-memory.
+- `examples/aws-cli.rs` rewritten as a thin adapter around `vantage_cli_util::model_cli::run` — same end-to-end paths as before plus filters / index / column-overrides / ARN-as-first-argument. The previous clap subcommand surface is gone; everything goes through the generic argv parser.
+- Pins `vantage-table = "0.4.8"` for the new `TableLike` reflection methods + `with_title_column_of`.
+
 ## 0.4.2 — 2026-04-29
 
 AWS Query protocol (form-encoded request, XML response) lands alongside the existing JSON-1.1 transport, plus an IAM submodule that uses it. Same `AwsAccount` is the `TableSource` for both — relations span protocols freely. ([#212](https://github.com/romaninsh/vantage/pull/212))

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.4.4 — 2026-05-02
+
+Three more AWS wire protocols and three more model trees — S3, Lambda, DynamoDB — wired into the same `Factory` / `from_arn` surface as the IAM/ECS/CloudWatch models. ([#216](https://github.com/romaninsh/vantage/pull/216))
+
+- New `restxml/` protocol prefix, used by S3. Target syntax is `restxml/<array_key>:<service>/<METHOD> <path>?<static-query>` — conditions whose name matches a `{Placeholder}` segment fill the path; everything else appends to the query string. The transport adds `x-amz-content-sha256` to the signed headers (mandatory on S3, harmless elsewhere); the response parser strips the XML root and supports dotted lookup so callers can target nested arrays like `Buckets.Bucket`.
+- New `restjson/` protocol prefix, used by Lambda. Same request shape as `restxml/` (reuses the path-template builder) but parses a JSON response. No content-sha256 header — Lambda doesn't require it.
+- New `json10/` protocol prefix, used by DynamoDB. Differs from `json1/` only in the `application/x-amz-json-1.0` content type, so it shares the JSON-1.1 transport via a new `json_aws_call(..., content_type)` helper. Parse path is identical to `json1/`.
+- New `vantage_aws::models::s3` submodule: `buckets_table` (`ListBuckets`) + `objects_table` (`ListObjectsV2`, requires `Bucket`). `Bucket` carries an `objects` `with_many` relation. Path-style addressing only — cross-region buckets surface AWS's 301 verbatim with the home-region endpoint in the error body, so the caller can re-point `AwsAccount`'s region.
+- New `vantage_aws::models::lambda` submodule: `functions_table` (`ListFunctions`) + `aliases_table` / `versions_table` (per function). `Function` carries `aliases` and `versions` `with_many`s plus a cross-service `log_group` `with_foreign` that resolves to the matching CloudWatch group at `/aws/lambda/<FunctionName>` via a deferred expression — projects `FunctionName` from the source row, prefixes it, and hands the result to `logGroupNamePrefix` for AWS-side narrowing.
+- New `vantage_aws::models::dynamodb` submodule: `tables_table` (`ListTables`). The list-side response is just an array of strings, so v0 surfaces `TableName` only; richer `DescribeTable` metadata is a follow-up.
+- `Factory::known_names` picks up six new entries: `s3.bucket(s)`, `lambda.function(s)`, `dynamodb.table(s)`. Sub-resources (`s3.object`, `lambda.alias`, `lambda.version`) intentionally aren't exposed top-level — listing them standalone needs a parent filter, so they're reachable only via traversal. `Factory::from_arn` learns four new ARN shapes (S3 object, S3 bucket, Lambda function, DynamoDB table).
+- `dispatch::lookup_path` — small helper that walks dotted paths through `serde_json::Value`. Adopted by `json1::parse_records` and the new REST parsers so the same `array_key` syntax works across protocols.
+
 ## 0.4.3 — 2026-04-30
 
 `vantage-aws` picks up a generic, type-erased model factory and the AWS-side machinery to back the new model-driven CLI in `vantage-cli-util`. ([#215](https://github.com/romaninsh/vantage/pull/215))

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ciborium",
  "indexmap",

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2109,6 +2109,7 @@ name = "vantage-cli-util"
 version = "0.4.0"
 dependencies = [
  "async-trait",
+ "ciborium",
  "comfy-table",
  "indexmap",
  "owo-colors",

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -14,7 +14,7 @@ readme = "README.md"
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
-vantage-table = { version = "0.4.6", path = "../vantage-table" }
+vantage-table = { version = "0.4.8", path = "../vantage-table" }
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
 
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
@@ -40,7 +40,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 
 [dev-dependencies]
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
-vantage-cli-util = { version = "0.4", path = "../vantage-cli-util" }
+vantage-cli-util = { version = "0.4.1", path = "../vantage-cli-util" }
 
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-aws/examples/aws-cli.rs
+++ b/vantage-aws/examples/aws-cli.rs
@@ -1,165 +1,196 @@
-//! `vantage-aws-cli` — proof-of-concept CLI driving the CloudWatch
-//! Logs, ECS, and IAM models through `vantage-aws`. Renders results
-//! via `vantage_cli_util::print_table` so the output exercises the
-//! same `Table` / `TableSource` machinery the rest of the framework
-//! uses.
+//! `vantage-aws-cli` — generic, model-driven CLI over `vantage-aws`.
+//!
+//! Argument shape (everything after `--region`):
+//!
+//! ```text
+//! aws-cli <model | arn> [field=value ...] [[N]] [:relation [[N]] ...]
+//! ```
+//!
+//! - First positional is either a dotted model name (`iam.users`,
+//!   `log.group`, `ecs.task_definitions`, …) or an ARN (`arn:...`).
+//! - Singular forms (`iam.user`) drop into single-record mode and
+//!   render the first matching record. Plural forms (`iam.users`)
+//!   render a list.
+//! - Filters (`field=value` or `field="quoted value"`) AND together.
+//! - `[N]` selects the Nth record from a list and switches into
+//!   single-record mode.
+//! - `:relation` traverses a `with_many` / `with_one` registered on
+//!   the current table and switches into list mode for the child.
+//! - Glued forms work too: `users[0]`, `:members[0]`, `name=foo[0]`.
 //!
 //! Reads creds from the standard env vars (`AWS_ACCESS_KEY_ID`,
-//! `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, `AWS_REGION`),
-//! falling back to the `[default]` profile in `~/.aws/credentials`
-//! and `~/.aws/config`.
+//! `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`,
+//! `AWS_REGION`), falling back to the `[default]` profile in
+//! `~/.aws/credentials` and `~/.aws/config`.
 
 use anyhow::{Context, Result};
 use ciborium::Value as CborValue;
-use clap::{Parser, Subcommand};
+use clap::Parser;
 use indexmap::IndexMap;
-use vantage_aws::models::ecs::{
-    clusters_table, services_table, task_definitions_table, tasks_table,
-};
-use vantage_aws::models::iam::{
-    Role, User, access_keys_table, groups_table as iam_groups_table, instance_profiles_table,
-    policies_table, roles_table, users_table,
-};
-use vantage_aws::models::logs::{events_table, groups_table, streams_table};
-use vantage_aws::{AwsAccount, eq, typed_records, untyped_records};
-use vantage_cli_util::render_records_typed;
-use vantage_dataset::prelude::{ReadableDataSet, ReadableValueSet};
-use vantage_table::prelude::ColumnLike;
-use vantage_table::table::Table;
-use vantage_table::traits::table_source::TableSource;
-use vantage_types::{Entity, Record};
-
-/// Print an AWS table with rich rendering: ARNs and dates get
-/// multi-segment styling, booleans get green/red, etc. Reads column
-/// metadata to drive parsing of typed values from the raw response.
-async fn print_table<E>(t: &Table<AwsAccount, E>) -> Result<()>
-where
-    E: Entity<<AwsAccount as TableSource>::Value>,
-{
-    let id_field = t.id_field().map(|c| c.name().to_string());
-    let column_types: IndexMap<String, &'static str> = t
-        .columns()
-        .iter()
-        .map(|(name, col)| (name.clone(), col.get_type()))
-        .collect();
-    let records = t.list_values().await?;
-    let typed = typed_records(records, &column_types);
-    render_records_typed(&typed, id_field.as_deref(), &column_types);
-    Ok(())
-}
-
-/// Render ad-hoc records (e.g. from `AnyTable::list_values`) with
-/// detection-based ARN/datetime rendering — no column metadata
-/// available, so we sniff strings.
-fn render_any_records(records: IndexMap<String, Record<CborValue>>, id_field: Option<&str>) {
-    let typed = untyped_records(records);
-    render_records_typed(&typed, id_field, &IndexMap::new());
-}
-
-const TRAVERSE_GROUP: &str = "/ecs/ba-nginx";
+use vantage_aws::AwsAccount;
+use vantage_aws::models::{Factory, FactoryMode};
+use vantage_aws::types::{AnyAwsType, typed_records};
+use vantage_cli_util::model_cli::{self, Mode, ModelFactory, Renderer};
+use vantage_cli_util::{render_records_columns, render_records_typed};
+use vantage_table::any::AnyTable;
+use vantage_table::traits::table_like::TableLike;
+use vantage_types::{Record, TerminalRender};
 
 #[derive(Parser)]
 #[command(
     name = "vantage-aws-cli",
-    about = "vantage-aws CloudWatch + ECS + IAM demo"
+    about = "Generic CLI for vantage-aws models",
+    long_about = "Use a dotted model name (e.g. iam.users, log.group) or an ARN as the first arg, \
+                  then chain filters (field=value), index selectors ([0]), and relation \
+                  traversals (:relation). Example: aws-cli iam.user UserName=alice :groups."
 )]
 struct Cli {
     /// Override the AWS region (sets AWS_REGION before credential load).
     #[arg(long, global = true)]
     region: Option<String>,
 
-    #[command(subcommand)]
-    command: Command,
+    /// Positional tokens: model-or-ARN, filters, indices, traversals.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = false)]
+    args: Vec<String>,
 }
 
-#[derive(Subcommand)]
-enum Command {
-    /// CloudWatch: list log groups (optionally filtered by prefix).
-    LogGroups {
-        #[arg(long)]
-        prefix: Option<String>,
-    },
-    /// CloudWatch: list log streams in a group.
-    LogStreams { log_group_name: String },
-    /// CloudWatch: list log events in a group.
-    LogEvents { log_group_name: String },
-    /// CloudWatch: filter to one group, drill into its events via `with_many("events")`.
-    TraverseLogEvents,
-    /// CloudWatch: filter to one group, drill into its streams via `with_many("streams")`.
-    TraverseLogStreams,
+/// Adapts the standalone [`Factory`] (which lives in `vantage-aws`
+/// proper) to `vantage-cli-util`'s [`ModelFactory`] trait. Keeps
+/// `vantage-aws` itself free of a runtime dep on `vantage-cli-util`.
+struct AwsFactoryAdapter(Factory);
 
-    /// ECS: list clusters in the account.
-    ListClusters,
-    /// ECS: list services in a cluster (name or ARN).
-    ListServices { cluster: String },
-    /// ECS: list tasks in a cluster (name or ARN).
-    ListTasks {
-        cluster: String,
-        /// Filter by service name.
-        #[arg(long)]
-        service: Option<String>,
-        /// Filter by task definition family.
-        #[arg(long)]
-        family: Option<String>,
-        /// RUNNING / PENDING / STOPPED.
-        #[arg(long)]
-        status: Option<String>,
-    },
-    /// ECS: list active task definitions (optionally filtered by family prefix).
-    ListTaskDefs {
-        #[arg(long)]
-        family_prefix: Option<String>,
-    },
+impl ModelFactory for AwsFactoryAdapter {
+    fn for_name(&self, name: &str) -> Option<(AnyTable, Mode)> {
+        self.0.for_name(name).map(|(t, m)| {
+            (
+                t,
+                match m {
+                    FactoryMode::List => Mode::List,
+                    FactoryMode::Single => Mode::Single,
+                },
+            )
+        })
+    }
 
-    /// IAM: list users in the account.
-    ListUsers {
-        /// Filter by IAM path prefix.
-        #[arg(long)]
-        path_prefix: Option<String>,
-    },
-    /// IAM: list groups in the account.
-    ListGroups {
-        #[arg(long)]
-        path_prefix: Option<String>,
-    },
-    /// IAM: list roles in the account.
-    ListRoles {
-        /// Filter by IAM path prefix (e.g. "/service-role/").
-        #[arg(long)]
-        path_prefix: Option<String>,
-    },
-    /// IAM: list managed policies in the account.
-    ListPolicies {
-        /// AWS / Local / All — defaults to All on the AWS side.
-        #[arg(long)]
-        scope: Option<String>,
-        /// true to skip dormant policies.
-        #[arg(long)]
-        only_attached: Option<String>,
-        #[arg(long)]
-        path_prefix: Option<String>,
-    },
-    /// IAM: list access keys for a user (defaults to the caller).
-    ListAccessKeys {
-        #[arg(long)]
-        user: Option<String>,
-    },
-    /// IAM: list instance profiles in the account.
-    ListInstanceProfiles {
-        #[arg(long)]
-        path_prefix: Option<String>,
-    },
+    fn for_arn(&self, arn: &str) -> Option<AnyTable> {
+        self.0.from_arn(arn)
+    }
+}
 
-    /// IAM: filter to one user, drill into their groups via `with_many("groups")`.
-    TraverseUserGroups { user: String },
-    /// IAM: filter to one user, drill into their attached managed policies.
-    TraverseUserPolicies { user: String },
-    /// IAM: filter to one user, drill into their access keys.
-    TraverseUserAccessKeys { user: String },
-    /// IAM: filter to one role, drill into its attached managed policies.
-    TraverseRolePolicies { role: String },
-    /// IAM: filter to one role, drill into the instance profiles wrapping it.
-    TraverseRoleProfiles { role: String },
+/// AWS-aware renderer. Lists go through the existing typed table
+/// renderer (with non-title columns hidden); single records print
+/// `id` + title columns, then `----`, then the rest, and finally a
+/// list of traversable relations.
+struct AwsRenderer;
+
+impl Renderer for AwsRenderer {
+    fn render_list(
+        &self,
+        table: &AnyTable,
+        records: &IndexMap<String, Record<CborValue>>,
+        column_override: Option<&[String]>,
+    ) {
+        let id_field = table.id_field_name();
+        let column_types = table.column_types();
+        let title_fields = table.title_field_names();
+
+        let typed = typed_records(records.clone(), &column_types);
+
+        if let Some(cols) = column_override {
+            // Explicit override: only the spelled-out columns are
+            // shown. `id` resolves to the table's id field.
+            let resolved: Vec<String> = cols
+                .iter()
+                .map(|raw| {
+                    if raw == "id" {
+                        id_field.clone().unwrap_or_else(|| raw.clone())
+                    } else {
+                        raw.clone()
+                    }
+                })
+                .collect();
+            render_records_columns(&typed, &resolved, &column_types);
+            return;
+        }
+
+        // Default: show id + title columns. Tables with no title
+        // columns (single-column ARN tables in ECS) fall back to
+        // every non-id column so the listing isn't empty.
+        let visible: IndexMap<String, &'static str> = if title_fields.is_empty() {
+            column_types.clone()
+        } else {
+            let mut v = IndexMap::new();
+            for f in &title_fields {
+                if let Some(t) = column_types.get(f) {
+                    v.insert(f.clone(), *t);
+                }
+            }
+            v
+        };
+        render_records_typed(&typed, id_field.as_deref(), &visible);
+    }
+
+    fn render_record(
+        &self,
+        table: &AnyTable,
+        id: &str,
+        record: &Record<CborValue>,
+        relations: &[String],
+    ) {
+        let id_field = table.id_field_name();
+        let title_fields = table.title_field_names();
+        let column_types = table.column_types();
+
+        let typed_rec: Record<AnyAwsType> = record
+            .iter()
+            .map(|(k, v)| {
+                let declared = column_types.get(k).copied().unwrap_or("");
+                (k.clone(), AnyAwsType::from_cbor_typed(v.clone(), declared))
+            })
+            .collect();
+
+        // id leads, then title columns, then `--------`, then the rest.
+        if let Some(ref name) = id_field {
+            println!(
+                "{}: {}",
+                name,
+                format_field(&typed_rec, name).unwrap_or_else(|| id.to_string())
+            );
+        } else {
+            println!("id: {id}");
+        }
+        for tf in &title_fields {
+            if Some(tf.as_str()) == id_field.as_deref() {
+                continue;
+            }
+            if let Some(s) = format_field(&typed_rec, tf) {
+                println!("{tf}: {s}");
+            }
+        }
+
+        println!("--------");
+
+        for k in column_types.keys() {
+            if Some(k.as_str()) == id_field.as_deref() || title_fields.contains(k) {
+                continue;
+            }
+            if let Some(s) = format_field(&typed_rec, k) {
+                println!("{k}: {s}");
+            }
+        }
+
+        if !relations.is_empty() {
+            println!();
+            println!("Relations:");
+            for r in relations {
+                println!("  :{r}");
+            }
+        }
+    }
+}
+
+fn format_field(record: &Record<AnyAwsType>, key: &str) -> Option<String> {
+    record.get(key).map(|v| v.render().to_string())
 }
 
 #[tokio::main]
@@ -173,192 +204,17 @@ async fn main() -> Result<()> {
         "Set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_REGION, or configure ~/.aws/credentials [default]",
     )?;
 
-    match cli.command {
-        Command::LogGroups { prefix } => {
-            let mut t = groups_table(aws);
-            if let Some(p) = prefix {
-                t.add_condition(eq("logGroupNamePrefix", p));
-            }
-            print_table(&t).await?;
+    if cli.args.is_empty() {
+        eprintln!("usage: aws-cli <model | arn> [field=value ...] [[N]] [:relation ...]");
+        eprintln!("\nKnown models:");
+        for name in Factory::known_names() {
+            eprintln!("  {name}");
         }
-
-        Command::LogStreams { log_group_name } => {
-            let mut t = streams_table(aws);
-            t.add_condition(eq("logGroupName", log_group_name));
-            print_table(&t).await?;
-        }
-
-        Command::LogEvents { log_group_name } => {
-            let mut t = events_table(aws);
-            t.add_condition(eq("logGroupName", log_group_name));
-            print_table(&t).await?;
-        }
-
-        Command::TraverseLogEvents => {
-            let mut log_groups = groups_table(aws);
-            log_groups.add_condition(eq("logGroupNamePrefix", TRAVERSE_GROUP));
-            print_table(&log_groups).await?;
-
-            println!("\n→ events via with_many(\"events\"):\n");
-
-            let events_any = log_groups.get_ref("events")?;
-            let records = events_any.list_values().await?;
-            render_any_records(records, Some("eventId"));
-        }
-
-        Command::TraverseLogStreams => {
-            let mut log_groups = groups_table(aws);
-            log_groups.add_condition(eq("logGroupNamePrefix", TRAVERSE_GROUP));
-            print_table(&log_groups).await?;
-
-            println!("\n→ streams via with_many(\"streams\"):\n");
-
-            let streams_any = log_groups.get_ref("streams")?;
-            let records = streams_any.list_values().await?;
-            render_any_records(records, Some("logStreamName"));
-        }
-
-        Command::ListClusters => {
-            let t = clusters_table(aws);
-            print_table(&t).await?;
-        }
-
-        Command::ListServices { cluster } => {
-            let mut t = services_table(aws);
-            t.add_condition(eq("cluster", cluster));
-            print_table(&t).await?;
-        }
-
-        Command::ListTasks {
-            cluster,
-            service,
-            family,
-            status,
-        } => {
-            let mut t = tasks_table(aws);
-            t.add_condition(eq("cluster", cluster));
-            if let Some(s) = service {
-                t.add_condition(eq("serviceName", s));
-            }
-            if let Some(f) = family {
-                t.add_condition(eq("family", f));
-            }
-            if let Some(s) = status {
-                t.add_condition(eq("desiredStatus", s));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListTaskDefs { family_prefix } => {
-            let mut t = task_definitions_table(aws);
-            if let Some(p) = family_prefix {
-                t.add_condition(eq("familyPrefix", p));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListUsers { path_prefix } => {
-            let mut t = users_table(aws);
-            if let Some(p) = path_prefix {
-                t.add_condition(eq("PathPrefix", p));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListGroups { path_prefix } => {
-            let mut t = iam_groups_table(aws);
-            if let Some(p) = path_prefix {
-                t.add_condition(eq("PathPrefix", p));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListRoles { path_prefix } => {
-            let mut t = roles_table(aws);
-            if let Some(p) = path_prefix {
-                t.add_condition(eq("PathPrefix", p));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListPolicies {
-            scope,
-            only_attached,
-            path_prefix,
-        } => {
-            let mut t = policies_table(aws);
-            if let Some(s) = scope {
-                t.add_condition(eq("Scope", s));
-            }
-            if let Some(o) = only_attached {
-                t.add_condition(eq("OnlyAttached", o));
-            }
-            if let Some(p) = path_prefix {
-                t.add_condition(eq("PathPrefix", p));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListAccessKeys { user } => {
-            let mut t = access_keys_table(aws);
-            if let Some(u) = user {
-                t.add_condition(eq("UserName", u));
-            }
-            print_table(&t).await?;
-        }
-
-        Command::ListInstanceProfiles { path_prefix } => {
-            let mut t = instance_profiles_table(aws);
-            if let Some(p) = path_prefix {
-                t.add_condition(eq("PathPrefix", p));
-            }
-            print_table(&t).await?;
-        }
-
-        // IAM ListUsers / ListRoles ignore unknown filters and return
-        // the whole account, so the parent table can't be narrowed
-        // API-side. The entity-method helpers (`User::ref_*`,
-        // `Role::ref_*`) are the right tool here — they take the
-        // already-loaded entity and pre-filter the child table.
-        Command::TraverseUserGroups { user } => {
-            let target = find_user(aws.clone(), &user).await?;
-            print_table(&target.ref_groups(aws)).await?;
-        }
-
-        Command::TraverseUserPolicies { user } => {
-            let target = find_user(aws.clone(), &user).await?;
-            print_table(&target.ref_attached_policies(aws)).await?;
-        }
-
-        Command::TraverseUserAccessKeys { user } => {
-            let target = find_user(aws.clone(), &user).await?;
-            print_table(&target.ref_access_keys(aws)).await?;
-        }
-
-        Command::TraverseRolePolicies { role } => {
-            let target = find_role(aws.clone(), &role).await?;
-            print_table(&target.ref_attached_policies(aws)).await?;
-        }
-
-        Command::TraverseRoleProfiles { role } => {
-            let target = find_role(aws.clone(), &role).await?;
-            print_table(&target.ref_instance_profiles(aws)).await?;
-        }
+        std::process::exit(2);
     }
 
+    let factory = AwsFactoryAdapter(Factory::new(aws));
+    let renderer = AwsRenderer;
+    model_cli::run(&factory, &renderer, &cli.args).await?;
     Ok(())
-}
-
-async fn find_user(aws: AwsAccount, name: &str) -> Result<User> {
-    users_table(aws)
-        .get(name.to_string())
-        .await?
-        .with_context(|| format!("IAM user {name:?} not found in this account"))
-}
-
-async fn find_role(aws: AwsAccount, name: &str) -> Result<Role> {
-    roles_table(aws)
-        .get(name.to_string())
-        .await?
-        .with_context(|| format!("IAM role {name:?} not found in this account"))
 }

--- a/vantage-aws/src/dispatch.rs
+++ b/vantage-aws/src/dispatch.rs
@@ -23,15 +23,21 @@ use vantage_types::Record;
 
 use crate::account::AwsAccount;
 use crate::condition::AwsCondition;
-use crate::{json1, query};
+use crate::{json1, json10, query, restjson, restxml};
 
 /// Which AWS wire protocol an operation uses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Protocol {
-    /// `application/x-amz-json-1.1`. CloudWatch Logs, ECS, KMS, DynamoDB, …
+    /// `application/x-amz-json-1.1`. CloudWatch Logs, ECS, KMS, …
     Json1,
+    /// `application/x-amz-json-1.0`. DynamoDB control + data plane.
+    Json10,
     /// AWS Query (form-encoded request, XML response). IAM, STS, EC2, …
     Query,
+    /// REST-XML over GET/POST. S3.
+    RestXml,
+    /// REST-JSON over GET/POST. Lambda, API Gateway v2, …
+    RestJson,
 }
 
 /// Parsed table name. Borrows from the input string.
@@ -57,14 +63,17 @@ impl AwsAccount {
         let resolved = self.resolve_conditions(conditions).await?;
         match op.protocol {
             Protocol::Json1 => json1::execute(self, &op, &resolved).await,
+            Protocol::Json10 => json10::execute(self, &op, &resolved).await,
             Protocol::Query => query::execute(self, &op, &resolved).await,
+            Protocol::RestXml => restxml::execute(self, &op, &resolved).await,
+            Protocol::RestJson => restjson::execute(self, &op, &resolved).await,
         }
     }
 
     /// Pull records out of a successful response. Each protocol owns
     /// the array-extraction since their wire shapes differ (json1
     /// returns the array at the top level; query wraps it in
-    /// `{Action}Result`).
+    /// `{Action}Result`; restxml/restjson follow REST conventions).
     pub(crate) fn parse_records(
         &self,
         table_name: &str,
@@ -73,8 +82,10 @@ impl AwsAccount {
     ) -> Result<IndexMap<String, Record<CborValue>>> {
         let op = parse_table_name(table_name)?;
         match op.protocol {
-            Protocol::Json1 => json1::parse_records(&op, resp, id_field),
+            Protocol::Json1 | Protocol::Json10 => json1::parse_records(&op, resp, id_field),
             Protocol::Query => query::parse_records(&op, resp, id_field),
+            Protocol::RestXml => restxml::parse_records(&op, resp, id_field),
+            Protocol::RestJson => restjson::parse_records(&op, resp, id_field),
         }
     }
 
@@ -133,10 +144,14 @@ pub(crate) fn parse_table_name(name: &str) -> Result<OperationDescriptor<'_>> {
     let (proto_str, rest) = name.split_once('/').ok_or_else(bad)?;
     let protocol = match proto_str {
         "json1" => Protocol::Json1,
+        "json10" => Protocol::Json10,
         "query" => Protocol::Query,
+        "restxml" => Protocol::RestXml,
+        "restjson" => Protocol::RestJson,
         other => {
             return Err(error!(
-                "Unknown AWS protocol prefix — expected \"json1\" or \"query\"",
+                "Unknown AWS protocol prefix — expected one of \
+                 json1, json10, query, restxml, restjson",
                 got = other
             ));
         }
@@ -161,6 +176,17 @@ pub(crate) fn parse_table_name(name: &str) -> Result<OperationDescriptor<'_>> {
 /// well-formed `serde_json::Value`.
 pub(crate) fn json_to_cbor(v: JsonValue) -> CborValue {
     CborValue::serialized(&v).expect("json → cbor cannot fail")
+}
+
+/// Walk a dotted path (`"Buckets.Bucket"`) through a JSON value, taking
+/// each segment as an object key. Returns `None` if any segment misses.
+/// Plain (non-dotted) keys are passed through `Value::get` directly.
+pub(crate) fn lookup_path<'a>(value: &'a JsonValue, path: &str) -> Option<&'a JsonValue> {
+    let mut cur = value;
+    for part in path.split('.') {
+        cur = cur.get(part)?;
+    }
+    Some(cur)
 }
 
 #[cfg(test)]

--- a/vantage-aws/src/impls/table_source.rs
+++ b/vantage-aws/src/impls/table_source.rs
@@ -42,6 +42,10 @@ impl TableSource for AwsAccount {
     type Id = String;
     type Condition = AwsCondition;
 
+    fn eq_condition(field: &str, value: &str) -> DatasetResult<Self::Condition> {
+        Ok(AwsCondition::eq(field.to_string(), value.to_string()))
+    }
+
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         Column::new(name)
     }
@@ -93,7 +97,26 @@ impl TableSource for AwsAccount {
         let id_field = table.id_field().map(|c| c.name().to_string());
         let conditions: Vec<AwsCondition> = table.conditions().cloned().collect();
         let resp = self.execute_rpc(table.table_name(), &conditions).await?;
-        Ok(self.parse_records(table.table_name(), resp, id_field.as_deref())?)
+        let mut records = self.parse_records(table.table_name(), resp, id_field.as_deref())?;
+
+        // AWS APIs only push down their own request-param filters
+        // (e.g. `PathPrefix`, `logGroupNamePrefix`, `cluster`). Eq
+        // conditions naming actual record fields (`UserName`, `Path`,
+        // `clusterArn`) are still useful — apply them post-hoc so
+        // narrowing works regardless of what the API filters
+        // server-side. Field names that don't appear on any record are
+        // assumed to be request params and skipped.
+        records.retain(|_id, record| {
+            conditions.iter().all(|c| match c {
+                AwsCondition::Eq { field, value } => match record.get(field) {
+                    Some(rec_val) => rec_val == value,
+                    None => true,
+                },
+                _ => true,
+            })
+        });
+
+        Ok(records)
     }
 
     async fn get_table_value<E>(

--- a/vantage-aws/src/json1/mod.rs
+++ b/vantage-aws/src/json1/mod.rs
@@ -25,7 +25,7 @@ use crate::account::AwsAccount;
 use crate::condition::{AwsCondition, build_json1_body};
 use crate::dispatch::{OperationDescriptor, json_to_cbor, lookup_path};
 
-pub(crate) use transport::{json1_call, json_aws_call};
+pub(crate) use transport::{json_aws_call, json1_call};
 
 /// Build the JSON-1.1 request body and post it. `target` is used
 /// verbatim as the `X-Amz-Target` header; `service` is both the SigV4

--- a/vantage-aws/src/json1/transport.rs
+++ b/vantage-aws/src/json1/transport.rs
@@ -15,14 +15,30 @@ use crate::sign::sign_v4;
 
 /// Issue a JSON-1.1 RPC and return the parsed response body.
 ///
-/// `service` is the lowercased service code (e.g. `"logs"`, `"ecs"`),
-/// which is both the SigV4 service name and the URL hostname segment.
-/// `target` is the full `X-Amz-Target` header value.
+/// Thin wrapper around [`json_aws_call`] for the 1.1 case — the only
+/// thing it sets is the content type.
 pub(crate) async fn json1_call(
     account: &AwsAccount,
     service: &str,
     target: &str,
     body: &Value,
+) -> Result<Value> {
+    json_aws_call(account, service, target, body, "application/x-amz-json-1.1").await
+}
+
+/// Underlying JSON-RPC dispatcher. Same shape as the 1.1 form but with
+/// a caller-supplied content type — DynamoDB and a few siblings still
+/// expect 1.0 (`application/x-amz-json-1.0`) on the wire.
+///
+/// `service` is the lowercased service code (e.g. `"logs"`, `"dynamodb"`),
+/// which is both the SigV4 service name and the URL hostname segment.
+/// `target` is the full `X-Amz-Target` header value.
+pub(crate) async fn json_aws_call(
+    account: &AwsAccount,
+    service: &str,
+    target: &str,
+    body: &Value,
+    content_type: &str,
 ) -> Result<Value> {
     let region = account.region();
     if region.is_empty() {
@@ -39,10 +55,7 @@ pub(crate) async fn json1_call(
 
     let signing_headers = [
         ("host".to_string(), host.clone()),
-        (
-            "content-type".to_string(),
-            "application/x-amz-json-1.1".to_string(),
-        ),
+        ("content-type".to_string(), content_type.to_string()),
         ("x-amz-target".to_string(), target.to_string()),
     ];
 
@@ -62,7 +75,7 @@ pub(crate) async fn json1_call(
     let mut req = account
         .http()
         .post(&url)
-        .header("content-type", "application/x-amz-json-1.1")
+        .header("content-type", content_type)
         .header("x-amz-target", target)
         .body(body_bytes);
     for h in &signed {
@@ -71,7 +84,7 @@ pub(crate) async fn json1_call(
 
     let resp = req.send().await.map_err(|e| {
         error!(
-            "AWS JSON-1.1 request failed",
+            "AWS JSON-RPC request failed",
             url = url.as_str(),
             target = target,
             detail = e
@@ -95,7 +108,7 @@ pub(crate) async fn json1_call(
 
     serde_json::from_str(&response_text).map_err(|e| {
         error!(
-            "Failed to parse AWS JSON-1.1 response",
+            "Failed to parse AWS JSON-RPC response",
             target = target,
             detail = e,
             body_preview = response_text.chars().take(200).collect::<String>()

--- a/vantage-aws/src/json10/mod.rs
+++ b/vantage-aws/src/json10/mod.rs
@@ -1,0 +1,37 @@
+//! JSON-1.0 protocol — DynamoDB control + data plane.
+//!
+//! Wire shape is identical to JSON-1.1 (POST a JSON object,
+//! `X-Amz-Target` selects the operation, response is a JSON object).
+//! The only difference DynamoDB cares about is the content type,
+//! `application/x-amz-json-1.0`, which is what trips up callers who try
+//! to reuse [`crate::json1`] verbatim.
+//!
+//! Record extraction is delegated to [`crate::json1::parse_records`] —
+//! the response shape is the same, including the dotted-path lookup
+//! for nested arrays (DynamoDB's `Table` is a single object rather
+//! than an array, which is fine: callers can target a different
+//! `array_key` per operation).
+
+use serde_json::Value as JsonValue;
+use vantage_core::Result;
+
+use crate::account::AwsAccount;
+use crate::condition::{AwsCondition, build_json1_body};
+use crate::dispatch::OperationDescriptor;
+use crate::json1::json_aws_call;
+
+pub(crate) async fn execute(
+    account: &AwsAccount,
+    op: &OperationDescriptor<'_>,
+    resolved: &[AwsCondition],
+) -> Result<JsonValue> {
+    let body = build_json1_body(resolved)?;
+    json_aws_call(
+        account,
+        op.service,
+        op.target,
+        &JsonValue::Object(body),
+        "application/x-amz-json-1.0",
+    )
+    .await
+}

--- a/vantage-aws/src/lib.rs
+++ b/vantage-aws/src/lib.rs
@@ -52,8 +52,11 @@ mod condition;
 mod dispatch;
 mod impls;
 mod json1;
+mod json10;
 mod operation;
 mod query;
+mod restjson;
+mod restxml;
 mod sign;
 
 pub mod models;

--- a/vantage-aws/src/models/dynamodb/mod.rs
+++ b/vantage-aws/src/models/dynamodb/mod.rs
@@ -1,0 +1,11 @@
+//! Ready-made DynamoDB tables — table-level metadata only.
+//!
+//! DynamoDB control plane runs on JSON-1.0 (note the version: not 1.1).
+//! [`tables_table`] enumerates the account/region's tables via
+//! `ListTables`, which returns nothing but the table name per row.
+//! Item-level scan/query is a different beast and isn't surfaced
+//! here — `vantage-aws` is read-list-only in v0.
+
+pub mod table;
+
+pub use table::{DynamoDbTable, tables_table};

--- a/vantage-aws/src/models/dynamodb/table.rs
+++ b/vantage-aws/src/models/dynamodb/table.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+use vantage_table::table::Table;
+
+use crate::{AwsAccount, eq};
+
+/// One DynamoDB table from `ListTables`. The list-side response is
+/// minimal — just an array of strings — so v0 surfaces the name only.
+/// `DescribeTable` (single-record, richer metadata) is a v0+ feature.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DynamoDbTable {
+    #[serde(rename = "TableName")]
+    pub table_name: String,
+}
+
+/// `ListTables` table — every DynamoDB table in the account/region.
+/// Use `eq("Limit", N)` if you need to cap the page; pagination via
+/// `ExclusiveStartTableName` isn't surfaced in v0.
+///
+/// ```no_run
+/// # use vantage_aws::AwsAccount;
+/// # use vantage_aws::models::dynamodb::tables_table;
+/// # async fn run() -> vantage_core::Result<()> {
+/// # let aws = AwsAccount::from_default()?;
+/// let tables = tables_table(aws);
+/// # Ok(()) }
+/// ```
+pub fn tables_table(aws: AwsAccount) -> Table<AwsAccount, DynamoDbTable> {
+    Table::new(
+        "json10/TableNames:dynamodb/DynamoDB_20120810.ListTables",
+        aws,
+    )
+    .with_id_column("TableName")
+}
+
+impl DynamoDbTable {
+    /// Build a [`tables_table`] narrowed to the table named in `arn`.
+    /// Accepts ARNs of the shape
+    /// `arn:aws:dynamodb:<region>:<account>:table/<name>`.
+    ///
+    /// `ListTables` doesn't take a name filter, so the narrowing
+    /// happens post-hoc client-side via the standard
+    /// `impls::table_source` retain pass.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, DynamoDbTable>> {
+        let after = arn.split(":table/").nth(1)?;
+        let name = after.split('/').next().unwrap_or(after);
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = tables_table(aws);
+        t.add_condition(eq("TableName", name.to_string()));
+        Some(t)
+    }
+}

--- a/vantage-aws/src/models/ecs/cluster.rs
+++ b/vantage-aws/src/models/ecs/cluster.rs
@@ -30,9 +30,23 @@ pub fn clusters_table(aws: AwsAccount) -> Table<AwsAccount, Cluster> {
         aws,
     )
     .with_id_column("clusterArn")
+    .with_many("services", "cluster", services_table)
+    .with_many("tasks", "cluster", tasks_table)
 }
 
 impl Cluster {
+    /// Build a [`clusters_table`] narrowed to the cluster identified
+    /// by `arn`. Accepts ARNs of the shape
+    /// `arn:aws:ecs:<region>:<account>:cluster/<name>`.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Cluster>> {
+        if !arn.contains(":cluster/") {
+            return None;
+        }
+        let mut t = clusters_table(aws);
+        t.add_condition(eq("clusterArn", arn.to_string()));
+        Some(t)
+    }
+
     /// The cluster's short name, parsed out of [`Self::cluster_arn`].
     /// Cluster ARNs have the shape
     /// `arn:aws:ecs:<region>:<account>:cluster/<name>`.

--- a/vantage-aws/src/models/iam/access_key.rs
+++ b/vantage-aws/src/models/iam/access_key.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
-use crate::AwsAccount;
+use crate::{AwsAccount, eq};
 
 /// One IAM access key from `ListAccessKeys`. Secret material is
 /// never returned by the API — only the metadata you can use to
@@ -26,7 +26,25 @@ pub struct AccessKey {
 pub fn access_keys_table(aws: AwsAccount) -> Table<AwsAccount, AccessKey> {
     Table::new("query/AccessKeyMetadata:iam/2010-05-08.ListAccessKeys", aws)
         .with_id_column("AccessKeyId")
-        .with_column_of::<String>("UserName")
-        .with_column_of::<String>("Status")
+        .with_title_column_of::<String>("UserName")
+        .with_title_column_of::<String>("Status")
         .with_column_of::<String>("CreateDate")
+}
+
+impl AccessKey {
+    /// Access keys don't have stable, addressable ARNs in IAM. The
+    /// closest thing is the user-scoped form
+    /// `arn:aws:iam::<account>:user/<name>/access-key/<id>` — accepted
+    /// here as a convenience: we filter by `UserName` since that's the
+    /// only condition `ListAccessKeys` accepts.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, AccessKey>> {
+        let after = arn.strip_prefix("arn:aws:iam::")?.split(":user/").nth(1)?;
+        let user_name = after.split("/access-key/").next()?;
+        if user_name.is_empty() {
+            return None;
+        }
+        let mut t = access_keys_table(aws);
+        t.add_condition(eq("UserName", user_name.to_string()));
+        Some(t)
+    }
 }

--- a/vantage-aws/src/models/iam/attached_policy.rs
+++ b/vantage-aws/src/models/iam/attached_policy.rs
@@ -28,7 +28,7 @@ pub fn attached_user_policies_table(aws: AwsAccount) -> Table<AwsAccount, Attach
         aws,
     )
     .with_id_column("PolicyArn")
-    .with_column_of::<String>("PolicyName")
+    .with_title_column_of::<String>("PolicyName")
 }
 
 /// `ListAttachedGroupPolicies` — requires `eq("GroupName", "...")`.
@@ -39,7 +39,7 @@ pub fn attached_group_policies_table(aws: AwsAccount) -> Table<AwsAccount, Attac
         aws,
     )
     .with_id_column("PolicyArn")
-    .with_column_of::<String>("PolicyName")
+    .with_title_column_of::<String>("PolicyName")
 }
 
 /// `ListAttachedRolePolicies` — requires `eq("RoleName", "...")`.
@@ -50,5 +50,5 @@ pub fn attached_role_policies_table(aws: AwsAccount) -> Table<AwsAccount, Attach
         aws,
     )
     .with_id_column("PolicyArn")
-    .with_column_of::<String>("PolicyName")
+    .with_title_column_of::<String>("PolicyName")
 }

--- a/vantage-aws/src/models/iam/group.rs
+++ b/vantage-aws/src/models/iam/group.rs
@@ -33,8 +33,8 @@ pub fn groups_table(aws: AwsAccount) -> Table<AwsAccount, Group> {
         .with_id_column("GroupName")
         .with_column_of::<String>("GroupId")
         .with_column_of::<Arn>("Arn")
-        .with_column_of::<String>("Path")
-        .with_column_of::<AwsDateTime>("CreateDate")
+        .with_title_column_of::<String>("Path")
+        .with_title_column_of::<AwsDateTime>("CreateDate")
         .with_many(
             "attached_policies",
             "GroupName",
@@ -55,6 +55,21 @@ pub(crate) fn groups_for_user_table(aws: AwsAccount) -> Table<AwsAccount, Group>
 }
 
 impl Group {
+    /// Build a [`groups_table`] narrowed to the group named in `arn`.
+    ///
+    /// Accepts ARNs of the shape
+    /// `arn:aws:iam::<account>:group/<name>`. Returns `None` if `arn`
+    /// isn't an IAM-group ARN.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Group>> {
+        let name = arn.strip_prefix("arn:aws:iam::")?.split(":group/").nth(1)?;
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = groups_table(aws);
+        t.add_condition(eq("GroupName", name.to_string()));
+        Some(t)
+    }
+
     /// Attached managed policies for *this* group.
     pub fn ref_attached_policies(&self, aws: AwsAccount) -> Table<AwsAccount, AttachedPolicy> {
         let mut t = attached_group_policies_table(aws);

--- a/vantage-aws/src/models/iam/instance_profile.rs
+++ b/vantage-aws/src/models/iam/instance_profile.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
-use crate::AwsAccount;
+use crate::{AwsAccount, eq};
 
 /// One IAM instance profile from `ListInstanceProfiles` /
 /// `ListInstanceProfilesForRole`. The nested `Roles` array isn't
@@ -31,7 +31,7 @@ pub fn instance_profiles_table(aws: AwsAccount) -> Table<AwsAccount, InstancePro
     .with_id_column("InstanceProfileName")
     .with_column_of::<String>("InstanceProfileId")
     .with_column_of::<String>("Arn")
-    .with_column_of::<String>("Path")
+    .with_title_column_of::<String>("Path")
     .with_column_of::<String>("CreateDate")
 }
 
@@ -50,4 +50,23 @@ pub(crate) fn instance_profiles_for_role_table(
     .with_column_of::<String>("Arn")
     .with_column_of::<String>("Path")
     .with_column_of::<String>("CreateDate")
+}
+
+impl InstanceProfile {
+    /// Build an [`instance_profiles_table`] narrowed to the profile
+    /// named in `arn`. Accepts ARNs of the shape
+    /// `arn:aws:iam::<account>:instance-profile/<path/>?<name>`.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, InstanceProfile>> {
+        let after = arn
+            .strip_prefix("arn:aws:iam::")?
+            .split(":instance-profile/")
+            .nth(1)?;
+        let name = after.rsplit('/').next()?;
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = instance_profiles_table(aws);
+        t.add_condition(eq("InstanceProfileName", name.to_string()));
+        Some(t)
+    }
 }

--- a/vantage-aws/src/models/iam/policy.rs
+++ b/vantage-aws/src/models/iam/policy.rs
@@ -67,7 +67,10 @@ impl Policy {
     /// `arn`. Accepts both AWS-managed (`arn:aws:iam::aws:policy/...`)
     /// and customer-managed (`arn:aws:iam::<account>:policy/...`) ARNs.
     pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Policy>> {
-        let after = arn.strip_prefix("arn:aws:iam::")?.split(":policy/").nth(1)?;
+        let after = arn
+            .strip_prefix("arn:aws:iam::")?
+            .split(":policy/")
+            .nth(1)?;
         // Customer-managed policies can sit under a path; managed
         // policies don't. Either way, the policy name is the last
         // path component.

--- a/vantage-aws/src/models/iam/policy.rs
+++ b/vantage-aws/src/models/iam/policy.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
-use crate::AwsAccount;
 use crate::types::{Arn, AwsDateTime};
+use crate::{AwsAccount, eq};
 
 /// One IAM managed policy from `ListPolicies`. Numeric fields stay as
 /// strings — the Query protocol's XML response is untyped, and we
@@ -52,12 +52,31 @@ pub fn policies_table(aws: AwsAccount) -> Table<AwsAccount, Policy> {
         .with_id_column("PolicyName")
         .with_column_of::<String>("PolicyId")
         .with_column_of::<Arn>("Arn")
-        .with_column_of::<String>("Path")
+        .with_title_column_of::<String>("Path")
         .with_column_of::<String>("DefaultVersionId")
-        .with_column_of::<i64>("AttachmentCount")
+        .with_title_column_of::<i64>("AttachmentCount")
         .with_column_of::<i64>("PermissionsBoundaryUsageCount")
-        .with_column_of::<bool>("IsAttachable")
+        .with_title_column_of::<bool>("IsAttachable")
         .with_column_of::<AwsDateTime>("CreateDate")
         .with_column_of::<AwsDateTime>("UpdateDate")
         .with_column_of::<String>("Description")
+}
+
+impl Policy {
+    /// Build a [`policies_table`] narrowed to the policy named in
+    /// `arn`. Accepts both AWS-managed (`arn:aws:iam::aws:policy/...`)
+    /// and customer-managed (`arn:aws:iam::<account>:policy/...`) ARNs.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Policy>> {
+        let after = arn.strip_prefix("arn:aws:iam::")?.split(":policy/").nth(1)?;
+        // Customer-managed policies can sit under a path; managed
+        // policies don't. Either way, the policy name is the last
+        // path component.
+        let name = after.rsplit('/').next()?;
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = policies_table(aws);
+        t.add_condition(eq("PolicyName", name.to_string()));
+        Some(t)
+    }
 }

--- a/vantage-aws/src/models/iam/role.rs
+++ b/vantage-aws/src/models/iam/role.rs
@@ -51,8 +51,8 @@ pub fn roles_table(aws: AwsAccount) -> Table<AwsAccount, Role> {
         .with_id_column("RoleName")
         .with_column_of::<String>("RoleId")
         .with_column_of::<Arn>("Arn")
-        .with_column_of::<String>("Path")
-        .with_column_of::<AwsDateTime>("CreateDate")
+        .with_title_column_of::<String>("Path")
+        .with_title_column_of::<AwsDateTime>("CreateDate")
         .with_column_of::<String>("Description")
         .with_column_of::<String>("AssumeRolePolicyDocument")
         .with_column_of::<String>("MaxSessionDuration")
@@ -69,6 +69,24 @@ pub fn roles_table(aws: AwsAccount) -> Table<AwsAccount, Role> {
 }
 
 impl Role {
+    /// Build a [`roles_table`] narrowed to the role named in `arn`.
+    ///
+    /// Accepts ARNs of the shape
+    /// `arn:aws:iam::<account>:role/<path/>?<name>`. Returns `None` if
+    /// `arn` isn't an IAM-role ARN.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Role>> {
+        // Role names can sit under a path: arn:aws:iam::123:role/some/path/MyRole
+        // — strip back to the trailing component for the IAM filter.
+        let after = arn.strip_prefix("arn:aws:iam::")?.split(":role/").nth(1)?;
+        let name = after.rsplit('/').next()?;
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = roles_table(aws);
+        t.add_condition(eq("RoleName", name.to_string()));
+        Some(t)
+    }
+
     /// Attached managed policies for *this* role.
     pub fn ref_attached_policies(&self, aws: AwsAccount) -> Table<AwsAccount, AttachedPolicy> {
         let mut t = attached_role_policies_table(aws);

--- a/vantage-aws/src/models/iam/user.rs
+++ b/vantage-aws/src/models/iam/user.rs
@@ -56,8 +56,8 @@ pub fn users_table(aws: AwsAccount) -> Table<AwsAccount, User> {
         .with_id_column("UserName")
         .with_column_of::<String>("UserId")
         .with_column_of::<Arn>("Arn")
-        .with_column_of::<String>("Path")
-        .with_column_of::<AwsDateTime>("CreateDate")
+        .with_title_column_of::<String>("Path")
+        .with_title_column_of::<AwsDateTime>("CreateDate")
         .with_column_of::<AwsDateTime>("PasswordLastUsed")
         .with_many("groups", "UserName", groups_for_user_table)
         .with_many("access_keys", "UserName", access_keys_table)
@@ -69,6 +69,21 @@ pub fn users_table(aws: AwsAccount) -> Table<AwsAccount, User> {
 }
 
 impl User {
+    /// Build a [`users_table`] narrowed to the user named in `arn`.
+    ///
+    /// Accepts ARNs of the shape
+    /// `arn:aws:iam::<account>:user/<name>`. Returns `None` if `arn`
+    /// isn't an IAM-user ARN.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, User>> {
+        let name = arn.strip_prefix("arn:aws:iam::")?.split(":user/").nth(1)?;
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = users_table(aws);
+        t.add_condition(eq("UserName", name.to_string()));
+        Some(t)
+    }
+
     /// Groups *this* user belongs to.
     pub fn ref_groups(&self, aws: AwsAccount) -> Table<AwsAccount, Group> {
         let mut t = groups_for_user_table(aws);

--- a/vantage-aws/src/models/lambda/alias.rs
+++ b/vantage-aws/src/models/lambda/alias.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+use vantage_table::table::Table;
+
+use crate::AwsAccount;
+
+/// One Lambda alias from `ListAliases`. Field names match the wire
+/// JSON; v0 surfaces them flat.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Alias {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "AliasArn", default)]
+    pub alias_arn: String,
+    #[serde(rename = "FunctionVersion", default)]
+    pub function_version: String,
+    #[serde(rename = "Description", default)]
+    pub description: String,
+    #[serde(rename = "RevisionId", default)]
+    pub revision_id: String,
+}
+
+/// `ListAliases` table. Requires `eq("FunctionName", "...")` — without
+/// it the `{FunctionName}` path placeholder errors at request-build
+/// time. Used as the `aliases` relation on [`super::function::Function`].
+pub fn aliases_table(aws: AwsAccount) -> Table<AwsAccount, Alias> {
+    Table::new(
+        "restjson/Aliases:lambda/GET /2015-03-31/functions/{FunctionName}/aliases",
+        aws,
+    )
+    .with_id_column("Name")
+    .with_title_column_of::<String>("FunctionVersion")
+    .with_column_of::<String>("AliasArn")
+    .with_column_of::<String>("Description")
+    .with_column_of::<String>("RevisionId")
+}

--- a/vantage-aws/src/models/lambda/function.rs
+++ b/vantage-aws/src/models/lambda/function.rs
@@ -64,28 +64,25 @@ pub struct Function {
 /// # Ok(()) }
 /// ```
 pub fn functions_table(aws: AwsAccount) -> Table<AwsAccount, Function> {
-    Table::new(
-        "restjson/Functions:lambda/GET /2015-03-31/functions/",
-        aws,
-    )
-    .with_id_column("FunctionName")
-    .with_column_of::<Arn>("FunctionArn")
-    .with_title_column_of::<String>("Runtime")
-    .with_title_column_of::<String>("Handler")
-    .with_column_of::<String>("Description")
-    .with_column_of::<Arn>("Role")
-    .with_column_of::<i64>("Timeout")
-    .with_column_of::<i64>("MemorySize")
-    .with_column_of::<AwsDateTime>("LastModified")
-    .with_column_of::<String>("Version")
-    .with_column_of::<String>("PackageType")
-    .with_many("aliases", "FunctionName", aliases_table)
-    .with_many("versions", "FunctionName", versions_table)
-    .with_foreign(
-        "log_group",
-        std::any::type_name::<Table<AwsAccount, LogGroup>>(),
-        log_group_relation,
-    )
+    Table::new("restjson/Functions:lambda/GET /2015-03-31/functions/", aws)
+        .with_id_column("FunctionName")
+        .with_column_of::<Arn>("FunctionArn")
+        .with_title_column_of::<String>("Runtime")
+        .with_title_column_of::<String>("Handler")
+        .with_column_of::<String>("Description")
+        .with_column_of::<Arn>("Role")
+        .with_column_of::<i64>("Timeout")
+        .with_column_of::<i64>("MemorySize")
+        .with_column_of::<AwsDateTime>("LastModified")
+        .with_column_of::<String>("Version")
+        .with_column_of::<String>("PackageType")
+        .with_many("aliases", "FunctionName", aliases_table)
+        .with_many("versions", "FunctionName", versions_table)
+        .with_foreign(
+            "log_group",
+            std::any::type_name::<Table<AwsAccount, LogGroup>>(),
+            log_group_relation,
+        )
 }
 
 /// Build the `:log_group` traversal target for a Lambda function.
@@ -99,9 +96,7 @@ pub fn functions_table(aws: AwsAccount) -> Table<AwsAccount, Function> {
 /// constraint that all `Deferred` conditions live under still applies
 /// — multi-row sources error at execute time, same as any other
 /// traversal.
-fn log_group_relation(
-    functions: &Table<AwsAccount, Function>,
-) -> vantage_core::Result<AnyTable> {
+fn log_group_relation(functions: &Table<AwsAccount, Function>) -> vantage_core::Result<AnyTable> {
     let aws = functions.data_source().clone();
     let mut groups = log_groups_table(aws.clone());
 
@@ -115,9 +110,7 @@ fn log_group_relation(
             let names: Vec<CborValue> = records
                 .values()
                 .filter_map(|r| match r.get("FunctionName") {
-                    Some(CborValue::Text(s)) => {
-                        Some(CborValue::Text(format!("/aws/lambda/{s}")))
-                    }
+                    Some(CborValue::Text(s)) => Some(CborValue::Text(format!("/aws/lambda/{s}"))),
                     _ => None,
                 })
                 .collect();

--- a/vantage-aws/src/models/lambda/function.rs
+++ b/vantage-aws/src/models/lambda/function.rs
@@ -1,0 +1,181 @@
+use ciborium::Value as CborValue;
+use serde::{Deserialize, Serialize};
+use vantage_expressions::Expression;
+use vantage_expressions::expr_any;
+use vantage_expressions::traits::expressive::{DeferredFn, ExpressiveEnum};
+use vantage_table::any::AnyTable;
+use vantage_table::table::Table;
+use vantage_table::traits::table_source::TableSource;
+
+use crate::condition::AwsCondition;
+use crate::types::{Arn, AwsDateTime};
+use crate::{AwsAccount, eq};
+
+use super::alias::{Alias, aliases_table};
+use super::version::{Version, versions_table};
+use crate::models::logs::group::{LogGroup, groups_table as log_groups_table};
+
+/// One Lambda function from `ListFunctions`. Lambda's response
+/// includes nested config blobs (`LoggingConfig`, `TracingConfig`,
+/// `VpcConfig`, …) that v0 leaves nested as wire-shape — we surface
+/// the scalars callers usually want at the top level.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Function {
+    #[serde(rename = "FunctionName")]
+    pub function_name: String,
+    #[serde(rename = "FunctionArn", default)]
+    pub function_arn: String,
+    #[serde(rename = "Runtime", default)]
+    pub runtime: String,
+    #[serde(rename = "Role", default)]
+    pub role: String,
+    #[serde(rename = "Handler", default)]
+    pub handler: String,
+    #[serde(rename = "Description", default)]
+    pub description: String,
+    #[serde(rename = "Timeout", default)]
+    pub timeout: i64,
+    #[serde(rename = "MemorySize", default)]
+    pub memory_size: i64,
+    #[serde(rename = "LastModified", default)]
+    pub last_modified: String,
+    #[serde(rename = "Version", default)]
+    pub version: String,
+    #[serde(rename = "PackageType", default)]
+    pub package_type: String,
+}
+
+/// `ListFunctions` table — every function in the configured region.
+/// `MasterRegion` and `FunctionVersion` are the only AWS-side filters;
+/// most callers leave them off and rely on post-hoc narrowing.
+///
+/// Relations:
+///   - `aliases` → `ListAliases` for this function
+///   - `versions` → `ListVersionsByFunction` for this function
+///   - `log_group` → CloudWatch Logs group at `/aws/lambda/<name>`
+///     (cross-service into [`crate::models::logs`])
+///
+/// ```no_run
+/// # use vantage_aws::AwsAccount;
+/// # use vantage_aws::models::lambda::functions_table;
+/// # async fn run() -> vantage_core::Result<()> {
+/// # let aws = AwsAccount::from_default()?;
+/// let functions = functions_table(aws);
+/// # Ok(()) }
+/// ```
+pub fn functions_table(aws: AwsAccount) -> Table<AwsAccount, Function> {
+    Table::new(
+        "restjson/Functions:lambda/GET /2015-03-31/functions/",
+        aws,
+    )
+    .with_id_column("FunctionName")
+    .with_column_of::<Arn>("FunctionArn")
+    .with_title_column_of::<String>("Runtime")
+    .with_title_column_of::<String>("Handler")
+    .with_column_of::<String>("Description")
+    .with_column_of::<Arn>("Role")
+    .with_column_of::<i64>("Timeout")
+    .with_column_of::<i64>("MemorySize")
+    .with_column_of::<AwsDateTime>("LastModified")
+    .with_column_of::<String>("Version")
+    .with_column_of::<String>("PackageType")
+    .with_many("aliases", "FunctionName", aliases_table)
+    .with_many("versions", "FunctionName", versions_table)
+    .with_foreign(
+        "log_group",
+        std::any::type_name::<Table<AwsAccount, LogGroup>>(),
+        log_group_relation,
+    )
+}
+
+/// Build the `:log_group` traversal target for a Lambda function.
+///
+/// Standard `with_many` would project `FunctionName` straight into the
+/// log-group filter, which doesn't match — log groups carry the
+/// derived name `/aws/lambda/<FunctionName>`. So we splice that prefix
+/// in here: a deferred expression runs the source query, pulls
+/// `FunctionName` from each row, and prefixes it before handing it to
+/// `logGroupNamePrefix` for AWS-side narrowing. The single-value
+/// constraint that all `Deferred` conditions live under still applies
+/// — multi-row sources error at execute time, same as any other
+/// traversal.
+fn log_group_relation(
+    functions: &Table<AwsAccount, Function>,
+) -> vantage_core::Result<AnyTable> {
+    let aws = functions.data_source().clone();
+    let mut groups = log_groups_table(aws.clone());
+
+    let table = functions.clone();
+    let aws_for_fn = aws.clone();
+    let inner: DeferredFn<CborValue> = DeferredFn::new(move || {
+        let aws = aws_for_fn.clone();
+        let table = table.clone();
+        Box::pin(async move {
+            let records = aws.list_table_values(&table).await?;
+            let names: Vec<CborValue> = records
+                .values()
+                .filter_map(|r| match r.get("FunctionName") {
+                    Some(CborValue::Text(s)) => {
+                        Some(CborValue::Text(format!("/aws/lambda/{s}")))
+                    }
+                    _ => None,
+                })
+                .collect();
+            Ok(ExpressiveEnum::Scalar(CborValue::Array(names)))
+        })
+    });
+
+    let source: Expression<CborValue> = expr_any!("{}", { inner });
+
+    groups.add_condition(AwsCondition::Deferred {
+        field: "logGroupNamePrefix".to_string(),
+        source,
+    });
+
+    Ok(AnyTable::from_table(groups))
+}
+
+impl Function {
+    /// Build a [`functions_table`] narrowed to the function named in
+    /// `arn`. Accepts ARNs of the shape
+    /// `arn:aws:lambda:<region>:<account>:function:<name>` (with or
+    /// without a trailing `:<qualifier>`).
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Function>> {
+        let after = arn.split(":function:").nth(1)?;
+        // Strip optional version/alias qualifier.
+        let name = after.split(':').next().unwrap_or(after);
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = functions_table(aws);
+        t.add_condition(eq("FunctionName", name.to_string()));
+        Some(t)
+    }
+
+    /// Aliases for *this* function.
+    pub fn ref_aliases(&self, aws: AwsAccount) -> Table<AwsAccount, Alias> {
+        let mut t = aliases_table(aws);
+        t.add_condition(eq("FunctionName", self.function_name.clone()));
+        t
+    }
+
+    /// Published versions for *this* function (always includes
+    /// `$LATEST`).
+    pub fn ref_versions(&self, aws: AwsAccount) -> Table<AwsAccount, Version> {
+        let mut t = versions_table(aws);
+        t.add_condition(eq("FunctionName", self.function_name.clone()));
+        t
+    }
+
+    /// CloudWatch Logs group for *this* function — `/aws/lambda/<name>`
+    /// by default. Returns a [`crate::models::logs::group::LogGroup`]
+    /// table pre-narrowed via `logGroupNamePrefix`.
+    pub fn ref_log_group(&self, aws: AwsAccount) -> Table<AwsAccount, LogGroup> {
+        let mut t = log_groups_table(aws);
+        t.add_condition(eq(
+            "logGroupNamePrefix",
+            format!("/aws/lambda/{}", self.function_name),
+        ));
+        t
+    }
+}

--- a/vantage-aws/src/models/lambda/mod.rs
+++ b/vantage-aws/src/models/lambda/mod.rs
@@ -1,0 +1,23 @@
+//! Ready-made Lambda tables — functions, aliases, versions.
+//!
+//! Lambda speaks REST-JSON (see [`crate::restjson`]). The control
+//! plane URL pattern is `/2015-03-31/functions/...` — old version
+//! prefix, never going to change.
+//!
+//! Top-level: [`functions_table`] enumerates every function in the
+//! account/region. Aliases and versions only make sense scoped to a
+//! function, so they aren't exposed top-level — reach them via
+//! `lambda.function ... :aliases` / `:versions`.
+//!
+//! `Function` also carries a cross-service `:log_group` relation that
+//! resolves to the matching CloudWatch Logs group at
+//! `/aws/lambda/<FunctionName>`, regardless of whether the function
+//! has a custom logging config.
+
+pub mod alias;
+pub mod function;
+pub mod version;
+
+pub use alias::{Alias, aliases_table};
+pub use function::{Function, functions_table};
+pub use version::{Version, versions_table};

--- a/vantage-aws/src/models/lambda/version.rs
+++ b/vantage-aws/src/models/lambda/version.rs
@@ -1,0 +1,40 @@
+use serde::{Deserialize, Serialize};
+use vantage_table::table::Table;
+
+use crate::AwsAccount;
+
+/// One Lambda function version from `ListVersionsByFunction`. We keep
+/// only the identifying fields here — the full FunctionConfiguration
+/// is huge and rarely useful in a list view.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Version {
+    #[serde(rename = "Version")]
+    pub version: String,
+    #[serde(rename = "FunctionName", default)]
+    pub function_name: String,
+    #[serde(rename = "FunctionArn", default)]
+    pub function_arn: String,
+    #[serde(rename = "Runtime", default)]
+    pub runtime: String,
+    #[serde(rename = "LastModified", default)]
+    pub last_modified: String,
+    #[serde(rename = "Description", default)]
+    pub description: String,
+}
+
+/// `ListVersionsByFunction` table. Requires `eq("FunctionName", "...")`.
+/// Used as the `versions` relation on [`super::function::Function`].
+///
+/// Lambda always returns at least `$LATEST`; published versions show
+/// up only after the function has been explicitly versioned.
+pub fn versions_table(aws: AwsAccount) -> Table<AwsAccount, Version> {
+    Table::new(
+        "restjson/Versions:lambda/GET /2015-03-31/functions/{FunctionName}/versions",
+        aws,
+    )
+    .with_id_column("Version")
+    .with_title_column_of::<String>("Runtime")
+    .with_column_of::<String>("FunctionArn")
+    .with_column_of::<String>("LastModified")
+    .with_column_of::<String>("Description")
+}

--- a/vantage-aws/src/models/logs/event.rs
+++ b/vantage-aws/src/models/logs/event.rs
@@ -33,7 +33,7 @@ pub struct LogEvent {
 pub fn events_table(aws: AwsAccount) -> Table<AwsAccount, LogEvent> {
     Table::new("json1/events:logs/Logs_20140328.FilterLogEvents", aws)
         .with_id_column("eventId")
-        .with_column_of::<String>("logStreamName")
-        .with_column_of::<i64>("timestamp")
+        .with_title_column_of::<String>("logStreamName")
+        .with_title_column_of::<i64>("timestamp")
         .with_column_of::<String>("message")
 }

--- a/vantage-aws/src/models/logs/group.rs
+++ b/vantage-aws/src/models/logs/group.rs
@@ -42,12 +42,34 @@ pub fn groups_table(aws: AwsAccount) -> Table<AwsAccount, LogGroup> {
     Table::new("json1/logGroups:logs/Logs_20140328.DescribeLogGroups", aws)
         .with_id_column("logGroupName")
         .with_column_of::<i64>("creationTime")
-        .with_column_of::<i64>("storedBytes")
+        .with_title_column_of::<i64>("storedBytes")
         .with_many("events", "logGroupName", events_table)
         .with_many("streams", "logGroupName", streams_table)
 }
 
 impl LogGroup {
+    /// Build a [`groups_table`] narrowed to the group named in `arn`.
+    ///
+    /// Accepts ARNs of the shape
+    /// `arn:aws:logs:<region>:<account>:log-group:<name>` with an
+    /// optional trailing `:*` (the form returned by IAM policy
+    /// resources). Returns `None` if the ARN isn't a log-group ARN.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, LogGroup>> {
+        let after = arn.split(":log-group:").nth(1)?;
+        // Strip the optional :log-stream:... or :* suffix.
+        let name = after
+            .split(":log-stream:")
+            .next()
+            .unwrap_or(after)
+            .trim_end_matches(":*");
+        if name.is_empty() {
+            return None;
+        }
+        let mut t = groups_table(aws);
+        t.add_condition(eq("logGroupNamePrefix", name.to_string()));
+        Some(t)
+    }
+
     /// Events table pre-filtered to *this* group's name.
     pub fn ref_events(&self, aws: AwsAccount) -> Table<AwsAccount, LogEvent> {
         let mut t = events_table(aws);

--- a/vantage-aws/src/models/logs/stream.rs
+++ b/vantage-aws/src/models/logs/stream.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
-use crate::{eq, AwsAccount};
+use crate::{AwsAccount, eq};
 
-use super::event::{events_table, LogEvent};
+use super::event::{LogEvent, events_table};
 
 /// One CloudWatch Logs stream from `DescribeLogStreams`. Field names
 /// match the wire shape.

--- a/vantage-aws/src/models/logs/stream.rs
+++ b/vantage-aws/src/models/logs/stream.rs
@@ -48,13 +48,30 @@ pub fn streams_table(aws: AwsAccount) -> Table<AwsAccount, LogStream> {
     .with_column_of::<String>("arn")
     .with_column_of::<i64>("creationTime")
     .with_column_of::<i64>("firstEventTimestamp")
-    .with_column_of::<i64>("lastEventTimestamp")
+    .with_title_column_of::<i64>("lastEventTimestamp")
     .with_column_of::<i64>("lastIngestionTime")
-    .with_column_of::<i64>("storedBytes")
+    .with_title_column_of::<i64>("storedBytes")
     .with_column_of::<String>("uploadSequenceToken")
 }
 
 impl LogStream {
+    /// Build a [`streams_table`] narrowed to the stream identified by
+    /// `arn`. Accepts ARNs of the shape
+    /// `arn:aws:logs:<region>:<account>:log-group:<group>:log-stream:<stream>`.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, LogStream>> {
+        let after_group = arn.split(":log-group:").nth(1)?;
+        let mut parts = after_group.splitn(2, ":log-stream:");
+        let group_name = parts.next()?;
+        let stream_name = parts.next()?;
+        if group_name.is_empty() || stream_name.is_empty() {
+            return None;
+        }
+        let mut t = streams_table(aws);
+        t.add_condition(eq("logGroupName", group_name.to_string()));
+        t.add_condition(eq("logStreamNamePrefix", stream_name.to_string()));
+        Some(t)
+    }
+
     /// The owning log group's name, parsed out of [`Self::arn`].
     /// Stream ARNs have the shape
     /// `arn:aws:logs:<region>:<account>:log-group:<group>:log-stream:<stream>`.

--- a/vantage-aws/src/models/logs/stream.rs
+++ b/vantage-aws/src/models/logs/stream.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 use vantage_table::table::Table;
 
-use crate::{AwsAccount, eq};
+use crate::{eq, AwsAccount};
 
-use super::event::{LogEvent, events_table};
+use super::event::{events_table, LogEvent};
 
 /// One CloudWatch Logs stream from `DescribeLogStreams`. Field names
 /// match the wire shape.
@@ -60,9 +60,7 @@ impl LogStream {
     /// `arn:aws:logs:<region>:<account>:log-group:<group>:log-stream:<stream>`.
     pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, LogStream>> {
         let after_group = arn.split(":log-group:").nth(1)?;
-        let mut parts = after_group.splitn(2, ":log-stream:");
-        let group_name = parts.next()?;
-        let stream_name = parts.next()?;
+        let (group_name, stream_name) = after_group.split_once(":log-stream:")?;
         if group_name.is_empty() || stream_name.is_empty() {
             return None;
         }

--- a/vantage-aws/src/models/mod.rs
+++ b/vantage-aws/src/models/mod.rs
@@ -19,6 +19,15 @@
 //!   - [`iam::access_keys_table`]        — `ListAccessKeys`  (per user)
 //!   - [`iam::instance_profiles_table`]  — `ListInstanceProfiles`
 //!
+//! ## Generic factory ([`Factory`])
+//!
+//! Wraps every table above behind dotted-string names (`iam.users`,
+//! `log.group`, `ecs.task_definitions`, …) and a single
+//! [`Factory::from_arn`] entry point. Powers the `aws-cli` example
+//! (which adapts it to `vantage_cli_util`'s `ModelFactory` trait);
+//! anything else that needs a generic, type-erased AWS table by name
+//! can reuse it without dragging in a CLI rendering crate.
+//!
 //! ```no_run
 //! # use vantage_aws::{AwsAccount, eq};
 //! # use vantage_aws::models::logs::groups_table;
@@ -32,3 +41,156 @@
 pub mod ecs;
 pub mod iam;
 pub mod logs;
+
+use vantage_table::any::AnyTable;
+
+use crate::AwsAccount;
+
+/// Whether a [`Factory`] lookup should drop into list mode (returning
+/// every matching record) or single-record mode (returning just the
+/// first match).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FactoryMode {
+    List,
+    Single,
+}
+
+/// Generic, type-erased model factory.
+///
+/// The factory maps dotted string names to the typed `*_table`
+/// factories above and dispatches ARN parsing across each entity's
+/// `from_arn`. Singular forms (e.g. `iam.user`) drop into
+/// [`FactoryMode::Single`]; plural forms (`iam.users`) drop into
+/// [`FactoryMode::List`].
+#[derive(Debug, Clone)]
+pub struct Factory {
+    aws: AwsAccount,
+}
+
+impl Factory {
+    /// Build a factory bound to a specific AWS account.
+    pub fn new(aws: AwsAccount) -> Self {
+        Self { aws }
+    }
+
+    /// All known model names, in registration order.
+    ///
+    /// Models whose AWS API requires a parent filter aren't exposed
+    /// top-level — listing them standalone would either error
+    /// or quietly return only the caller's slice. Reach them via
+    /// traversal from their parent:
+    ///   - `iam.user ... :access_keys`        (ListAccessKeys needs UserName)
+    ///   - `log.group ... :streams`           (DescribeLogStreams needs logGroupName)
+    ///   - `log.group ... :events`            (FilterLogEvents needs logGroupName)
+    ///   - `ecs.cluster ... :services`        (ListServices needs cluster)
+    ///   - `ecs.cluster ... :tasks`           (ListTasks needs cluster)
+    ///
+    /// Per-resource ARNs still work as the first argument for any of
+    /// these — see [`Factory::from_arn`].
+    pub fn known_names() -> &'static [&'static str] {
+        &[
+            "iam.user",
+            "iam.users",
+            "iam.group",
+            "iam.groups",
+            "iam.role",
+            "iam.roles",
+            "iam.policy",
+            "iam.policies",
+            "iam.instance_profile",
+            "iam.instance_profiles",
+            "log.group",
+            "log.groups",
+            "ecs.cluster",
+            "ecs.clusters",
+            "ecs.task_definition",
+            "ecs.task_definitions",
+        ]
+    }
+
+    /// Resolve a model name to an `AnyTable` plus its mode.
+    pub fn for_name(&self, name: &str) -> Option<(AnyTable, FactoryMode)> {
+        let aws = self.aws.clone();
+        let (table, mode) = match name {
+            "iam.user" => (AnyTable::new(iam::users_table(aws)), FactoryMode::Single),
+            "iam.users" => (AnyTable::new(iam::users_table(aws)), FactoryMode::List),
+            "iam.group" => (AnyTable::new(iam::groups_table(aws)), FactoryMode::Single),
+            "iam.groups" => (AnyTable::new(iam::groups_table(aws)), FactoryMode::List),
+            "iam.role" => (AnyTable::new(iam::roles_table(aws)), FactoryMode::Single),
+            "iam.roles" => (AnyTable::new(iam::roles_table(aws)), FactoryMode::List),
+            "iam.policy" => (AnyTable::new(iam::policies_table(aws)), FactoryMode::Single),
+            "iam.policies" => (AnyTable::new(iam::policies_table(aws)), FactoryMode::List),
+            // iam.access_key / iam.access_keys intentionally omitted:
+            // listing them standalone returns just the caller's keys,
+            // which is rarely what people mean. Reach them via
+            // `iam.user ... :access_keys`.
+            "iam.instance_profile" => (
+                AnyTable::new(iam::instance_profiles_table(aws)),
+                FactoryMode::Single,
+            ),
+            "iam.instance_profiles" => (
+                AnyTable::new(iam::instance_profiles_table(aws)),
+                FactoryMode::List,
+            ),
+            "log.group" => (AnyTable::new(logs::groups_table(aws)), FactoryMode::Single),
+            "log.groups" => (AnyTable::new(logs::groups_table(aws)), FactoryMode::List),
+            // log.stream / log.event intentionally omitted: AWS
+            // requires `logGroupName`. Reach them via
+            // `log.group ... :streams` / `:events`.
+            "ecs.cluster" => (
+                AnyTable::new(ecs::clusters_table(aws)),
+                FactoryMode::Single,
+            ),
+            "ecs.clusters" => (AnyTable::new(ecs::clusters_table(aws)), FactoryMode::List),
+            // ecs.service / ecs.task intentionally omitted: AWS
+            // requires `cluster` as a filter, so listing them
+            // standalone returns nothing useful. Reach them via
+            // `ecs.cluster ... :services` / `:tasks`.
+            "ecs.task_definition" => (
+                AnyTable::new(ecs::task_definitions_table(aws)),
+                FactoryMode::Single,
+            ),
+            "ecs.task_definitions" => (
+                AnyTable::new(ecs::task_definitions_table(aws)),
+                FactoryMode::List,
+            ),
+            _ => return None,
+        };
+        Some((table, mode))
+    }
+
+    /// Resolve an ARN to a pre-conditioned single-record table by
+    /// dispatching to each entity's `from_arn`. Returns `None` if no
+    /// entity recognises the ARN's resource type.
+    pub fn from_arn(&self, arn: &str) -> Option<AnyTable> {
+        let aws = self.aws.clone();
+        if let Some(t) = iam::user::User::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = iam::group::Group::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = iam::role::Role::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = iam::policy::Policy::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = iam::instance_profile::InstanceProfile::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = iam::access_key::AccessKey::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = logs::stream::LogStream::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = logs::group::LogGroup::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = ecs::cluster::Cluster::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        None
+    }
+}

--- a/vantage-aws/src/models/mod.rs
+++ b/vantage-aws/src/models/mod.rs
@@ -19,6 +19,18 @@
 //!   - [`iam::access_keys_table`]        — `ListAccessKeys`  (per user)
 //!   - [`iam::instance_profiles_table`]  — `ListInstanceProfiles`
 //!
+//! S3 (REST-XML, under [`s3`]):
+//!   - [`s3::buckets_table`] — `ListBuckets`
+//!   - [`s3::objects_table`] — `ListObjectsV2` (per bucket)
+//!
+//! Lambda (REST-JSON, under [`lambda`]):
+//!   - [`lambda::functions_table`] — `ListFunctions`
+//!   - [`lambda::aliases_table`]   — `ListAliases` (per function)
+//!   - [`lambda::versions_table`]  — `ListVersionsByFunction` (per function)
+//!
+//! DynamoDB (JSON-1.0, under [`dynamodb`]):
+//!   - [`dynamodb::tables_table`] — `ListTables`
+//!
 //! ## Generic factory ([`Factory`])
 //!
 //! Wraps every table above behind dotted-string names (`iam.users`,
@@ -38,9 +50,12 @@
 //! # Ok(()) }
 //! ```
 
+pub mod dynamodb;
 pub mod ecs;
 pub mod iam;
+pub mod lambda;
 pub mod logs;
+pub mod s3;
 
 use vantage_table::any::AnyTable;
 
@@ -84,6 +99,10 @@ impl Factory {
     ///   - `log.group ... :events`            (FilterLogEvents needs logGroupName)
     ///   - `ecs.cluster ... :services`        (ListServices needs cluster)
     ///   - `ecs.cluster ... :tasks`           (ListTasks needs cluster)
+    ///   - `s3.bucket ... :objects`           (ListObjectsV2 needs Bucket)
+    ///   - `lambda.function ... :aliases`     (ListAliases needs FunctionName)
+    ///   - `lambda.function ... :versions`    (ListVersionsByFunction needs FunctionName)
+    ///   - `lambda.function ... :log_group`   (CloudWatch group at /aws/lambda/<name>)
     ///
     /// Per-resource ARNs still work as the first argument for any of
     /// these — see [`Factory::from_arn`].
@@ -105,6 +124,12 @@ impl Factory {
             "ecs.clusters",
             "ecs.task_definition",
             "ecs.task_definitions",
+            "s3.bucket",
+            "s3.buckets",
+            "lambda.function",
+            "lambda.functions",
+            "dynamodb.table",
+            "dynamodb.tables",
         ]
     }
 
@@ -151,6 +176,29 @@ impl Factory {
                 AnyTable::new(ecs::task_definitions_table(aws)),
                 FactoryMode::List,
             ),
+            "s3.bucket" => (AnyTable::new(s3::buckets_table(aws)), FactoryMode::Single),
+            "s3.buckets" => (AnyTable::new(s3::buckets_table(aws)), FactoryMode::List),
+            // s3.object intentionally omitted: ListObjectsV2 requires
+            // a Bucket. Reach via `s3.bucket ... :objects`.
+            "lambda.function" => (
+                AnyTable::new(lambda::functions_table(aws)),
+                FactoryMode::Single,
+            ),
+            "lambda.functions" => (
+                AnyTable::new(lambda::functions_table(aws)),
+                FactoryMode::List,
+            ),
+            // lambda.alias / lambda.version intentionally omitted:
+            // both list APIs require FunctionName. Reach via
+            // `lambda.function ... :aliases` / `:versions`.
+            "dynamodb.table" => (
+                AnyTable::new(dynamodb::tables_table(aws)),
+                FactoryMode::Single,
+            ),
+            "dynamodb.tables" => (
+                AnyTable::new(dynamodb::tables_table(aws)),
+                FactoryMode::List,
+            ),
             _ => return None,
         };
         Some((table, mode))
@@ -186,6 +234,20 @@ impl Factory {
             return Some(AnyTable::new(t));
         }
         if let Some(t) = ecs::cluster::Cluster::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        // S3 — object ARNs (`arn:aws:s3:::bucket/key`) check first
+        // since they're a strict superset of bucket ARNs.
+        if let Some(t) = s3::object::Object::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = s3::bucket::Bucket::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = lambda::function::Function::from_arn(arn, aws.clone()) {
+            return Some(AnyTable::new(t));
+        }
+        if let Some(t) = dynamodb::table::DynamoDbTable::from_arn(arn, aws.clone()) {
             return Some(AnyTable::new(t));
         }
         None

--- a/vantage-aws/src/models/mod.rs
+++ b/vantage-aws/src/models/mod.rs
@@ -137,10 +137,7 @@ impl Factory {
             // log.stream / log.event intentionally omitted: AWS
             // requires `logGroupName`. Reach them via
             // `log.group ... :streams` / `:events`.
-            "ecs.cluster" => (
-                AnyTable::new(ecs::clusters_table(aws)),
-                FactoryMode::Single,
-            ),
+            "ecs.cluster" => (AnyTable::new(ecs::clusters_table(aws)), FactoryMode::Single),
             "ecs.clusters" => (AnyTable::new(ecs::clusters_table(aws)), FactoryMode::List),
             // ecs.service / ecs.task intentionally omitted: AWS
             // requires `cluster` as a filter, so listing them

--- a/vantage-aws/src/models/s3/bucket.rs
+++ b/vantage-aws/src/models/s3/bucket.rs
@@ -1,0 +1,67 @@
+use serde::{Deserialize, Serialize};
+use vantage_table::table::Table;
+
+use crate::types::AwsDateTime;
+use crate::{AwsAccount, eq};
+
+use super::object::{Object, objects_table};
+
+/// One S3 bucket from `ListBuckets`. The wire shape is
+/// `<Bucket><Name>...</Name><CreationDate>...</CreationDate></Bucket>`
+/// inside `<Buckets>` — we surface those two fields verbatim.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Bucket {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "CreationDate", default)]
+    pub creation_date: String,
+}
+
+/// `ListBuckets` table — every bucket the caller can see. S3 returns
+/// buckets across all regions here, but cross-region object listings
+/// require the bucket's home region — the caller is expected to set
+/// `AwsAccount`'s region accordingly before traversing `:objects`.
+///
+/// Relation:
+///   - `objects` → `ListObjectsV2` for the bucket
+///
+/// ```no_run
+/// # use vantage_aws::AwsAccount;
+/// # use vantage_aws::models::s3::buckets_table;
+/// # async fn run() -> vantage_core::Result<()> {
+/// # let aws = AwsAccount::from_default()?;
+/// let buckets = buckets_table(aws);
+/// # Ok(()) }
+/// ```
+pub fn buckets_table(aws: AwsAccount) -> Table<AwsAccount, Bucket> {
+    Table::new("restxml/Buckets.Bucket:s3/GET /", aws)
+        .with_id_column("Name")
+        .with_title_column_of::<AwsDateTime>("CreationDate")
+        .with_many("objects", "Bucket", objects_table)
+}
+
+impl Bucket {
+    /// Build a [`buckets_table`] narrowed to the bucket named in `arn`.
+    /// Accepts ARNs of the shape `arn:aws:s3:::<name>` (S3 ARNs have
+    /// no region or account segment — that's the protocol's quirk,
+    /// not a bug here).
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Bucket>> {
+        let name = arn.strip_prefix("arn:aws:s3:::")?;
+        // Object-level ARNs (`arn:aws:s3:::bucket/key`) collapse to the
+        // bucket; `Object::from_arn` handles the object-level case.
+        let bucket = name.split('/').next().unwrap_or(name);
+        if bucket.is_empty() {
+            return None;
+        }
+        let mut t = buckets_table(aws);
+        t.add_condition(eq("Name", bucket.to_string()));
+        Some(t)
+    }
+
+    /// Objects table pre-filtered to *this* bucket.
+    pub fn ref_objects(&self, aws: AwsAccount) -> Table<AwsAccount, Object> {
+        let mut t = objects_table(aws);
+        t.add_condition(eq("Bucket", self.name.clone()));
+        t
+    }
+}

--- a/vantage-aws/src/models/s3/mod.rs
+++ b/vantage-aws/src/models/s3/mod.rs
@@ -1,0 +1,18 @@
+//! Ready-made S3 tables — buckets, objects.
+//!
+//! S3 speaks REST-XML (see [`crate::restxml`]). Listing is shallow:
+//! `ListBuckets` returns one row per bucket with name + creation
+//! timestamp; `ListObjectsV2` returns one row per object key under a
+//! given bucket. v0 doesn't paginate — anything past the first page
+//! quietly drops, same caveat as the rest of `vantage-aws`.
+//!
+//! Path-style addressing only — `https://s3.{region}.amazonaws.com/{bucket}/`.
+//! Buckets in regions other than the configured one will surface as
+//! 301 redirects we don't follow; the caller is expected to point
+//! `AwsAccount` at the bucket's home region first.
+
+pub mod bucket;
+pub mod object;
+
+pub use bucket::{Bucket, buckets_table};
+pub use object::{Object, objects_table};

--- a/vantage-aws/src/models/s3/object.rs
+++ b/vantage-aws/src/models/s3/object.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+use vantage_table::table::Table;
+
+use crate::types::AwsDateTime;
+use crate::{AwsAccount, eq};
+
+/// One S3 object from `ListObjectsV2`. Field names match the wire XML
+/// (`<Contents><Key/><Size/>…</Contents>`) — we surface them as-is so
+/// existing S3 docs translate directly. `Size` arrives as a numeric
+/// string in v0 (no XML-to-typed coercion).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Object {
+    #[serde(rename = "Key")]
+    pub key: String,
+    #[serde(rename = "Size", default)]
+    pub size: String,
+    #[serde(rename = "LastModified", default)]
+    pub last_modified: String,
+    #[serde(rename = "ETag", default)]
+    pub etag: String,
+    #[serde(rename = "StorageClass", default)]
+    pub storage_class: String,
+}
+
+/// `ListObjectsV2` table. Requires `eq("Bucket", "...")` — without it
+/// the path placeholder errors out at request-build time. Optional
+/// `prefix` / `delimiter` / `max-keys` filters become query params if
+/// supplied.
+///
+/// Used as the `objects` relation on [`super::bucket::Bucket`] —
+/// traversing from a single bucket fills `Bucket` automatically.
+pub fn objects_table(aws: AwsAccount) -> Table<AwsAccount, Object> {
+    Table::new("restxml/Contents:s3/GET /{Bucket}?list-type=2", aws)
+        .with_id_column("Key")
+        .with_title_column_of::<String>("Size")
+        .with_title_column_of::<AwsDateTime>("LastModified")
+        .with_column_of::<String>("ETag")
+        .with_column_of::<String>("StorageClass")
+}
+
+impl Object {
+    /// Build an [`objects_table`] narrowed to the object named in
+    /// `arn`. Accepts ARNs of the shape `arn:aws:s3:::<bucket>/<key>` —
+    /// the bucket fills the path placeholder, the key narrows
+    /// `prefix` so we only fetch the matching object.
+    pub fn from_arn(arn: &str, aws: AwsAccount) -> Option<Table<AwsAccount, Object>> {
+        let rest = arn.strip_prefix("arn:aws:s3:::")?;
+        let (bucket, key) = rest.split_once('/')?;
+        if bucket.is_empty() || key.is_empty() {
+            return None;
+        }
+        let mut t = objects_table(aws);
+        t.add_condition(eq("Bucket", bucket.to_string()));
+        t.add_condition(eq("prefix", key.to_string()));
+        // The post-hoc client filter at `impls::table_source` will
+        // narrow on `Key` once the response comes back — `prefix` only
+        // narrows server-side, so we add the literal Key match too.
+        t.add_condition(eq("Key", key.to_string()));
+        Some(t)
+    }
+}

--- a/vantage-aws/src/restjson/mod.rs
+++ b/vantage-aws/src/restjson/mod.rs
@@ -1,17 +1,10 @@
-//! JSON-1.1 protocol — the wire used by CloudWatch, ECS, KMS,
-//! DynamoDB control plane, etc.
+//! REST-JSON protocol — Lambda, API Gateway v2, and a few others.
 //!
-//! Two entry points:
-//!   - [`execute`] builds the JSON request body, signs, sends.
-//!   - [`parse_records`] plucks the configured array from the
-//!     parsed response and folds it into `Record<CborValue>`s.
-//!
-//! Both are called from [`crate::dispatch`] after the protocol switch
-//! has fired. The shape that distinguishes JSON-1.1 from sibling
-//! protocols: request body is a JSON object posted with
-//! `Content-Type: application/x-amz-json-1.1` and an `X-Amz-Target`
-//! header naming the operation; response body is a JSON object whose
-//! top-level key is the array of rows.
+//! Same request shape as [`crate::restxml`] (METHOD + path-template,
+//! placeholders filled from conditions, leftovers go to the query
+//! string), but the response body is JSON. Records get plucked using
+//! the dotted-path lookup so callers can target nested arrays
+//! (`Functions`, `Aliases`, `Versions`, …).
 
 mod transport;
 
@@ -22,30 +15,21 @@ use vantage_core::{Result, error};
 use vantage_types::Record;
 
 use crate::account::AwsAccount;
-use crate::condition::{AwsCondition, build_json1_body};
+use crate::condition::AwsCondition;
 use crate::dispatch::{OperationDescriptor, json_to_cbor, lookup_path};
 
-pub(crate) use transport::{json1_call, json_aws_call};
-
-/// Build the JSON-1.1 request body and post it. `target` is used
-/// verbatim as the `X-Amz-Target` header; `service` is both the SigV4
-/// service name and the URL hostname segment.
 pub(crate) async fn execute(
     account: &AwsAccount,
     op: &OperationDescriptor<'_>,
     resolved: &[AwsCondition],
 ) -> Result<JsonValue> {
-    let body = build_json1_body(resolved)?;
-    json1_call(account, op.service, op.target, &JsonValue::Object(body)).await
+    // REST-JSON request shape is identical to REST-XML, so reuse the
+    // builder. Path templating, placeholder substitution, and query
+    // assembly are all in one place.
+    let (method, path, query) = crate::restxml::transport::build_request(op.target, resolved)?;
+    transport::restjson_call(account, op.service, &method, &path, &query).await
 }
 
-/// Pull the configured array out of the response and build records
-/// keyed by `id_field`. Each value is converted from
-/// `serde_json::Value` to `ciborium::Value` via the serde bridge.
-///
-/// Scalar array elements (strings/numbers) get wrapped as
-/// `{<id_field>: value}` — this is what the ECS List* APIs return
-/// (`clusterArns: ["arn:…", …]` instead of objects).
 pub(crate) fn parse_records(
     op: &OperationDescriptor<'_>,
     resp: JsonValue,
@@ -55,7 +39,7 @@ pub(crate) fn parse_records(
         .and_then(|v| v.as_array())
         .ok_or_else(|| {
             error!(
-                "AWS JSON-1.1 response missing expected array key",
+                "AWS REST-JSON response missing expected array key",
                 array_key = op.array_key,
                 body = format!("{}", resp)
             )
@@ -75,7 +59,7 @@ pub(crate) fn parse_records(
             }
             other => {
                 return Err(error!(
-                    "AWS response array entry is not an object or scalar",
+                    "AWS REST-JSON response array entry is not an object or scalar",
                     index = idx,
                     got = format!("{:?}", other)
                 ));

--- a/vantage-aws/src/restjson/transport.rs
+++ b/vantage-aws/src/restjson/transport.rs
@@ -1,0 +1,125 @@
+//! REST-JSON HTTP transport (Lambda etc.).
+//!
+//! Mirror of [`crate::restxml::transport`] but for JSON responses and
+//! without the `x-amz-content-sha256` header — Lambda accepts the
+//! standard SigV4 minimum-signed-headers set without it. Empty body
+//! since v0 is read-only.
+
+use std::time::SystemTime;
+
+use serde_json::Value as JsonValue;
+use vantage_core::{Result, error};
+
+use crate::account::AwsAccount;
+use crate::sign::sign_v4;
+
+pub(crate) async fn restjson_call(
+    account: &AwsAccount,
+    service: &str,
+    method: &str,
+    path: &str,
+    query: &[(String, String)],
+) -> Result<JsonValue> {
+    let region = account.region();
+    if region.is_empty() {
+        return Err(error!(
+            "AWS region is not configured — pass it to AwsAccount::new \
+             or set AWS_REGION before issuing a REST-JSON request"
+        ));
+    }
+    let host = format!("{service}.{region}.amazonaws.com");
+    let url = build_url(&host, path, query);
+
+    let body_bytes: Vec<u8> = Vec::new();
+
+    let signing_headers = [("host".to_string(), host.clone())];
+
+    let signed = sign_v4(
+        account.access_key(),
+        account.secret_key(),
+        account.session_token(),
+        region,
+        service,
+        method,
+        &url,
+        &signing_headers,
+        &body_bytes,
+        SystemTime::now(),
+    )?;
+
+    let req_builder = match method {
+        "GET" => account.http().get(&url),
+        "HEAD" => account.http().head(&url),
+        other => {
+            return Err(error!(
+                "REST-JSON transport currently only supports read methods",
+                method = other
+            ));
+        }
+    };
+    let mut req = req_builder;
+    for h in &signed {
+        req = req.header(h.name.as_str(), h.value.as_str());
+    }
+
+    let resp = req.send().await.map_err(|e| {
+        error!(
+            "AWS REST-JSON request failed",
+            url = url.as_str(),
+            method = method,
+            detail = e
+        )
+    })?;
+
+    let status = resp.status();
+    let response_text = resp
+        .text()
+        .await
+        .map_err(|e| error!("Failed to read AWS REST-JSON response body", detail = e))?;
+
+    if !status.is_success() {
+        return Err(error!(
+            "AWS REST-JSON request returned error status",
+            url = url.as_str(),
+            status = status.as_u16(),
+            body = response_text
+        ));
+    }
+
+    serde_json::from_str(&response_text).map_err(|e| {
+        error!(
+            "Failed to parse AWS REST-JSON response",
+            detail = e,
+            body_preview = response_text.chars().take(200).collect::<String>()
+        )
+    })
+}
+
+fn build_url(host: &str, path: &str, query: &[(String, String)]) -> String {
+    let mut url = format!("https://{host}{path}");
+    if !query.is_empty() {
+        url.push('?');
+        for (i, (k, v)) in query.iter().enumerate() {
+            if i > 0 {
+                url.push('&');
+            }
+            url.push_str(&query_part_encode(k));
+            url.push('=');
+            url.push_str(&query_part_encode(v));
+        }
+    }
+    url
+}
+
+fn query_part_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        let unreserved = b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~');
+        if unreserved {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("%{b:02X}"));
+        }
+    }
+    out
+}

--- a/vantage-aws/src/restxml/mod.rs
+++ b/vantage-aws/src/restxml/mod.rs
@@ -1,0 +1,113 @@
+//! REST-XML protocol — the wire used by S3 (and a handful of older
+//! services like Route 53 and CloudFront).
+//!
+//! Two entry points:
+//!   - [`execute`] builds the URL from a `METHOD path-template` target,
+//!     fills `{Placeholder}` segments from conditions, and posts the
+//!     remainder to the query string.
+//!   - [`parse_records`] strips the outer XML root and plucks the
+//!     configured array — supports dotted lookup (`Buckets.Bucket`)
+//!     since S3 nests its lists.
+//!
+//! Target syntax: `"METHOD path?static-query"` — e.g.
+//! `"GET /{Bucket}?list-type=2"` for `ListObjectsV2`. Conditions whose
+//! field name matches a `{Placeholder}` get spliced into the path; all
+//! others append to the query string.
+//!
+//! S3 mandates `x-amz-content-sha256` on every signed request, so the
+//! transport adds it unconditionally. Other REST-XML services accept
+//! it without complaint, so we don't gate on the service name.
+
+pub(crate) mod transport;
+mod xml;
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use serde_json::Value as JsonValue;
+use vantage_core::{Result, error};
+use vantage_types::Record;
+
+use crate::account::AwsAccount;
+use crate::condition::AwsCondition;
+use crate::dispatch::{OperationDescriptor, json_to_cbor, lookup_path};
+
+pub(crate) use transport::restxml_call;
+
+/// Build the URL from `METHOD path?query`, fill path placeholders from
+/// conditions, send the (empty-body) request, and parse the XML
+/// response into a normalised `JsonValue`.
+pub(crate) async fn execute(
+    account: &AwsAccount,
+    op: &OperationDescriptor<'_>,
+    resolved: &[AwsCondition],
+) -> Result<JsonValue> {
+    let (method, path, query) = transport::build_request(op.target, resolved)?;
+    let body = restxml_call(account, op.service, &method, &path, &query).await?;
+    xml::parse_xml_response(&body)
+}
+
+/// Pull `op.array_key` out of the parsed response. S3 wraps its lists
+/// inside a named element (`<Buckets>` containing repeated `<Bucket>`),
+/// not the IAM-style `<member>` shim, so callers point at the array
+/// with a dotted path: `array_key = "Buckets.Bucket"`.
+///
+/// Plain (no dot) array keys still work for flat shapes like S3's
+/// `<Contents>` repeats inside `<ListBucketResult>`.
+pub(crate) fn parse_records(
+    op: &OperationDescriptor<'_>,
+    resp: JsonValue,
+    id_field: Option<&str>,
+) -> Result<IndexMap<String, Record<CborValue>>> {
+    let array = match lookup_path(&resp, op.array_key) {
+        Some(JsonValue::Array(a)) => a.clone(),
+        // Single repeating element: the XML normaliser kept it scalar.
+        // Promote to a one-element array so the caller sees a row.
+        Some(JsonValue::Object(_)) => vec![lookup_path(&resp, op.array_key).unwrap().clone()],
+        // Empty self-closing element collapses to "" — treat as no rows.
+        Some(JsonValue::String(s)) if s.is_empty() => Vec::new(),
+        Some(other) => {
+            return Err(error!(
+                "AWS REST-XML response array key has unexpected shape",
+                array_key = op.array_key,
+                got = format!("{:?}", other),
+                body = format!("{}", resp)
+            ));
+        }
+        None => Vec::new(),
+    };
+
+    let scalar_field = id_field.unwrap_or("value");
+
+    let mut out = IndexMap::with_capacity(array.len());
+    for (idx, item) in array.into_iter().enumerate() {
+        let obj = match item {
+            JsonValue::Object(map) => map,
+            JsonValue::String(_) | JsonValue::Number(_) => {
+                let mut m = serde_json::Map::new();
+                m.insert(scalar_field.to_string(), item);
+                m
+            }
+            other => {
+                return Err(error!(
+                    "AWS REST-XML response array entry is not an object or scalar",
+                    index = idx,
+                    got = format!("{:?}", other)
+                ));
+            }
+        };
+
+        let id = id_field
+            .and_then(|f| obj.get(f))
+            .and_then(|v| match v {
+                JsonValue::String(s) => Some(s.clone()),
+                JsonValue::Number(n) => Some(n.to_string()),
+                _ => None,
+            })
+            .unwrap_or_else(|| idx.to_string());
+
+        let record: Record<CborValue> =
+            obj.into_iter().map(|(k, v)| (k, json_to_cbor(v))).collect();
+        out.insert(id, record);
+    }
+    Ok(out)
+}

--- a/vantage-aws/src/restxml/transport.rs
+++ b/vantage-aws/src/restxml/transport.rs
@@ -1,0 +1,361 @@
+//! REST-XML HTTP transport (S3 etc.).
+//!
+//! Two halves:
+//!   - [`build_request`] turns the operation's `"METHOD path?query"`
+//!     target plus the resolved conditions into the wire-ready
+//!     `(method, path, query_pairs)`. Path placeholders (`{Bucket}`)
+//!     pull their value from conditions; remaining conditions become
+//!     query-string params.
+//!   - [`restxml_call`] signs and sends the request, returning the raw
+//!     XML text.
+//!
+//! Path-style addressing only — `https://{service}.{region}.amazonaws.com/...`.
+//! Virtual-host style (`{bucket}.s3.{region}...`) would need DNS-safe
+//! bucket names and additional cross-region routing; v0 stays simple
+//! and lets the caller set the region for the bucket they're targeting.
+//!
+//! S3 always requires `x-amz-content-sha256` to be a signed header
+//! with the body's hex sha256. We add it unconditionally for every
+//! REST-XML service — others accept it fine, S3 errors without it.
+
+use std::time::SystemTime;
+
+use vantage_core::{Result, error};
+
+use crate::account::AwsAccount;
+use crate::condition::AwsCondition;
+use crate::sign::sign_v4;
+
+/// SHA256 of the empty body — used as the `x-amz-content-sha256`
+/// value for every read-only request we issue (always GET / no body).
+const EMPTY_BODY_SHA256: &str =
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+/// Parse a `"METHOD path?query"` target and splice the resolved
+/// conditions in: `{Placeholder}` segments take their value from a
+/// matching `eq("Placeholder", _)` condition, and any leftover
+/// conditions are appended to the query string.
+///
+/// Returns `(method, path, query_pairs)`. `query_pairs` carry the
+/// static query from the target plus any condition-derived params,
+/// in target-then-condition order.
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_request(
+    target: &str,
+    resolved: &[AwsCondition],
+) -> Result<(String, String, Vec<(String, String)>)> {
+    let (method, rest) = target.split_once(' ').ok_or_else(|| {
+        error!(
+            "REST target must be \"METHOD path[?query]\" — got",
+            target = target
+        )
+    })?;
+    let method = method.trim().to_ascii_uppercase();
+    let (path_template, static_query) = match rest.split_once('?') {
+        Some((p, q)) => (p, q),
+        None => (rest, ""),
+    };
+
+    // Pull (field, value) pairs from the resolved conditions. By the
+    // time we get here Deferred has been materialised, multi-value
+    // sets have errored out.
+    let mut params: Vec<(String, String)> = Vec::with_capacity(resolved.len());
+    for cond in resolved {
+        match cond {
+            AwsCondition::Eq { field, value } => {
+                params.push((field.clone(), cbor_scalar_to_string(value)));
+            }
+            AwsCondition::In { field, values } => match values.as_slice() {
+                [single] => params.push((field.clone(), cbor_scalar_to_string(single))),
+                [] => {
+                    return Err(error!(
+                        "AwsCondition::In with zero values is not representable",
+                        field = field.as_str()
+                    ));
+                }
+                _ => {
+                    return Err(error!(
+                        "AWS REST APIs don't accept multi-value filters; \
+                         resolved condition must collapse to one value",
+                        field = field.as_str(),
+                        count = values.len()
+                    ));
+                }
+            },
+            AwsCondition::Deferred { field, .. } => {
+                return Err(error!(
+                    "Internal: Deferred condition reached REST builder unresolved",
+                    field = field.as_str()
+                ));
+            }
+        }
+    }
+
+    // Substitute {Placeholder} segments from the params, dropping each
+    // one we consumed so it doesn't reappear in the query string.
+    let mut path = String::with_capacity(path_template.len());
+    let mut consumed: Vec<String> = Vec::new();
+    let mut chars = path_template.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '{' {
+            let mut name = String::new();
+            for nc in chars.by_ref() {
+                if nc == '}' {
+                    break;
+                }
+                name.push(nc);
+            }
+            let value = params
+                .iter()
+                .find(|(k, _)| k == &name)
+                .map(|(_, v)| v.clone())
+                .ok_or_else(|| {
+                    error!(
+                        "REST path placeholder has no matching condition",
+                        placeholder = name.as_str()
+                    )
+                })?;
+            // Path segments are URL-path-encoded — keep `/` literal so
+            // multi-segment placeholders (rare, but Lambda allows them)
+            // don't double-encode.
+            path.push_str(&path_segment_encode(&value));
+            consumed.push(name);
+        } else {
+            path.push(c);
+        }
+    }
+
+    // Build the query string: static pairs from the target first, then
+    // conditions that weren't consumed by path placeholders. Both come
+    // through the same encoder so signing matches the wire bytes.
+    let mut query_pairs: Vec<(String, String)> = Vec::new();
+    if !static_query.is_empty() {
+        for kv in static_query.split('&') {
+            let (k, v) = match kv.split_once('=') {
+                Some((k, v)) => (k.to_string(), v.to_string()),
+                None => (kv.to_string(), String::new()),
+            };
+            query_pairs.push((k, v));
+        }
+    }
+    for (k, v) in params {
+        if consumed.contains(&k) {
+            continue;
+        }
+        query_pairs.push((k, v));
+    }
+
+    Ok((method, path, query_pairs))
+}
+
+/// Issue a signed REST-XML request and return the response body as
+/// raw text. Empty body — we're read-only in v0.
+pub(crate) async fn restxml_call(
+    account: &AwsAccount,
+    service: &str,
+    method: &str,
+    path: &str,
+    query: &[(String, String)],
+) -> Result<String> {
+    let region = account.region();
+    if region.is_empty() {
+        return Err(error!(
+            "AWS region is not configured — pass it to AwsAccount::new \
+             or set AWS_REGION before issuing a REST-XML request"
+        ));
+    }
+    let host = format!("{service}.{region}.amazonaws.com");
+    let url = build_url(&host, path, query);
+
+    let body_bytes: Vec<u8> = Vec::new();
+
+    let signing_headers = [
+        ("host".to_string(), host.clone()),
+        (
+            "x-amz-content-sha256".to_string(),
+            EMPTY_BODY_SHA256.to_string(),
+        ),
+    ];
+
+    let signed = sign_v4(
+        account.access_key(),
+        account.secret_key(),
+        account.session_token(),
+        region,
+        service,
+        method,
+        &url,
+        &signing_headers,
+        &body_bytes,
+        SystemTime::now(),
+    )?;
+
+    let req_builder = match method {
+        "GET" => account.http().get(&url),
+        "HEAD" => account.http().head(&url),
+        other => {
+            return Err(error!(
+                "REST-XML transport currently only supports read methods",
+                method = other
+            ));
+        }
+    };
+    let mut req = req_builder.header("x-amz-content-sha256", EMPTY_BODY_SHA256);
+    for h in &signed {
+        req = req.header(h.name.as_str(), h.value.as_str());
+    }
+
+    let resp = req.send().await.map_err(|e| {
+        error!(
+            "AWS REST-XML request failed",
+            url = url.as_str(),
+            method = method,
+            detail = e
+        )
+    })?;
+
+    let status = resp.status();
+    let response_text = resp
+        .text()
+        .await
+        .map_err(|e| error!("Failed to read AWS REST-XML response body", detail = e))?;
+
+    if !status.is_success() {
+        return Err(error!(
+            "AWS REST-XML request returned error status",
+            url = url.as_str(),
+            status = status.as_u16(),
+            body = response_text
+        ));
+    }
+
+    Ok(response_text)
+}
+
+fn build_url(host: &str, path: &str, query: &[(String, String)]) -> String {
+    let mut url = format!("https://{host}{path}");
+    if !query.is_empty() {
+        url.push('?');
+        for (i, (k, v)) in query.iter().enumerate() {
+            if i > 0 {
+                url.push('&');
+            }
+            url.push_str(&query_part_encode(k));
+            url.push('=');
+            url.push_str(&query_part_encode(v));
+        }
+    }
+    url
+}
+
+/// Path-segment encoder: keep `/` literal (multi-segment placeholders
+/// like `{Key}` may legitimately contain it) and percent-encode the
+/// rest of the reserved set per RFC 3986.
+fn path_segment_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        let unreserved = b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~' | b'/');
+        if unreserved {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("%{b:02X}"));
+        }
+    }
+    out
+}
+
+/// Query-string component encoder — matches the SigV4 alphabet.
+fn query_part_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        let unreserved = b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~');
+        if unreserved {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("%{b:02X}"));
+        }
+    }
+    out
+}
+
+/// Render a CBOR scalar for use in a path / query string. Matches the
+/// shape of `condition::cbor_to_string` — kept local to avoid making
+/// that module's helper public.
+fn cbor_scalar_to_string(v: &ciborium::Value) -> String {
+    match v {
+        ciborium::Value::Text(s) => s.clone(),
+        ciborium::Value::Integer(i) => {
+            let n: i128 = (*i).into();
+            n.to_string()
+        }
+        ciborium::Value::Float(f) => f.to_string(),
+        ciborium::Value::Bool(b) => b.to_string(),
+        ciborium::Value::Null => String::new(),
+        // Compound values shouldn't reach here for REST APIs, but
+        // defensively render via JSON so we don't drop data silently.
+        other => other
+            .deserialized::<serde_json::Value>()
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::condition::AwsCondition;
+    use ciborium::Value as CborValue;
+
+    #[test]
+    fn build_request_substitutes_placeholders_from_conditions() {
+        let target = "GET /{Bucket}?list-type=2";
+        let conds = [AwsCondition::Eq {
+            field: "Bucket".into(),
+            value: CborValue::from("my-bucket"),
+        }];
+        let (m, p, q) = build_request(target, &conds).unwrap();
+        assert_eq!(m, "GET");
+        assert_eq!(p, "/my-bucket");
+        assert_eq!(q, vec![("list-type".to_string(), "2".to_string())]);
+    }
+
+    #[test]
+    fn build_request_pushes_unmatched_conditions_to_query() {
+        let target = "GET /{Bucket}?list-type=2";
+        let conds = [
+            AwsCondition::Eq {
+                field: "Bucket".into(),
+                value: CborValue::from("foo"),
+            },
+            AwsCondition::Eq {
+                field: "prefix".into(),
+                value: CborValue::from("logs/"),
+            },
+        ];
+        let (_m, p, q) = build_request(target, &conds).unwrap();
+        assert_eq!(p, "/foo");
+        assert_eq!(
+            q,
+            vec![
+                ("list-type".to_string(), "2".to_string()),
+                ("prefix".to_string(), "logs/".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_request_errors_on_missing_placeholder_value() {
+        let target = "GET /{Bucket}";
+        let err = build_request(target, &[]).unwrap_err();
+        assert!(format!("{err}").contains("placeholder"));
+    }
+
+    #[test]
+    fn build_request_no_query_section_is_fine() {
+        let target = "GET /";
+        let (m, p, q) = build_request(target, &[]).unwrap();
+        assert_eq!(m, "GET");
+        assert_eq!(p, "/");
+        assert!(q.is_empty());
+    }
+}

--- a/vantage-aws/src/restxml/transport.rs
+++ b/vantage-aws/src/restxml/transport.rs
@@ -28,8 +28,7 @@ use crate::sign::sign_v4;
 
 /// SHA256 of the empty body — used as the `x-amz-content-sha256`
 /// value for every read-only request we issue (always GET / no body).
-const EMPTY_BODY_SHA256: &str =
-    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+const EMPTY_BODY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
 /// Parse a `"METHOD path?query"` target and splice the resolved
 /// conditions in: `{Placeholder}` segments take their value from a

--- a/vantage-aws/src/restxml/xml.rs
+++ b/vantage-aws/src/restxml/xml.rs
@@ -1,0 +1,249 @@
+//! REST-XML response normaliser.
+//!
+//! S3 (and other rest-xml services) skip the `<{Action}Response>` /
+//! `<{Action}Result>` wrappers that the AWS Query protocol uses —
+//! the response root *is* the result element. So this parser strips
+//! the root element and surfaces its children as a JSON object,
+//! collapsing repeated child names into JSON arrays.
+//!
+//! That lets callers reach into the response with a dotted lookup
+//! like `Buckets.Bucket` for `ListBuckets`, or `Contents` for
+//! `ListObjectsV2`.
+
+use quick_xml::Reader;
+use quick_xml::events::Event;
+use serde_json::{Map, Value as JsonValue};
+use vantage_core::{Result, error};
+
+pub(crate) fn parse_xml_response(xml: &str) -> Result<JsonValue> {
+    let root = parse_root_element(xml)?;
+    match root {
+        XmlNode::Element { children, .. } => {
+            let refs: Vec<&XmlNode> = children.iter().collect();
+            Ok(nodes_to_json(&refs))
+        }
+        XmlNode::Text(t) => Ok(JsonValue::String(t)),
+    }
+}
+
+#[derive(Debug)]
+enum XmlNode {
+    Element {
+        name: String,
+        children: Vec<XmlNode>,
+    },
+    Text(String),
+}
+
+fn parse_root_element(xml: &str) -> Result<XmlNode> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(e)) => {
+                let name = local_name(e.name().as_ref());
+                let children = read_children(&mut reader)?;
+                return Ok(XmlNode::Element { name, children });
+            }
+            Ok(Event::Empty(e)) => {
+                let name = local_name(e.name().as_ref());
+                return Ok(XmlNode::Element {
+                    name,
+                    children: Vec::new(),
+                });
+            }
+            Ok(Event::Eof) => {
+                return Err(error!("AWS REST-XML response is empty"));
+            }
+            Ok(_) => continue,
+            Err(e) => {
+                return Err(error!("Failed to parse AWS REST-XML response", detail = e));
+            }
+        }
+    }
+}
+
+fn read_children(reader: &mut Reader<&[u8]>) -> Result<Vec<XmlNode>> {
+    let mut children = Vec::new();
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(e)) => {
+                let name = local_name(e.name().as_ref());
+                let nested = read_children(reader)?;
+                children.push(XmlNode::Element {
+                    name,
+                    children: nested,
+                });
+            }
+            Ok(Event::Empty(e)) => {
+                let name = local_name(e.name().as_ref());
+                children.push(XmlNode::Element {
+                    name,
+                    children: Vec::new(),
+                });
+            }
+            Ok(Event::Text(t)) => {
+                let s = t
+                    .unescape()
+                    .map_err(|e| error!("XML text decode failed", detail = e))?
+                    .into_owned();
+                if !s.is_empty() {
+                    children.push(XmlNode::Text(s));
+                }
+            }
+            Ok(Event::CData(t)) => {
+                children.push(XmlNode::Text(
+                    String::from_utf8_lossy(t.as_ref()).into_owned(),
+                ));
+            }
+            Ok(Event::End(_)) => return Ok(children),
+            Ok(Event::Eof) => {
+                return Err(error!("AWS REST-XML ended mid-element"));
+            }
+            Ok(_) => continue,
+            Err(e) => {
+                return Err(error!("Failed to parse AWS REST-XML", detail = e));
+            }
+        }
+    }
+}
+
+fn local_name(qname: &[u8]) -> String {
+    let s = std::str::from_utf8(qname).unwrap_or("");
+    match s.split_once(':') {
+        Some((_, local)) => local.to_string(),
+        None => s.to_string(),
+    }
+}
+
+fn element_children_to_json(children: &[XmlNode]) -> JsonValue {
+    let refs: Vec<&XmlNode> = children.iter().collect();
+    nodes_to_json(&refs)
+}
+
+fn nodes_to_json(children: &[&XmlNode]) -> JsonValue {
+    let only_text =
+        !children.is_empty() && children.iter().all(|n| matches!(n, XmlNode::Text(_)));
+    if only_text {
+        let mut s = String::new();
+        for n in children {
+            if let XmlNode::Text(t) = n {
+                s.push_str(t);
+            }
+        }
+        return JsonValue::String(s);
+    }
+
+    let elements: Vec<&XmlNode> = children
+        .iter()
+        .copied()
+        .filter(|n| matches!(n, XmlNode::Element { .. }))
+        .collect();
+
+    if elements.is_empty() {
+        return JsonValue::String(String::new());
+    }
+
+    // Same flattening rule as the Query parser, minus the `<member>`
+    // shortcut: REST-XML names every element after its entity
+    // (`<Bucket>`, `<Contents>`), so repeated children with the same
+    // name collapse into a JSON array.
+    let mut map: Map<String, JsonValue> = Map::new();
+    for n in &elements {
+        if let XmlNode::Element { name, children } = n {
+            let v = element_children_to_json(children);
+            match map.remove(name) {
+                None => {
+                    map.insert(name.clone(), v);
+                }
+                Some(existing) => {
+                    let arr = match existing {
+                        JsonValue::Array(mut a) => {
+                            a.push(v);
+                            a
+                        }
+                        other => vec![other, v],
+                    };
+                    map.insert(name.clone(), JsonValue::Array(arr));
+                }
+            }
+        }
+    }
+    JsonValue::Object(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn list_buckets_response_round_trip() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+   <Owner>
+      <ID>abc</ID>
+      <DisplayName>name</DisplayName>
+   </Owner>
+   <Buckets>
+      <Bucket>
+         <Name>foo</Name>
+         <CreationDate>2024-01-01T00:00:00Z</CreationDate>
+      </Bucket>
+      <Bucket>
+         <Name>bar</Name>
+         <CreationDate>2024-02-01T00:00:00Z</CreationDate>
+      </Bucket>
+   </Buckets>
+</ListAllMyBucketsResult>"#;
+        let v = parse_xml_response(xml).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "Owner": { "ID": "abc", "DisplayName": "name" },
+                "Buckets": {
+                    "Bucket": [
+                        { "Name": "foo", "CreationDate": "2024-01-01T00:00:00Z" },
+                        { "Name": "bar", "CreationDate": "2024-02-01T00:00:00Z" },
+                    ]
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn list_objects_v2_response_round_trip() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+   <Name>my-bucket</Name>
+   <KeyCount>2</KeyCount>
+   <Contents>
+      <Key>a/b.txt</Key>
+      <Size>10</Size>
+      <ETag>"x"</ETag>
+   </Contents>
+   <Contents>
+      <Key>a/c.txt</Key>
+      <Size>20</Size>
+      <ETag>"y"</ETag>
+   </Contents>
+</ListBucketResult>"#;
+        let v = parse_xml_response(xml).unwrap();
+        assert_eq!(
+            v["Contents"],
+            json!([
+                { "Key": "a/b.txt", "Size": "10", "ETag": "\"x\"" },
+                { "Key": "a/c.txt", "Size": "20", "ETag": "\"y\"" },
+            ])
+        );
+    }
+
+    #[test]
+    fn empty_root_element_is_empty_object_shape() {
+        let xml = r#"<ListBucketResult/>"#;
+        let v = parse_xml_response(xml).unwrap();
+        // No children at all — falls through to empty-string shape.
+        assert_eq!(v, json!(""));
+    }
+}

--- a/vantage-aws/src/restxml/xml.rs
+++ b/vantage-aws/src/restxml/xml.rs
@@ -123,8 +123,7 @@ fn element_children_to_json(children: &[XmlNode]) -> JsonValue {
 }
 
 fn nodes_to_json(children: &[&XmlNode]) -> JsonValue {
-    let only_text =
-        !children.is_empty() && children.iter().all(|n| matches!(n, XmlNode::Text(_)));
+    let only_text = !children.is_empty() && children.iter().all(|n| matches!(n, XmlNode::Text(_)));
     if only_text {
         let mut s = String::new();
         for n in children {

--- a/vantage-cli-util/CHANGELOG.md
+++ b/vantage-cli-util/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.1 — 2026-04-30
+
+- New `model_cli` module — generic, model-driven CLI runner over any `AnyTable`. Argv shape: `<model | arn> [field=value ...] [[N]] [:relation [[N]] ...] [=col1,col2 ...]`. Singular vs plural model names drive list/single mode; `id=value` is sugar that resolves to the table's id field and forces single-record mode; `[N]` selects the Nth record and switches into single-record mode by adding `eq(id_field, that_id)`; `:relation` traverses a registered `with_many` / `with_one`; `=col1,col2` overrides the visible columns in list mode. Glued forms (`users[0]`, `:members[0]`, `name=foo[0]`, `=msg,timestamp[0]`) split into a base token plus an index selector.
+- Two new traits the caller implements: `ModelFactory` (resolve a name or ARN to an `AnyTable`) and `Renderer` (render lists / single records). The crate stays UI-/backend-agnostic — actual record rendering is delegated to the caller.
+- New `render_records_columns` helper alongside the existing `render_records_typed`. Takes an explicit column list and does *not* auto-prepend an id column — for the case where the caller spelled out exactly what they want to see (e.g. the `=col1,col2` override path) and an extra id column would just be noise. Existing `render_records` / `render_records_typed` are unchanged.
+- New `ciborium` dep (used at the model_cli boundary, where records flow as `Record<CborValue>`).
+- Pins `vantage-table = "0.4.8"` for the new `TableLike` reflection methods (`id_field_name`, `title_field_names`, `column_types`, `get_ref_names`, `add_condition_eq`).
+
 ## 0.4.0 — 2026-04-16
 
 - Initial 0.4 release. Generic CLI helpers (`render_records`, `handle_commands`) for driving any vantage backend through a uniform command set.

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/romaninsh/vantage"
 
 [dependencies]
 async-trait = "0.1"
+ciborium = "0.2.2"
 comfy-table = { version = "7", features = ["custom_styling"] }
 indexmap = "2"
 owo-colors = "4"

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-cli-util"
-version = "0.4.0"
+version = "0.4.1"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "CLI utilities for Vantage data framework"
@@ -15,5 +15,5 @@ indexmap = "2"
 owo-colors = "4"
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
-vantage-table = { version = "0.4", path = "../vantage-table" }
+vantage-table = { version = "0.4.8", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types" }

--- a/vantage-cli-util/src/lib.rs
+++ b/vantage-cli-util/src/lib.rs
@@ -1,3 +1,7 @@
+pub mod model_cli;
 mod table_display;
 
-pub use table_display::{print_table, render_records, render_records_typed};
+pub use model_cli::{Mode, ModelFactory, Renderer};
+pub use table_display::{
+    print_table, render_records, render_records_columns, render_records_typed,
+};

--- a/vantage-cli-util/src/model_cli.rs
+++ b/vantage-cli-util/src/model_cli.rs
@@ -1,0 +1,395 @@
+//! Generic model-driven CLI runner.
+//!
+//! Drives an `AnyTable` from positional argv tokens — model name, ARN,
+//! `field=value` filters, `[N]` index selectors, and `:relation`
+//! traversals. Backend specifics (which names map to which tables, how
+//! ARNs are parsed, how records are rendered) are injected through the
+//! [`ModelFactory`] and [`Renderer`] traits.
+//!
+//! ## Token forms
+//!
+//! - `arn:...` — ARN; resolved via [`ModelFactory::for_arn`]; drops
+//!   straight into single-record mode.
+//! - `iam.user`, `iam.users` — model name (singular drops into single
+//!   mode, plural into list mode).
+//! - `field=value` or `field="quoted value"` — adds an equality
+//!   condition. Multiple are ANDed.
+//! - `[N]` — selects the Nth record from a list (zero-indexed) and
+//!   narrows the table to that record. Switches to single-record mode.
+//! - `:relation` — traverses a relation registered via `with_many` /
+//!   `with_one`. Only allowed in single-record mode (so the deferred
+//!   child query yields a single foreign-key value); switches to list
+//!   mode for the child table.
+//! - `=col1,col2,...` — overrides the visible columns in list mode.
+//!   Stays in effect for the rest of the run; later relation
+//!   traversals reset it. The literal `id` resolves to the table's id
+//!   field at render time.
+//!
+//! Glued forms are accepted: `users[0]`, `:members[0]`,
+//! `name=foo[0]`, and `=col1,col2[0]` all split into a base token plus
+//! an index selector.
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_table::any::AnyTable;
+use vantage_table::traits::table_like::TableLike;
+use vantage_types::Record;
+
+/// Whether the current state is a list of records or a single record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    List,
+    Single,
+}
+
+/// Resolves model identifiers (singular/plural names, ARNs) to
+/// `AnyTable`s. Implemented per-backend.
+pub trait ModelFactory {
+    /// Resolve a model name (e.g. `iam.user` or `iam.users`).
+    /// Singular names should return [`Mode::Single`], plural
+    /// [`Mode::List`]. Returns `None` for unknown names.
+    fn for_name(&self, name: &str) -> Option<(AnyTable, Mode)>;
+
+    /// Resolve an ARN to a single-record table with any required
+    /// conditions (e.g. resource-name eq) already applied.
+    fn for_arn(&self, arn: &str) -> Option<AnyTable>;
+}
+
+/// Backend hook for printing list and single-record results.
+pub trait Renderer {
+    fn render_list(
+        &self,
+        table: &AnyTable,
+        records: &IndexMap<String, Record<CborValue>>,
+        column_override: Option<&[String]>,
+    );
+    fn render_record(
+        &self,
+        table: &AnyTable,
+        id: &str,
+        record: &Record<CborValue>,
+        relations: &[String],
+    );
+}
+
+#[derive(Debug)]
+enum Token {
+    ModelName(String, Option<usize>),
+    Arn(String),
+    Condition(String, String, Option<usize>),
+    Relation(String, Option<usize>),
+    Index(usize),
+    Columns(Vec<String>, Option<usize>),
+}
+
+fn split_index_suffix(s: &str) -> (&str, Option<usize>) {
+    if let Some(stripped) = s.strip_suffix(']') {
+        if let Some(open) = stripped.rfind('[') {
+            let inner = &stripped[open + 1..];
+            if !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit()) {
+                if let Ok(n) = inner.parse::<usize>() {
+                    return (&stripped[..open], Some(n));
+                }
+            }
+        }
+    }
+    (s, None)
+}
+
+fn parse_token(arg: &str) -> Result<Token> {
+    if arg.is_empty() {
+        return Err(error!("Empty argument"));
+    }
+    if arg.starts_with("arn:") {
+        return Ok(Token::Arn(arg.to_string()));
+    }
+    if let Some(rest) = arg.strip_prefix(':') {
+        let (rel, idx) = split_index_suffix(rest);
+        if rel.is_empty() {
+            return Err(error!(format!("Empty relation name in token `{arg}`")));
+        }
+        return Ok(Token::Relation(rel.to_string(), idx));
+    }
+    if arg.starts_with('[') {
+        let (_, idx) = split_index_suffix(arg);
+        let idx = idx.ok_or_else(|| error!(format!("Invalid index token `{arg}`")))?;
+        return Ok(Token::Index(idx));
+    }
+    if let Some(rest) = arg.strip_prefix('=') {
+        let (cols_part, idx) = split_index_suffix(rest);
+        if cols_part.is_empty() {
+            return Err(error!(format!(
+                "Empty column list in token `{arg}` — write `=col1,col2`"
+            )));
+        }
+        let cols: Vec<String> = cols_part
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if cols.is_empty() {
+            return Err(error!(format!("Empty column list in token `{arg}`")));
+        }
+        return Ok(Token::Columns(cols, idx));
+    }
+    if let Some(eq_pos) = arg.find('=') {
+        let field = arg[..eq_pos].to_string();
+        if field.is_empty() {
+            return Err(error!(format!("Empty field name in token `{arg}`")));
+        }
+        let value_part = &arg[eq_pos + 1..];
+        let (value, idx) = if value_part.starts_with('"') && value_part.ends_with('"') && value_part.len() >= 2 {
+            (value_part[1..value_part.len() - 1].to_string(), None)
+        } else {
+            let (v, i) = split_index_suffix(value_part);
+            (v.to_string(), i)
+        };
+        return Ok(Token::Condition(field, value, idx));
+    }
+    let (name, idx) = split_index_suffix(arg);
+    Ok(Token::ModelName(name.to_string(), idx))
+}
+
+/// Run a model-driven CLI.
+///
+/// `args` is the list of positional arguments after any global flags
+/// (region, profile, etc.) have been stripped out.
+pub async fn run<F: ModelFactory, R: Renderer>(
+    factory: &F,
+    renderer: &R,
+    args: &[String],
+) -> Result<()> {
+    if args.is_empty() {
+        return Err(error!(
+            "No model specified — pass a model name (e.g. `iam.users`) or an ARN"
+        ));
+    }
+
+    let mut tokens: Vec<Token> = args.iter().map(|s| parse_token(s)).collect::<Result<_>>()?;
+    let first = tokens.remove(0);
+    let mut column_override: Option<Vec<String>> = None;
+
+    let (mut table, mut mode) = match first {
+        Token::ModelName(name, idx) => {
+            let (t, m) = factory
+                .for_name(&name)
+                .ok_or_else(|| error!(format!("Unknown model `{name}`")))?;
+            if let Some(i) = idx {
+                apply_index(t, i).await?
+            } else {
+                (t, m)
+            }
+        }
+        Token::Arn(arn) => {
+            let t = factory
+                .for_arn(&arn)
+                .ok_or_else(|| error!(format!("Cannot resolve ARN `{arn}`")))?;
+            (t, Mode::Single)
+        }
+        Token::Condition(_, _, _)
+        | Token::Relation(_, _)
+        | Token::Index(_)
+        | Token::Columns(_, _) => {
+            return Err(error!(format!(
+                "First argument must be a model name or ARN, got `{}`",
+                args[0]
+            )));
+        }
+    };
+
+    for token in tokens {
+        match token {
+            Token::Condition(field, value, idx) => {
+                // `id=value` is a sugared "fetch this specific record":
+                // resolve to the actual id field and force single-record
+                // mode. Anything else is just a regular eq filter.
+                let is_id_alias = field == "id";
+                let resolved_field = if is_id_alias {
+                    table.id_field_name().ok_or_else(|| {
+                        error!(format!(
+                            "`id=` used but table `{}` has no id field",
+                            table.table_name()
+                        ))
+                    })?
+                } else {
+                    field.clone()
+                };
+                table.add_condition_eq(&resolved_field, &value)?;
+                if is_id_alias {
+                    mode = Mode::Single;
+                }
+                if let Some(i) = idx {
+                    let (t, m) = apply_index(table, i).await?;
+                    table = t;
+                    mode = m;
+                }
+            }
+            Token::Index(i) => {
+                let (t, m) = apply_index(table, i).await?;
+                table = t;
+                mode = m;
+            }
+            Token::Relation(rel, idx) => {
+                if mode != Mode::Single {
+                    return Err(error!(format!(
+                        "Cannot traverse `:{rel}` from list mode — narrow to a single record first (add a filter or `[N]`)"
+                    )));
+                }
+                table = table.get_ref(&rel)?;
+                mode = Mode::List;
+                // A new table means the column override no longer
+                // applies — drop it so the child renders with its own
+                // default columns until a new override appears.
+                column_override = None;
+                if let Some(i) = idx {
+                    let (t, m) = apply_index(table, i).await?;
+                    table = t;
+                    mode = m;
+                }
+            }
+            Token::Columns(cols, idx) => {
+                column_override = Some(cols);
+                if let Some(i) = idx {
+                    let (t, m) = apply_index(table, i).await?;
+                    table = t;
+                    mode = m;
+                }
+            }
+            Token::ModelName(_, _) | Token::Arn(_) => {
+                return Err(error!(
+                    "Model name or ARN may only appear as the first argument"
+                ));
+            }
+        }
+    }
+
+    match mode {
+        Mode::List => {
+            let records = table.list_values().await?;
+            renderer.render_list(&table, &records, column_override.as_deref());
+        }
+        Mode::Single => {
+            let (id, record) = table
+                .get_some_value()
+                .await?
+                .ok_or_else(|| error!("No record found"))?;
+            let relations = table.get_ref_names();
+            renderer.render_record(&table, &id, &record, &relations);
+        }
+    }
+
+    Ok(())
+}
+
+/// List the table, take the Nth row, narrow the table to that row by
+/// adding `eq(id_field, that_id)`. Returns the narrowed table in
+/// single-record mode so subsequent traversals see one parent.
+async fn apply_index(mut table: AnyTable, index: usize) -> Result<(AnyTable, Mode)> {
+    let records = table.list_values().await?;
+    let total = records.len();
+    let (id, _record) = records.into_iter().nth(index).ok_or_else(|| {
+        error!(format!(
+            "Index [{index}] out of bounds — only {total} record(s) match"
+        ))
+    })?;
+    let id_field = table.id_field_name().ok_or_else(|| {
+        error!(format!(
+            "Cannot apply index — table `{}` has no id field",
+            table.table_name()
+        ))
+    })?;
+    table.add_condition_eq(&id_field, &id)?;
+    Ok((table, Mode::Single))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_split_index_suffix() {
+        assert_eq!(split_index_suffix("users"), ("users", None));
+        assert_eq!(split_index_suffix("users[0]"), ("users", Some(0)));
+        assert_eq!(split_index_suffix("users[42]"), ("users", Some(42)));
+        assert_eq!(split_index_suffix("[3]"), ("", Some(3)));
+        assert_eq!(split_index_suffix("foo[bar]"), ("foo[bar]", None));
+        assert_eq!(split_index_suffix("foo[]"), ("foo[]", None));
+    }
+
+    #[test]
+    fn token_parse_kinds() {
+        match parse_token("iam.users").unwrap() {
+            Token::ModelName(n, i) => {
+                assert_eq!(n, "iam.users");
+                assert_eq!(i, None);
+            }
+            t => panic!("expected ModelName, got {t:?}"),
+        }
+        match parse_token("iam.users[0]").unwrap() {
+            Token::ModelName(n, i) => {
+                assert_eq!(n, "iam.users");
+                assert_eq!(i, Some(0));
+            }
+            t => panic!("expected ModelName with index, got {t:?}"),
+        }
+        match parse_token(":members[2]").unwrap() {
+            Token::Relation(r, i) => {
+                assert_eq!(r, "members");
+                assert_eq!(i, Some(2));
+            }
+            t => panic!("expected Relation, got {t:?}"),
+        }
+        match parse_token("name=alice").unwrap() {
+            Token::Condition(f, v, i) => {
+                assert_eq!(f, "name");
+                assert_eq!(v, "alice");
+                assert_eq!(i, None);
+            }
+            t => panic!("expected Condition, got {t:?}"),
+        }
+        match parse_token("name=\"john doe\"").unwrap() {
+            Token::Condition(f, v, i) => {
+                assert_eq!(f, "name");
+                assert_eq!(v, "john doe");
+                assert_eq!(i, None);
+            }
+            t => panic!("expected Condition, got {t:?}"),
+        }
+        match parse_token("name=alice[0]").unwrap() {
+            Token::Condition(f, v, i) => {
+                assert_eq!(f, "name");
+                assert_eq!(v, "alice");
+                assert_eq!(i, Some(0));
+            }
+            t => panic!("expected Condition with index, got {t:?}"),
+        }
+        match parse_token("[7]").unwrap() {
+            Token::Index(i) => assert_eq!(i, 7),
+            t => panic!("expected Index, got {t:?}"),
+        }
+        match parse_token("arn:aws:iam::123:user/alice").unwrap() {
+            Token::Arn(s) => assert_eq!(s, "arn:aws:iam::123:user/alice"),
+            t => panic!("expected Arn, got {t:?}"),
+        }
+        match parse_token("=timestamp,message").unwrap() {
+            Token::Columns(cols, idx) => {
+                assert_eq!(cols, vec!["timestamp".to_string(), "message".to_string()]);
+                assert_eq!(idx, None);
+            }
+            t => panic!("expected Columns, got {t:?}"),
+        }
+        match parse_token("=id, name [0]").unwrap_or_else(|_| {
+            // trim handles the spaces, but split on `[0]` requires no
+            // intervening space — skip that variant.
+            parse_token("=id,name[0]").unwrap()
+        }) {
+            Token::Columns(cols, idx) => {
+                assert_eq!(cols, vec!["id".to_string(), "name".to_string()]);
+                assert_eq!(idx, Some(0));
+            }
+            t => panic!("expected Columns with index, got {t:?}"),
+        }
+    }
+}

--- a/vantage-cli-util/src/model_cli.rs
+++ b/vantage-cli-util/src/model_cli.rs
@@ -85,14 +85,15 @@ enum Token {
 }
 
 fn split_index_suffix(s: &str) -> (&str, Option<usize>) {
-    if let Some(stripped) = s.strip_suffix(']') {
-        if let Some(open) = stripped.rfind('[') {
-            let inner = &stripped[open + 1..];
-            if !inner.is_empty() && inner.chars().all(|c| c.is_ascii_digit()) {
-                if let Ok(n) = inner.parse::<usize>() {
-                    return (&stripped[..open], Some(n));
-                }
-            }
+    if let Some(stripped) = s.strip_suffix(']')
+        && let Some(open) = stripped.rfind('[')
+    {
+        let inner = &stripped[open + 1..];
+        if !inner.is_empty()
+            && inner.chars().all(|c| c.is_ascii_digit())
+            && let Ok(n) = inner.parse::<usize>()
+        {
+            return (&stripped[..open], Some(n));
         }
     }
     (s, None)
@@ -140,12 +141,13 @@ fn parse_token(arg: &str) -> Result<Token> {
             return Err(error!(format!("Empty field name in token `{arg}`")));
         }
         let value_part = &arg[eq_pos + 1..];
-        let (value, idx) = if value_part.starts_with('"') && value_part.ends_with('"') && value_part.len() >= 2 {
-            (value_part[1..value_part.len() - 1].to_string(), None)
-        } else {
-            let (v, i) = split_index_suffix(value_part);
-            (v.to_string(), i)
-        };
+        let (value, idx) =
+            if value_part.starts_with('"') && value_part.ends_with('"') && value_part.len() >= 2 {
+                (value_part[1..value_part.len() - 1].to_string(), None)
+            } else {
+                let (v, i) = split_index_suffix(value_part);
+                (v.to_string(), i)
+            };
         return Ok(Token::Condition(field, value, idx));
     }
     let (name, idx) = split_index_suffix(arg);

--- a/vantage-cli-util/src/table_display.rs
+++ b/vantage-cli-util/src/table_display.rs
@@ -98,6 +98,64 @@ where
     render_records_typed(records, id_field, &IndexMap::new());
 }
 
+/// Render records with an explicit column list — no auto-prepended
+/// id column. `column_types` is consulted for per-column alignment but
+/// doesn't drive which columns appear; `columns` does.
+///
+/// Used by the model-driven CLI when the caller passes `=col1,col2`:
+/// the user spelled out exactly what they want to see, and an extra
+/// id column would just be noise.
+pub fn render_records_columns<Id, V>(
+    records: &IndexMap<Id, Record<V>>,
+    columns: &[String],
+    column_types: &IndexMap<String, &'static str>,
+) where
+    Id: std::fmt::Display,
+    V: TerminalRender,
+{
+    if records.is_empty() {
+        println!("{}", "No records.".dimmed());
+        return;
+    }
+
+    let mut table = ComfyTable::new();
+    table
+        .load_preset(presets::UTF8_HORIZONTAL_ONLY)
+        .remove_style(TableComponent::HorizontalLines)
+        .remove_style(TableComponent::MiddleIntersections)
+        .remove_style(TableComponent::LeftBorderIntersections)
+        .remove_style(TableComponent::RightBorderIntersections)
+        .set_content_arrangement(ContentArrangement::Disabled);
+
+    let header: Vec<Cell> = columns.iter().map(|c| header_cell(c)).collect();
+    table.set_header(header);
+
+    for (idx, name) in columns.iter().enumerate() {
+        if let Some(type_name) = column_types.get(name) {
+            let align = alignment_for(type_name);
+            if let Some(col) = table.column_mut(idx) {
+                col.set_cell_alignment(align);
+            }
+        }
+    }
+
+    for (_id, record) in records {
+        let row: Vec<Cell> = columns
+            .iter()
+            .map(|col| match record.get(col.as_str()) {
+                Some(value) => Cell::new(rich_to_ansi(&value.render())),
+                None => Cell::new("—".bright_black().to_string()),
+            })
+            .collect();
+        table.add_row(row);
+    }
+
+    println!("{table}");
+    let n = records.len();
+    let label = if n == 1 { "record" } else { "records" };
+    println!("{}", format!("{n} {label}").dimmed());
+}
+
 /// Render records as a styled table.
 ///
 /// `id_field` names the column used as the record key — printed as the

--- a/vantage-live/CHANGELOG.md
+++ b/vantage-live/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.3 — 2026-04-30
+
+- `LiveTable` forwards the four new `TableLike` reflection methods (`id_field_name`, `title_field_names`, `column_types`, `get_ref_names`) through to the master `AnyTable`, so generic UIs that drive a `LiveTable` see the same metadata they would see on the underlying table.
+- Pins `vantage-table = "0.4.8"` for those new trait surfaces.
+
 ## 0.4.2 — 2026-04-29
 
 - `LiveTable::get_ref(relation)` now forwards through to the master `AnyTable`, so reference traversal works on a `LiveTable` the same way it does on the underlying table — `live.get_ref("orders")` returns an `AnyTable` you can keep wrapping.

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-live"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -15,7 +15,7 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
-vantage-table = { version = "0.4.7", path = "../vantage-table" }
+vantage-table = { version = "0.4.8", path = "../vantage-table" }
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-live/src/live_table/impls/table_like.rs
+++ b/vantage-live/src/live_table/impls/table_like.rs
@@ -5,6 +5,7 @@
 
 use async_trait::async_trait;
 use ciborium::Value as CborValue;
+use indexmap::IndexMap;
 use tracing::warn;
 use vantage_core::{Result, error};
 use vantage_expressions::AnyExpression;
@@ -27,6 +28,22 @@ impl TableLike for LiveTable {
 
     fn column_names(&self) -> Vec<String> {
         self.master.column_names()
+    }
+
+    fn id_field_name(&self) -> Option<String> {
+        self.master.id_field_name()
+    }
+
+    fn title_field_names(&self) -> Vec<String> {
+        self.master.title_field_names()
+    }
+
+    fn column_types(&self) -> IndexMap<String, &'static str> {
+        self.master.column_types()
+    }
+
+    fn get_ref_names(&self) -> Vec<String> {
+        self.master.get_ref_names()
     }
 
     fn add_condition(&mut self, _condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()> {

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.8 — 2026-04-30
+
+- `TableLike` gains five reflection / mutation methods so type-erased callers (the new model-driven CLI in `vantage-cli-util`, anything else holding an `AnyTable`) can reach metadata that previously only existed on the typed side. All have default impls so existing implementors compile unchanged.
+  - `id_field_name() -> Option<String>`
+  - `title_field_names() -> Vec<String>`
+  - `column_types() -> IndexMap<String, &'static str>`
+  - `get_ref_names() -> Vec<String>`
+  - `add_condition_eq(field, value) -> Result<()>`
+- New `TableSource::eq_condition(field, value) -> Result<Self::Condition>` (default: error). Backends that support textual eq filtering override; `add_condition_eq` dispatches through it.
+- New `Table::with_title_column_of::<Type>(name)` builder — adds a typed column and records its name in an ordered `title_fields: Vec<String>` on the table. `title_field_names()` returns that vec, then unions in any columns that carry `ColumnFlag::TitleField` directly.
+- `AnyTable` and the internal `CborAdapter` forward all five new methods through to the wrapped table.
+
 ## 0.4.7 — 2026-04-29
 
 - New `AnyTable::get_ref(relation) -> Result<AnyTable>`. Lets reference traversal continue on the type-erased side — previously `get_ref` only existed on the typed `Table<T, E>`, so once you wrapped a table into `AnyTable` the relation graph was unreachable.

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/any.rs
+++ b/vantage-table/src/any.rs
@@ -257,8 +257,28 @@ impl TableLike for AnyTable {
         self.inner.column_names()
     }
 
+    fn id_field_name(&self) -> Option<String> {
+        self.inner.id_field_name()
+    }
+
+    fn title_field_names(&self) -> Vec<String> {
+        self.inner.title_field_names()
+    }
+
+    fn column_types(&self) -> IndexMap<String, &'static str> {
+        self.inner.column_types()
+    }
+
+    fn get_ref_names(&self) -> Vec<String> {
+        self.inner.get_ref_names()
+    }
+
     fn add_condition(&mut self, condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()> {
         self.inner.add_condition(condition)
+    }
+
+    fn add_condition_eq(&mut self, field: &str, value: &str) -> Result<()> {
+        self.inner.add_condition_eq(field, value)
     }
 
     fn temp_add_condition(
@@ -500,8 +520,28 @@ where
         self.inner.columns().keys().cloned().collect()
     }
 
+    fn id_field_name(&self) -> Option<String> {
+        TableLike::id_field_name(&self.inner)
+    }
+
+    fn title_field_names(&self) -> Vec<String> {
+        TableLike::title_field_names(&self.inner)
+    }
+
+    fn column_types(&self) -> IndexMap<String, &'static str> {
+        TableLike::column_types(&self.inner)
+    }
+
+    fn get_ref_names(&self) -> Vec<String> {
+        TableLike::get_ref_names(&self.inner)
+    }
+
     fn add_condition(&mut self, _condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()> {
         Err(error!("add_condition not supported through CborAdapter"))
+    }
+
+    fn add_condition_eq(&mut self, field: &str, value: &str) -> Result<()> {
+        TableLike::add_condition_eq(&mut self.inner, field, value)
     }
 
     fn temp_add_condition(

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -32,6 +32,7 @@ where
     pub(super) expressions: IndexMap<String, ExpressionFn<T, E>>,
     pub(super) pagination: Option<Pagination>,
     pub(super) title_field: Option<String>,
+    pub(super) title_fields: Vec<String>,
     pub(super) id_field: Option<String>,
 }
 
@@ -51,6 +52,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             expressions: IndexMap::new(),
             pagination: None,
             title_field: None,
+            title_fields: Vec::new(),
             id_field: None,
         }
     }
@@ -70,6 +72,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             expressions: IndexMap::new(),
             pagination: self.pagination,
             title_field: self.title_field,
+            title_fields: self.title_fields,
             id_field: self.id_field,
         }
     }
@@ -108,6 +111,13 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
         self.title_field
             .as_ref()
             .and_then(|name| self.columns.get(name))
+    }
+
+    /// Names of columns marked as display titles (set via
+    /// [`Self::with_title_column_of`]). These show alongside the id in
+    /// list views and on the leading lines of single-record displays.
+    pub fn title_fields(&self) -> &[String] {
+        &self.title_fields
     }
 
     /// Get the id field column if set

--- a/vantage-table/src/table/impls/columns.rs
+++ b/vantage-table/src/table/impls/columns.rs
@@ -55,6 +55,27 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
         self
     }
 
+    /// Add a typed column AND mark it as a display title.
+    ///
+    /// Title columns show alongside the id in generic list views and
+    /// lead the body of single-record displays. Multiple title columns
+    /// are allowed; their order matches the order of these calls.
+    pub fn with_title_column_of<NewColumnType>(mut self, name: impl Into<String>) -> Self
+    where
+        NewColumnType: ColumnType,
+    {
+        let name = name.into();
+        if !self.title_fields.contains(&name) {
+            self.title_fields.push(name.clone());
+        }
+        if self.title_field.is_none() {
+            self.title_field = Some(name.clone());
+        }
+        let column = self.data_source.create_column::<NewColumnType>(&name);
+        self.add_column(column);
+        self
+    }
+
     /// Add a typed column to the table (builder pattern)
     pub fn with_column_of<NewColumnType>(self, name: impl Into<String>) -> Self
     where

--- a/vantage-table/src/table/impls/table_like.rs
+++ b/vantage-table/src/table/impls/table_like.rs
@@ -1,14 +1,16 @@
 use async_trait::async_trait;
+use indexmap::IndexMap;
 use vantage_core::{Result, error};
 use vantage_expressions::AnyExpression;
 use vantage_types::Entity;
 
 use crate::{
     any::AnyTable,
+    column::flags::ColumnFlag,
     conditions::ConditionHandle,
     pagination::Pagination,
     table::Table,
-    traits::{table_like::TableLike, table_source::TableSource},
+    traits::{column_like::ColumnLike, table_like::TableLike, table_source::TableSource},
 };
 
 #[async_trait]
@@ -29,6 +31,35 @@ where
         self.columns.keys().cloned().collect()
     }
 
+    fn id_field_name(&self) -> Option<String> {
+        self.id_field().map(|c| c.name().to_string())
+    }
+
+    fn title_field_names(&self) -> Vec<String> {
+        // Two paths: the explicit `with_title_column_of` ordered list,
+        // and any columns that have `TitleField` flagged on them
+        // directly. The flagged path covers backends whose column type
+        // sets flags during construction (e.g. SQL).
+        let mut out: Vec<String> = self.title_fields.clone();
+        for (name, col) in &self.columns {
+            if col.flags().contains(&ColumnFlag::TitleField) && !out.contains(name) {
+                out.push(name.clone());
+            }
+        }
+        out
+    }
+
+    fn column_types(&self) -> IndexMap<String, &'static str> {
+        self.columns
+            .iter()
+            .map(|(name, col)| (name.clone(), col.get_type()))
+            .collect()
+    }
+
+    fn get_ref_names(&self) -> Vec<String> {
+        self.references()
+    }
+
     fn add_condition(&mut self, condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()> {
         // Downcast the boxed Any to T::Condition
         let cond = condition
@@ -40,6 +71,15 @@ where
         let id = -next_id;
         *self.next_condition_id_mut() = next_id + 1;
         self.conditions_mut().insert(id, *cond);
+        Ok(())
+    }
+
+    fn add_condition_eq(&mut self, field: &str, value: &str) -> Result<()> {
+        let cond = T::eq_condition(field, value)?;
+        let next_id = *self.next_condition_id_mut();
+        let id = -next_id;
+        *self.next_condition_id_mut() = next_id + 1;
+        self.conditions_mut().insert(id, cond);
         Ok(())
     }
 

--- a/vantage-table/src/traits/table_like.rs
+++ b/vantage-table/src/traits/table_like.rs
@@ -31,7 +31,7 @@ pub trait TableLike: ReadableValueSet + WritableValueSet + Send + Sync {
         IndexMap::new()
     }
 
-    /// Names of relations traversable via [`get_ref`].
+    /// Names of relations traversable via `get_ref`.
     fn get_ref_names(&self) -> Vec<String> {
         Vec::new()
     }

--- a/vantage-table/src/traits/table_like.rs
+++ b/vantage-table/src/traits/table_like.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use indexmap::IndexMap;
 use vantage_core::Result;
 use vantage_dataset::prelude::{ReadableValueSet, WritableValueSet};
 use vantage_expressions::AnyExpression;
@@ -12,9 +13,45 @@ pub trait TableLike: ReadableValueSet + WritableValueSet + Send + Sync {
     fn table_alias(&self) -> &str;
     fn column_names(&self) -> Vec<String>;
 
+    /// Name of the column flagged as the id field, if any.
+    fn id_field_name(&self) -> Option<String> {
+        None
+    }
+
+    /// Names of columns flagged as `TitleField`.
+    fn title_field_names(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    /// Map of column name -> original Rust type name. Backends that
+    /// preserve type metadata (e.g. `Column::get_type()`) override this
+    /// so generic UIs can drive type-aware rendering without poking at
+    /// concrete column types.
+    fn column_types(&self) -> IndexMap<String, &'static str> {
+        IndexMap::new()
+    }
+
+    /// Names of relations traversable via [`get_ref`].
+    fn get_ref_names(&self) -> Vec<String> {
+        Vec::new()
+    }
+
     /// Add a condition to this table using a type-erased expression
     /// The expression must be of type T::Expr for the underlying table's TableSource
     fn add_condition(&mut self, condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()>;
+
+    /// Add a permanent equality condition expressed as raw strings.
+    ///
+    /// Generic CLIs (and other type-erased callers) work with
+    /// `field=value` text and cannot reach into `T::Condition`. Each
+    /// backend that supports textual eq filtering overrides this; the
+    /// default returns an error.
+    fn add_condition_eq(&mut self, field: &str, value: &str) -> Result<()> {
+        let _ = (field, value);
+        Err(vantage_core::error!(
+            "add_condition_eq not supported on this TableLike"
+        ))
+    }
 
     /// Add a temporary condition using AnyExpression that can be removed later
     fn temp_add_condition(&mut self, condition: AnyExpression) -> Result<ConditionHandle>;

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -31,6 +31,20 @@ pub trait TableSource: DataSource + Clone + 'static {
     /// can use a native filter type (e.g. `bson::Document`).
     type Condition: Clone + Send + Sync + 'static;
 
+    /// Build a textual `field == value` condition.
+    ///
+    /// Generic UIs (e.g. CLI argument parsers) only have strings on
+    /// hand, so they need a way to construct a `Self::Condition` without
+    /// knowing the backend's native expression type. Backends that
+    /// don't support raw text filtering can leave the default, which
+    /// returns an error.
+    fn eq_condition(field: &str, value: &str) -> Result<Self::Condition> {
+        let _ = (field, value);
+        Err(vantage_core::error!(
+            "eq_condition not implemented for this TableSource"
+        ))
+    }
+
     /// Create a new column with the given name
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type>;
 

--- a/vantage-types/CHANGELOG.md
+++ b/vantage-types/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.2 — 2026-04-30
+
+Catches up the crates.io release with the additions that landed locally in [#214](https://github.com/romaninsh/vantage/pull/214) but never got their own version bump.
+
+- New `RichText` / `Span` / `Style` types and a refactored `TerminalRender` trait — `render() -> RichText` instead of `render() -> String` plus a separate `color_hint()`. `Style` is semantic (`Default`, `Dim`, `Muted`, `Strong`, `Success`, `Error`, `Warning`, `Info`) — UI layers map to native presentation. `RichText` impls `Display` (writes the plain text), so existing string-shaped consumers keep compiling without code changes.
+- Default `TerminalRender` impls migrated for `String`, `&str`, `i32` / `i64` / `f64`, `bool`, `Option<T>`, `serde_json::Value`, and `ciborium::Value`. Booleans render as `Style::Success` / `Style::Error`; nulls render as a dim em-dash.
+
 ## 0.4.1 — 2026-04-25
 
 - `TerminalRender` impl for `ciborium::Value` so generic CLI/UI rendering keeps working when records flow through `AnyTable`.

--- a/vantage-types/Cargo.toml
+++ b/vantage-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-types"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Type system and Record types for the Vantage data framework"


### PR DESCRIPTION
`vantage-aws` 0.4.4 brings S3, Lambda, and DynamoDB online — three more services on the same `AwsAccount`, three more wire protocols, no extra configuration on the caller side.

### What you can list now

- **S3** (`restxml/`): `s3::buckets_table` (`ListBuckets`) + `s3::objects_table` (`ListObjectsV2`, scoped to a `Bucket`). `Bucket` carries an `objects` `with_many`; path-style addressing only, so cross-region buckets surface AWS's 301 with the home-region endpoint in the error body.
- **Lambda** (`restjson/`): `lambda::functions_table`, plus per-function `aliases_table` / `versions_table`. `Function` traverses to CloudWatch Logs at `/aws/lambda/<name>` via a `log_group` `with_foreign` — cross-service, cross-protocol, no glue needed.
- **DynamoDB** (`json10/`): `dynamodb::tables_table` (`ListTables`). List response is just an array of names, so v0 surfaces `TableName` only — `DescribeTable` metadata is a follow-up.

`Factory` picks up six new top-level names (`s3.bucket(s)`, `lambda.function(s)`, `dynamodb.table(s)`) and four new ARN shapes; sub-resources stay traversal-only since listing them needs a parent filter.

### Three more protocols, one dispatcher

`dispatch.rs`'s prefix match grows three arms. REST-JSON reuses REST-XML's path-template builder (`METHOD /{Placeholder}?query` — conditions matching a placeholder fill the path, the rest go to the query string). JSON-1.0 reuses the JSON-1.1 transport via a new `json_aws_call(..., content_type)` — the only thing DynamoDB cares about is the `application/x-amz-json-1.0` content type. The same hand-rolled SigV4 signer powers all five.