### PR TITLE
wire vantage-csv to vista

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "vantage-surrealdb",
  "vantage-table",
  "vantage-types",
+ "vantage-vista",
 ]
 
 [[package]]
@@ -4002,6 +4003,7 @@ dependencies = [
  "vantage-expressions",
  "vantage-table",
  "vantage-types",
+ "vantage-vista",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/bakery_model3/Cargo.toml
+++ b/bakery_model3/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2024"
 [dependencies]
 vantage-core = { path = "../vantage-core" }
 vantage-table = { path = "../vantage-table" }
-vantage-csv = { path = "../vantage-csv" }
+vantage-csv = { path = "../vantage-csv", features = ["vista"] }
+vantage-vista = { path = "../vantage-vista" }
 vantage-expressions = { path = "../vantage-expressions" }
 vantage-dataset = { path = "../vantage-dataset" }
 vantage-types = { path = "../vantage-types" }

--- a/bakery_model3/examples/cli-vista.rs
+++ b/bakery_model3/examples/cli-vista.rs
@@ -1,0 +1,180 @@
+//! Vista-driven CLI for browsing bakery data backed by CSV files.
+//!
+//! Usage: db-vista <entity> [command ...]
+//!
+//! Entities: bakery, client, product, order
+//!
+//! Commands:
+//!   list              List all records as a table
+//!   get               Show first record in detail
+//!   count             Count records
+//!   add <id> <json>   Insert a record (CSV is read-only — errors out)
+//!   delete <id>       Delete a record by ID (CSV is read-only — errors out)
+
+use bakery_model3::*;
+use clap::{Arg, Command};
+use vantage_cli_util::render_records;
+use vantage_csv::Csv;
+use vantage_dataset::prelude::*;
+use vantage_vista::Vista;
+
+fn model_names() -> Vec<&'static str> {
+    vec!["bakery", "client", "product", "order"]
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> vantage_core::Result<()> {
+    let app = Command::new("db-vista")
+        .about("Vista-driven CLI for the CSV bakery dataset")
+        .arg(
+            Arg::new("entity")
+                .help("Entity name (bakery, client, product, order)")
+                .required(false),
+        )
+        .arg(
+            Arg::new("commands")
+                .help("Commands: list, get, count, add <id> <json>, delete <id>")
+                .num_args(0..)
+                .trailing_var_arg(true),
+        );
+
+    let matches = app.get_matches();
+
+    let entity_name = match matches.get_one::<String>("entity") {
+        Some(name) => name.clone(),
+        None => {
+            println!("Available entities: {}", model_names().join(", "));
+            print_usage();
+            return Ok(());
+        }
+    };
+
+    let commands: Vec<String> = matches
+        .get_many::<String>("commands")
+        .unwrap_or_default()
+        .cloned()
+        .collect();
+
+    let vista = match build_vista(&entity_name)? {
+        Some(v) => v,
+        None => return Ok(()),
+    };
+
+    handle_commands(vista, commands).await
+}
+
+fn build_vista(entity_name: &str) -> vantage_core::Result<Option<Vista>> {
+    let csv = Csv::new("bakery_model3/data");
+    let factory = csv.vista_factory();
+    let vista = match entity_name {
+        "bakery" => factory.from_table(Bakery::csv_table(csv))?,
+        "client" => factory.from_table(Client::csv_table(csv))?,
+        "product" => factory.from_table(Product::csv_table(csv))?,
+        "order" => factory.from_table(Order::csv_table(csv))?,
+        _ => {
+            println!("Unknown entity: {}", entity_name);
+            return Ok(None);
+        }
+    };
+    Ok(Some(vista))
+}
+
+fn print_usage() {
+    println!();
+    println!("Usage: db-vista <entity> <command>");
+    println!();
+    println!("Commands:");
+    println!("  list              List all records");
+    println!("  get               Get first record (detailed)");
+    println!("  count             Count records");
+    println!("  add <id> <json>   Insert a record");
+    println!("  delete <id>       Delete a record by ID");
+    println!();
+    println!("Examples:");
+    println!("  db-vista bakery list");
+    println!("  db-vista product count");
+    println!("  db-vista client get");
+}
+
+async fn handle_commands(vista: Vista, commands: Vec<String>) -> vantage_core::Result<()> {
+    if commands.is_empty() {
+        println!("No command. Try: list, get, count, add, delete");
+        return Ok(());
+    }
+
+    let mut i = 0;
+    while i < commands.len() {
+        let cmd = &commands[i];
+        i += 1;
+
+        match cmd.as_str() {
+            "list" => {
+                let records = vista.list_values().await?;
+                render_records(&records, None);
+            }
+            "get" => match vista.get_some_value().await? {
+                Some((id, record)) => {
+                    println!("id: {}", id);
+                    for (k, v) in record.iter() {
+                        println!("  {}: {}", k, serde_json::to_string(v).unwrap_or_default());
+                    }
+                }
+                None => println!("No records found"),
+            },
+            "count" => {
+                let count = vista.get_count().await?;
+                println!("{} records", count);
+            }
+            "add" => {
+                if i + 1 >= commands.len() {
+                    println!("Usage: add <id> <json>");
+                    break;
+                }
+                let id = commands[i].clone();
+                i += 1;
+                let json_str = &commands[i];
+                i += 1;
+
+                let json_val: serde_json::Value =
+                    serde_json::from_str(json_str).map_err(|e: serde_json::Error| {
+                        vantage_core::error!("Invalid JSON", details = e.to_string())
+                    })?;
+
+                if !json_val.is_object() {
+                    println!("Error: JSON must be an object, e.g. '{{\"name\":\"value\"}}'");
+                    break;
+                }
+
+                let cbor_val = ciborium::Value::serialized(&json_val).map_err(|e| {
+                    vantage_core::error!("Invalid JSON for CBOR", details = e.to_string())
+                })?;
+                let record = vantage_types::Record::from(cbor_val);
+                vista.insert_value(&id, &record).await?;
+                println!("Inserted: {}", id);
+            }
+            "delete" => {
+                if i >= commands.len() {
+                    println!("Usage: delete <id>");
+                    break;
+                }
+                let id = commands[i].clone();
+                i += 1;
+
+                vista.delete(&id).await?;
+                println!("Deleted: {}", id);
+            }
+            other => {
+                println!("Unknown command: {}", other);
+                println!("Available: list, get, count, add <id> <json>, delete <id>");
+            }
+        }
+    }
+    Ok(())
+}

--- a/vantage-csv/CHANGELOG.md
+++ b/vantage-csv/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.4 — 2026-05-03
+
+- New opt-in [`vista`](https://docs.rs/vantage-csv/0.4.4/vantage_csv/struct.CsvVistaFactory.html) feature: turn a typed `Table<Csv, E>` into a [`Vista`](https://docs.rs/vantage-vista/0.4.0/vantage_vista/struct.Vista.html) via `csv.vista_factory().from_table(table)` and read rows as `ciborium::Value` records through the universal data handle.
+- Read-only by design — `list`, `get`, `get_some`, and `count` work (with `eq` filters); writes return a clear "CSV is a read-only data source" error and `VistaCapabilities` advertise `can_count: true` only.
+- Existing `TableSource` / `AnyTable` paths are unchanged; the feature is off by default.
+
 ## 0.4.3 — 2026-04-25
 
 - `From`/`Into<ciborium::Value>` impls on `AnyCsvType` so CSV tables can be wrapped via `AnyTable::from_table`. Round-trips via `serde_json::Value` (same lossy bits as the existing JSON bridge — binary, NaN, etc.).

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.4.3"
+version = "0.4.4"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -8,6 +8,10 @@ description = "Vantage extension for CSV files"
 homepage = "https://romaninsh.github.io/vantage"
 repository = "https://github.com/romaninsh/vantage"
 
+[features]
+default = []
+vista = ["dep:vantage-vista"]
+
 [dependencies]
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }
@@ -20,7 +24,9 @@ vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.4.4", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
+vantage-vista = { version = "0.4", path = "../vantage-vista", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.48", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
+vantage-vista = { version = "0.4", path = "../vantage-vista" }

--- a/vantage-csv/src/lib.rs
+++ b/vantage-csv/src/lib.rs
@@ -4,6 +4,10 @@ mod expr_data_source;
 pub mod operation;
 mod table_source;
 pub mod type_system;
+#[cfg(feature = "vista")]
+mod vista;
 
 pub use crate::csv::Csv;
 pub use type_system::{AnyCsvType, CsvType, CsvTypeStringMarker, CsvTypeVariants, record_to_json};
+#[cfg(feature = "vista")]
+pub use vista::{CsvVistaFactory, CsvVistaSource};

--- a/vantage-csv/src/vista.rs
+++ b/vantage-csv/src/vista.rs
@@ -1,0 +1,199 @@
+//! Vista bridge for the CSV backend.
+//!
+//! Construct a `Vista` from a typed `Table<Csv, E>` via `Csv::vista_factory()`.
+//! At the Vista boundary, CSV's `AnyCsvType` is translated to `ciborium::Value`
+//! via the existing CBOR bridge in `type_system.rs`. CSV remains read-only —
+//! all write methods on `VistaSource` return errors.
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_table::column::core::Column as TableColumn;
+use vantage_table::column::flags::ColumnFlag;
+use vantage_table::table::Table;
+use vantage_table::traits::column_like::ColumnLike;
+use vantage_types::{Entity, Record};
+use vantage_vista::{
+    Column as VistaColumn, Vista, VistaCapabilities, VistaFactory, VistaMetadata, VistaSource,
+};
+
+use crate::csv::Csv;
+use crate::type_system::AnyCsvType;
+
+/// Driver-side factory producing `Vista`s backed by CSV files.
+pub struct CsvVistaFactory {
+    csv: Csv,
+}
+
+impl CsvVistaFactory {
+    pub fn new(csv: Csv) -> Self {
+        Self { csv }
+    }
+
+    /// Produce a `Vista` from a typed `Table<Csv, E>`.
+    ///
+    /// Column metadata is harvested from the typed table; the resulting Vista
+    /// owns a `CsvVistaSource` that re-reads the CSV file on each call.
+    pub fn from_table<E>(&self, table: Table<Csv, E>) -> Result<Vista>
+    where
+        E: Entity<AnyCsvType> + 'static,
+    {
+        let mut metadata = VistaMetadata::new();
+        for (name, col) in table.columns() {
+            let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+            if col.flags().contains(&ColumnFlag::Hidden) {
+                vc = vc.hidden();
+            }
+            metadata = metadata.with_column(vc);
+        }
+        if let Some(id_field) = table.id_field() {
+            metadata = metadata.with_id_column(id_field.name().to_string());
+        }
+        if !table.title_fields().is_empty() {
+            metadata = metadata.with_title_columns(table.title_fields().to_vec());
+        }
+
+        let table_name = table.table_name().to_string();
+        let columns = table.columns().clone();
+
+        let source = CsvVistaSource {
+            csv: self.csv.clone(),
+            table_name: table_name.clone(),
+            columns,
+            capabilities: VistaCapabilities {
+                can_count: true,
+                ..VistaCapabilities::default()
+            },
+        };
+
+        Ok(Vista::new(table_name, Box::new(source), metadata))
+    }
+}
+
+impl VistaFactory for CsvVistaFactory {
+    fn from_yaml(&self, _yaml: &str) -> Result<Vista> {
+        Err(error!("CSV vista YAML loader not yet implemented"))
+    }
+}
+
+/// Per-Vista executor for CSV files.
+pub struct CsvVistaSource {
+    csv: Csv,
+    table_name: String,
+    columns: IndexMap<String, TableColumn<AnyCsvType>>,
+    capabilities: VistaCapabilities,
+}
+
+impl CsvVistaSource {
+    fn read_filtered(&self, vista: &Vista) -> Result<IndexMap<String, Record<CborValue>>> {
+        let raw = self.csv.read_csv(&self.table_name, &self.columns)?;
+        let out = raw
+            .into_iter()
+            .filter(|(_, record)| matches_eq_conditions(record, vista))
+            .map(|(id, record)| (id, csv_record_to_cbor(record)))
+            .collect();
+        Ok(out)
+    }
+}
+
+fn csv_record_to_cbor(record: Record<AnyCsvType>) -> Record<CborValue> {
+    record.into_iter().map(|(k, v)| (k, v.into())).collect()
+}
+
+fn matches_eq_conditions(record: &Record<AnyCsvType>, vista: &Vista) -> bool {
+    vista.eq_conditions().iter().all(|(field, expected)| {
+        match record.get(field) {
+            Some(v) => {
+                let actual: CborValue = v.clone().into();
+                &actual == expected
+            }
+            None => false,
+        }
+    })
+}
+
+#[async_trait]
+impl VistaSource for CsvVistaSource {
+    async fn list_vista_values(
+        &self,
+        vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        self.read_filtered(vista)
+    }
+
+    async fn get_vista_value(
+        &self,
+        vista: &Vista,
+        id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        let mut data = self.read_filtered(vista)?;
+        Ok(data.shift_remove(id))
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        let data = self.read_filtered(vista)?;
+        Ok(data.into_iter().next())
+    }
+
+    async fn insert_vista_value(
+        &self,
+        _: &Vista,
+        _: &String,
+        _: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        Err(error!("CSV is a read-only data source"))
+    }
+
+    async fn replace_vista_value(
+        &self,
+        _: &Vista,
+        _: &String,
+        _: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        Err(error!("CSV is a read-only data source"))
+    }
+
+    async fn patch_vista_value(
+        &self,
+        _: &Vista,
+        _: &String,
+        _: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        Err(error!("CSV is a read-only data source"))
+    }
+
+    async fn delete_vista_value(&self, _: &Vista, _: &String) -> Result<()> {
+        Err(error!("CSV is a read-only data source"))
+    }
+
+    async fn delete_vista_all_values(&self, _: &Vista) -> Result<()> {
+        Err(error!("CSV is a read-only data source"))
+    }
+
+    async fn insert_vista_return_id_value(
+        &self,
+        _: &Vista,
+        _: &Record<CborValue>,
+    ) -> Result<String> {
+        Err(error!("CSV is a read-only data source"))
+    }
+
+    async fn get_vista_count(&self, vista: &Vista) -> Result<i64> {
+        Ok(self.read_filtered(vista)?.len() as i64)
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.capabilities
+    }
+}
+
+impl Csv {
+    /// Return a Vista factory bound to this CSV data source.
+    pub fn vista_factory(&self) -> CsvVistaFactory {
+        CsvVistaFactory::new(self.clone())
+    }
+}

--- a/vantage-csv/src/vista.rs
+++ b/vantage-csv/src/vista.rs
@@ -102,15 +102,16 @@ fn csv_record_to_cbor(record: Record<AnyCsvType>) -> Record<CborValue> {
 }
 
 fn matches_eq_conditions(record: &Record<AnyCsvType>, vista: &Vista) -> bool {
-    vista.eq_conditions().iter().all(|(field, expected)| {
-        match record.get(field) {
+    vista
+        .eq_conditions()
+        .iter()
+        .all(|(field, expected)| match record.get(field) {
             Some(v) => {
                 let actual: CborValue = v.clone().into();
                 &actual == expected
             }
             None => false,
-        }
-    })
+        })
 }
 
 #[async_trait]

--- a/vantage-csv/tests/vista.rs
+++ b/vantage-csv/tests/vista.rs
@@ -112,8 +112,8 @@ async fn vista_writes_return_read_only_error() {
 #[tokio::test]
 async fn vista_capabilities_advertise_read_only() {
     let csv = csv();
-    let table = Table::<Csv, EmptyEntity>::new("bakery", csv.clone())
-        .with_column_of::<String>("name");
+    let table =
+        Table::<Csv, EmptyEntity>::new("bakery", csv.clone()).with_column_of::<String>("name");
     let vista = csv.vista_factory().from_table(table).unwrap();
 
     let caps = vista.capabilities();

--- a/vantage-csv/tests/vista.rs
+++ b/vantage-csv/tests/vista.rs
@@ -1,0 +1,125 @@
+//! End-to-end round-trip: typed `Table<Csv, _>` → `Vista` → CBOR rows.
+//!
+//! Validates the stage 2 contract against a real backend (CSV).
+
+#![cfg(feature = "vista")]
+
+use ciborium::Value as CborValue;
+use vantage_csv::Csv;
+use vantage_dataset::prelude::ReadableValueSet;
+use vantage_table::table::Table;
+use vantage_types::EmptyEntity;
+
+fn csv() -> Csv {
+    Csv::new(format!("{}/data", env!("CARGO_MANIFEST_DIR")))
+}
+
+#[tokio::test]
+async fn vista_lists_typed_csv_as_cbor() {
+    let csv = csv();
+    let table = Table::<Csv, EmptyEntity>::new("product", csv.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("calories")
+        .with_column_of::<i64>("price")
+        .with_column_of::<bool>("is_deleted");
+
+    let vista = csv.vista_factory().from_table(table).unwrap();
+
+    assert_eq!(vista.name(), "product");
+    assert_eq!(vista.get_id_column(), Some("id"));
+
+    let rows = vista.list_values().await.unwrap();
+    assert_eq!(rows.len(), 5);
+
+    let cupcake = &rows["flux_cupcake"];
+    let name = cupcake.get("name").expect("name field");
+    assert_eq!(name, &CborValue::Text("Flux Capacitor Cupcake".to_string()));
+
+    // Numeric round-trip: CSV "300" → AnyCsvType::Int → CBOR Integer
+    let calories = cupcake.get("calories").expect("calories field");
+    assert!(
+        matches!(calories, CborValue::Integer(_)),
+        "calories should be a CBOR integer, got {:?}",
+        calories
+    );
+
+    // Bool round-trip: CSV "false" → AnyCsvType::Bool → CBOR Bool
+    let is_deleted = cupcake.get("is_deleted").expect("is_deleted field");
+    assert_eq!(is_deleted, &CborValue::Bool(false));
+}
+
+#[tokio::test]
+async fn vista_get_value_by_id() {
+    let csv = csv();
+    let table = Table::<Csv, EmptyEntity>::new("client", csv.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<bool>("is_paying_client");
+    let vista = csv.vista_factory().from_table(table).unwrap();
+
+    let doc = vista
+        .get_value(&"doc".to_string())
+        .await
+        .unwrap()
+        .expect("doc exists");
+    assert_eq!(
+        doc.get("name"),
+        Some(&CborValue::Text("Doc Brown".to_string()))
+    );
+
+    let missing = vista.get_value(&"nonexistent".to_string()).await.unwrap();
+    assert!(missing.is_none());
+}
+
+#[tokio::test]
+async fn vista_count_with_eq_condition() {
+    let csv = csv();
+    let table = Table::<Csv, EmptyEntity>::new("client", csv.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<bool>("is_paying_client");
+    let mut vista = csv.vista_factory().from_table(table).unwrap();
+
+    assert_eq!(vista.get_count().await.unwrap(), 3);
+
+    vista.add_condition_eq("is_paying_client", CborValue::Bool(true));
+    assert_eq!(vista.get_count().await.unwrap(), 2);
+
+    let rows = vista.list_values().await.unwrap();
+    assert_eq!(rows.len(), 2);
+    assert!(rows.contains_key("marty"));
+    assert!(rows.contains_key("doc"));
+    assert!(!rows.contains_key("biff"));
+}
+
+#[tokio::test]
+async fn vista_writes_return_read_only_error() {
+    use vantage_dataset::prelude::WritableValueSet;
+    use vantage_types::Record;
+
+    let csv = csv();
+    let table = Table::<Csv, EmptyEntity>::new("bakery", csv.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name");
+    let vista = csv.vista_factory().from_table(table).unwrap();
+
+    let empty = Record::new();
+    assert!(vista.insert_value(&"x".to_string(), &empty).await.is_err());
+    assert!(vista.delete(&"x".to_string()).await.is_err());
+}
+
+#[tokio::test]
+async fn vista_capabilities_advertise_read_only() {
+    let csv = csv();
+    let table = Table::<Csv, EmptyEntity>::new("bakery", csv.clone())
+        .with_column_of::<String>("name");
+    let vista = csv.vista_factory().from_table(table).unwrap();
+
+    let caps = vista.capabilities();
+    assert!(caps.can_count);
+    assert!(!caps.can_insert);
+    assert!(!caps.can_update);
+    assert!(!caps.can_delete);
+    assert!(!caps.can_subscribe);
+}

--- a/vantage-vista/plans/0-overview.md
+++ b/vantage-vista/plans/0-overview.md
@@ -24,7 +24,7 @@ consumers — it only changes how the produced Vista behaves at runtime.
 | Stage | File | Status |
 |---|---|---|
 | 1 | [Crate skeleton](1-skeleton.md) | Done |
-| 2 | [First driver integration](2-first-driver.md) | Not started |
+| 2 | [First driver integration](2-first-driver.md) | Done |
 | 3 | [Universal YAML loader](3-yaml-loader.md) | Not started |
 | 4 | [Driver rollout](4-driver-rollout.md) | Not started |
 | 5 | [Portable conditions](5-conditions.md) | Not started |

--- a/vantage-vista/plans/2-first-driver.md
+++ b/vantage-vista/plans/2-first-driver.md
@@ -1,6 +1,6 @@
 # Stage 2 — First driver integration
 
-Status: **Not started**
+Status: **Done**
 
 Pick one driver and wire it through end-to-end: typed `Table<T, E>` →
 Vista via that driver's factory, executing a real `list` query. Validates
@@ -8,17 +8,20 @@ the trait shape from stage 1 against a real backend.
 
 ## Discussion phase
 
-- [ ] Pick first driver. Recommendation: **vantage-sqlite** (simple,
-      well-understood, no async runtime quirks). Alternative:
-      **vantage-mongodb** (already exercises type translation deeply).
-- [ ] Confirm the bridge approach: factory in the driver crate consumes
-      typed `Table<T, E>` and produces a `Vista`. `vantage-table` is
-      *not* a god-struct — it gains only minimal accessors (typed column
-      iteration) needed by drivers.
-- [ ] Confirm CBOR translation lives in the driver, not in vantage-table
-      or vantage-vista.
-- [ ] Confirm what vantage-table accessors drivers need (column kinds,
-      flags, refs definitions) — minimise additions.
+Confirmed with the user:
+
+- [x] First driver: **vantage-csv**. CSV stores everything as `String`,
+      which makes the CBOR conversion boundary easy to inspect, and
+      sample fixture rows already live under `vantage-csv/data/`.
+- [x] Bridge approach: factory in the driver crate consumes typed
+      `Table<Csv, E>` and produces a `Vista`. `vantage-table` already
+      exposed every accessor we needed (`columns()`, `id_field()`,
+      `title_fields()`, `table_name()`); no additions required.
+- [x] CBOR translation lives in the driver — vantage-csv already had
+      `From<AnyCsvType> for ciborium::Value` for the `AnyTable` path,
+      and vista reuses it at the `VistaSource` boundary.
+- [x] vantage-vista is opt-in via a `vista` cargo feature on
+      vantage-csv; the existing TableSource path is unaffected.
 
 ## Scope
 
@@ -37,19 +40,27 @@ Out:
 
 ## Plan
 
-- [ ] Discuss with user: which driver, which accessors to add to
+- [x] Discuss with user: which driver, which accessors to add to
       vantage-table
-- [ ] In `vantage-table`: add minimal typed-column accessor methods
-      drivers need (no behaviour change, just visibility)
-- [ ] In chosen driver crate: `pub fn vista_factory(&self) -> XVistaFactory`
-- [ ] Implement `VistaFactory::from_table` for that driver
-- [ ] Implement `VistaSource` for the driver — `list`, `get`, `count`
-      sufficient for first slice; rest stub with `not implemented`
-- [ ] CBOR translation: per-type bridges in the driver
-- [ ] Capability declaration — populate `VistaCapabilities` honestly
-- [ ] Round-trip integration test: typed Table → Vista → list → assert
-      CBOR shape
-- [ ] Ensure typed `Table<T, E>` is unchanged in API; only added accessors
+- [x] In `vantage-table`: no additions needed — `Table::columns`,
+      `id_field`, `title_fields`, `table_name` already public
+- [x] In `vantage-csv`: `pub fn vista_factory(&self) -> CsvVistaFactory`
+      (gated behind the `vista` feature)
+- [x] Implement `VistaFactory::from_table` for `CsvVistaFactory`
+- [x] Implement `VistaSource` for `CsvVistaSource` — read path
+      (`list`, `get`, `get_some`, `count`) returns CBOR; writes return
+      "CSV is a read-only data source"
+- [x] CBOR translation: reused existing `From<AnyCsvType>` impls at
+      the Vista boundary (`csv_record_to_cbor` + eq-condition matcher)
+- [x] Capability declaration — `can_count: true`; everything else
+      `false` (CSV is read-only)
+- [x] Round-trip integration test in `vantage-csv/tests/vista.rs` —
+      typed Table → Vista → list/get/count, eq-condition filtering,
+      write-error advertising
+- [x] Typed `Table<Csv, E>` API unchanged
+- [x] Convert the csv branch of `bakery_model3/examples/cli.rs` to
+      drive a Vista — preserves identical command surface, validates
+      the API on real fixtures
 
 ## References
 


### PR DESCRIPTION
First driver wiring for [`vantage-vista`](https://docs.rs/vantage-vista/0.4.0/vantage_vista/) — the universal handle that landed shape-only in #221. CSV is read-only and easy to inspect, which made it the right backend to validate the trait surface against real fixtures before rolling out to Mongo / SQLite / AWS.

Existing `vantage-csv` users see no change. The bridge sits behind a new `vista` cargo feature, off by default. Opt in:

```toml
[dependencies]
vantage-csv = { version = "0.4.4", features = ["vista"] }
```

Then any typed `Table<Csv, E>` becomes a `Vista`:

```rust
let csv = Csv::new("data/");
let table = Table::<Csv, Product>::new("product", csv.clone())
    .with_column_of::<String>("name")
    .with_column_of::<i64>("price");

let vista: Vista = csv.vista_factory().from_table(table)?;
let rows = vista.list_values().await?;     // IndexMap<String, Record<CborValue>>
```

Reads (`list`, `get`, `get_some`, `count`) work and honour `eq` conditions. Writes return `"CSV is a read-only data source"`, and `VistaCapabilities` advertise `can_count: true` with everything else `false` — so a generic UI driving CSV through Vista already knows not to draw a "+ New" button.

### Why a factory method, not a trait

`VistaFactory::from_table<E>(Table<Driver, E>)` would have created a `vantage-vista → vantage-table → vantage-expressions → vantage-vista` cycle. Each driver instead exposes `from_table` as an inherent method on its own concrete factory (`CsvVistaFactory::from_table` here). The trait keeps `from_yaml` for the universal loader (stage 3).

### What stage 2 confirmed

`vantage-table` already exposed every accessor a driver needs (`columns`, `id_field`, `title_fields`, `table_name`); no additions. CBOR translation lives in the driver — `vantage-csv` already had `From<AnyCsvType> for ciborium::Value` from 0.4.3, reused at the Vista boundary. `bakery_model3/examples/cli-vista.rs` is the working demo: same command surface as `cli.rs`, but every record flows through `Vista`.

`vantage-csv` 0.4.3 → 0.4.4. No breaking changes.