### PR TITLE
vantage-live 0.4.4: propagate tracing span across spawned tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,16 +788,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
-name = "debugid"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
-dependencies = [
- "serde",
- "uuid",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,36 +2848,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
-name = "sentry-core"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56de6f8c10ed1b74543b9654b99d3d9a2d876bd5996f3ecd60afdc30ef40ad0e"
-dependencies = [
- "rand 0.9.4",
- "sentry-types",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c69667ff14f47aad798e6be2ad8409e350b3ab0b8d72b338b462ed35f7bcc4"
-dependencies = [
- "debugid",
- "hex",
- "rand 0.9.4",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "time",
- "url",
- "uuid",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4101,7 +4061,6 @@ dependencies = [
  "indexmap",
  "pretty_assertions",
  "redb",
- "sentry-core",
  "serde_json",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
  "indexmap",
  "js-sys",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -786,6 +786,16 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
 
 [[package]]
 name = "der"
@@ -1304,7 +1314,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1326,7 +1336,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -2037,7 +2047,7 @@ dependencies = [
  "mongodb-internal-macros",
  "pbkdf2",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustc_version_runtime",
  "rustls",
  "rustversion",
@@ -2483,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2846,6 +2856,36 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "sentry-core"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56de6f8c10ed1b74543b9654b99d3d9a2d876bd5996f3ecd60afdc30ef40ad0e"
+dependencies = [
+ "rand 0.9.4",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c69667ff14f47aad798e6be2ad8409e350b3ab0b8d72b338b462ed35f7bcc4"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "serde"
@@ -3774,7 +3814,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -4052,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-live"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4061,6 +4101,7 @@ dependencies = [
  "indexmap",
  "pretty_assertions",
  "redb",
+ "sentry-core",
  "serde_json",
  "tempfile",
  "tokio",

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-live"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -25,6 +25,14 @@ redb = "2.6"
 tokio = { version = "1", features = ["sync", "rt", "macros", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
+sentry-core = { version = "0.48", default-features = false, features = ["client"], optional = true }
+
+[features]
+default = []
+# Propagate the calling task's Sentry Hub onto background workers
+# (write queue + live-stream consumer) so panics and tracing events
+# emitted from those tasks correlate to the same trace as the caller.
+sentry = ["dep:sentry-core"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -25,14 +25,6 @@ redb = "2.6"
 tokio = { version = "1", features = ["sync", "rt", "macros", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
-sentry-core = { version = "0.48", default-features = false, features = ["client"], optional = true }
-
-[features]
-default = []
-# Propagate the calling task's Sentry Hub onto background workers
-# (write queue + live-stream consumer) so panics and tracing events
-# emitted from those tasks correlate to the same trace as the caller.
-sentry = ["dep:sentry-core"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/vantage-live/src/live_table/event_consumer.rs
+++ b/vantage-live/src/live_table/event_consumer.rs
@@ -14,7 +14,7 @@ use crate::cache::Cache;
 use crate::live_stream::{LiveEvent, LiveStream};
 
 pub(super) fn spawn(stream: Arc<dyn LiveStream>, cache_key: String, cache: Arc<dyn Cache>) {
-    tokio::spawn(async move {
+    let fut = async move {
         let mut sub = stream.subscribe();
         debug!(target: "vantage_live::events", cache_key = %cache_key, "event consumer started");
 
@@ -22,7 +22,15 @@ pub(super) fn spawn(stream: Arc<dyn LiveStream>, cache_key: String, cache: Arc<d
             handle(&cache_key, &cache, event).await;
         }
         debug!(target: "vantage_live::events", cache_key = %cache_key, "event consumer stopped");
-    });
+    };
+
+    #[cfg(feature = "sentry")]
+    {
+        use sentry_core::SentryFutureExt as _;
+        tokio::spawn(fut.bind_hub(sentry_core::Hub::current()));
+    }
+    #[cfg(not(feature = "sentry"))]
+    tokio::spawn(fut);
 }
 
 #[instrument(

--- a/vantage-live/src/live_table/event_consumer.rs
+++ b/vantage-live/src/live_table/event_consumer.rs
@@ -8,29 +8,28 @@
 use std::sync::Arc;
 
 use futures_util::StreamExt;
-use tracing::{debug, instrument, warn};
+use tracing::{debug, instrument, warn, Instrument as _};
 
 use crate::cache::Cache;
 use crate::live_stream::{LiveEvent, LiveStream};
 
 pub(super) fn spawn(stream: Arc<dyn LiveStream>, cache_key: String, cache: Arc<dyn Cache>) {
-    let fut = async move {
-        let mut sub = stream.subscribe();
-        debug!(target: "vantage_live::events", cache_key = %cache_key, "event consumer started");
+    // `.in_current_span()` propagates the caller's tracing span across
+    // the `tokio::spawn` boundary so any tracing layer the consumer
+    // installed (sentry-tracing, tracing-opentelemetry, ...) sees the
+    // event-consumer's events as descendants of the caller.
+    tokio::spawn(
+        async move {
+            let mut sub = stream.subscribe();
+            debug!(target: "vantage_live::events", cache_key = %cache_key, "event consumer started");
 
-        while let Some(event) = sub.next().await {
-            handle(&cache_key, &cache, event).await;
+            while let Some(event) = sub.next().await {
+                handle(&cache_key, &cache, event).await;
+            }
+            debug!(target: "vantage_live::events", cache_key = %cache_key, "event consumer stopped");
         }
-        debug!(target: "vantage_live::events", cache_key = %cache_key, "event consumer stopped");
-    };
-
-    #[cfg(feature = "sentry")]
-    {
-        use sentry_core::SentryFutureExt as _;
-        tokio::spawn(fut.bind_hub(sentry_core::Hub::current()));
-    }
-    #[cfg(not(feature = "sentry"))]
-    tokio::spawn(fut);
+        .in_current_span(),
+    );
 }
 
 #[instrument(

--- a/vantage-live/src/live_table/worker.rs
+++ b/vantage-live/src/live_table/worker.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
-use tracing::{debug, instrument, warn};
+use tracing::{debug, instrument, warn, Instrument as _};
 use vantage_dataset::traits::WritableValueSet;
 use vantage_table::any::AnyTable;
 
@@ -23,20 +23,21 @@ pub(super) fn spawn(
     cache_key: String,
     cache: Arc<dyn Cache>,
 ) {
-    let fut = async move {
-        while let Some(op) = rx.recv().await {
-            handle(&master, &custom_write_target, &cache_key, &cache, op).await;
+    // `.in_current_span()` carries the caller's tracing span across the
+    // `tokio::spawn` boundary. Any tracing layer the consumer installed
+    // (sentry-tracing, tracing-opentelemetry, console-subscriber, ...)
+    // sees the spawned task's events as descendants of the caller, so
+    // panics and errors stitch into the same trace as the originating
+    // write request rather than appearing as orphans.
+    tokio::spawn(
+        async move {
+            while let Some(op) = rx.recv().await {
+                handle(&master, &custom_write_target, &cache_key, &cache, op).await;
+            }
+            debug!(target: "vantage_live::worker", cache_key = %cache_key, "write-queue worker shutting down");
         }
-        debug!(target: "vantage_live::worker", cache_key = %cache_key, "write-queue worker shutting down");
-    };
-
-    #[cfg(feature = "sentry")]
-    {
-        use sentry_core::SentryFutureExt as _;
-        tokio::spawn(fut.bind_hub(sentry_core::Hub::current()));
-    }
-    #[cfg(not(feature = "sentry"))]
-    tokio::spawn(fut);
+        .in_current_span(),
+    );
 }
 
 #[instrument(

--- a/vantage-live/src/live_table/worker.rs
+++ b/vantage-live/src/live_table/worker.rs
@@ -23,12 +23,20 @@ pub(super) fn spawn(
     cache_key: String,
     cache: Arc<dyn Cache>,
 ) {
-    tokio::spawn(async move {
+    let fut = async move {
         while let Some(op) = rx.recv().await {
             handle(&master, &custom_write_target, &cache_key, &cache, op).await;
         }
         debug!(target: "vantage_live::worker", cache_key = %cache_key, "write-queue worker shutting down");
-    });
+    };
+
+    #[cfg(feature = "sentry")]
+    {
+        use sentry_core::SentryFutureExt as _;
+        tokio::spawn(fut.bind_hub(sentry_core::Hub::current()));
+    }
+    #[cfg(not(feature = "sentry"))]
+    tokio::spawn(fut);
 }
 
 #[instrument(


### PR DESCRIPTION
If you have a `tracing` layer installed (sentry-tracing, tracing-opentelemetry, console-subscriber, plain `fmt`), `vantage-live`'s background tasks now stitch into your trace tree instead of appearing as orphans.

Both spawn sites — the write-queue worker and the live-event consumer — wrap their `tokio::spawn` in `.in_current_span()`, so worker-side warnings (failed cache invalidations, write errors) carry the span of the request that triggered them. Went with `tracing::Instrument` rather than a vendor SDK like `sentry-core`'s Hub binding so the choice of observability backend stays with whoever installs the layer; no new dep, no feature flag.

`vantage-live` 0.4.3 → 0.4.4. No API changes. The same treatment lands in `vantage-api-pool` and `surreal-client` in #220.