### PR TITLE
propagate tracing spans across vantage's tokio::spawn boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,16 +788,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
-name = "debugid"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
-dependencies = [
- "serde",
- "uuid",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,36 +2848,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
-name = "sentry-core"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56de6f8c10ed1b74543b9654b99d3d9a2d876bd5996f3ecd60afdc30ef40ad0e"
-dependencies = [
- "rand 0.9.4",
- "sentry-types",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
-name = "sentry-types"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c69667ff14f47aad798e6be2ad8409e350b3ab0b8d72b338b462ed35f7bcc4"
-dependencies = [
- "debugid",
- "hex",
- "rand 0.9.4",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "time",
- "url",
- "uuid",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4101,7 +4061,6 @@ dependencies = [
  "indexmap",
  "pretty_assertions",
  "redb",
- "sentry-core",
  "serde_json",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
  "indexmap",
  "js-sys",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -786,6 +786,16 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
 
 [[package]]
 name = "der"
@@ -1304,7 +1314,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1326,7 +1336,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -2037,7 +2047,7 @@ dependencies = [
  "mongodb-internal-macros",
  "pbkdf2",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustc_version_runtime",
  "rustls",
  "rustversion",
@@ -2483,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2846,6 +2856,36 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "sentry-core"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56de6f8c10ed1b74543b9654b99d3d9a2d876bd5996f3ecd60afdc30ef40ad0e"
+dependencies = [
+ "rand 0.9.4",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c69667ff14f47aad798e6be2ad8409e350b3ab0b8d72b338b462ed35f7bcc4"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "serde"
@@ -3774,7 +3814,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -4052,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-live"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4061,6 +4101,7 @@ dependencies = [
  "indexmap",
  "pretty_assertions",
  "redb",
+ "sentry-core",
  "serde_json",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,7 +3283,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surreal-client"
-version = "0.5.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3935,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-pool"
-version = "0.2.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-live"
-version = "0.5.0"
+version = "0.4.5"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,7 +3283,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surreal-client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3302,6 +3302,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
+ "tracing",
  "url",
  "uuid",
  "vantage-core",
@@ -3934,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-pool"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3947,6 +3948,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tracing",
  "urlencoding",
  "vantage-cli-util",
  "vantage-core",
@@ -4052,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-live"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/surreal-client/CHANGELOG.md
+++ b/surreal-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.0 — 2026-05-03
+## 0.4.1 — 2026-05-03
 
 - WebSocket message handlers (`ws`, `ws_cbor`, `ws_pool`) wrap their spawned futures with `tracing::Instrument::in_current_span()` so connection events stay attached to the trace that opened the connection.
 - Replaced `println!` / `eprintln!` in the WS handlers with `tracing::debug!` / `warn!` so consumers' subscribers see them. `tracing` becomes a direct dependency.

--- a/surreal-client/CHANGELOG.md
+++ b/surreal-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.0 — 2026-05-03
+
+- WebSocket message handlers (`ws`, `ws_cbor`, `ws_pool`) wrap their spawned futures with `tracing::Instrument::in_current_span()` so connection events stay attached to the trace that opened the connection.
+- Replaced `println!` / `eprintln!` in the WS handlers with `tracing::debug!` / `warn!` so consumers' subscribers see them. `tracing` becomes a direct dependency.
+- The JSON `WsEngine` no longer panics on malformed inbound payloads — bad JSON, missing `id`, and unexpected frames now log at `warn` / `debug` and the message is dropped instead of taking the entire message-handler task down.
+
 ## 0.4.0 — 2026-04-16
 
 - Initial 0.4 release. Standalone SurrealDB client over WebSocket with CBOR transport — used by `vantage-surrealdb` and usable on its own.

--- a/surreal-client/Cargo.toml
+++ b/surreal-client/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "surreal-client"
-version = "0.5.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "CBOR-based SurrealDB client for the Vantage data framework"

--- a/surreal-client/Cargo.toml
+++ b/surreal-client/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "surreal-client"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "CBOR-based SurrealDB client for the Vantage data framework"
@@ -26,6 +26,7 @@ serde_json = "1.0.145"
 thiserror = "2.0.17"
 tokio = { version = "1.48.0", features = ["full"] }
 tokio-tungstenite = "0.27.0"
+tracing = "0.1"
 futures = "0.3.31"
 url = "2.5.7"
 uuid = { version = "1.0", features = ["v4"] }

--- a/surreal-client/src/engines/ws.rs
+++ b/surreal-client/src/engines/ws.rs
@@ -11,6 +11,7 @@ use tokio::net::TcpStream;
 use tokio::sync::{Mutex, oneshot};
 use tokio_tungstenite::MaybeTlsStream;
 use tokio_tungstenite::{WebSocketStream, connect_async, tungstenite::Message};
+use tracing::{Instrument as _, debug, warn};
 
 use crate::SurrealConnection;
 use crate::{
@@ -60,55 +61,70 @@ impl WsEngine {
         let stream = Arc::clone(&self.stream);
         let pending_requests = Arc::clone(&self.pending_requests);
 
-        tokio::spawn(async move {
-            loop {
-                let msg = {
-                    let mut stream_guard = stream.lock().await;
-                    stream_guard.next().await
-                };
+        // `.in_current_span()` carries the caller's tracing span across the
+        // `tokio::spawn` boundary so connection-level events stay attached to
+        // the trace that opened the connection.
+        tokio::spawn(
+            async move {
+                loop {
+                    let msg = {
+                        let mut stream_guard = stream.lock().await;
+                        stream_guard.next().await
+                    };
 
-                let msg = match msg {
-                    None => {
-                        println!("Stream ended");
-                        break;
-                    }
-                    Some(Err(e)) => {
-                        eprintln!("Error receiving message: {}", e);
-                        break;
-                    }
-                    Some(Ok(msg)) => msg,
-                };
-
-                match msg {
-                    Message::Text(text) => {
-                        let parsed = serde_json::from_str::<Value>(&text).unwrap();
-                        let id = parsed.get("id").unwrap().as_u64().unwrap();
-
-                        let tx = {
-                            let mut pending = pending_requests.lock().await;
-                            pending.remove(&id)
-                        };
-
-                        if let Some(tx) = tx {
-                            // Send the entire response, not just the result field
-                            let _ = tx.send(parsed);
+                    let msg = match msg {
+                        None => {
+                            debug!("ws stream ended");
+                            break;
                         }
-                    }
-                    Message::Ping(_) => {}
-                    Message::Pong(_) => {}
-                    Message::Binary(bin) => {
-                        println!("Received binary: {:?}", bin);
-                    }
-                    Message::Close(_) => {
-                        println!("Connection closed");
-                        break;
-                    }
-                    x => {
-                        println!("Received something weird: {:?}", x)
+                        Some(Err(e)) => {
+                            warn!(error = %e, "ws receive error");
+                            break;
+                        }
+                        Some(Ok(msg)) => msg,
+                    };
+
+                    match msg {
+                        Message::Text(text) => {
+                            let parsed = match serde_json::from_str::<Value>(&text) {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    warn!(error = %e, payload_len = text.len(), "ws JSON parse failed");
+                                    continue;
+                                }
+                            };
+                            let Some(id) = parsed.get("id").and_then(|v| v.as_u64()) else {
+                                warn!("ws message missing numeric id field");
+                                continue;
+                            };
+
+                            let tx = {
+                                let mut pending = pending_requests.lock().await;
+                                pending.remove(&id)
+                            };
+
+                            if let Some(tx) = tx {
+                                // Send the entire response, not just the result field
+                                let _ = tx.send(parsed);
+                            }
+                        }
+                        Message::Ping(_) => {}
+                        Message::Pong(_) => {}
+                        Message::Binary(bin) => {
+                            debug!(bytes = bin.len(), "ws binary frame on JSON engine");
+                        }
+                        Message::Close(_) => {
+                            debug!("ws connection closed by peer");
+                            break;
+                        }
+                        x => {
+                            debug!(frame = ?x, "ws unexpected frame");
+                        }
                     }
                 }
             }
-        });
+            .in_current_span(),
+        );
     }
 }
 

--- a/surreal-client/src/engines/ws_cbor.rs
+++ b/surreal-client/src/engines/ws_cbor.rs
@@ -18,6 +18,7 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::tungstenite::http::header::SEC_WEBSOCKET_PROTOCOL;
 use tokio_tungstenite::{WebSocketStream, connect_async, tungstenite::Message};
+use tracing::{Instrument as _, warn};
 
 use crate::SurrealConnection;
 use crate::{
@@ -102,84 +103,87 @@ impl WsCborEngine {
         let stream = Arc::clone(&self.stream);
         let pending_requests = Arc::clone(&self.pending_requests);
 
-        tokio::spawn(async move {
-            loop {
-                let msg = {
-                    let mut stream_guard = stream.lock().await;
-                    stream_guard.next().await
-                };
+        tokio::spawn(
+            async move {
+                loop {
+                    let msg = {
+                        let mut stream_guard = stream.lock().await;
+                        stream_guard.next().await
+                    };
 
-                let msg = match msg {
-                    None => break,
-                    Some(Err(e)) => {
-                        eprintln!("CBOR Engine error: {}", e);
-                        break;
-                    }
-                    Some(Ok(msg)) => msg,
-                };
+                    let msg = match msg {
+                        None => break,
+                        Some(Err(e)) => {
+                            warn!(error = %e, "CBOR ws receive error");
+                            break;
+                        }
+                        Some(Ok(msg)) => msg,
+                    };
 
-                match msg {
-                    Message::Text(_text) => {
-                        // Ignore text messages - we only use CBOR binary
-                    }
-                    Message::Binary(binary) => {
-                        // Parse CBOR response: {id, result} or {id, error}
-                        match ciborium::from_reader(binary.as_ref()) {
-                            Ok(cbor_response) => {
-                                // Handle map format: {id: "0", result: "..."}
-                                if let CborValue::Map(map) = cbor_response {
-                                    let mut id_str = None;
-                                    let mut result = None;
-                                    let mut error = None;
+                    match msg {
+                        Message::Text(_text) => {
+                            // Ignore text messages - we only use CBOR binary
+                        }
+                        Message::Binary(binary) => {
+                            // Parse CBOR response: {id, result} or {id, error}
+                            match ciborium::from_reader(binary.as_ref()) {
+                                Ok(cbor_response) => {
+                                    // Handle map format: {id: "0", result: "..."}
+                                    if let CborValue::Map(map) = cbor_response {
+                                        let mut id_str = None;
+                                        let mut result = None;
+                                        let mut error = None;
 
-                                    for (key, value) in &map {
-                                        if let CborValue::Text(k) = key {
-                                            match k.as_str() {
-                                                "id" => {
-                                                    if let CborValue::Text(id) = value {
-                                                        id_str = Some(id.clone());
+                                        for (key, value) in &map {
+                                            if let CborValue::Text(k) = key {
+                                                match k.as_str() {
+                                                    "id" => {
+                                                        if let CborValue::Text(id) = value {
+                                                            id_str = Some(id.clone());
+                                                        }
                                                     }
+                                                    "result" => result = Some(value.clone()),
+                                                    "error" => error = Some(value.clone()),
+                                                    _ => {}
                                                 }
-                                                "result" => result = Some(value.clone()),
-                                                "error" => error = Some(value.clone()),
-                                                _ => {}
                                             }
                                         }
-                                    }
 
-                                    if let Some(id) = id_str {
-                                        let tx = {
-                                            let mut pending = pending_requests.lock().await;
-                                            pending.remove(&id)
-                                        };
+                                        if let Some(id) = id_str {
+                                            let tx = {
+                                                let mut pending = pending_requests.lock().await;
+                                                pending.remove(&id)
+                                            };
 
-                                        if let Some(tx) = tx {
-                                            if let Some(err) = error {
-                                                let _ = tx.send(CborValue::Map(vec![(
-                                                    CborValue::Text("error".to_string()),
-                                                    err,
-                                                )]));
-                                            } else if let Some(res) = result {
-                                                let _ = tx.send(res);
-                                            } else {
-                                                let _ = tx.send(CborValue::Null);
+                                            if let Some(tx) = tx {
+                                                if let Some(err) = error {
+                                                    let _ = tx.send(CborValue::Map(vec![(
+                                                        CborValue::Text("error".to_string()),
+                                                        err,
+                                                    )]));
+                                                } else if let Some(res) = result {
+                                                    let _ = tx.send(res);
+                                                } else {
+                                                    let _ = tx.send(CborValue::Null);
+                                                }
                                             }
                                         }
                                     }
                                 }
-                            }
-                            Err(_e) => {
-                                // Failed to parse CBOR response
+                                Err(e) => {
+                                    warn!(error = %e, bytes = binary.len(), "CBOR parse failed");
+                                }
                             }
                         }
+                        Message::Ping(_) => {}
+                        Message::Pong(_) => {}
+                        Message::Close(_) => break,
+                        _ => {}
                     }
-                    Message::Ping(_) => {}
-                    Message::Pong(_) => {}
-                    Message::Close(_) => break,
-                    _ => {}
                 }
             }
-        })
+            .in_current_span(),
+        )
     }
 }
 

--- a/surreal-client/src/engines/ws_pool.rs
+++ b/surreal-client/src/engines/ws_pool.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio_tungstenite::{WebSocketStream, connect_async, tungstenite::Message};
+use tracing::Instrument as _;
 use url::Url;
 
 use crate::surreal_client::{
@@ -47,7 +48,7 @@ impl WsConnection {
         let stream = Arc::new(Mutex::new(ws_stream));
 
         // Start the message handler
-        let handle = tokio::spawn(Self::handle_messages(stream, request_rx));
+        let handle = tokio::spawn(Self::handle_messages(stream, request_rx).in_current_span());
 
         Ok(WsConnection {
             request_tx,

--- a/vantage-api-pool/CHANGELOG.md
+++ b/vantage-api-pool/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.2.0 — 2026-05-03
+## 0.1.2 — 2026-05-03
 
 - HTTP worker pool, request/response matcher, and all paginator variants now wrap their spawned futures with `tracing::Instrument::in_current_span()` so the caller's span follows the future across the `tokio::spawn` boundary. Any tracing layer the consumer installs sees background-task events as descendants of the originating request.
 - `eprintln!` calls in the worker, matcher, and retry paths replaced with `tracing::warn!` / `error!` so subscribers actually see them. `tracing` becomes a direct dependency.

--- a/vantage-api-pool/CHANGELOG.md
+++ b/vantage-api-pool/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0 — 2026-05-03
+
+- HTTP worker pool, request/response matcher, and all paginator variants now wrap their spawned futures with `tracing::Instrument::in_current_span()` so the caller's span follows the future across the `tokio::spawn` boundary. Any tracing layer the consumer installs sees background-task events as descendants of the originating request.
+- `eprintln!` calls in the worker, matcher, and retry paths replaced with `tracing::warn!` / `error!` so subscribers actually see them. `tracing` becomes a direct dependency.
+
 ## 0.1.1 — 2026-04-19
 
 - Pinned dependency versions for crates.io publishing.

--- a/vantage-api-pool/Cargo.toml
+++ b/vantage-api-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "vantage-api-pool"
-version = "0.1.1"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 description = "Paginated REST API client pool for Vantage"
 
@@ -14,6 +14,7 @@ rust_decimal = { version = "1.39", features = ["serde", "macros"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
+tracing = "0.1"
 
 async-trait = "0.1"
 indexmap = { version = "2", features = ["serde"] }

--- a/vantage-api-pool/Cargo.toml
+++ b/vantage-api-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "vantage-api-pool"
-version = "0.2.0"
+version = "0.1.2"
 license = "MIT OR Apache-2.0"
 description = "Paginated REST API client pool for Vantage"
 

--- a/vantage-api-pool/src/client_pool/http.rs
+++ b/vantage-api-pool/src/client_pool/http.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use rust_decimal::prelude::*;
 use tokio::{sync::mpsc, task::JoinHandle};
+use tracing::{error, Instrument as _};
 
 use crate::{eventual_request::EventualRequestResult, EventualRequest, KeyedRateLimiter};
 
@@ -27,14 +28,20 @@ impl<T: Sync + Send + Sized> HttpClientPool<T> {
 
         let rate_limit = rate_limit.map(|d| Arc::new(KeyedRateLimiter::new(d)));
 
+        // `.in_current_span()` carries the caller's tracing span across the
+        // `tokio::spawn` boundary, so per-worker errors stitch into the same
+        // trace as the originating request rather than appearing as orphans.
         for w in 0..workers {
-            shared_handles.push(tokio::spawn(Self::worker_thread(
-                reqwest::Client::new(),
-                rate_limit.clone(),
-                request_receiver.clone(),
-                response_sender.clone(),
-                w,
-            )));
+            shared_handles.push(tokio::spawn(
+                Self::worker_thread(
+                    reqwest::Client::new(),
+                    rate_limit.clone(),
+                    request_receiver.clone(),
+                    response_sender.clone(),
+                    w,
+                )
+                .in_current_span(),
+            ));
         }
 
         (
@@ -84,7 +91,7 @@ impl<T: Sync + Send + Sized> HttpClientPool<T> {
                 EventualRequestResult::Success => {
                     request.time_queue_start();
                     if let Err(e) = response_sender.send(request).await {
-                        eprintln!("Error sending response back from worker: {}", e)
+                        error!(error = %e, worker = w, "failed to send response from worker");
                     }
                 }
                 EventualRequestResult::Retry => {
@@ -92,7 +99,7 @@ impl<T: Sync + Send + Sized> HttpClientPool<T> {
                     continue;
                 }
                 EventualRequestResult::Error(e) => {
-                    eprintln!("Error executing http request in worker {}: {}", w, e)
+                    error!(error = %e, worker = w, "http request failed in worker");
                 }
             };
         }

--- a/vantage-api-pool/src/eventual_request/mod.rs
+++ b/vantage-api-pool/src/eventual_request/mod.rs
@@ -9,6 +9,7 @@ use tokio::{
     sync::{oneshot, Mutex},
     time::sleep,
 };
+use tracing::warn;
 
 /// Eventual request will be sent to the client... eventually. Might take
 /// a little bit of time, but we will get that response back.
@@ -130,10 +131,7 @@ impl<T: Sync + Send + Sized> EventualRequest<T> {
                     .unwrap_or_else(|| self.calculate_backoff_delay());
 
                 self.response = Some(response);
-                eprintln!(
-                    "Received 429, retrying... attempt {} (delay: {:?})",
-                    self.retries, delay
-                );
+                warn!(attempt = self.retries, ?delay, "received 429, retrying");
                 sleep(delay).await;
                 EventualRequestResult::Retry
             }
@@ -145,10 +143,7 @@ impl<T: Sync + Send + Sized> EventualRequest<T> {
 
                 self.response = Some(response);
                 sleep(delay).await;
-                eprintln!(
-                    "Received 5xx error ({}), retrying... attempt {} (delay: {:?})",
-                    status, self.retries, delay
-                );
+                warn!(%status, attempt = self.retries, ?delay, "received 5xx, retrying");
                 EventualRequestResult::Retry
             }
             Ok(response) if response.status().is_success() => {
@@ -167,10 +162,7 @@ impl<T: Sync + Send + Sized> EventualRequest<T> {
                 let delay = self.calculate_backoff_delay();
 
                 sleep(delay).await;
-                eprintln!(
-                    "Network error: {}, retrying... attempt {} (delay: {:?})",
-                    err, self.retries, delay
-                );
+                warn!(error = %err, attempt = self.retries, ?delay, "network error, retrying");
                 EventualRequestResult::Retry
             }
         }

--- a/vantage-api-pool/src/matcher/mod.rs
+++ b/vantage-api-pool/src/matcher/mod.rs
@@ -5,6 +5,7 @@ use std::{
 
 use reqwest::{Request, Response};
 use tokio::sync::{mpsc, oneshot, Mutex};
+use tracing::{warn, Instrument as _};
 
 use crate::EventualRequest;
 
@@ -21,10 +22,9 @@ impl<T: Send + Sync + Sized + 'static> EventualRequestMatcher<T> {
         response_receiver: mpsc::Receiver<EventualRequest<T>>,
     ) -> Self {
         let pending_requests = Arc::new(Mutex::new(HashMap::new()));
-        let thread_handle = tokio::spawn(Self::worker_thread(
-            pending_requests.clone(),
-            response_receiver,
-        ));
+        let thread_handle = tokio::spawn(
+            Self::worker_thread(pending_requests.clone(), response_receiver).in_current_span(),
+        );
 
         Self {
             request_sender,
@@ -45,21 +45,15 @@ impl<T: Send + Sync + Sized + 'static> EventualRequestMatcher<T> {
     ) {
         loop {
             let Some(response) = response_receiver.recv().await else {
-                eprintln!("EventualRequestMatcher: response channel closed");
+                warn!("response channel closed, matcher shutting down");
                 break;
             };
 
             match ch.lock().await.remove(&response.get_id().unwrap()) {
                 Some(sender) => sender.send(response).unwrap_or_else(|response| {
-                    eprintln!(
-                        "EventualRequestMatcher: failed to send response for id {:?}",
-                        response.get_id()
-                    )
+                    warn!(id = ?response.get_id(), "failed to send response (caller dropped receiver)");
                 }),
-                None => eprintln!(
-                    "EventualRequestMatcher: no pending request found for id {:?}",
-                    response.get_id()
-                ),
+                None => warn!(id = ?response.get_id(), "no pending request found for response"),
             }
         }
     }

--- a/vantage-api-pool/src/paginator/my_paginated_stream.rs
+++ b/vantage-api-pool/src/paginator/my_paginated_stream.rs
@@ -9,6 +9,7 @@ use std::{
 use anyhow::Result;
 use futures_core::Stream;
 use serde_json::Value;
+use tracing::Instrument as _;
 
 use crate::AwwPool;
 
@@ -51,13 +52,16 @@ impl PageStream {
         let endpoint = self.endpoint.clone();
         let page_num = self.page.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        tokio::spawn(async move {
-            let path = format!("{}?page={}", endpoint, page_num + 1);
-            let response = pool.get(&path).await?;
-            let json = response.json::<Value>().await?;
+        tokio::spawn(
+            async move {
+                let path = format!("{}?page={}", endpoint, page_num + 1);
+                let response = pool.get(&path).await?;
+                let json = response.json::<Value>().await?;
 
-            Ok(json)
-        })
+                Ok(json)
+            }
+            .in_current_span(),
+        )
     }
 }
 

--- a/vantage-api-pool/src/paginator/paginated_stream.rs
+++ b/vantage-api-pool/src/paginator/paginated_stream.rs
@@ -7,6 +7,7 @@ use anyhow::Error;
 use futures_core::{Future, Stream};
 use serde_json::Value;
 use tokio::task::JoinHandle;
+use tracing::Instrument as _;
 
 use crate::AwwPool;
 
@@ -66,11 +67,14 @@ impl PaginatedStream {
         let url = format!("{}?page={}", self.endpoint, page);
         let pool = self.pool.clone();
 
-        let handle = tokio::spawn(async move {
-            let response = pool.get(&url).await?;
-            let body: Value = response.json().await?;
-            Ok((page, body))
-        });
+        let handle = tokio::spawn(
+            async move {
+                let response = pool.get(&url).await?;
+                let body: Value = response.json().await?;
+                Ok((page, body))
+            }
+            .in_current_span(),
+        );
 
         self.fetch_queue.push_back(handle);
     }

--- a/vantage-api-pool/src/paginator/paginated_stream2.rs
+++ b/vantage-api-pool/src/paginator/paginated_stream2.rs
@@ -6,6 +6,7 @@ use anyhow::Error;
 use futures_core::{Future, Stream};
 use serde_json::Value;
 use tokio::task::JoinHandle;
+use tracing::Instrument as _;
 
 use crate::AwwPool;
 
@@ -58,11 +59,14 @@ impl PaginatedStream {
         let url = format!("{}?page={}", self.endpoint, page);
         let pool = self.pool.clone();
 
-        tokio::spawn(async move {
-            let response = pool.get(&url).await?;
-            let body: Value = response.json().await?;
-            Ok(body)
-        })
+        tokio::spawn(
+            async move {
+                let response = pool.get(&url).await?;
+                let body: Value = response.json().await?;
+                Ok(body)
+            }
+            .in_current_span(),
+        )
     }
 
     fn extract_page_data(&mut self, body: &Value) -> (Vec<Value>, Option<usize>) {

--- a/vantage-api-pool/src/paginator/paginated_stream3.rs
+++ b/vantage-api-pool/src/paginator/paginated_stream3.rs
@@ -6,6 +6,7 @@ use anyhow::Error;
 use futures_core::{Future, Stream};
 use serde_json::Value;
 use tokio::task::JoinHandle;
+use tracing::Instrument as _;
 
 use crate::AwwPool;
 
@@ -34,11 +35,14 @@ impl PaginatedStream {
         let url = format!("{}?page={}", endpoint, 1);
         let pool_clone = pool.clone();
 
-        let handle = tokio::spawn(async move {
-            let response = pool_clone.get(&url).await?;
-            let body: Value = response.json().await?;
-            Ok(body)
-        });
+        let handle = tokio::spawn(
+            async move {
+                let response = pool_clone.get(&url).await?;
+                let body: Value = response.json().await?;
+                Ok(body)
+            }
+            .in_current_span(),
+        );
 
         Self {
             pool,
@@ -143,11 +147,14 @@ impl Stream for PaginatedStream {
                             // Start fetching next page
                             let url = format!("{}?page={}", endpoint, page_num);
 
-                            let handle = tokio::spawn(async move {
-                                let response = pool.get(&url).await?;
-                                let body: Value = response.json().await?;
-                                Ok(body)
-                            });
+                            let handle = tokio::spawn(
+                                async move {
+                                    let response = pool.get(&url).await?;
+                                    let body: Value = response.json().await?;
+                                    Ok(body)
+                                }
+                                .in_current_span(),
+                            );
 
                             self.state = StreamState::FetchingPage {
                                 handle,

--- a/vantage-api-pool/src/paginator/paginated_stream4.rs
+++ b/vantage-api-pool/src/paginator/paginated_stream4.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use futures_core::Stream;
 use serde_json::Value;
 use tokio::sync::mpsc;
+use tracing::Instrument as _;
 
 use crate::AwwPool;
 
@@ -21,9 +22,12 @@ impl PageStream {
     pub fn new(pool: Arc<AwwPool>, endpoint: String, prefetch_limit: Option<usize>) -> Self {
         let (item_sender, item_receiver) = mpsc::unbounded_channel();
 
-        let worker_handle = tokio::spawn(async move {
-            Self::worker_thread(pool, endpoint, prefetch_limit, item_sender).await;
-        });
+        let worker_handle = tokio::spawn(
+            async move {
+                Self::worker_thread(pool, endpoint, prefetch_limit, item_sender).await;
+            }
+            .in_current_span(),
+        );
 
         Self {
             item_receiver,
@@ -93,11 +97,14 @@ impl PageStream {
             let pool = pool.clone();
             let endpoint = endpoint.clone();
             let page = next_page;
-            let handle = tokio::spawn(async move {
-                let response = pool.get(&format!("{}?page={}", endpoint, page)).await?;
-                let json: Value = response.json().await?;
-                Ok((page, json))
-            });
+            let handle = tokio::spawn(
+                async move {
+                    let response = pool.get(&format!("{}?page={}", endpoint, page)).await?;
+                    let json: Value = response.json().await?;
+                    Ok((page, json))
+                }
+                .in_current_span(),
+            );
             join_handles.push_back(handle);
             pages_spawned += 1;
             next_page += 1;
@@ -121,11 +128,15 @@ impl PageStream {
                         let pool = pool.clone();
                         let endpoint = endpoint.clone();
                         let page = next_page;
-                        let handle = tokio::spawn(async move {
-                            let response = pool.get(&format!("{}?page={}", endpoint, page)).await?;
-                            let json: Value = response.json().await?;
-                            Ok((page, json))
-                        });
+                        let handle = tokio::spawn(
+                            async move {
+                                let response =
+                                    pool.get(&format!("{}?page={}", endpoint, page)).await?;
+                                let json: Value = response.json().await?;
+                                Ok((page, json))
+                            }
+                            .in_current_span(),
+                        );
                         join_handles.push_back(handle);
                         next_page += 1;
                     }

--- a/vantage-live/CHANGELOG.md
+++ b/vantage-live/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-03
+
+- The write-queue worker and live-event consumer wrap their spawned futures with `tracing::Instrument::in_current_span()` so the caller's span follows the future across the `tokio::spawn` boundary. With a tracing layer installed (e.g. `sentry-tracing`, `tracing-opentelemetry`), worker errors and panics stitch into the same trace as the originating write request rather than appearing as orphans.
+
 ## 0.4.3 — 2026-04-30
 
 - `LiveTable` forwards the four new `TableLike` reflection methods (`id_field_name`, `title_field_names`, `column_types`, `get_ref_names`) through to the master `AnyTable`, so generic UIs that drive a `LiveTable` see the same metadata they would see on the underlying table.

--- a/vantage-live/CHANGELOG.md
+++ b/vantage-live/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.5.0 — 2026-05-03
+## 0.4.5 — 2026-05-03
 
 - The write-queue worker and live-event consumer wrap their spawned futures with `tracing::Instrument::in_current_span()` so the caller's span follows the future across the `tokio::spawn` boundary. With a tracing layer installed (e.g. `sentry-tracing`, `tracing-opentelemetry`), worker errors and panics stitch into the same trace as the originating write request rather than appearing as orphans.
 

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-live"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -25,6 +25,14 @@ redb = "2.6"
 tokio = { version = "1", features = ["sync", "rt", "macros", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
+sentry-core = { version = "0.48", default-features = false, features = ["client"], optional = true }
+
+[features]
+default = []
+# Propagate the calling task's Sentry Hub onto background workers
+# (write queue + live-stream consumer) so panics and tracing events
+# emitted from those tasks correlate to the same trace as the caller.
+sentry = ["dep:sentry-core"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -25,14 +25,6 @@ redb = "2.6"
 tokio = { version = "1", features = ["sync", "rt", "macros", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
-sentry-core = { version = "0.48", default-features = false, features = ["client"], optional = true }
-
-[features]
-default = []
-# Propagate the calling task's Sentry Hub onto background workers
-# (write queue + live-stream consumer) so panics and tracing events
-# emitted from those tasks correlate to the same trace as the caller.
-sentry = ["dep:sentry-core"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-live"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-live"
-version = "0.5.0"
+version = "0.4.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-live/src/live_table/event_consumer.rs
+++ b/vantage-live/src/live_table/event_consumer.rs
@@ -14,10 +14,6 @@ use crate::cache::Cache;
 use crate::live_stream::{LiveEvent, LiveStream};
 
 pub(super) fn spawn(stream: Arc<dyn LiveStream>, cache_key: String, cache: Arc<dyn Cache>) {
-    // `.in_current_span()` propagates the caller's tracing span across
-    // the `tokio::spawn` boundary so any tracing layer the consumer
-    // installed (sentry-tracing, tracing-opentelemetry, ...) sees the
-    // event-consumer's events as descendants of the caller.
     tokio::spawn(
         async move {
             let mut sub = stream.subscribe();

--- a/vantage-live/src/live_table/event_consumer.rs
+++ b/vantage-live/src/live_table/event_consumer.rs
@@ -14,7 +14,7 @@ use crate::cache::Cache;
 use crate::live_stream::{LiveEvent, LiveStream};
 
 pub(super) fn spawn(stream: Arc<dyn LiveStream>, cache_key: String, cache: Arc<dyn Cache>) {
-    tokio::spawn(async move {
+    let fut = async move {
         let mut sub = stream.subscribe();
         debug!(target: "vantage_live::events", cache_key = %cache_key, "event consumer started");
 
@@ -22,7 +22,15 @@ pub(super) fn spawn(stream: Arc<dyn LiveStream>, cache_key: String, cache: Arc<d
             handle(&cache_key, &cache, event).await;
         }
         debug!(target: "vantage_live::events", cache_key = %cache_key, "event consumer stopped");
-    });
+    };
+
+    #[cfg(feature = "sentry")]
+    {
+        use sentry_core::SentryFutureExt as _;
+        tokio::spawn(fut.bind_hub(sentry_core::Hub::current()));
+    }
+    #[cfg(not(feature = "sentry"))]
+    tokio::spawn(fut);
 }
 
 #[instrument(

--- a/vantage-live/src/live_table/event_consumer.rs
+++ b/vantage-live/src/live_table/event_consumer.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 
 use futures_util::StreamExt;
-use tracing::{debug, instrument, warn, Instrument as _};
+use tracing::{Instrument as _, debug, instrument, warn};
 
 use crate::cache::Cache;
 use crate::live_stream::{LiveEvent, LiveStream};

--- a/vantage-live/src/live_table/event_consumer.rs
+++ b/vantage-live/src/live_table/event_consumer.rs
@@ -8,29 +8,28 @@
 use std::sync::Arc;
 
 use futures_util::StreamExt;
-use tracing::{debug, instrument, warn};
+use tracing::{debug, instrument, warn, Instrument as _};
 
 use crate::cache::Cache;
 use crate::live_stream::{LiveEvent, LiveStream};
 
 pub(super) fn spawn(stream: Arc<dyn LiveStream>, cache_key: String, cache: Arc<dyn Cache>) {
-    let fut = async move {
-        let mut sub = stream.subscribe();
-        debug!(target: "vantage_live::events", cache_key = %cache_key, "event consumer started");
+    // `.in_current_span()` propagates the caller's tracing span across
+    // the `tokio::spawn` boundary so any tracing layer the consumer
+    // installed (sentry-tracing, tracing-opentelemetry, ...) sees the
+    // event-consumer's events as descendants of the caller.
+    tokio::spawn(
+        async move {
+            let mut sub = stream.subscribe();
+            debug!(target: "vantage_live::events", cache_key = %cache_key, "event consumer started");
 
-        while let Some(event) = sub.next().await {
-            handle(&cache_key, &cache, event).await;
+            while let Some(event) = sub.next().await {
+                handle(&cache_key, &cache, event).await;
+            }
+            debug!(target: "vantage_live::events", cache_key = %cache_key, "event consumer stopped");
         }
-        debug!(target: "vantage_live::events", cache_key = %cache_key, "event consumer stopped");
-    };
-
-    #[cfg(feature = "sentry")]
-    {
-        use sentry_core::SentryFutureExt as _;
-        tokio::spawn(fut.bind_hub(sentry_core::Hub::current()));
-    }
-    #[cfg(not(feature = "sentry"))]
-    tokio::spawn(fut);
+        .in_current_span(),
+    );
 }
 
 #[instrument(

--- a/vantage-live/src/live_table/worker.rs
+++ b/vantage-live/src/live_table/worker.rs
@@ -23,12 +23,8 @@ pub(super) fn spawn(
     cache_key: String,
     cache: Arc<dyn Cache>,
 ) {
-    // `.in_current_span()` carries the caller's tracing span across the
-    // `tokio::spawn` boundary. Any tracing layer the consumer installed
-    // (sentry-tracing, tracing-opentelemetry, console-subscriber, ...)
-    // sees the spawned task's events as descendants of the caller, so
-    // panics and errors stitch into the same trace as the originating
-    // write request rather than appearing as orphans.
+    // Propagate the caller's tracing span across the spawn boundary so
+    // worker errors stitch into the same trace as the originating write.
     tokio::spawn(
         async move {
             while let Some(op) = rx.recv().await {

--- a/vantage-live/src/live_table/worker.rs
+++ b/vantage-live/src/live_table/worker.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
-use tracing::{debug, instrument, warn};
+use tracing::{debug, instrument, warn, Instrument as _};
 use vantage_dataset::traits::WritableValueSet;
 use vantage_table::any::AnyTable;
 
@@ -23,20 +23,21 @@ pub(super) fn spawn(
     cache_key: String,
     cache: Arc<dyn Cache>,
 ) {
-    let fut = async move {
-        while let Some(op) = rx.recv().await {
-            handle(&master, &custom_write_target, &cache_key, &cache, op).await;
+    // `.in_current_span()` carries the caller's tracing span across the
+    // `tokio::spawn` boundary. Any tracing layer the consumer installed
+    // (sentry-tracing, tracing-opentelemetry, console-subscriber, ...)
+    // sees the spawned task's events as descendants of the caller, so
+    // panics and errors stitch into the same trace as the originating
+    // write request rather than appearing as orphans.
+    tokio::spawn(
+        async move {
+            while let Some(op) = rx.recv().await {
+                handle(&master, &custom_write_target, &cache_key, &cache, op).await;
+            }
+            debug!(target: "vantage_live::worker", cache_key = %cache_key, "write-queue worker shutting down");
         }
-        debug!(target: "vantage_live::worker", cache_key = %cache_key, "write-queue worker shutting down");
-    };
-
-    #[cfg(feature = "sentry")]
-    {
-        use sentry_core::SentryFutureExt as _;
-        tokio::spawn(fut.bind_hub(sentry_core::Hub::current()));
-    }
-    #[cfg(not(feature = "sentry"))]
-    tokio::spawn(fut);
+        .in_current_span(),
+    );
 }
 
 #[instrument(

--- a/vantage-live/src/live_table/worker.rs
+++ b/vantage-live/src/live_table/worker.rs
@@ -8,7 +8,7 @@
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
-use tracing::{debug, instrument, warn, Instrument as _};
+use tracing::{Instrument as _, debug, instrument, warn};
 use vantage_dataset::traits::WritableValueSet;
 use vantage_table::any::AnyTable;
 

--- a/vantage-live/src/live_table/worker.rs
+++ b/vantage-live/src/live_table/worker.rs
@@ -23,12 +23,20 @@ pub(super) fn spawn(
     cache_key: String,
     cache: Arc<dyn Cache>,
 ) {
-    tokio::spawn(async move {
+    let fut = async move {
         while let Some(op) = rx.recv().await {
             handle(&master, &custom_write_target, &cache_key, &cache, op).await;
         }
         debug!(target: "vantage_live::worker", cache_key = %cache_key, "write-queue worker shutting down");
-    });
+    };
+
+    #[cfg(feature = "sentry")]
+    {
+        use sentry_core::SentryFutureExt as _;
+        tokio::spawn(fut.bind_hub(sentry_core::Hub::current()));
+    }
+    #[cfg(not(feature = "sentry"))]
+    tokio::spawn(fut);
 }
 
 #[instrument(

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -20,7 +20,7 @@ vantage-expressions = { version = "0.4", path = "../vantage-expressions", featur
 vantage-table = { version = "0.4.2", path = "../vantage-table" }
 vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
-surreal-client = { version = "0.5", path = "../surreal-client" }
+surreal-client = { version = "0.4", path = "../surreal-client" }
 
 ciborium = "0.2"
 hex = "0.4"

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -20,7 +20,7 @@ vantage-expressions = { version = "0.4", path = "../vantage-expressions", featur
 vantage-table = { version = "0.4.2", path = "../vantage-table" }
 vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
-surreal-client = { version = "0.4", path = "../surreal-client" }
+surreal-client = { version = "0.5", path = "../surreal-client" }
 
 ciborium = "0.2"
 hex = "0.4"

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "sync"] }
 serde_json = "1.0"
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 # vantage-surrealdb = { path = "../vantage-surrealdb" }
-surreal-client = { version = "0.5", path = "../surreal-client" }
+surreal-client = { version = "0.4", path = "../surreal-client" }
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }
 url = { version = "2.5", features = ["serde"] }

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1.48", features = ["macros", "rt-multi-thread", "sync"] }
 serde_json = "1.0"
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 # vantage-surrealdb = { path = "../vantage-surrealdb" }
-surreal-client = { version = "0.4", path = "../surreal-client" }
+surreal-client = { version = "0.5", path = "../surreal-client" }
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }
 url = { version = "2.5", features = ["serde"] }


### PR DESCRIPTION
Makes vantage's background tasks visible to whatever tracing layer you've installed.

If you've ever seen a vantage error in production with no breadcrumb back to the request that triggered it, this is why. Three crates spawn background work — `vantage-live` (write queue, event consumer), `vantage-api-pool` (HTTP workers, paginators), `surreal-client` (WebSocket handlers) — and until now, none of them carried the caller's tracing span across the `tokio::spawn` boundary. So worker-side errors looked like orphans in your trace tree.

This PR wraps every spawn site in `.in_current_span()`. With any tracing layer installed — `sentry-tracing`, `tracing-opentelemetry` (Datadog / Honeycomb / Jaeger), `console-subscriber`, plain `fmt` — worker errors now stitch into the same trace as the request that started them. No feature flags, no vendor lock-in: you pick the layer.

Along the way, `eprintln!` / `println!` calls inside the touched crates move to `tracing::warn!` / `debug!` so they actually flow through your subscriber instead of going to stderr. The JSON `WsEngine` also stops panicking on malformed inbound payloads — bad frames now log a warning and the handler keeps running.

### Versions

- `vantage-api-pool` 0.1.1 → 0.1.2 (gains a direct `tracing` dep)
- `surreal-client` 0.4.0 → 0.4.1 (gains a direct `tracing` dep)
- `vantage-live` 0.4.4 → 0.4.5

No public API changes, no breaking changes for callers.

