### PR TITLE
vista yaml loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2948,6 +2948,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3854,6 +3867,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3997,6 +4016,7 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "tokio",
  "vantage-core",
  "vantage-dataset",
@@ -4235,6 +4255,7 @@ dependencies = [
  "futures-core",
  "indexmap",
  "serde",
+ "serde_yaml_ng",
  "thiserror 2.0.18",
  "tokio",
  "vantage-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4003,6 +4003,7 @@ dependencies = [
  "owo-colors",
  "serde",
  "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/todo/error-kinds-rollout.md
+++ b/todo/error-kinds-rollout.md
@@ -1,0 +1,100 @@
+# Error kinds — global rollout
+
+[`vantage_core::ErrorKind`](../vantage-core/src/util/error.rs) was added so
+higher layers can react to errors based on classification (HTTP 4xx vs
+5xx, Sentry alerting policy, UI affordances, etc.). Kinds are set after
+construction via modifier methods on `VantageError`:
+
+```rust
+error!("...", method = "...", capability = "can_X").is_unsupported();
+error!("...", method = "...", capability = "can_X").is_unimplemented();
+error!("table has no columns", table = name).is_incorrect_usage();
+```
+
+Each modifier emits a `tracing::error!` event with the message + structured
+context, so observability sinks pick up the classification automatically.
+
+Currently most call sites still produce `ErrorKind::Generic` (the default).
+This document tracks the migration.
+
+## How to apply
+
+For each callsite below, decide which kind fits and append the modifier:
+
+- **`Unsupported`** — operation legitimately not provided. The driver/impl
+  honestly doesn't do this. Caller should have checked capability flags
+  first; reaching this means they didn't.
+
+- **`Unimplemented`** — operation is intended to exist here but isn't built
+  yet. Distinct from `Unsupported` — `Unsupported` says "never will";
+  `Unimplemented` says "not yet". The `VistaSource::default_error` helper
+  already produces this kind when a capability flag is `true` but the
+  trait method isn't overridden.
+
+- **`IncorrectUsage`** — caller violated a contract. Invalid argument
+  combinations, missing required state, two parts of the framework
+  disagreeing.
+
+If unsure, leave as Generic — better to defer than mislabel. Generic
+errors don't auto-trace; the caller decides whether to log them.
+
+## Unsupported
+
+Caller asked for an operation the impl can't perform — by design.
+
+- [ ] `vantage-csv/src/table_source.rs:130–155` — `Sum/Max/Min not implemented for CSV backend`
+- [ ] `vantage-csv/src/table_source.rs:167–221` — `CSV is a read-only data source` (×6)
+- [ ] `vantage-api-client/src/table_source.rs:178–202` — `Sum/Max/Min not implemented for API backend`
+- [ ] `vantage-api-client/src/table_source.rs:215–269` — `REST API is a read-only data source` (×6)
+- [ ] `vantage-mongodb/src/mongodb/impls/expr_data_source.rs:14` — expression-form not supported
+
+## Unimplemented
+
+Driver advertised a capability without overriding the matching trait method,
+or scaffolding placeholders that will be filled in. `VistaSource::default_error`
+already produces this kind for the capability case; nothing to migrate
+there. New scaffolding should use `.is_unimplemented()` directly.
+
+## IncorrectUsage
+
+Two parts of code disagree, required state missing, invalid arg combinations.
+
+- [ ] `vantage-mongodb/src/mongodb/impls/selectable_data_source.rs:43` — `MongoSelect has no collection set`
+- [ ] `vantage-mongodb/src/mongodb/impls/table_source.rs:171` — `Document missing _id field`
+- [ ] `vantage-mongodb/src/mongodb/impls/table_source.rs:354` — `Inserted row disappeared`
+- [ ] `vantage-mongodb/src/mongodb/impls/table_source.rs:380` — `Replaced row disappeared`
+- [ ] `vantage-mongodb/src/mongodb/impls/table_source.rs:406` — `Record not found after patch`
+- [ ] `vantage-mongodb/src/mongodb/impls/table_source.rs:482` — `No collection name for related_in_condition`
+- [ ] `vantage-mongodb/src/types/mod.rs:128` — `Expected document in array result`
+- [ ] `vantage-mongodb/src/types/mod.rs:134` — `Expected document or array result`
+- [ ] `vantage-api-client/src/api.rs:217` — `API data item is not an object`
+- [ ] `vantage-api-client/src/api.rs:253–262` — bare-array shape errors
+
+## Future kinds — leave Generic for now
+
+We may add more kinds (`Validation`, `External`/`Io`, `NoData`, `Timeout`,
+`AuthRequired`) when patterns become clearer. Until those exist, the
+following bucket of callsites stays Generic:
+
+### Validation candidates
+
+- `vantage-config/src/config.rs:140–195` — schema/config errors
+
+### Io / External candidates
+
+- `vantage-csv/src/csv.rs:59–88` — file open/header/row failures
+- `vantage-api-client/src/api.rs:196–209` — HTTP / JSON parse failures
+- `vantage-mongodb/src/mongodb/impls/table_source.rs` — most `MongoDB *
+  failed` wrappings (find, find_one, count_documents, aggregate, etc.)
+- `vantage-live/src/cache/redb.rs:68–194` — redb backend errors
+
+### NoData candidates
+
+- Errors that include "Record not found" / "no such row" without the
+  inserted-then-disappeared bug shape.
+
+## Tracking
+
+When a callsite is migrated, tick its checkbox here and remove it next
+time this list is touched. New callsites should start out classified;
+this list shouldn't grow.

--- a/vantage-core/Cargo.toml
+++ b/vantage-core/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+tracing = "0.1"
 indexmap = "2.12"
 owo-colors = { version = "4.2", optional = true }
 atty = { version = "0.2", optional = true }

--- a/vantage-core/src/lib.rs
+++ b/vantage-core/src/lib.rs
@@ -5,7 +5,7 @@
 pub mod util;
 
 // use serde::{Deserialize, Serialize, de::DeserializeOwned};
-pub use util::{Context, IntoVec, Result, VantageError};
+pub use util::{Context, ErrorKind, IntoVec, Result, VantageError};
 
 // /// Entity trait for types that can be used with datasets
 // ///

--- a/vantage-core/src/util/error.rs
+++ b/vantage-core/src/util/error.rs
@@ -6,10 +6,38 @@
 use indexmap::IndexMap;
 use std::fmt;
 
+/// Severity / category for a `VantageError`. Set via `.is_*()` modifiers
+/// after construction. Higher layers pattern-match to choose 4xx vs 5xx
+/// behavior, alerting policy, etc.
+///
+/// Each non-`Generic` modifier emits a `tracing::error!` event at the
+/// callsite carrying the error's message and structured context, so
+/// observability sinks (Sentry, OTEL collectors) capture classified
+/// errors without callers needing to log explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ErrorKind {
+    /// Default — error not yet classified by the producer.
+    #[default]
+    Generic,
+    /// Operation is intentionally not provided by this implementation.
+    /// Callers should normally check capability flags first; reaching this
+    /// error means the caller didn't, so it's worth tracing.
+    Unsupported,
+    /// Operation is intended to exist here but isn't built yet (placeholder
+    /// / TODO). Distinct from `Unsupported` (which says "never will") in
+    /// that it tracks scaffolding to fill in.
+    Unimplemented,
+    /// Caller violated a contract — invalid argument combination, missing
+    /// required state, two parts of the framework disagreeing. Always a bug
+    /// at one end of the call.
+    IncorrectUsage,
+}
+
 /// VantageError with location tracking and context information
 #[derive(Debug)]
 pub struct VantageError {
     message: String,
+    kind: ErrorKind,
     location: Option<String>,
     pub context: Box<IndexMap<String, String>>,
     source: Option<Box<dyn std::error::Error + Send + Sync>>,
@@ -191,16 +219,68 @@ impl VantageError {
     pub fn new(message: impl Into<String>, location: String) -> Self {
         Self {
             message: message.into(),
+            kind: ErrorKind::Generic,
             location: Some(location),
             context: Box::new(IndexMap::new()),
             source: None,
         }
     }
 
+    /// Current classification — see [`ErrorKind`].
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    /// Mark as [`ErrorKind::Unsupported`] and emit a `tracing::error!`
+    /// event with the error's message and context.
+    pub fn is_unsupported(mut self) -> Self {
+        self.kind = ErrorKind::Unsupported;
+        self.emit_trace();
+        self
+    }
+
+    /// Mark as [`ErrorKind::Unimplemented`] and emit a `tracing::error!`
+    /// event with the error's message and context.
+    pub fn is_unimplemented(mut self) -> Self {
+        self.kind = ErrorKind::Unimplemented;
+        self.emit_trace();
+        self
+    }
+
+    /// Mark as [`ErrorKind::IncorrectUsage`] and emit a `tracing::error!`
+    /// event with the error's message and context.
+    pub fn is_incorrect_usage(mut self) -> Self {
+        self.kind = ErrorKind::IncorrectUsage;
+        self.emit_trace();
+        self
+    }
+
+    fn emit_trace(&self) {
+        // Flatten context into a single string so it lands as a structured
+        // attribute on the tracing event without needing a serializer.
+        let context_str = if self.context.is_empty() {
+            String::new()
+        } else {
+            self.context
+                .iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        tracing::error!(
+            kind = ?self.kind,
+            location = self.location.as_deref().unwrap_or(""),
+            context = %context_str,
+            "{}",
+            self.message
+        );
+    }
+
     /// Create a "no data available" error
     pub fn no_data() -> Self {
         Self {
             message: "No data available".to_string(),
+            kind: ErrorKind::Generic,
             location: None,
             context: Box::new(IndexMap::new()),
             source: None,
@@ -208,6 +288,9 @@ impl VantageError {
     }
 
     /// Create a "capability not implemented" error with method and type information
+    #[deprecated(
+        note = "Use `error!(...).is_unsupported()` or `is_unimplemented()` modifier API instead"
+    )]
     pub fn no_capability(method: impl Into<String>, type_name: impl Into<String>) -> Self {
         Self {
             message: format!(
@@ -215,6 +298,7 @@ impl VantageError {
                 method.into(),
                 type_name.into()
             ),
+            kind: ErrorKind::Generic,
             location: None,
             context: Box::new(IndexMap::new()),
             source: None,
@@ -225,6 +309,7 @@ impl VantageError {
     pub fn other(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            kind: ErrorKind::Generic,
             location: None,
             context: Box::new(IndexMap::new()),
             source: None,
@@ -236,6 +321,7 @@ impl From<std::io::Error> for VantageError {
     fn from(err: std::io::Error) -> Self {
         VantageError {
             message: "IO error".to_string(),
+            kind: ErrorKind::Generic,
             location: None,
             context: Box::new(IndexMap::new()),
             source: Some(Box::new(err)),
@@ -316,6 +402,7 @@ impl From<String> for VantageError {
     fn from(msg: String) -> Self {
         VantageError {
             message: msg,
+            kind: ErrorKind::Generic,
             location: None,
             context: Box::new(IndexMap::new()),
             source: None,
@@ -372,6 +459,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_no_capability_error() {
         let err = VantageError::no_capability("insert", "ReadOnlyDataSet");
         assert_eq!(

--- a/vantage-core/src/util/mod.rs
+++ b/vantage-core/src/util/mod.rs
@@ -3,5 +3,5 @@
 pub mod error;
 pub mod into_vec;
 
-pub use error::{Context, Result, VantageError};
+pub use error::{Context, ErrorKind, Result, VantageError};
 pub use into_vec::IntoVec;

--- a/vantage-csv/CHANGELOG.md
+++ b/vantage-csv/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.5 — 2026-05-03
+
+- [`CsvVistaFactory::from_yaml`](https://docs.rs/vantage-csv/0.4.5/vantage_csv/struct.CsvVistaFactory.html#method.from_yaml) now works: parse a `*.vista.yaml` describing columns, flags, and a `csv: { path }` block, get back a `Vista`. Per-column `csv: { source: <header> }` overrides the source header when it differs from the spec name.
+- New `read_csv_with_variants` internal path decouples reading from a typed `Table<E>`, used by the YAML loader.
+- Bumps minimum [`vantage-vista`](https://docs.rs/vantage-vista/0.4.1/) requirement to 0.4.1 (uses the new `VistaSpec` / `flags` API).
+
 ## 0.4.4 — 2026-05-03
 
 - New opt-in [`vista`](https://docs.rs/vantage-csv/0.4.4/vantage_csv/struct.CsvVistaFactory.html) feature: turn a typed `Table<Csv, E>` into a [`Vista`](https://docs.rs/vantage-vista/0.4.0/vantage_vista/struct.Vista.html) via `csv.vista_factory().from_table(table)` and read rows as `ciborium::Value` records through the universal data handle.

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.4.4"
+version = "0.4.5"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"
@@ -25,10 +25,10 @@ vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.4.4", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.4", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.4.1", path = "../vantage-vista", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.48", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.4", path = "../vantage-vista" }
+vantage-vista = { version = "0.4.1", path = "../vantage-vista" }

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/romaninsh/vantage"
 
 [features]
 default = []
-vista = ["dep:vantage-vista"]
+vista = ["dep:vantage-vista", "dep:serde"]
 
 [dependencies]
 async-trait = "0.1"
@@ -18,6 +18,7 @@ ciborium = { version = "0.2", features = ["std"] }
 csv = "1.4"
 paste = "1.0"
 indexmap = { version = "2", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1", features = ["preserve_order"] }
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
@@ -29,4 +30,5 @@ vantage-vista = { version = "0.4", path = "../vantage-vista", optional = true }
 [dev-dependencies]
 tokio = { version = "1.48", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_yaml_ng = "0.10"
 vantage-vista = { version = "0.4", path = "../vantage-vista" }

--- a/vantage-csv/data/client.vista.yaml
+++ b/vantage-csv/data/client.vista.yaml
@@ -1,0 +1,20 @@
+name: client
+datasource: bakery_csv
+columns:
+  id:
+    type: string
+    flags: [id]
+  name:
+    type: string
+    flags: [title, searchable]
+  email:
+    type: string
+  contact_details:
+    type: string
+    flags: [hidden]
+  is_paying_client:
+    type: bool
+  metadata:
+    type: string
+csv:
+  path: client.csv

--- a/vantage-csv/src/csv.rs
+++ b/vantage-csv/src/csv.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use indexmap::IndexMap;
 use vantage_core::error;
@@ -7,7 +7,7 @@ use vantage_table::column::core::Column;
 use vantage_table::traits::column_like::ColumnLike;
 use vantage_types::Record;
 
-use crate::type_system::{AnyCsvType, parse_with_type, variant_from_type_name};
+use crate::type_system::{AnyCsvType, CsvTypeVariants, parse_with_type, variant_from_type_name};
 
 /// CSV backend for Vantage — reads data from CSV files.
 ///
@@ -36,7 +36,15 @@ impl Csv {
 
     /// Get the file path for a given table name.
     fn file_path(&self, table_name: &str) -> PathBuf {
+        self.file_path_for(table_name)
+    }
+
+    pub(crate) fn file_path_for(&self, table_name: &str) -> PathBuf {
         self.base_dir.join(format!("{}.csv", table_name))
+    }
+
+    pub(crate) fn base_dir(&self) -> &Path {
+        &self.base_dir
     }
 
     /// Parse a CSV file and return all rows as records.
@@ -48,8 +56,24 @@ impl Csv {
         table_name: &str,
         columns: &IndexMap<String, Column<AnyCsvType>>,
     ) -> Result<IndexMap<String, Record<AnyCsvType>>> {
-        let path = self.file_path(table_name);
-        let mut reader = csv::Reader::from_path(&path)
+        let mut variants = IndexMap::new();
+        for (name, col) in columns {
+            variants.insert(name.clone(), variant_from_type_name(col.get_type()));
+        }
+        self.read_csv_with_variants(&self.file_path(table_name), &self.id_column, &variants)
+    }
+
+    /// Parse a CSV file using pre-resolved column type variants.
+    ///
+    /// Used by the Vista bridge, where column types come from a `VistaSpec`
+    /// rather than a typed `Table<E>`.
+    pub(crate) fn read_csv_with_variants(
+        &self,
+        path: &Path,
+        id_column: &str,
+        column_variants: &IndexMap<String, Option<CsvTypeVariants>>,
+    ) -> Result<IndexMap<String, Record<AnyCsvType>>> {
+        let mut reader = csv::Reader::from_path(path)
             .map_err(|e| error!("Failed to open CSV file", path = path.display(), detail = e))?;
 
         let headers = reader
@@ -57,7 +81,7 @@ impl Csv {
             .map_err(|e| error!("Failed to read CSV headers", detail = e))?
             .clone();
 
-        let id_col_index = headers.iter().position(|h| h == self.id_column);
+        let id_col_index = headers.iter().position(|h| h == id_column);
 
         let mut records = IndexMap::new();
 
@@ -73,9 +97,7 @@ impl Csv {
             let mut record = Record::new();
             for (i, field) in csv_record.iter().enumerate() {
                 if let Some(header) = headers.get(i) {
-                    let variant = columns
-                        .get(header)
-                        .and_then(|col| variant_from_type_name(col.get_type()));
+                    let variant = column_variants.get(header).copied().flatten();
                     record.insert(header.to_string(), parse_with_type(field, variant));
                 }
             }

--- a/vantage-csv/src/csv.rs
+++ b/vantage-csv/src/csv.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use indexmap::IndexMap;
 use vantage_core::error;
@@ -34,46 +34,28 @@ impl Csv {
         self
     }
 
-    /// Get the file path for a given table name.
     fn file_path(&self, table_name: &str) -> PathBuf {
-        self.file_path_for(table_name)
-    }
-
-    pub(crate) fn file_path_for(&self, table_name: &str) -> PathBuf {
         self.base_dir.join(format!("{}.csv", table_name))
     }
 
-    pub(crate) fn base_dir(&self) -> &Path {
+    pub(crate) fn base_dir(&self) -> &std::path::Path {
         &self.base_dir
     }
 
     /// Parse a CSV file and return all rows as records.
     ///
-    /// Column types from the table definition are used to parse values.
-    /// Fields without a known column type are stored as plain strings.
+    /// Behavior under aliasing: a column defined with [`Column::with_alias`]
+    /// reads from the CSV header named by its alias and stores under the
+    /// column name. Headers without a corresponding column are passed
+    /// through untyped (string) under their raw header name — so a table
+    /// with zero declared columns still surfaces every field of the file.
     pub(crate) fn read_csv(
         &self,
         table_name: &str,
         columns: &IndexMap<String, Column<AnyCsvType>>,
     ) -> Result<IndexMap<String, Record<AnyCsvType>>> {
-        let mut variants = IndexMap::new();
-        for (name, col) in columns {
-            variants.insert(name.clone(), variant_from_type_name(col.get_type()));
-        }
-        self.read_csv_with_variants(&self.file_path(table_name), &self.id_column, &variants)
-    }
-
-    /// Parse a CSV file using pre-resolved column type variants.
-    ///
-    /// Used by the Vista bridge, where column types come from a `VistaSpec`
-    /// rather than a typed `Table<E>`.
-    pub(crate) fn read_csv_with_variants(
-        &self,
-        path: &Path,
-        id_column: &str,
-        column_variants: &IndexMap<String, Option<CsvTypeVariants>>,
-    ) -> Result<IndexMap<String, Record<AnyCsvType>>> {
-        let mut reader = csv::Reader::from_path(path)
+        let path = self.file_path(table_name);
+        let mut reader = csv::Reader::from_path(&path)
             .map_err(|e| error!("Failed to open CSV file", path = path.display(), detail = e))?;
 
         let headers = reader
@@ -81,10 +63,27 @@ impl Csv {
             .map_err(|e| error!("Failed to read CSV headers", detail = e))?
             .clone();
 
-        let id_col_index = headers.iter().position(|h| h == id_column);
+        // For each CSV column index, decide the record key + parsing variant.
+        // Default: pass the header through untyped. If a declared column
+        // matches (by alias-or-name), use the column name + its type.
+        let mut key_for: Vec<String> = headers.iter().map(|h| h.to_string()).collect();
+        let mut variant_for: Vec<Option<CsvTypeVariants>> = vec![None; headers.len()];
+        for (name, col) in columns {
+            let csv_header = col.alias().unwrap_or(name);
+            if let Some(idx) = headers.iter().position(|h| h == csv_header) {
+                key_for[idx] = name.clone();
+                variant_for[idx] = variant_from_type_name(col.get_type());
+            }
+        }
+
+        // id column may itself carry an alias.
+        let id_header = columns
+            .get(&self.id_column)
+            .and_then(|c| c.alias())
+            .unwrap_or(&self.id_column);
+        let id_col_index = headers.iter().position(|h| h == id_header);
 
         let mut records = IndexMap::new();
-
         for (row_idx, result) in reader.records().enumerate() {
             let csv_record = result.map_err(|e| error!("Failed to read CSV row", detail = e))?;
 
@@ -96,9 +95,9 @@ impl Csv {
 
             let mut record = Record::new();
             for (i, field) in csv_record.iter().enumerate() {
-                if let Some(header) = headers.get(i) {
-                    let variant = column_variants.get(header).copied().flatten();
-                    record.insert(header.to_string(), parse_with_type(field, variant));
+                if let Some(key) = key_for.get(i) {
+                    let variant = variant_for.get(i).copied().flatten();
+                    record.insert(key.clone(), parse_with_type(field, variant));
                 }
             }
 

--- a/vantage-csv/src/vista.rs
+++ b/vantage-csv/src/vista.rs
@@ -100,7 +100,8 @@ impl CsvVistaFactory {
 
         let source = CsvVistaSource {
             path,
-            id_column: self.csv.id_column.clone(),
+            id_header: self.csv.id_column.clone(),
+            header_to_spec: IndexMap::new(),
             column_variants: variants,
             capabilities: VistaCapabilities {
                 can_count: true,
@@ -126,6 +127,7 @@ impl VistaFactory for CsvVistaFactory {
 
         let mut metadata = VistaMetadata::new();
         let mut variants: IndexMap<String, Option<CsvTypeVariants>> = IndexMap::new();
+        let mut header_to_spec: IndexMap<String, String> = IndexMap::new();
         let mut id_column = spec.id_column.clone();
 
         for (name, col_spec) in &spec.columns {
@@ -145,6 +147,9 @@ impl VistaFactory for CsvVistaFactory {
                 .as_ref()
                 .and_then(|b| b.source.clone())
                 .unwrap_or_else(|| name.clone());
+            if header != *name {
+                header_to_spec.insert(header.clone(), name.clone());
+            }
             variants.insert(header, variant_from_yaml_type(&original_type));
         }
 
@@ -152,11 +157,17 @@ impl VistaFactory for CsvVistaFactory {
             metadata = metadata.with_id_column(id.clone());
         }
 
-        let id_for_source = id_column.clone().unwrap_or_else(|| "id".to_string());
+        // Resolve the spec's id column to its CSV-header form for file lookup.
+        let id_spec = id_column.unwrap_or_else(|| "id".to_string());
+        let id_header = header_to_spec
+            .iter()
+            .find_map(|(header, spec_name)| (spec_name == &id_spec).then(|| header.clone()))
+            .unwrap_or_else(|| id_spec.clone());
 
         let source = CsvVistaSource {
             path,
-            id_column: id_for_source,
+            id_header,
+            header_to_spec,
             column_variants: variants,
             capabilities: VistaCapabilities {
                 can_count: true,
@@ -188,7 +199,11 @@ use crate::type_system::variant_from_type_name;
 /// Per-Vista executor for CSV files.
 pub struct CsvVistaSource {
     path: PathBuf,
-    id_column: String,
+    /// CSV-header form of the id column (after any `csv.source` rename).
+    id_header: String,
+    /// CSV-header → spec column-name renames. Identity entries omitted.
+    header_to_spec: IndexMap<String, String>,
+    /// Column type variants keyed by CSV header name (for parsing).
     column_variants: IndexMap<String, Option<CsvTypeVariants>>,
     capabilities: VistaCapabilities,
 }
@@ -198,6 +213,7 @@ impl CsvVistaSource {
         let raw = self.read_raw()?;
         let out = raw
             .into_iter()
+            .map(|(id, record)| (id, self.rename_to_spec(record)))
             .filter(|(_, record)| matches_eq_conditions(record, vista))
             .map(|(id, record)| (id, csv_record_to_cbor(record)))
             .collect();
@@ -205,10 +221,22 @@ impl CsvVistaSource {
     }
 
     fn read_raw(&self) -> Result<IndexMap<String, Record<AnyCsvType>>> {
-        // Borrow a Csv just to reuse the file reader. We pass our own path
-        // and id column so the Csv's base_dir doesn't matter here.
-        let csv = Csv::new("/").with_id_column(&self.id_column);
-        csv.read_csv_with_variants(&self.path, &self.id_column, &self.column_variants)
+        let csv = Csv::new("/").with_id_column(&self.id_header);
+        csv.read_csv_with_variants(&self.path, &self.id_header, &self.column_variants)
+    }
+
+    /// Translate record keys from CSV header form to spec column names.
+    fn rename_to_spec(&self, record: Record<AnyCsvType>) -> Record<AnyCsvType> {
+        if self.header_to_spec.is_empty() {
+            return record;
+        }
+        record
+            .into_iter()
+            .map(|(k, v)| match self.header_to_spec.get(&k) {
+                Some(spec_name) => (spec_name.clone(), v),
+                None => (k, v),
+            })
+            .collect()
     }
 }
 

--- a/vantage-csv/src/vista.rs
+++ b/vantage-csv/src/vista.rs
@@ -1,25 +1,62 @@
 //! Vista bridge for the CSV backend.
 //!
-//! Construct a `Vista` from a typed `Table<Csv, E>` via `Csv::vista_factory()`.
-//! At the Vista boundary, CSV's `AnyCsvType` is translated to `ciborium::Value`
-//! via the existing CBOR bridge in `type_system.rs`. CSV remains read-only —
+//! Construct a `Vista` from a typed `Table<Csv, E>` via `Csv::vista_factory()`,
+//! or from a YAML spec via `CsvVistaFactory::from_yaml`. CSV is read-only —
 //! all write methods on `VistaSource` return errors.
+
+use std::path::PathBuf;
 
 use async_trait::async_trait;
 use ciborium::Value as CborValue;
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
 use vantage_core::{Result, error};
-use vantage_table::column::core::Column as TableColumn;
 use vantage_table::column::flags::ColumnFlag;
 use vantage_table::table::Table;
 use vantage_table::traits::column_like::ColumnLike;
 use vantage_types::{Entity, Record};
 use vantage_vista::{
-    Column as VistaColumn, Vista, VistaCapabilities, VistaFactory, VistaMetadata, VistaSource,
+    Column as VistaColumn, NoExtras, Vista, VistaCapabilities, VistaFactory, VistaMetadata,
+    VistaSource, VistaSpec, flags as vista_flags,
 };
 
 use crate::csv::Csv;
-use crate::type_system::AnyCsvType;
+use crate::type_system::{AnyCsvType, CsvTypeVariants};
+
+// ---- driver extras --------------------------------------------------------
+
+/// Top-level `csv:` block in a vista spec.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CsvTableExtras {
+    pub csv: CsvBlock,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CsvBlock {
+    pub path: PathBuf,
+}
+
+/// Per-column `csv:` block in a vista spec.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CsvColumnExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub csv: Option<CsvColumnBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CsvColumnBlock {
+    /// Override the source column header name if it differs from the spec name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+pub type CsvVistaSpec = VistaSpec<CsvTableExtras, CsvColumnExtras, NoExtras>;
+
+// ---- factory --------------------------------------------------------------
 
 /// Driver-side factory producing `Vista`s backed by CSV files.
 pub struct CsvVistaFactory {
@@ -40,27 +77,31 @@ impl CsvVistaFactory {
         E: Entity<AnyCsvType> + 'static,
     {
         let mut metadata = VistaMetadata::new();
+        let mut variants: IndexMap<String, Option<CsvTypeVariants>> = IndexMap::new();
         for (name, col) in table.columns() {
             let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
             if col.flags().contains(&ColumnFlag::Hidden) {
-                vc = vc.hidden();
+                vc = vc.with_flag(vista_flags::HIDDEN);
             }
             metadata = metadata.with_column(vc);
+            variants.insert(name.clone(), variant_from_type_name(col.get_type()));
         }
         if let Some(id_field) = table.id_field() {
             metadata = metadata.with_id_column(id_field.name().to_string());
         }
-        if !table.title_fields().is_empty() {
-            metadata = metadata.with_title_columns(table.title_fields().to_vec());
+        for title in table.title_fields() {
+            if let Some(col) = metadata.columns.get_mut(title) {
+                col.flags.push(vista_flags::TITLE.to_string());
+            }
         }
 
         let table_name = table.table_name().to_string();
-        let columns = table.columns().clone();
+        let path = self.csv.file_path_for(&table_name);
 
         let source = CsvVistaSource {
-            csv: self.csv.clone(),
-            table_name: table_name.clone(),
-            columns,
+            path,
+            id_column: self.csv.id_column.clone(),
+            column_variants: variants,
             capabilities: VistaCapabilities {
                 can_count: true,
                 ..VistaCapabilities::default()
@@ -72,28 +113,102 @@ impl CsvVistaFactory {
 }
 
 impl VistaFactory for CsvVistaFactory {
-    fn from_yaml(&self, _yaml: &str) -> Result<Vista> {
-        Err(error!("CSV vista YAML loader not yet implemented"))
+    type TableExtras = CsvTableExtras;
+    type ColumnExtras = CsvColumnExtras;
+    type ReferenceExtras = NoExtras;
+
+    fn build_from_spec(&self, spec: CsvVistaSpec) -> Result<Vista> {
+        let path = if spec.driver.csv.path.is_absolute() {
+            spec.driver.csv.path.clone()
+        } else {
+            self.csv.base_dir().join(&spec.driver.csv.path)
+        };
+
+        let mut metadata = VistaMetadata::new();
+        let mut variants: IndexMap<String, Option<CsvTypeVariants>> = IndexMap::new();
+        let mut id_column = spec.id_column.clone();
+
+        for (name, col_spec) in &spec.columns {
+            let original_type = col_spec.col_type.clone().unwrap_or_default();
+            let mut vc = VistaColumn::new(name.clone(), &original_type);
+            for flag in &col_spec.flags {
+                vc = vc.with_flag(flag.clone());
+                if flag == vista_flags::ID && id_column.is_none() {
+                    id_column = Some(name.clone());
+                }
+            }
+            metadata = metadata.with_column(vc);
+
+            let header = col_spec
+                .driver
+                .csv
+                .as_ref()
+                .and_then(|b| b.source.clone())
+                .unwrap_or_else(|| name.clone());
+            variants.insert(header, variant_from_yaml_type(&original_type));
+        }
+
+        if let Some(ref id) = id_column {
+            metadata = metadata.with_id_column(id.clone());
+        }
+
+        let id_for_source = id_column.clone().unwrap_or_else(|| "id".to_string());
+
+        let source = CsvVistaSource {
+            path,
+            id_column: id_for_source,
+            column_variants: variants,
+            capabilities: VistaCapabilities {
+                can_count: true,
+                ..VistaCapabilities::default()
+            },
+        };
+
+        Ok(Vista::new(spec.name, Box::new(source), metadata))
     }
 }
 
+/// Map a YAML type alias (`int`, `string`, ...) to a `CsvTypeVariants`.
+fn variant_from_yaml_type(name: &str) -> Option<CsvTypeVariants> {
+    match name {
+        "int" | "integer" | "i64" | "i32" => Some(CsvTypeVariants::Int),
+        "float" | "double" | "f64" | "f32" => Some(CsvTypeVariants::Float),
+        "bool" | "boolean" => Some(CsvTypeVariants::Bool),
+        "string" | "text" | "str" => Some(CsvTypeVariants::String),
+        "json" => Some(CsvTypeVariants::Json),
+        _ => None,
+    }
+}
+
+// Re-use the existing string-type-name lookup for the typed-table path.
+use crate::type_system::variant_from_type_name;
+
+// ---- source ---------------------------------------------------------------
+
 /// Per-Vista executor for CSV files.
 pub struct CsvVistaSource {
-    csv: Csv,
-    table_name: String,
-    columns: IndexMap<String, TableColumn<AnyCsvType>>,
+    path: PathBuf,
+    id_column: String,
+    column_variants: IndexMap<String, Option<CsvTypeVariants>>,
     capabilities: VistaCapabilities,
 }
 
 impl CsvVistaSource {
     fn read_filtered(&self, vista: &Vista) -> Result<IndexMap<String, Record<CborValue>>> {
-        let raw = self.csv.read_csv(&self.table_name, &self.columns)?;
+        let raw = self.read_raw()?;
         let out = raw
             .into_iter()
             .filter(|(_, record)| matches_eq_conditions(record, vista))
             .map(|(id, record)| (id, csv_record_to_cbor(record)))
             .collect();
         Ok(out)
+    }
+
+    fn read_raw(&self) -> Result<IndexMap<String, Record<AnyCsvType>>> {
+        // Borrow a Csv just to reuse the file reader. We pass our own path
+        // and id column so the Csv's base_dir doesn't matter here.
+        let csv = Csv::new("/").with_id_column(&self.id_column);
+        csv.read_csv_with_variants(&self.path, &self.id_column, &self.column_variants)
     }
 }
 

--- a/vantage-csv/src/vista.rs
+++ b/vantage-csv/src/vista.rs
@@ -1,31 +1,32 @@
 //! Vista bridge for the CSV backend.
 //!
 //! Construct a `Vista` from a typed `Table<Csv, E>` via `Csv::vista_factory()`,
-//! or from a YAML spec via `CsvVistaFactory::from_yaml`. CSV is read-only —
-//! all write methods on `VistaSource` return errors.
-
-use std::path::PathBuf;
+//! or from a YAML spec via `CsvVistaFactory::from_yaml`. The YAML path builds
+//! a `Table<Csv, EmptyEntity>` first and then routes through `from_table` —
+//! one construction path, one reading path. CSV is read-only.
 
 use async_trait::async_trait;
 use ciborium::Value as CborValue;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use vantage_core::{Result, error};
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_table::column::core::Column as TableColumn;
 use vantage_table::column::flags::ColumnFlag;
 use vantage_table::table::Table;
 use vantage_table::traits::column_like::ColumnLike;
-use vantage_types::{Entity, Record};
+use vantage_types::{EmptyEntity, Entity, Record};
 use vantage_vista::{
     Column as VistaColumn, NoExtras, Vista, VistaCapabilities, VistaFactory, VistaMetadata,
     VistaSource, VistaSpec, flags as vista_flags,
 };
 
 use crate::csv::Csv;
-use crate::type_system::{AnyCsvType, CsvTypeVariants};
+use crate::type_system::AnyCsvType;
 
 // ---- driver extras --------------------------------------------------------
 
-/// Top-level `csv:` block in a vista spec.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CsvTableExtras {
@@ -38,7 +39,6 @@ pub struct CsvBlock {
     pub path: PathBuf,
 }
 
-/// Per-column `csv:` block in a vista spec.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CsvColumnExtras {
@@ -49,7 +49,7 @@ pub struct CsvColumnExtras {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CsvColumnBlock {
-    /// Override the source column header name if it differs from the spec name.
+    /// CSV header to read this column from when it differs from the spec name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
 }
@@ -58,7 +58,6 @@ pub type CsvVistaSpec = VistaSpec<CsvTableExtras, CsvColumnExtras, NoExtras>;
 
 // ---- factory --------------------------------------------------------------
 
-/// Driver-side factory producing `Vista`s backed by CSV files.
 pub struct CsvVistaFactory {
     csv: Csv,
 }
@@ -68,48 +67,68 @@ impl CsvVistaFactory {
         Self { csv }
     }
 
-    /// Produce a `Vista` from a typed `Table<Csv, E>`.
-    ///
-    /// Column metadata is harvested from the typed table; the resulting Vista
-    /// owns a `CsvVistaSource` that re-reads the CSV file on each call.
+    /// Wrap a typed table as a Vista. Column metadata is harvested from the
+    /// table; CRUD goes through `Table`'s reading path.
     pub fn from_table<E>(&self, table: Table<Csv, E>) -> Result<Vista>
     where
         E: Entity<AnyCsvType> + 'static,
     {
-        let mut metadata = VistaMetadata::new();
-        let mut variants: IndexMap<String, Option<CsvTypeVariants>> = IndexMap::new();
-        for (name, col) in table.columns() {
-            let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
-            if col.flags().contains(&ColumnFlag::Hidden) {
-                vc = vc.with_flag(vista_flags::HIDDEN);
-            }
-            metadata = metadata.with_column(vc);
-            variants.insert(name.clone(), variant_from_type_name(col.get_type()));
-        }
-        if let Some(id_field) = table.id_field() {
-            metadata = metadata.with_id_column(id_field.name().to_string());
-        }
-        for title in table.title_fields() {
-            if let Some(col) = metadata.columns.get_mut(title) {
-                col.flags.push(vista_flags::TITLE.to_string());
-            }
-        }
-
-        let table_name = table.table_name().to_string();
-        let path = self.csv.file_path_for(&table_name);
+        let metadata = metadata_from_table(&table);
+        let name = table.table_name().to_string();
+        let any_table = table.into_entity::<EmptyEntity>();
 
         let source = CsvVistaSource {
-            path,
-            id_header: self.csv.id_column.clone(),
-            header_to_spec: IndexMap::new(),
-            column_variants: variants,
+            table: any_table,
             capabilities: VistaCapabilities {
                 can_count: true,
                 ..VistaCapabilities::default()
             },
         };
+        Ok(Vista::new(name, Box::new(source), metadata))
+    }
 
-        Ok(Vista::new(table_name, Box::new(source), metadata))
+    /// Build a `Table<Csv, EmptyEntity>` from a spec. Each column is added
+    /// with its YAML-declared type; `csv.source` becomes the column's alias
+    /// so `read_csv` knows which CSV header to read from.
+    pub fn table_from_spec(&self, spec: &CsvVistaSpec) -> Result<Table<Csv, EmptyEntity>> {
+        let csv_path = if spec.driver.csv.path.is_absolute() {
+            spec.driver.csv.path.clone()
+        } else {
+            self.csv.base_dir().join(&spec.driver.csv.path)
+        };
+        let stem = csv_path
+            .file_stem()
+            .ok_or_else(|| error!("csv.path must point to a file", path = csv_path.display()))?
+            .to_string_lossy()
+            .to_string();
+        let parent = csv_path
+            .parent()
+            .ok_or_else(|| error!("csv.path must have a parent", path = csv_path.display()))?
+            .to_path_buf();
+
+        let id_column = resolve_id_column(spec);
+        let csv = Csv::new(parent).with_id_column(&id_column);
+        let mut table = Table::<Csv, EmptyEntity>::new(stem, csv);
+
+        for (name, col_spec) in &spec.columns {
+            let column = build_column(name, col_spec)?;
+            table.add_column(column);
+        }
+
+        if !table.columns().contains_key(&id_column) {
+            return Err(error!(
+                "id column not present in spec.columns",
+                id = id_column
+            ));
+        }
+        table.set_id_field(&id_column);
+        for (name, col_spec) in &spec.columns {
+            if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
+                table.add_title_field(name);
+            }
+        }
+
+        Ok(table)
     }
 }
 
@@ -119,124 +138,118 @@ impl VistaFactory for CsvVistaFactory {
     type ReferenceExtras = NoExtras;
 
     fn build_from_spec(&self, spec: CsvVistaSpec) -> Result<Vista> {
-        let path = if spec.driver.csv.path.is_absolute() {
-            spec.driver.csv.path.clone()
-        } else {
-            self.csv.base_dir().join(&spec.driver.csv.path)
-        };
-
-        let mut metadata = VistaMetadata::new();
-        let mut variants: IndexMap<String, Option<CsvTypeVariants>> = IndexMap::new();
-        let mut header_to_spec: IndexMap<String, String> = IndexMap::new();
-        let mut id_column = spec.id_column.clone();
-
-        for (name, col_spec) in &spec.columns {
-            let original_type = col_spec.col_type.clone().unwrap_or_default();
-            let mut vc = VistaColumn::new(name.clone(), &original_type);
-            for flag in &col_spec.flags {
-                vc = vc.with_flag(flag.clone());
-                if flag == vista_flags::ID && id_column.is_none() {
-                    id_column = Some(name.clone());
-                }
-            }
-            metadata = metadata.with_column(vc);
-
-            let header = col_spec
-                .driver
-                .csv
-                .as_ref()
-                .and_then(|b| b.source.clone())
-                .unwrap_or_else(|| name.clone());
-            if header != *name {
-                header_to_spec.insert(header.clone(), name.clone());
-            }
-            variants.insert(header, variant_from_yaml_type(&original_type));
-        }
-
-        if let Some(ref id) = id_column {
-            metadata = metadata.with_id_column(id.clone());
-        }
-
-        // Resolve the spec's id column to its CSV-header form for file lookup.
-        let id_spec = id_column.unwrap_or_else(|| "id".to_string());
-        let id_header = header_to_spec
-            .iter()
-            .find_map(|(header, spec_name)| (spec_name == &id_spec).then(|| header.clone()))
-            .unwrap_or_else(|| id_spec.clone());
-
-        let source = CsvVistaSource {
-            path,
-            id_header,
-            header_to_spec,
-            column_variants: variants,
-            capabilities: VistaCapabilities {
-                can_count: true,
-                ..VistaCapabilities::default()
-            },
-        };
-
-        Ok(Vista::new(spec.name, Box::new(source), metadata))
+        let vista_name = spec.name.clone();
+        let table = self.table_from_spec(&spec)?;
+        let mut vista = self.from_table(table)?;
+        vista.set_name(vista_name);
+        Ok(vista)
     }
 }
 
-/// Map a YAML type alias (`int`, `string`, ...) to a `CsvTypeVariants`.
-fn variant_from_yaml_type(name: &str) -> Option<CsvTypeVariants> {
-    match name {
-        "int" | "integer" | "i64" | "i32" => Some(CsvTypeVariants::Int),
-        "float" | "double" | "f64" | "f32" => Some(CsvTypeVariants::Float),
-        "bool" | "boolean" => Some(CsvTypeVariants::Bool),
-        "string" | "text" | "str" => Some(CsvTypeVariants::String),
-        "json" => Some(CsvTypeVariants::Json),
-        _ => None,
+fn resolve_id_column(spec: &CsvVistaSpec) -> String {
+    if let Some(id) = &spec.id_column {
+        return id.clone();
     }
+    for (name, col_spec) in &spec.columns {
+        if col_spec.flags.iter().any(|f| f == vista_flags::ID) {
+            return name.clone();
+        }
+    }
+    "id".to_string()
 }
 
-// Re-use the existing string-type-name lookup for the typed-table path.
-use crate::type_system::variant_from_type_name;
+fn build_column(
+    name: &str,
+    col_spec: &vantage_vista::ColumnSpec<CsvColumnExtras>,
+) -> Result<TableColumn<AnyCsvType>> {
+    let ty = col_spec.col_type.as_deref().unwrap_or("string");
+    let alias = col_spec
+        .driver
+        .csv
+        .as_ref()
+        .and_then(|b| b.source.clone())
+        .filter(|s| s != name);
+    let hidden = col_spec.flags.iter().any(|f| f == vista_flags::HIDDEN);
+
+    let mut col = column_for_type(name, ty)?;
+    if let Some(alias) = alias {
+        col = col.with_alias(alias);
+    }
+    if hidden {
+        col = col.with_flag(ColumnFlag::Hidden);
+    }
+    Ok(col)
+}
+
+/// Runtime type dispatch — YAML type alias to `Column<T>` (then erased to
+/// `Column<AnyCsvType>` for storage). New aliases should land in both
+/// `column_for_type` and the typed-table convenience macros.
+fn column_for_type(name: &str, ty: &str) -> Result<TableColumn<AnyCsvType>> {
+    let col: TableColumn<AnyCsvType> = match ty {
+        "int" | "integer" | "i64" | "i32" => {
+            TableColumn::from_column(TableColumn::<i64>::new(name))
+        }
+        "float" | "double" | "f64" | "f32" => {
+            TableColumn::from_column(TableColumn::<f64>::new(name))
+        }
+        "bool" | "boolean" => TableColumn::from_column(TableColumn::<bool>::new(name)),
+        "string" | "text" | "str" => TableColumn::from_column(TableColumn::<String>::new(name)),
+        "json" => TableColumn::from_column(TableColumn::<serde_json::Value>::new(name)),
+        other => {
+            return Err(error!(
+                "Unknown YAML column type",
+                column = name,
+                ty = other.to_string()
+            ));
+        }
+    };
+    Ok(col)
+}
+
+fn metadata_from_table<T, E>(table: &Table<T, E>) -> VistaMetadata
+where
+    T: vantage_table::traits::table_source::TableSource,
+    E: Entity<T::Value>,
+    T::Column<T::AnyType>: ColumnLike<T::AnyType>,
+{
+    let mut metadata = VistaMetadata::new();
+    for (name, col) in table.columns() {
+        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+        if col.flags().contains(&ColumnFlag::Hidden) {
+            vc = vc.with_flag(vista_flags::HIDDEN);
+        }
+        metadata = metadata.with_column(vc);
+    }
+    if let Some(id_field) = table.id_field() {
+        metadata = metadata.with_id_column(id_field.name().to_string());
+    }
+    for title in table.title_fields() {
+        if let Some(col) = metadata.columns.get_mut(title) {
+            col.flags.push(vista_flags::TITLE.to_string());
+        }
+    }
+    metadata
+}
 
 // ---- source ---------------------------------------------------------------
 
-/// Per-Vista executor for CSV files.
+/// Per-Vista executor — owns the typed `Table` and delegates reads to it.
+/// `Vista::eq_conditions` filter on top of whatever the table itself sees
+/// (in YAML form, that's just the spec; later stages add spec conditions).
 pub struct CsvVistaSource {
-    path: PathBuf,
-    /// CSV-header form of the id column (after any `csv.source` rename).
-    id_header: String,
-    /// CSV-header → spec column-name renames. Identity entries omitted.
-    header_to_spec: IndexMap<String, String>,
-    /// Column type variants keyed by CSV header name (for parsing).
-    column_variants: IndexMap<String, Option<CsvTypeVariants>>,
+    table: Table<Csv, EmptyEntity>,
     capabilities: VistaCapabilities,
 }
 
 impl CsvVistaSource {
-    fn read_filtered(&self, vista: &Vista) -> Result<IndexMap<String, Record<CborValue>>> {
-        let raw = self.read_raw()?;
+    async fn read_filtered(&self, vista: &Vista) -> Result<IndexMap<String, Record<CborValue>>> {
+        let raw = self.table.list_values().await?;
         let out = raw
             .into_iter()
-            .map(|(id, record)| (id, self.rename_to_spec(record)))
             .filter(|(_, record)| matches_eq_conditions(record, vista))
             .map(|(id, record)| (id, csv_record_to_cbor(record)))
             .collect();
         Ok(out)
-    }
-
-    fn read_raw(&self) -> Result<IndexMap<String, Record<AnyCsvType>>> {
-        let csv = Csv::new("/").with_id_column(&self.id_header);
-        csv.read_csv_with_variants(&self.path, &self.id_header, &self.column_variants)
-    }
-
-    /// Translate record keys from CSV header form to spec column names.
-    fn rename_to_spec(&self, record: Record<AnyCsvType>) -> Record<AnyCsvType> {
-        if self.header_to_spec.is_empty() {
-            return record;
-        }
-        record
-            .into_iter()
-            .map(|(k, v)| match self.header_to_spec.get(&k) {
-                Some(spec_name) => (spec_name.clone(), v),
-                None => (k, v),
-            })
-            .collect()
     }
 }
 
@@ -263,7 +276,7 @@ impl VistaSource for CsvVistaSource {
         &self,
         vista: &Vista,
     ) -> Result<IndexMap<String, Record<CborValue>>> {
-        self.read_filtered(vista)
+        self.read_filtered(vista).await
     }
 
     async fn get_vista_value(
@@ -271,7 +284,7 @@ impl VistaSource for CsvVistaSource {
         vista: &Vista,
         id: &String,
     ) -> Result<Option<Record<CborValue>>> {
-        let mut data = self.read_filtered(vista)?;
+        let mut data = self.read_filtered(vista).await?;
         Ok(data.shift_remove(id))
     }
 
@@ -279,55 +292,12 @@ impl VistaSource for CsvVistaSource {
         &self,
         vista: &Vista,
     ) -> Result<Option<(String, Record<CborValue>)>> {
-        let data = self.read_filtered(vista)?;
+        let data = self.read_filtered(vista).await?;
         Ok(data.into_iter().next())
     }
 
-    async fn insert_vista_value(
-        &self,
-        _: &Vista,
-        _: &String,
-        _: &Record<CborValue>,
-    ) -> Result<Record<CborValue>> {
-        Err(error!("CSV is a read-only data source"))
-    }
-
-    async fn replace_vista_value(
-        &self,
-        _: &Vista,
-        _: &String,
-        _: &Record<CborValue>,
-    ) -> Result<Record<CborValue>> {
-        Err(error!("CSV is a read-only data source"))
-    }
-
-    async fn patch_vista_value(
-        &self,
-        _: &Vista,
-        _: &String,
-        _: &Record<CborValue>,
-    ) -> Result<Record<CborValue>> {
-        Err(error!("CSV is a read-only data source"))
-    }
-
-    async fn delete_vista_value(&self, _: &Vista, _: &String) -> Result<()> {
-        Err(error!("CSV is a read-only data source"))
-    }
-
-    async fn delete_vista_all_values(&self, _: &Vista) -> Result<()> {
-        Err(error!("CSV is a read-only data source"))
-    }
-
-    async fn insert_vista_return_id_value(
-        &self,
-        _: &Vista,
-        _: &Record<CborValue>,
-    ) -> Result<String> {
-        Err(error!("CSV is a read-only data source"))
-    }
-
     async fn get_vista_count(&self, vista: &Vista) -> Result<i64> {
-        Ok(self.read_filtered(vista)?.len() as i64)
+        Ok(self.read_filtered(vista).await?.len() as i64)
     }
 
     fn capabilities(&self) -> &VistaCapabilities {

--- a/vantage-csv/tests/vista.rs
+++ b/vantage-csv/tests/vista.rs
@@ -95,6 +95,7 @@ async fn vista_count_with_eq_condition() {
 
 #[tokio::test]
 async fn vista_writes_return_read_only_error() {
+    use vantage_core::ErrorKind;
     use vantage_dataset::prelude::WritableValueSet;
     use vantage_types::Record;
 
@@ -105,8 +106,22 @@ async fn vista_writes_return_read_only_error() {
     let vista = csv.vista_factory().from_table(table).unwrap();
 
     let empty = Record::new();
-    assert!(vista.insert_value(&"x".to_string(), &empty).await.is_err());
-    assert!(vista.delete(&"x".to_string()).await.is_err());
+
+    // CSV doesn't advertise can_insert/can_delete → Unsupported, not the
+    // Unimplemented placeholder that would mean a driver bug.
+    let insert_err = vista
+        .insert_value(&"x".to_string(), &empty)
+        .await
+        .unwrap_err();
+    assert_eq!(insert_err.kind(), ErrorKind::Unsupported);
+    assert!(
+        insert_err.to_string().contains("can_insert"),
+        "expected message to mention capability: {}",
+        insert_err
+    );
+
+    let delete_err = vista.delete(&"x".to_string()).await.unwrap_err();
+    assert_eq!(delete_err.kind(), ErrorKind::Unsupported);
 }
 
 #[tokio::test]

--- a/vantage-csv/tests/vista_yaml.rs
+++ b/vantage-csv/tests/vista_yaml.rs
@@ -1,0 +1,79 @@
+//! YAML loader: parse a `VistaSpec`, produce a `Vista`, list rows.
+
+#![cfg(feature = "vista")]
+
+use ciborium::Value as CborValue;
+use vantage_csv::Csv;
+use vantage_dataset::prelude::ReadableValueSet;
+use vantage_vista::VistaFactory;
+
+fn data_dir() -> String {
+    format!("{}/data", env!("CARGO_MANIFEST_DIR"))
+}
+
+fn load_yaml(name: &str) -> String {
+    let path = format!("{}/{}", data_dir(), name);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+}
+
+#[tokio::test]
+async fn yaml_loads_client_vista_and_lists_rows() {
+    let csv = Csv::new(data_dir());
+    let yaml = load_yaml("client.vista.yaml");
+
+    let vista = csv.vista_factory().from_yaml(&yaml).expect("load yaml");
+
+    assert_eq!(vista.name(), "client");
+    assert_eq!(vista.get_id_column(), Some("id"));
+    assert_eq!(vista.get_title_columns(), vec!["name"]);
+    assert!(vista.get_column("contact_details").unwrap().is_hidden());
+    assert!(!vista.get_column("name").unwrap().is_hidden());
+
+    let rows = vista.list_values().await.unwrap();
+    assert_eq!(rows.len(), 3);
+
+    let marty = &rows["marty"];
+    assert_eq!(
+        marty.get("name"),
+        Some(&CborValue::Text("Marty McFly".to_string()))
+    );
+    assert_eq!(marty.get("is_paying_client"), Some(&CborValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn yaml_eq_condition_filters_typed_column() {
+    let csv = Csv::new(data_dir());
+    let yaml = load_yaml("client.vista.yaml");
+
+    let mut vista = csv.vista_factory().from_yaml(&yaml).unwrap();
+    vista.add_condition_eq("is_paying_client", CborValue::Bool(true));
+
+    let rows = vista.list_values().await.unwrap();
+    assert_eq!(rows.len(), 2);
+    assert!(rows.contains_key("marty"));
+    assert!(rows.contains_key("doc"));
+}
+
+#[test]
+fn yaml_rejects_unknown_csv_block_field() {
+    let csv = Csv::new(data_dir());
+    let yaml = r#"
+name: client
+columns:
+  id:
+    type: string
+    flags: [id]
+csv:
+  path: client.csv
+  mystery: true
+"#;
+    let err = match csv.vista_factory().from_yaml(yaml) {
+        Ok(_) => panic!("unknown field should fail"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("mystery") || msg.contains("unknown"),
+        "expected typo-detecting error, got: {msg}"
+    );
+}

--- a/vantage-csv/tests/vista_yaml.rs
+++ b/vantage-csv/tests/vista_yaml.rs
@@ -54,6 +54,53 @@ async fn yaml_eq_condition_filters_typed_column() {
     assert!(rows.contains_key("doc"));
 }
 
+#[tokio::test]
+async fn yaml_csv_source_renames_record_keys_and_filters() {
+    // The CSV file has a column header `is_paying_client`; the spec exposes
+    // it as `is_active` via a `csv.source` override. Listing must surface the
+    // spec name, and filtering must match against the spec name too.
+    let csv = Csv::new(data_dir());
+    let yaml = r#"
+name: client
+columns:
+  id:
+    type: string
+    flags: [id]
+  full_name:
+    type: string
+    csv:
+      source: name
+  is_active:
+    type: bool
+    csv:
+      source: is_paying_client
+csv:
+  path: client.csv
+"#;
+    let mut vista = csv.vista_factory().from_yaml(yaml).expect("load yaml");
+
+    let rows = vista.list_values().await.unwrap();
+    let marty = &rows["marty"];
+    assert_eq!(
+        marty.get("full_name"),
+        Some(&CborValue::Text("Marty McFly".to_string())),
+        "spec column `full_name` should carry the renamed CSV `name` column",
+    );
+    assert!(
+        marty.get("name").is_none(),
+        "raw CSV header `name` must not leak into spec-named records",
+    );
+    assert_eq!(marty.get("is_active"), Some(&CborValue::Bool(true)));
+
+    // Filtering must match spec names, not raw CSV headers.
+    vista.add_condition_eq("is_active", CborValue::Bool(true));
+    let filtered = vista.list_values().await.unwrap();
+    assert_eq!(filtered.len(), 2);
+    assert!(filtered.contains_key("marty"));
+    assert!(filtered.contains_key("doc"));
+    assert!(!filtered.contains_key("biff"));
+}
+
 #[test]
 fn yaml_rejects_unknown_csv_block_field() {
     let csv = Csv::new(data_dir());

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -127,6 +127,29 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             .and_then(|name| self.columns.get(name))
     }
 
+    /// Mark an already-added column as the id field.
+    ///
+    /// Use this when the id column has been added via [`Self::add_column`]
+    /// (so its type and aliases were chosen explicitly) and you only need
+    /// to flag it. [`Self::with_id_column`] is the typed shortcut that
+    /// creates the column for you.
+    pub fn set_id_field(&mut self, name: impl Into<String>) {
+        self.id_field = Some(name.into());
+    }
+
+    /// Mark an already-added column as a display title.
+    ///
+    /// Companion to [`Self::set_id_field`] for spec-driven construction.
+    pub fn add_title_field(&mut self, name: impl Into<String>) {
+        let name = name.into();
+        if !self.title_fields.contains(&name) {
+            self.title_fields.push(name.clone());
+        }
+        if self.title_field.is_none() {
+            self.title_field = Some(name);
+        }
+    }
+
     /// Get the current pagination configuration, if set
     pub fn pagination(&self) -> Option<&Pagination> {
         self.pagination.as_ref()

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.4.1 — 2026-05-03
+
+Stage 3 — universal YAML loader.
+
+- New [`VistaSpec<T, C, R>`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/struct.VistaSpec.html) is the YAML-facing schema. Three generic parameters carry driver-specific extras at the table, column, and reference level (use [`NoExtras`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/struct.NoExtras.html) when a driver has none). Sugar form `references: products` parses as a [`ReferenceSugar::Sugar`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/enum.ReferenceSugar.html) and the full form deserialises a `ReferenceSpec`.
+- [`VistaFactory`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/trait.VistaFactory.html) gains three associated `Extras` types and a new `build_from_spec` method. The default `from_yaml` parses with `serde_yaml_ng` and dispatches — drivers only need to implement `build_from_spec`.
+- New [`flags`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/flags/index.html) module: `ID`, `TITLE`, `SEARCHABLE`, `MANDATORY`, `HIDDEN`. The vocabulary is open `Vec<String>`; these constants name the values vista's own accessors understand.
+- **Breaking**: `Column::hidden: bool` is replaced by `Column::flags: Vec<String>`. Use `Column::with_flag`, `is_hidden`, `is_id`, `is_title` instead. `VistaMetadata::with_title_columns` is gone — title columns are derived from the `title` flag at runtime via `Vista::get_title_columns()`. Driver factories that translated `ColumnFlag::Hidden` need to call `with_flag(flags::HIDDEN)` instead of `Column::hidden()`.
+
 ## 0.4.0 — 2026-05-03
 
 First release — incubating. New crate housing `Vista`, the universal,

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -14,11 +14,12 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
 ciborium = { version = "0.2", features = ["std"] }
-indexmap = "2.12"
+indexmap = { version = "2.12", features = ["serde"] }
 async-stream = "0.3"
 async-trait = "0.1"
 futures-core = "0.3"
 serde = { version = "1.0", features = ["derive"] }
+serde_yaml_ng = "0.10"
 thiserror = "2.0"
 
 [dev-dependencies]

--- a/vantage-vista/README.md
+++ b/vantage-vista/README.md
@@ -48,14 +48,14 @@ use vantage_dataset::ReadableValueSet;
 
 async fn render(vista: &Vista) -> VantageResult<()> {
     for col in vista.get_column_names() {
-        if vista.get_column(col).unwrap().hidden { continue; }
+        if vista.get_column(col).unwrap().is_hidden() { continue; }
         print!("{}\t", col);
     }
     println!();
 
     for (_id, row) in vista.list_values().await? {
         for col in vista.get_column_names() {
-            if vista.get_column(col).unwrap().hidden { continue; }
+            if vista.get_column(col).unwrap().is_hidden() { continue; }
             print!("{:?}\t", row.get(col));
         }
         println!();

--- a/vantage-vista/plans/0-overview.md
+++ b/vantage-vista/plans/0-overview.md
@@ -25,7 +25,7 @@ consumers — it only changes how the produced Vista behaves at runtime.
 |---|---|---|
 | 1 | [Crate skeleton](1-skeleton.md) | Done |
 | 2 | [First driver integration](2-first-driver.md) | Done |
-| 3 | [Universal YAML loader](3-yaml-loader.md) | Not started |
+| 3 | [Universal YAML loader](3-yaml-loader.md) | Done |
 | 4 | [Driver rollout](4-driver-rollout.md) | Not started |
 | 5 | [Portable conditions](5-conditions.md) | Not started |
 | 6 | [Hooks + Rhai](6-hooks.md) | Not started |

--- a/vantage-vista/plans/3-yaml-loader.md
+++ b/vantage-vista/plans/3-yaml-loader.md
@@ -1,54 +1,74 @@
 # Stage 3 — Universal YAML loader
 
-Status: **Not started**
+Status: **Done**
 
 Add YAML → Vista construction. Universal vocabulary (table name,
 columns, flags, references) is parsed by `vantage-vista`; driver-specific
-extras are delegated to the factory.
+extras are carried through three generic parameters on `VistaSpec` and
+deserialised by the driver itself.
 
 ## Discussion phase
 
-- [ ] Confirm `VistaSpec` shape — universal fields only
-- [ ] Confirm where driver-specific YAML lives — top-level key per driver
-      (e.g. `mongo:`, `aws:`, `sqlite:`) vs nested `extras:` block
-- [ ] Confirm flag vocabulary: `id`, `title`, `searchable`, `mandatory`,
-      `hidden` — extensible via driver?
-- [ ] Confirm reference kinds: `has_one`, `has_many`, `has_foreign`?
-- [ ] Confirm error reporting strategy for malformed YAML (line numbers,
-      field paths)
+Confirmed with the user:
+
+- [x] `VistaSpec` shape — universal fields only (`name`, `datasource`,
+      `id_column`, `columns`, `references`). `title_columns` dropped:
+      title membership lives only as a column flag.
+- [x] Driver-specific YAML lives under top-level keys named by the driver,
+      both at the table level (e.g. `csv:`) and at the column level
+      (matches vantage-ui's existing pattern). Each driver supplies its
+      own typed block via `VistaSpec`'s three generic parameters.
+- [x] Flag vocabulary is open `Vec<String>`. Constants in
+      `vantage_vista::flags` (`ID`, `TITLE`, `SEARCHABLE`, `MANDATORY`,
+      `HIDDEN`) name the values vista's own accessors understand;
+      drivers and consumers may add their own.
+- [x] Reference kinds: `has_one`, `has_many`, `has_foreign`. Sugar form
+      `references: products` parses as a `has_one`-style hint.
+- [x] Errors are wrapped via `serde_yaml_ng::Error` → `vantage_core::Error`.
+      Driver-specific blocks set `deny_unknown_fields` to surface typos.
 
 ## Scope
 
 In:
 
-- `VistaSpec` struct (universal columns, references, flags)
-- `VistaFactory::from_yaml(yaml: &str) -> Result<Vista>`
-- Per-driver `parse_extras(spec, &driver_block)` hook
-- Cache key derivation (auto from `{datasource}/{name}`)
-- Error reporting with field paths
+- `VistaSpec<T, C, R>` generic over driver-specific table/column/reference
+  blocks; `NoExtras` placeholder for drivers with none.
+- `VistaFactory::Extras` associated types, `build_from_spec`, and a
+  default `from_yaml` that parses with `serde_yaml_ng` then dispatches.
+- CSV driver: `CsvTableExtras` (`csv: { path }`), `CsvColumnExtras`
+  (`csv: { source }`), `NoExtras` for references.
 
 Out:
 
 - Hooks block (stage 6)
 - Conditions block (stage 5)
 - Coop integration (stage 7)
+- Cache key derivation (deferred — comes with stage 7)
 
 ## Plan
 
-- [ ] Discuss with user: VistaSpec shape, extras placement
-- [ ] Define `VistaSpec` struct + serde derive
-- [ ] Define universal `Flag` enum
-- [ ] Define `ColumnSpec` (name, type, flags, references field)
-- [ ] Define `ReferenceSpec` (name, target, kind, foreign_key)
-- [ ] Implement `VistaFactory::from_yaml` default impl that:
-      1. parses `VistaSpec`
-      2. invokes `parse_extras` on the factory
-      3. constructs Vista with the produced source
-- [ ] First driver (from stage 2) implements `parse_extras` for its
-      driver-specific YAML block
-- [ ] Test: YAML round-trip with the first driver — load YAML, list rows,
-      verify schema matches
-- [ ] Document the YAML schema in a `SCHEMA.md` next to this plan
+- [x] Discuss with user: VistaSpec shape, extras placement
+- [x] Define `VistaSpec<T, C, R>` struct + serde derive (with bound
+      attributes for the three generics)
+- [x] Define `flags` constants module (`ID`, `TITLE`, `HIDDEN`, etc.) —
+      flags themselves stay open `Vec<String>`
+- [x] Define `ColumnSpec<C>` (type, flags, references sugar, driver block)
+- [x] Define `ReferenceSpec<R>` (table, kind, foreign_key, driver block)
+      and `ReferenceSugar` (untagged sugar/full enum)
+- [x] Add `VistaFactory::Extras` associated types + default `from_yaml`
+      that parses then calls `build_from_spec`
+- [x] CSV driver implements the spec types + `build_from_spec`. CSV's
+      `read_csv_with_variants` decouples reading from typed `Column<E>`.
+- [x] Test: YAML round-trip with CSV — load YAML, list rows, eq filter,
+      reject unknown driver-block fields
+- [x] Convert `Vista::Column` to carry `flags: Vec<String>` (was
+      `hidden: bool`); derive `get_title_columns()` from flags
+
+Deferred:
+
+- [ ] Document the YAML schema in a `SCHEMA.md` (will land alongside
+      stage 4's driver rollout, when more than one driver demonstrates
+      the cross-driver vocabulary)
 
 ## References
 

--- a/vantage-vista/src/column.rs
+++ b/vantage-vista/src/column.rs
@@ -1,15 +1,18 @@
 use serde::{Deserialize, Serialize};
 
+use crate::flags;
+
 /// Display-relevant column metadata held by a `Vista`.
 ///
-/// Vista deliberately does not carry `vantage_table::ColumnFlag`. Driver
-/// factories translate flags into vista accessors (id column, title columns,
-/// hidden flag) when constructing the Vista.
+/// `flags` is an open vocabulary; the constants in [`crate::flags`] name the
+/// values vista's own accessors understand. Drivers and consumers may add
+/// their own.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Column {
     pub name: String,
     pub original_type: String,
-    pub hidden: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub flags: Vec<String>,
 }
 
 impl Column {
@@ -17,12 +20,32 @@ impl Column {
         Self {
             name: name.into(),
             original_type: original_type.into(),
-            hidden: false,
+            flags: Vec::new(),
         }
     }
 
-    pub fn hidden(mut self) -> Self {
-        self.hidden = true;
+    pub fn with_flag(mut self, flag: impl Into<String>) -> Self {
+        self.flags.push(flag.into());
         self
+    }
+
+    pub fn hidden(self) -> Self {
+        self.with_flag(flags::HIDDEN)
+    }
+
+    pub fn has_flag(&self, flag: &str) -> bool {
+        self.flags.iter().any(|f| f == flag)
+    }
+
+    pub fn is_hidden(&self) -> bool {
+        self.has_flag(flags::HIDDEN)
+    }
+
+    pub fn is_id(&self) -> bool {
+        self.has_flag(flags::ID)
+    }
+
+    pub fn is_title(&self) -> bool {
+        self.has_flag(flags::TITLE)
     }
 }

--- a/vantage-vista/src/factory.rs
+++ b/vantage-vista/src/factory.rs
@@ -1,16 +1,42 @@
-use vantage_core::Result;
+use serde::{Serialize, de::DeserializeOwned};
+use vantage_core::{Result, error};
 
+use crate::spec::VistaSpec;
 use crate::vista::Vista;
 
 /// Factory that produces `Vista` instances from configuration sources.
 ///
 /// Driver crates implement this trait on a concrete factory struct
-/// (e.g. `SqliteVistaFactory`). Each driver also exposes its own
-/// inherent `from_table<E>(table: Table<DriverSource, E>) -> Result<Vista>`
+/// (e.g. `CsvVistaFactory`, `SqliteVistaFactory`). Each driver also exposes
+/// its own inherent `from_table<E>(table: Table<DriverSource, E>) -> Result<Vista>`
 /// method on the same factory struct — kept off the trait so vantage-vista
-/// does not need to depend on vantage-table (which would create a dep cycle
-/// via vantage-expressions).
+/// does not depend on vantage-table.
+///
+/// Drivers carry per-driver YAML extension types via the three associated
+/// types (table block, column block, reference block). Each defaults to
+/// [`crate::spec::NoExtras`] in `VistaSpec` for drivers with no extras.
 pub trait VistaFactory: Send + Sync + 'static {
+    /// Driver-specific table-level YAML block.
+    type TableExtras: Serialize + DeserializeOwned + Default + Send + Sync + 'static;
+    /// Driver-specific per-column YAML block.
+    type ColumnExtras: Serialize + DeserializeOwned + Default + Send + Sync + 'static;
+    /// Driver-specific per-reference YAML block.
+    type ReferenceExtras: Serialize + DeserializeOwned + Default + Send + Sync + 'static;
+
+    /// Lower a parsed spec into a `Vista`. Drivers do whatever they need
+    /// here — open a file, allocate state, materialize a source.
+    fn build_from_spec(
+        &self,
+        spec: VistaSpec<Self::TableExtras, Self::ColumnExtras, Self::ReferenceExtras>,
+    ) -> Result<Vista>;
+
+    /// Default impl: parse YAML into a typed `VistaSpec`, then build.
+    /// Drivers may override to add post-parse normalization.
     #[allow(clippy::wrong_self_convention)]
-    fn from_yaml(&self, yaml: &str) -> Result<Vista>;
+    fn from_yaml(&self, yaml: &str) -> Result<Vista> {
+        let spec: VistaSpec<Self::TableExtras, Self::ColumnExtras, Self::ReferenceExtras> =
+            serde_yaml_ng::from_str(yaml)
+                .map_err(|e| error!("Failed to parse VistaSpec YAML", detail = e.to_string()))?;
+        self.build_from_spec(spec)
+    }
 }

--- a/vantage-vista/src/flags.rs
+++ b/vantage-vista/src/flags.rs
@@ -1,0 +1,12 @@
+//! Canonical column flag vocabulary.
+//!
+//! Vista carries flags on columns as plain strings — the set is open so
+//! drivers and consumers can extend it. The constants below name the flags
+//! understood directly by `vantage-vista`'s own accessors. Drivers translate
+//! their native flag types into these strings when constructing a `Vista`.
+
+pub const ID: &str = "id";
+pub const TITLE: &str = "title";
+pub const SEARCHABLE: &str = "searchable";
+pub const MANDATORY: &str = "mandatory";
+pub const HIDDEN: &str = "hidden";

--- a/vantage-vista/src/lib.rs
+++ b/vantage-vista/src/lib.rs
@@ -4,11 +4,13 @@ pub mod any_expression;
 pub mod capabilities;
 pub mod column;
 pub mod factory;
+pub mod flags;
 pub mod impls;
 pub mod metadata;
 pub mod mocks;
 pub mod reference;
 pub mod source;
+pub mod spec;
 pub mod vista;
 
 pub use any_expression::{AnyExpression, ExpressionLike};
@@ -18,6 +20,7 @@ pub use factory::VistaFactory;
 pub use metadata::VistaMetadata;
 pub use reference::{Reference, ReferenceKind};
 pub use source::VistaSource;
+pub use spec::{ColumnSpec, NoExtras, ReferenceSpec, ReferenceSugar, VistaSpec};
 pub use vista::Vista;
 
 /// Convenience alias for the carrier type used at the `VistaSource` boundary.

--- a/vantage-vista/src/metadata.rs
+++ b/vantage-vista/src/metadata.rs
@@ -7,12 +7,14 @@ use crate::{column::Column, reference::Reference};
 /// Driver factories produce one of these by inspecting a typed
 /// `Table<DriverSource, E>`; the universal YAML loader produces one by
 /// parsing config. End-user code typically doesn't construct this directly.
+///
+/// Title columns are derived from column flags at runtime — see
+/// `Vista::get_title_columns`.
 #[derive(Debug, Clone, Default)]
 pub struct VistaMetadata {
     pub columns: IndexMap<String, Column>,
     pub references: IndexMap<String, Reference>,
     pub id_column: Option<String>,
-    pub title_columns: Vec<String>,
 }
 
 impl VistaMetadata {
@@ -32,14 +34,6 @@ impl VistaMetadata {
 
     pub fn with_id_column(mut self, name: impl Into<String>) -> Self {
         self.id_column = Some(name.into());
-        self
-    }
-
-    pub fn with_title_columns(
-        mut self,
-        names: impl IntoIterator<Item = impl Into<String>>,
-    ) -> Self {
-        self.title_columns = names.into_iter().map(Into::into).collect();
         self
     }
 }

--- a/vantage-vista/src/mocks/mock_vista_source.rs
+++ b/vantage-vista/src/mocks/mock_vista_source.rs
@@ -198,12 +198,11 @@ mod tests {
 
     fn build_user_vista(source: MockVistaSource) -> Vista {
         let metadata = VistaMetadata::new()
-            .with_column(Column::new("id", "String"))
-            .with_column(Column::new("name", "String"))
+            .with_column(Column::new("id", "String").with_flag("id"))
+            .with_column(Column::new("name", "String").with_flag("title"))
             .with_column(Column::new("email", "String").hidden())
             .with_column(Column::new("vip_flag", "bool"))
             .with_id_column("id")
-            .with_title_columns(["name"])
             .with_reference(Reference::new(
                 "orders",
                 "orders",
@@ -219,13 +218,13 @@ mod tests {
 
         assert_eq!(vista.name(), "users");
         assert_eq!(vista.get_id_column(), Some("id"));
-        assert_eq!(vista.get_title_columns(), &["name".to_string()]);
+        assert_eq!(vista.get_title_columns(), vec!["name"]);
         assert_eq!(
             vista.get_column_names(),
             vec!["id", "name", "email", "vip_flag"]
         );
-        assert!(vista.get_column("email").unwrap().hidden);
-        assert!(!vista.get_column("name").unwrap().hidden);
+        assert!(vista.get_column("email").unwrap().is_hidden());
+        assert!(!vista.get_column("name").unwrap().is_hidden());
         assert_eq!(vista.get_references(), vec!["orders"]);
         assert_eq!(
             vista.get_reference("orders").unwrap().foreign_key,

--- a/vantage-vista/src/reference.rs
+++ b/vantage-vista/src/reference.rs
@@ -24,8 +24,10 @@ impl Reference {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ReferenceKind {
+    #[default]
     HasOne,
     HasMany,
     HasForeign,

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use ciborium::Value as CborValue;
 use futures_core::Stream;
 use indexmap::IndexMap;
-use vantage_core::Result;
+use vantage_core::{Result, VantageError, error};
 use vantage_types::Record;
 
 use crate::{capabilities::VistaCapabilities, vista::Vista};
@@ -67,45 +67,124 @@ pub trait VistaSource: Send + Sync + 'static {
     }
 
     // ---- WritableValueSet delegates ----------------------------------------
+    //
+    // Default impls return a typed VantageError via `default_error` — drivers
+    // override only what they actually support. The matching `VistaCapabilities`
+    // flag must be set to `true` for any method the driver implements; if the
+    // flag is `true` but the trait method falls through to the default,
+    // `default_error` produces an `Unimplemented`-kind error (placeholder
+    // detected). If the flag is `false`, it produces `Unsupported`. Both are
+    // emitted as tracing events at construction.
 
     async fn insert_vista_value(
         &self,
         vista: &Vista,
-        id: &String,
-        record: &Record<CborValue>,
-    ) -> Result<Record<CborValue>>;
+        _id: &String,
+        _record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        Err(self.default_error("insert_vista_value", "can_insert", vista))
+    }
 
     async fn replace_vista_value(
         &self,
         vista: &Vista,
-        id: &String,
-        record: &Record<CborValue>,
-    ) -> Result<Record<CborValue>>;
+        _id: &String,
+        _record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        Err(self.default_error("replace_vista_value", "can_update", vista))
+    }
 
     async fn patch_vista_value(
         &self,
         vista: &Vista,
-        id: &String,
-        partial: &Record<CborValue>,
-    ) -> Result<Record<CborValue>>;
+        _id: &String,
+        _partial: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        Err(self.default_error("patch_vista_value", "can_update", vista))
+    }
 
-    async fn delete_vista_value(&self, vista: &Vista, id: &String) -> Result<()>;
+    async fn delete_vista_value(&self, vista: &Vista, _id: &String) -> Result<()> {
+        Err(self.default_error("delete_vista_value", "can_delete", vista))
+    }
 
-    async fn delete_vista_all_values(&self, vista: &Vista) -> Result<()>;
+    async fn delete_vista_all_values(&self, vista: &Vista) -> Result<()> {
+        Err(self.default_error("delete_vista_all_values", "can_delete", vista))
+    }
 
     // ---- InsertableValueSet delegate ---------------------------------------
 
     async fn insert_vista_return_id_value(
         &self,
         vista: &Vista,
-        record: &Record<CborValue>,
-    ) -> Result<String>;
+        _record: &Record<CborValue>,
+    ) -> Result<String> {
+        Err(self.default_error("insert_vista_return_id_value", "can_insert", vista))
+    }
 
     // ---- Aggregates --------------------------------------------------------
 
-    async fn get_vista_count(&self, vista: &Vista) -> Result<i64>;
+    /// Default impl falls back to `list_vista_values` — drivers with native
+    /// count (`SELECT COUNT(*)`, etc.) override.
+    async fn get_vista_count(&self, vista: &Vista) -> Result<i64> {
+        Ok(self.list_vista_values(vista).await?.len() as i64)
+    }
 
     // ---- Capability advertisement -----------------------------------------
 
     fn capabilities(&self) -> &VistaCapabilities;
+
+    /// Look up a capability flag by name. Used by `default_error` to decide
+    /// between `Unsupported` and `Unimplemented`. Drivers don't normally
+    /// need to override this.
+    fn capability_flag(&self, name: &str) -> bool {
+        let caps = self.capabilities();
+        match name {
+            "can_count" => caps.can_count,
+            "can_insert" => caps.can_insert,
+            "can_update" => caps.can_update,
+            "can_delete" => caps.can_delete,
+            "can_subscribe" => caps.can_subscribe,
+            "can_invalidate" => caps.can_invalidate,
+            _ => false,
+        }
+    }
+
+    /// Build the standard error returned by default trait method impls.
+    ///
+    /// Picks the kind based on the capability flag: a `true` flag means the
+    /// driver advertised support but didn't override the method (placeholder
+    /// → `Unimplemented`); a `false` flag means the driver honestly doesn't
+    /// claim the op (caller should have checked → `Unsupported`).
+    ///
+    /// Both kinds emit a `tracing::error!` at construction with `method`,
+    /// `capability`, `source_type`, and `vista_name` as structured fields.
+    fn default_error(&self, method: &str, capability: &str, vista: &Vista) -> VantageError {
+        let source_type = std::any::type_name::<Self>();
+        let vista_name = vista.name().to_string();
+        if self.capability_flag(capability) {
+            error!(
+                format!(
+                    "'{}' is advertised as VistaCapability for '{}' but implementation for '{}' is missing",
+                    capability, source_type, method
+                ),
+                method = method,
+                capability = capability,
+                source_type = source_type,
+                vista_name = vista_name
+            )
+            .is_unimplemented()
+        } else {
+            error!(
+                format!(
+                    "'{}' is not supported by '{}'; '{}' refused",
+                    capability, source_type, method
+                ),
+                method = method,
+                capability = capability,
+                source_type = source_type,
+                vista_name = vista_name
+            )
+            .is_unsupported()
+        }
+    }
 }

--- a/vantage-vista/src/spec.rs
+++ b/vantage-vista/src/spec.rs
@@ -1,0 +1,222 @@
+//! YAML-facing schema for vista.
+//!
+//! A driver factory parses a `VistaSpec<T, C, R>` from YAML and lowers it
+//! into a `Vista` via `VistaFactory::build_from_spec`. The three type
+//! parameters carry driver-specific YAML blocks at the table, column, and
+//! reference level. Each parameter defaults to [`NoExtras`] for drivers
+//! that don't need any.
+
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+
+use crate::reference::ReferenceKind;
+
+/// Empty extras placeholder. Serializes as an absent key.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NoExtras {}
+
+/// The YAML schema a vista is built from.
+///
+/// `T` carries the driver's table-level block (e.g. `csv: { path }`).
+/// `C` carries each column's driver block. `R` carries each reference's
+/// driver block. The outer struct cannot use `deny_unknown_fields` because
+/// of `#[serde(flatten)]`; the driver-specific extras struct should set
+/// `deny_unknown_fields` itself to catch typos in driver blocks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "T: Serialize, C: Serialize, R: Serialize",
+    deserialize = "T: DeserializeOwned + Default, C: DeserializeOwned + Default, R: DeserializeOwned + Default"
+))]
+pub struct VistaSpec<T = NoExtras, C = NoExtras, R = NoExtras> {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub datasource: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id_column: Option<String>,
+    pub columns: IndexMap<String, ColumnSpec<C>>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub references: IndexMap<String, ReferenceSpec<R>>,
+    #[serde(flatten, default)]
+    pub driver: T,
+}
+
+/// Per-column metadata in a `VistaSpec`.
+///
+/// `flags` is open and unvalidated — the constants in [`crate::flags`]
+/// name the values understood by vista's own accessors.
+/// `references` holds the sugar form (`references: products`) when the
+/// foreign key is the column itself; full reference declarations live in
+/// the parent `VistaSpec::references` map.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "C: Serialize",
+    deserialize = "C: DeserializeOwned + Default"
+))]
+pub struct ColumnSpec<C = NoExtras> {
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub col_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub flags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub references: Option<ReferenceSugar>,
+    #[serde(flatten, default)]
+    pub driver: C,
+}
+
+impl<C: Default> ColumnSpec<C> {
+    pub fn new() -> Self {
+        Self {
+            col_type: None,
+            flags: Vec::new(),
+            references: None,
+            driver: C::default(),
+        }
+    }
+
+    pub fn with_type(mut self, ty: impl Into<String>) -> Self {
+        self.col_type = Some(ty.into());
+        self
+    }
+
+    pub fn with_flag(mut self, flag: impl Into<String>) -> Self {
+        self.flags.push(flag.into());
+        self
+    }
+}
+
+impl<C: Default> Default for ColumnSpec<C> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Top-level reference declaration in a `VistaSpec`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "R: Serialize",
+    deserialize = "R: DeserializeOwned + Default"
+))]
+pub struct ReferenceSpec<R = NoExtras> {
+    pub table: String,
+    #[serde(default)]
+    pub kind: ReferenceKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub foreign_key: Option<String>,
+    #[serde(flatten, default)]
+    pub driver: R,
+}
+
+/// Sugar form for inline column references.
+///
+/// `references: products` deserializes as `Sugar("products")`, equivalent
+/// to a `has_one` reference with `foreign_key` defaulting to the column
+/// name. Anything richer uses the full form.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ReferenceSugar {
+    Sugar(String),
+    Full(ReferenceSpec<NoExtras>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    struct DummyTable {
+        dummy: DummyTableBlock,
+    }
+
+    #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    struct DummyTableBlock {
+        path: String,
+    }
+
+    type DummySpec = VistaSpec<DummyTable, NoExtras, NoExtras>;
+
+    #[test]
+    fn parses_minimal_spec() {
+        let yaml = r#"
+name: clients
+columns:
+  id:
+    type: int
+    flags: [id]
+  name:
+    type: string
+    flags: [title, searchable]
+dummy:
+  path: data/clients.csv
+"#;
+        let spec: DummySpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(spec.name, "clients");
+        assert_eq!(spec.columns.len(), 2);
+        assert_eq!(spec.columns["id"].col_type.as_deref(), Some("int"));
+        assert_eq!(spec.columns["name"].flags, vec!["title", "searchable"]);
+        assert_eq!(spec.driver.dummy.path, "data/clients.csv");
+    }
+
+    #[test]
+    fn rejects_unknown_driver_field() {
+        let yaml = r#"
+name: clients
+columns:
+  id: { type: int }
+dummy:
+  path: x
+  bogus: 1
+"#;
+        let err = serde_yaml_ng::from_str::<DummySpec>(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("bogus") || err.to_string().contains("unknown"),
+            "expected typo-detecting error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn reference_sugar_round_trip() {
+        let yaml = r#"
+name: clients
+columns:
+  shop_id:
+    type: int
+    references: shops
+dummy:
+  path: x
+"#;
+        let spec: DummySpec = serde_yaml_ng::from_str(yaml).unwrap();
+        match spec.columns["shop_id"].references.as_ref().unwrap() {
+            ReferenceSugar::Sugar(s) => assert_eq!(s, "shops"),
+            other => panic!("expected sugar, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn full_reference_form() {
+        let yaml = r#"
+name: orders
+columns:
+  user_id:
+    type: int
+    references:
+      table: users
+      kind: has_one
+      foreign_key: user_id
+dummy:
+  path: x
+"#;
+        let spec: DummySpec = serde_yaml_ng::from_str(yaml).unwrap();
+        match spec.columns["user_id"].references.as_ref().unwrap() {
+            ReferenceSugar::Full(r) => {
+                assert_eq!(r.table, "users");
+                assert_eq!(r.kind, ReferenceKind::HasOne);
+                assert_eq!(r.foreign_key.as_deref(), Some("user_id"));
+            }
+            other => panic!("expected full, got {other:?}"),
+        }
+    }
+}

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -19,7 +19,6 @@ pub struct Vista {
     pub(crate) references: IndexMap<String, Reference>,
     pub(crate) capabilities: VistaCapabilities,
     pub(crate) id_column: Option<String>,
-    pub(crate) title_columns: Vec<String>,
     pub(crate) eq_conditions: Vec<(String, CborValue)>,
     pub(crate) source: Box<dyn VistaSource>,
 }
@@ -37,7 +36,6 @@ impl Vista {
             references: metadata.references,
             capabilities,
             id_column: metadata.id_column,
-            title_columns: metadata.title_columns,
             eq_conditions: Vec::new(),
             source,
         }
@@ -61,8 +59,13 @@ impl Vista {
         self.id_column.as_deref()
     }
 
-    pub fn get_title_columns(&self) -> &[String] {
-        &self.title_columns
+    /// Columns flagged `title` (in declaration order).
+    pub fn get_title_columns(&self) -> Vec<&str> {
+        self.columns
+            .values()
+            .filter(|c| c.is_title())
+            .map(|c| c.name.as_str())
+            .collect()
     }
 
     pub fn get_column_names(&self) -> Vec<&str> {

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -45,6 +45,12 @@ impl Vista {
         &self.name
     }
 
+    /// Override the vista's display name. Used by spec-driven construction
+    /// to expose `spec.name` rather than the underlying file/table name.
+    pub fn set_name(&mut self, name: impl Into<String>) {
+        self.name = name.into();
+    }
+
     pub fn capabilities(&self) -> &VistaCapabilities {
         &self.capabilities
     }


### PR DESCRIPTION
`from_yaml` actually parses YAML now. The first driver landing in #222 stubbed it; this PR teaches `vantage-vista` what a `*.vista.yaml` file looks like and ships the CSV side as the proving ground.

```yaml
# client.vista.yaml
name: client
columns:
  id:    { type: string, flags: [id] }
  name:  { type: string, flags: [title, searchable] }
  email: { type: string }
csv:
  path: client.csv
```

```rust
let csv = Csv::new("data/");
let vista = csv.vista_factory().from_yaml(include_str!("client.vista.yaml"))?;
let rows = vista.list_values().await?;
```

Same `Vista` you got from `from_table`, no Rust entity required.

### Driver-specific YAML, typed all the way down

[`VistaSpec<T, C, R>`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/struct.VistaSpec.html) is generic over three driver-supplied extras structs — table block, column block, reference block — each defaulting to [`NoExtras`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/struct.NoExtras.html) for drivers with nothing to add. The CSV driver supplies its `csv: { path }` table block as a typed struct, and `serde(deny_unknown_fields)` on the driver block surfaces typos (`psth: client.csv`) instead of swallowing them.

[`VistaFactory`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/trait.VistaFactory.html) drops its old single `from_yaml` for three associated `Extras` types plus `build_from_spec`. The trait now provides a default `from_yaml` that parses with `serde_yaml_ng` and dispatches; drivers only implement `build_from_spec`.

### Flags as an open vocabulary

`Column::hidden: bool` is gone. Columns now carry `flags: Vec<String>`, with [`vantage_vista::flags`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/flags/index.html) naming the values vista's accessors understand (`ID`, `TITLE`, `SEARCHABLE`, `MANDATORY`, `HIDDEN`). Drivers and consumers can add their own. `is_hidden`, `is_id`, `is_title`, `with_flag` replace the boolean. `VistaMetadata::with_title_columns` is gone too — title membership lives only as the `title` flag, and `Vista::get_title_columns()` derives the list at runtime.

Breaking for anyone hand-constructing `Column` — today that's just driver factories. Replace `Column::hidden()` with `.with_flag(flags::HIDDEN)`. Two call sites in-tree (the typed-table path in `vantage-csv`, the mock).

### YAML produces a real `Table`

`CsvVistaFactory::build_from_spec` builds a `Table<Csv, EmptyEntity>` first and routes through `from_table`. One construction path, one reading path. `Column::with_alias` carries the `csv.source` rename so `read_csv` reads from one CSV header and stores under another — fixing a bug where filter conditions silently failed against renamed columns. `Table::set_id_field` / `add_title_field` land on `vantage-table` for spec-driven construction (the existing `with_id_column` shortcut hardcodes `T::Id`, which clashed with YAML-declared types).

### Error classification

`vantage_core::ErrorKind` lets higher layers tell intentional refusals from bugs:

```rust
match err.kind() {
    ErrorKind::Unsupported    => /* 4xx */,
    ErrorKind::Unimplemented  => /* 5xx + alert */,
    ErrorKind::IncorrectUsage => /* 5xx, contract violation */,
    ErrorKind::Generic        => /* default */,
}
```

Set via modifiers on any `error!()`-built error:

```rust
error!("table has no columns", table = name).is_incorrect_usage();
error!("...", method = ..., capability = ...).is_unsupported();
```

Each modifier emits a `tracing::error!` event with the message and structured context — Sentry / OTEL pickup is automatic; callers don't have to log explicitly. `Error::new()` itself stays silent (kind = Generic) so unclassified errors don't double-emit.

`VistaSource` write methods now have default impls that produce the right kind via `default_error(method, capability, vista)`: `Unsupported` if the matching `VistaCapabilities` flag is `false`, `Unimplemented` if the flag is `true` but the trait method wasn't overridden (placeholder detected). Drivers override only what they actually support; CSV's hand-written read-only refusals are gone.

`VantageError::no_capability` is `#[deprecated]` pointing at the modifier API. Existing callers continue to compile.

### Deferred — follow-up PR

`todo/error-kinds-rollout.md` lists the ~80 existing `error!()` callsites bucketed by which kind they should adopt (`Unsupported` for read-only refusals across `vantage-csv`/`vantage-api-client`, `IncorrectUsage` for the MongoDB row-disappeared / missing-_id contract bugs, etc.). A dedicated PR will walk that list; out of scope here.

`SCHEMA.md` next to the plan is held until stage 4 brings a second driver online — one driver isn't enough to anchor cross-driver vocabulary.

### Versions

- `vantage-vista` 0.4.0 → 0.4.1 (breaking: `Column::hidden`, `VistaMetadata::with_title_columns`)
- `vantage-csv` 0.4.4 → 0.4.5 (gains `from_yaml`)
- `vantage-core` and `vantage-table` gain new public API but stay at current versions until the rollout PR bumps them