### PR TITLE
Sql vista integration

### DIFF
--- a/.github/workflows/vantage-sql.yaml
+++ b/.github/workflows/vantage-sql.yaml
@@ -106,13 +106,13 @@ jobs:
           done
 
       - name: Build
-        run: cargo build -p vantage-sql --features ${{ matrix.backend }}
+        run: cargo build -p vantage-sql --features "${{ matrix.backend }},vista"
 
       - name: Test
-        run: cargo test -p vantage-sql --features ${{ matrix.backend }} --test ${{ matrix.backend }}
+        run: cargo test -p vantage-sql --features "${{ matrix.backend }},vista" --test ${{ matrix.backend }}
 
       - name: Clippy
-        run: cargo clippy -p vantage-sql --features ${{ matrix.backend }} --all-targets -- -D warnings
+        run: cargo clippy -p vantage-sql --features "${{ matrix.backend }},vista" --all-targets -- -D warnings
 
       - name: Build bakery_model3
         if: matrix.backend != 'mysql'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4161,6 +4161,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "sqlx",
  "tokio",
  "uuid",
@@ -4169,6 +4170,7 @@ dependencies = [
  "vantage-expressions",
  "vantage-table",
  "vantage-types",
+ "vantage-vista",
 ]
 
 [[package]]

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.4 — 2026-05-04
+
+- New optional `vista` feature wires SQLite, Postgres, and MySQL into [`vantage-vista`](https://docs.rs/vantage-vista). Call `db.vista_factory().from_table(table)` to expose any typed `Table<…>` as a `Vista`, or load a YAML spec via `build_from_spec` for config-driven setups.
+- Each backend ships its own `*VistaSpec` / `*VistaFactory` / `*TableShell` triple under `mysql::vista`, `postgres::vista`, and `sqlite::vista`, with full read/write/count capabilities and `eq` filtering through the existing typed-column path.
+- Backend-specific `sqlite:` / `postgres:` / `mysql:` blocks in the YAML spec let you override table and column names without leaving the spec.
+
 ## 0.4.3 — 2026-04-19
 
 - SQL `is_null` / `is_not_null` operations rendered as `{} IS NULL` / `{} IS NOT NULL` for sqlite, postgres, mysql.

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -14,6 +14,7 @@ default = ["sqlite"]
 sqlite = ["sqlx/sqlite"]
 postgres = ["sqlx/postgres"]
 mysql = ["sqlx/mysql"]
+vista = ["dep:vantage-vista"]
 
 [dependencies]
 vantage-core = { version = "0.4", path = "../vantage-core" }
@@ -23,6 +24,7 @@ paste = "1.0"
 
 vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
 vantage-table = { version = "0.4.3", path = "../vantage-table" }
+vantage-vista = { version = "0.4.3", path = "../vantage-vista", optional = true }
 async-trait = "0.1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "rust_decimal", "uuid", "chrono"] }
 rust_decimal = "1"
@@ -37,3 +39,5 @@ tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+serde_yaml_ng = "0.10"
+vantage-vista = { version = "0.4.3", path = "../vantage-vista" }

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/mysql/mod.rs
+++ b/vantage-sql/src/mysql/mod.rs
@@ -6,6 +6,9 @@ pub mod statements;
 mod table_source;
 pub mod types;
 
+#[cfg(feature = "vista")]
+pub mod vista;
+
 use ciborium::Value as CborValue;
 use sqlx::mysql::MySqlPool;
 

--- a/vantage-sql/src/mysql/vista/factory.rs
+++ b/vantage-sql/src/mysql/vista/factory.rs
@@ -1,0 +1,185 @@
+//! `MysqlVistaFactory` — typed-table and YAML entry points, plus the
+//! `VistaFactory` trait impl. MySQL advertises full read/write/count.
+
+use vantage_core::{Result, error};
+use vantage_table::column::core::Column as TableColumn;
+use vantage_table::column::flags::ColumnFlag;
+use vantage_table::table::Table;
+use vantage_table::traits::column_like::ColumnLike;
+use vantage_types::{EmptyEntity, Entity};
+use vantage_vista::{
+    Column as VistaColumn, NoExtras, Vista, VistaCapabilities, VistaFactory, VistaMetadata,
+    flags as vista_flags,
+};
+
+use crate::mysql::MysqlDB;
+use crate::mysql::types::AnyMysqlType;
+use crate::mysql::vista::source::MysqlTableShell;
+use crate::mysql::vista::spec::{MysqlColumnExtras, MysqlTableExtras, MysqlVistaSpec};
+
+pub struct MysqlVistaFactory {
+    db: MysqlDB,
+}
+
+impl MysqlVistaFactory {
+    pub fn new(db: MysqlDB) -> Self {
+        Self { db }
+    }
+
+    pub fn from_table<E>(&self, table: Table<MysqlDB, E>) -> Result<Vista>
+    where
+        E: Entity<AnyMysqlType> + 'static,
+    {
+        let name = table.table_name().to_string();
+        let any_table = table.into_entity::<EmptyEntity>();
+        Ok(self.wrap(any_table, name))
+    }
+
+    fn wrap(&self, table: Table<MysqlDB, EmptyEntity>, name: String) -> Vista {
+        let metadata = metadata_from_table(&table);
+        let source = MysqlTableShell::new(
+            table,
+            VistaCapabilities {
+                can_count: true,
+                can_insert: true,
+                can_update: true,
+                can_delete: true,
+                ..VistaCapabilities::default()
+            },
+        );
+        Vista::new(name, Box::new(source), metadata)
+    }
+
+    pub fn table_from_spec(&self, spec: &MysqlVistaSpec) -> Result<Table<MysqlDB, EmptyEntity>> {
+        let table_name = spec
+            .driver
+            .mysql
+            .as_ref()
+            .and_then(|m| m.table.clone())
+            .unwrap_or_else(|| spec.name.clone());
+
+        let mut table = Table::<MysqlDB, EmptyEntity>::new(table_name, self.db.clone());
+
+        for (name, col_spec) in &spec.columns {
+            table.add_column(build_column(name, col_spec)?);
+            if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
+                table.add_title_field(name);
+            }
+        }
+
+        let id_column = resolve_id_column(spec);
+        if !table.columns().contains_key(&id_column) {
+            return Err(error!(
+                "id column not present in spec.columns",
+                id = id_column
+            ));
+        }
+        table.set_id_field(&id_column);
+
+        Ok(table)
+    }
+}
+
+impl VistaFactory for MysqlVistaFactory {
+    type TableExtras = MysqlTableExtras;
+    type ColumnExtras = MysqlColumnExtras;
+    type ReferenceExtras = NoExtras;
+
+    fn build_from_spec(&self, spec: MysqlVistaSpec) -> Result<Vista> {
+        let vista_name = spec.name.clone();
+        let table = self.table_from_spec(&spec)?;
+        let mut vista = self.wrap(table, vista_name.clone());
+        vista.set_name(vista_name);
+        Ok(vista)
+    }
+}
+
+pub(crate) fn resolve_id_column(spec: &MysqlVistaSpec) -> String {
+    if let Some(id) = &spec.id_column {
+        return id.clone();
+    }
+    for (name, col_spec) in &spec.columns {
+        if col_spec.flags.iter().any(|f| f == vista_flags::ID) {
+            return name.clone();
+        }
+    }
+    "id".to_string()
+}
+
+pub(crate) fn build_column(
+    name: &str,
+    col_spec: &vantage_vista::ColumnSpec<MysqlColumnExtras>,
+) -> Result<TableColumn<AnyMysqlType>> {
+    let ty = col_spec.col_type.as_deref().unwrap_or("string");
+    let alias = col_spec
+        .driver
+        .mysql
+        .as_ref()
+        .and_then(|b| b.column.clone())
+        .filter(|s| s != name);
+    let hidden = col_spec.flags.iter().any(|f| f == vista_flags::HIDDEN);
+
+    let mut col = column_for_type(name, ty)?;
+    if let Some(alias) = alias {
+        col = col.with_alias(alias);
+    }
+    if hidden {
+        col = col.with_flag(ColumnFlag::Hidden);
+    }
+    Ok(col)
+}
+
+pub(crate) fn column_for_type(name: &str, ty: &str) -> Result<TableColumn<AnyMysqlType>> {
+    let col: TableColumn<AnyMysqlType> = match ty {
+        "int" | "integer" | "i64" | "i32" => {
+            TableColumn::from_column(TableColumn::<i64>::new(name))
+        }
+        "float" | "double" | "f64" | "f32" => {
+            TableColumn::from_column(TableColumn::<f64>::new(name))
+        }
+        "bool" | "boolean" => TableColumn::from_column(TableColumn::<bool>::new(name)),
+        "string" | "text" | "str" => TableColumn::from_column(TableColumn::<String>::new(name)),
+        "decimal" | "numeric" => {
+            TableColumn::from_column(TableColumn::<rust_decimal::Decimal>::new(name))
+        }
+        "date" => TableColumn::from_column(TableColumn::<chrono::NaiveDate>::new(name)),
+        "time" => TableColumn::from_column(TableColumn::<chrono::NaiveTime>::new(name)),
+        "datetime" => TableColumn::from_column(TableColumn::<chrono::NaiveDateTime>::new(name)),
+        "timestamp" => {
+            TableColumn::from_column(TableColumn::<chrono::DateTime<chrono::Utc>>::new(name))
+        }
+        other => {
+            return Err(error!(
+                "Unknown YAML column type",
+                column = name,
+                ty = other.to_string()
+            ));
+        }
+    };
+    Ok(col)
+}
+
+pub(crate) fn metadata_from_table<T, E>(table: &Table<T, E>) -> VistaMetadata
+where
+    T: vantage_table::traits::table_source::TableSource,
+    E: Entity<T::Value>,
+    T::Column<T::AnyType>: ColumnLike<T::AnyType>,
+{
+    let mut metadata = VistaMetadata::new();
+    for (name, col) in table.columns() {
+        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+        if col.flags().contains(&ColumnFlag::Hidden) {
+            vc = vc.with_flag(vista_flags::HIDDEN);
+        }
+        metadata = metadata.with_column(vc);
+    }
+    if let Some(id_field) = table.id_field() {
+        metadata = metadata.with_id_column(id_field.name().to_string());
+    }
+    for title in table.title_fields() {
+        if let Some(col) = metadata.columns.get_mut(title) {
+            col.flags.push(vista_flags::TITLE.to_string());
+        }
+    }
+    metadata
+}

--- a/vantage-sql/src/mysql/vista/mod.rs
+++ b/vantage-sql/src/mysql/vista/mod.rs
@@ -1,0 +1,29 @@
+//! Vista bridge for the MySQL backend.
+//!
+//! Construct a `Vista` from a typed `Table<MysqlDB, E>` via
+//! `MysqlDB::vista_factory()`, or from a YAML spec via
+//! `MysqlVistaFactory::from_yaml`. The YAML path builds a
+//! `Table<MysqlDB, EmptyEntity>` first and then routes through `from_table` —
+//! one construction path, one reading path.
+//!
+//! `AnyMysqlType` already wraps `ciborium::Value`, so the boundary
+//! translation is a passthrough; ids stringify (matching `TableSource::Id`).
+
+pub mod factory;
+pub mod source;
+pub mod spec;
+
+pub use factory::MysqlVistaFactory;
+pub use source::MysqlTableShell;
+pub use spec::{
+    MysqlColumnBlock, MysqlColumnExtras, MysqlTableBlock, MysqlTableExtras, MysqlVistaSpec,
+};
+
+use crate::mysql::MysqlDB;
+
+impl MysqlDB {
+    /// Return a Vista factory bound to this MySQL data source.
+    pub fn vista_factory(&self) -> MysqlVistaFactory {
+        MysqlVistaFactory::new(self.clone())
+    }
+}

--- a/vantage-sql/src/mysql/vista/source.rs
+++ b/vantage-sql/src/mysql/vista/source.rs
@@ -1,0 +1,155 @@
+//! `MysqlTableShell` — owns the typed `Table<MysqlDB, EmptyEntity>` and
+//! exposes it through the `TableShell` boundary.
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_dataset::traits::{InsertableValueSet, ReadableValueSet, WritableValueSet};
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+use vantage_vista::{TableShell, Vista, VistaCapabilities};
+
+use crate::mysql::MysqlDB;
+use crate::mysql::operation::MysqlOperation;
+use crate::mysql::types::AnyMysqlType;
+
+pub struct MysqlTableShell {
+    pub(crate) table: Table<MysqlDB, EmptyEntity>,
+    pub(crate) capabilities: VistaCapabilities,
+}
+
+impl MysqlTableShell {
+    pub(crate) fn new(table: Table<MysqlDB, EmptyEntity>, capabilities: VistaCapabilities) -> Self {
+        Self {
+            table,
+            capabilities,
+        }
+    }
+}
+
+fn to_cbor_record(record: Record<AnyMysqlType>) -> Record<CborValue> {
+    record
+        .into_iter()
+        .map(|(k, v)| (k, v.into_value()))
+        .collect()
+}
+
+fn to_native_record(record: &Record<CborValue>) -> Record<AnyMysqlType> {
+    record
+        .iter()
+        .map(|(k, v)| (k.clone(), AnyMysqlType::untyped(v.clone())))
+        .collect()
+}
+
+#[async_trait]
+impl TableShell for MysqlTableShell {
+    async fn list_vista_values(
+        &self,
+        _vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        let raw = self.table.list_values().await?;
+        Ok(raw
+            .into_iter()
+            .map(|(id, record)| (id, to_cbor_record(record)))
+            .collect())
+    }
+
+    async fn get_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        let Some(record) = self.table.get_value(id).await? else {
+            return Ok(None);
+        };
+        Ok(Some(to_cbor_record(record)))
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        _vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        let Some((id, record)) = self.table.get_some_value().await? else {
+            return Ok(None);
+        };
+        Ok(Some((id, to_cbor_record(record))))
+    }
+
+    async fn get_vista_count(&self, _vista: &Vista) -> Result<i64> {
+        self.table.get_count().await
+    }
+
+    async fn insert_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let inserted = self
+            .table
+            .insert_value(id, &to_native_record(record))
+            .await?;
+        Ok(to_cbor_record(inserted))
+    }
+
+    async fn replace_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let replaced = self
+            .table
+            .replace_value(id, &to_native_record(record))
+            .await?;
+        Ok(to_cbor_record(replaced))
+    }
+
+    async fn patch_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        partial: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let patched = self
+            .table
+            .patch_value(id, &to_native_record(partial))
+            .await?;
+        Ok(to_cbor_record(patched))
+    }
+
+    async fn delete_vista_value(&self, _vista: &Vista, id: &String) -> Result<()> {
+        self.table.delete(id).await
+    }
+
+    async fn delete_vista_all_values(&self, _vista: &Vista) -> Result<()> {
+        self.table.delete_all().await
+    }
+
+    async fn insert_vista_return_id_value(
+        &self,
+        _vista: &Vista,
+        record: &Record<CborValue>,
+    ) -> Result<String> {
+        self.table
+            .insert_return_id_value(&to_native_record(record))
+            .await
+    }
+
+    fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
+        let column = self
+            .table
+            .columns()
+            .get(field)
+            .ok_or_else(|| error!("Unknown column for eq condition", field = field))?
+            .clone();
+        let sql_value = AnyMysqlType::untyped(value.clone());
+        self.table.add_condition(column.eq(sql_value));
+        Ok(())
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.capabilities
+    }
+}

--- a/vantage-sql/src/mysql/vista/spec.rs
+++ b/vantage-sql/src/mysql/vista/spec.rs
@@ -1,0 +1,77 @@
+//! YAML-facing types for the MySQL Vista driver.
+
+use serde::{Deserialize, Serialize};
+use vantage_vista::{NoExtras, VistaSpec};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MysqlTableExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mysql: Option<MysqlTableBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MysqlTableBlock {
+    /// Override for the MySQL table name. Defaults to the spec name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub table: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MysqlColumnExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mysql: Option<MysqlColumnBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MysqlColumnBlock {
+    /// SQL column name when it differs from the spec column name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column: Option<String>,
+}
+
+pub type MysqlVistaSpec = VistaSpec<MysqlTableExtras, MysqlColumnExtras, NoExtras>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yaml_parses_into_mysql_vista_spec() {
+        let yaml = r#"
+name: client
+columns:
+  id:
+    type: int
+    flags: [id]
+  name:
+    type: string
+    flags: [title]
+mysql:
+  table: clients
+"#;
+        let spec: MysqlVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(spec.name, "client");
+        assert_eq!(
+            spec.driver.mysql.as_ref().and_then(|m| m.table.as_deref()),
+            Some("clients")
+        );
+    }
+
+    #[test]
+    fn yaml_rejects_unknown_mysql_block_field() {
+        let yaml = r#"
+name: client
+columns:
+  id: { type: int, flags: [id] }
+mysql:
+  table: clients
+  bogus: 1
+"#;
+        let err = serde_yaml_ng::from_str::<MysqlVistaSpec>(yaml).unwrap_err();
+        assert!(err.to_string().contains("bogus") || err.to_string().contains("unknown"));
+    }
+}

--- a/vantage-sql/src/postgres/mod.rs
+++ b/vantage-sql/src/postgres/mod.rs
@@ -6,6 +6,9 @@ pub(crate) mod row;
 pub mod statements;
 pub mod types;
 
+#[cfg(feature = "vista")]
+pub mod vista;
+
 use ciborium::Value as CborValue;
 use sqlx::postgres::PgPool;
 

--- a/vantage-sql/src/postgres/vista/factory.rs
+++ b/vantage-sql/src/postgres/vista/factory.rs
@@ -1,0 +1,188 @@
+//! `PostgresVistaFactory` — typed-table and YAML entry points, plus the
+//! `VistaFactory` trait impl. PostgreSQL advertises full read/write/count.
+
+use vantage_core::{Result, error};
+use vantage_table::column::core::Column as TableColumn;
+use vantage_table::column::flags::ColumnFlag;
+use vantage_table::table::Table;
+use vantage_table::traits::column_like::ColumnLike;
+use vantage_types::{EmptyEntity, Entity};
+use vantage_vista::{
+    Column as VistaColumn, NoExtras, Vista, VistaCapabilities, VistaFactory, VistaMetadata,
+    flags as vista_flags,
+};
+
+use crate::postgres::PostgresDB;
+use crate::postgres::types::AnyPostgresType;
+use crate::postgres::vista::source::PostgresTableShell;
+use crate::postgres::vista::spec::{PostgresColumnExtras, PostgresTableExtras, PostgresVistaSpec};
+
+pub struct PostgresVistaFactory {
+    db: PostgresDB,
+}
+
+impl PostgresVistaFactory {
+    pub fn new(db: PostgresDB) -> Self {
+        Self { db }
+    }
+
+    pub fn from_table<E>(&self, table: Table<PostgresDB, E>) -> Result<Vista>
+    where
+        E: Entity<AnyPostgresType> + 'static,
+    {
+        let name = table.table_name().to_string();
+        let any_table = table.into_entity::<EmptyEntity>();
+        Ok(self.wrap(any_table, name))
+    }
+
+    fn wrap(&self, table: Table<PostgresDB, EmptyEntity>, name: String) -> Vista {
+        let metadata = metadata_from_table(&table);
+        let source = PostgresTableShell::new(
+            table,
+            VistaCapabilities {
+                can_count: true,
+                can_insert: true,
+                can_update: true,
+                can_delete: true,
+                ..VistaCapabilities::default()
+            },
+        );
+        Vista::new(name, Box::new(source), metadata)
+    }
+
+    pub fn table_from_spec(
+        &self,
+        spec: &PostgresVistaSpec,
+    ) -> Result<Table<PostgresDB, EmptyEntity>> {
+        let table_name = spec
+            .driver
+            .postgres
+            .as_ref()
+            .and_then(|m| m.table.clone())
+            .unwrap_or_else(|| spec.name.clone());
+
+        let mut table = Table::<PostgresDB, EmptyEntity>::new(table_name, self.db.clone());
+
+        for (name, col_spec) in &spec.columns {
+            table.add_column(build_column(name, col_spec)?);
+            if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
+                table.add_title_field(name);
+            }
+        }
+
+        let id_column = resolve_id_column(spec);
+        if !table.columns().contains_key(&id_column) {
+            return Err(error!(
+                "id column not present in spec.columns",
+                id = id_column
+            ));
+        }
+        table.set_id_field(&id_column);
+
+        Ok(table)
+    }
+}
+
+impl VistaFactory for PostgresVistaFactory {
+    type TableExtras = PostgresTableExtras;
+    type ColumnExtras = PostgresColumnExtras;
+    type ReferenceExtras = NoExtras;
+
+    fn build_from_spec(&self, spec: PostgresVistaSpec) -> Result<Vista> {
+        let vista_name = spec.name.clone();
+        let table = self.table_from_spec(&spec)?;
+        let mut vista = self.wrap(table, vista_name.clone());
+        vista.set_name(vista_name);
+        Ok(vista)
+    }
+}
+
+pub(crate) fn resolve_id_column(spec: &PostgresVistaSpec) -> String {
+    if let Some(id) = &spec.id_column {
+        return id.clone();
+    }
+    for (name, col_spec) in &spec.columns {
+        if col_spec.flags.iter().any(|f| f == vista_flags::ID) {
+            return name.clone();
+        }
+    }
+    "id".to_string()
+}
+
+pub(crate) fn build_column(
+    name: &str,
+    col_spec: &vantage_vista::ColumnSpec<PostgresColumnExtras>,
+) -> Result<TableColumn<AnyPostgresType>> {
+    let ty = col_spec.col_type.as_deref().unwrap_or("string");
+    let alias = col_spec
+        .driver
+        .postgres
+        .as_ref()
+        .and_then(|b| b.column.clone())
+        .filter(|s| s != name);
+    let hidden = col_spec.flags.iter().any(|f| f == vista_flags::HIDDEN);
+
+    let mut col = column_for_type(name, ty)?;
+    if let Some(alias) = alias {
+        col = col.with_alias(alias);
+    }
+    if hidden {
+        col = col.with_flag(ColumnFlag::Hidden);
+    }
+    Ok(col)
+}
+
+pub(crate) fn column_for_type(name: &str, ty: &str) -> Result<TableColumn<AnyPostgresType>> {
+    let col: TableColumn<AnyPostgresType> = match ty {
+        "int" | "integer" | "i64" | "i32" => {
+            TableColumn::from_column(TableColumn::<i64>::new(name))
+        }
+        "float" | "double" | "f64" | "f32" => {
+            TableColumn::from_column(TableColumn::<f64>::new(name))
+        }
+        "bool" | "boolean" => TableColumn::from_column(TableColumn::<bool>::new(name)),
+        "string" | "text" | "str" => TableColumn::from_column(TableColumn::<String>::new(name)),
+        "decimal" | "numeric" => {
+            TableColumn::from_column(TableColumn::<rust_decimal::Decimal>::new(name))
+        }
+        "date" => TableColumn::from_column(TableColumn::<chrono::NaiveDate>::new(name)),
+        "time" => TableColumn::from_column(TableColumn::<chrono::NaiveTime>::new(name)),
+        "datetime" => TableColumn::from_column(TableColumn::<chrono::NaiveDateTime>::new(name)),
+        "timestamp" => {
+            TableColumn::from_column(TableColumn::<chrono::DateTime<chrono::Utc>>::new(name))
+        }
+        other => {
+            return Err(error!(
+                "Unknown YAML column type",
+                column = name,
+                ty = other.to_string()
+            ));
+        }
+    };
+    Ok(col)
+}
+
+pub(crate) fn metadata_from_table<T, E>(table: &Table<T, E>) -> VistaMetadata
+where
+    T: vantage_table::traits::table_source::TableSource,
+    E: Entity<T::Value>,
+    T::Column<T::AnyType>: ColumnLike<T::AnyType>,
+{
+    let mut metadata = VistaMetadata::new();
+    for (name, col) in table.columns() {
+        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+        if col.flags().contains(&ColumnFlag::Hidden) {
+            vc = vc.with_flag(vista_flags::HIDDEN);
+        }
+        metadata = metadata.with_column(vc);
+    }
+    if let Some(id_field) = table.id_field() {
+        metadata = metadata.with_id_column(id_field.name().to_string());
+    }
+    for title in table.title_fields() {
+        if let Some(col) = metadata.columns.get_mut(title) {
+            col.flags.push(vista_flags::TITLE.to_string());
+        }
+    }
+    metadata
+}

--- a/vantage-sql/src/postgres/vista/mod.rs
+++ b/vantage-sql/src/postgres/vista/mod.rs
@@ -1,0 +1,30 @@
+//! Vista bridge for the PostgreSQL backend.
+//!
+//! Construct a `Vista` from a typed `Table<PostgresDB, E>` via
+//! `PostgresDB::vista_factory()`, or from a YAML spec via
+//! `PostgresVistaFactory::from_yaml`. The YAML path builds a
+//! `Table<PostgresDB, EmptyEntity>` first and then routes through `from_table` —
+//! one construction path, one reading path.
+//!
+//! `AnyPostgresType` already wraps `ciborium::Value`, so the boundary
+//! translation is a passthrough; ids stringify (matching `TableSource::Id`).
+
+pub mod factory;
+pub mod source;
+pub mod spec;
+
+pub use factory::PostgresVistaFactory;
+pub use source::PostgresTableShell;
+pub use spec::{
+    PostgresColumnBlock, PostgresColumnExtras, PostgresTableBlock, PostgresTableExtras,
+    PostgresVistaSpec,
+};
+
+use crate::postgres::PostgresDB;
+
+impl PostgresDB {
+    /// Return a Vista factory bound to this PostgreSQL data source.
+    pub fn vista_factory(&self) -> PostgresVistaFactory {
+        PostgresVistaFactory::new(self.clone())
+    }
+}

--- a/vantage-sql/src/postgres/vista/source.rs
+++ b/vantage-sql/src/postgres/vista/source.rs
@@ -1,0 +1,158 @@
+//! `PostgresTableShell` — owns the typed `Table<PostgresDB, EmptyEntity>` and
+//! exposes it through the `TableShell` boundary.
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_dataset::traits::{InsertableValueSet, ReadableValueSet, WritableValueSet};
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+use vantage_vista::{TableShell, Vista, VistaCapabilities};
+
+use crate::postgres::PostgresDB;
+use crate::postgres::operation::PostgresOperation;
+use crate::postgres::types::AnyPostgresType;
+
+pub struct PostgresTableShell {
+    pub(crate) table: Table<PostgresDB, EmptyEntity>,
+    pub(crate) capabilities: VistaCapabilities,
+}
+
+impl PostgresTableShell {
+    pub(crate) fn new(
+        table: Table<PostgresDB, EmptyEntity>,
+        capabilities: VistaCapabilities,
+    ) -> Self {
+        Self {
+            table,
+            capabilities,
+        }
+    }
+}
+
+fn to_cbor_record(record: Record<AnyPostgresType>) -> Record<CborValue> {
+    record
+        .into_iter()
+        .map(|(k, v)| (k, v.into_value()))
+        .collect()
+}
+
+fn to_native_record(record: &Record<CborValue>) -> Record<AnyPostgresType> {
+    record
+        .iter()
+        .map(|(k, v)| (k.clone(), AnyPostgresType::untyped(v.clone())))
+        .collect()
+}
+
+#[async_trait]
+impl TableShell for PostgresTableShell {
+    async fn list_vista_values(
+        &self,
+        _vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        let raw = self.table.list_values().await?;
+        Ok(raw
+            .into_iter()
+            .map(|(id, record)| (id, to_cbor_record(record)))
+            .collect())
+    }
+
+    async fn get_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        let Some(record) = self.table.get_value(id).await? else {
+            return Ok(None);
+        };
+        Ok(Some(to_cbor_record(record)))
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        _vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        let Some((id, record)) = self.table.get_some_value().await? else {
+            return Ok(None);
+        };
+        Ok(Some((id, to_cbor_record(record))))
+    }
+
+    async fn get_vista_count(&self, _vista: &Vista) -> Result<i64> {
+        self.table.get_count().await
+    }
+
+    async fn insert_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let inserted = self
+            .table
+            .insert_value(id, &to_native_record(record))
+            .await?;
+        Ok(to_cbor_record(inserted))
+    }
+
+    async fn replace_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let replaced = self
+            .table
+            .replace_value(id, &to_native_record(record))
+            .await?;
+        Ok(to_cbor_record(replaced))
+    }
+
+    async fn patch_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        partial: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let patched = self
+            .table
+            .patch_value(id, &to_native_record(partial))
+            .await?;
+        Ok(to_cbor_record(patched))
+    }
+
+    async fn delete_vista_value(&self, _vista: &Vista, id: &String) -> Result<()> {
+        self.table.delete(id).await
+    }
+
+    async fn delete_vista_all_values(&self, _vista: &Vista) -> Result<()> {
+        self.table.delete_all().await
+    }
+
+    async fn insert_vista_return_id_value(
+        &self,
+        _vista: &Vista,
+        record: &Record<CborValue>,
+    ) -> Result<String> {
+        self.table
+            .insert_return_id_value(&to_native_record(record))
+            .await
+    }
+
+    fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
+        let column = self
+            .table
+            .columns()
+            .get(field)
+            .ok_or_else(|| error!("Unknown column for eq condition", field = field))?
+            .clone();
+        let sql_value = AnyPostgresType::untyped(value.clone());
+        self.table.add_condition(column.eq(sql_value));
+        Ok(())
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.capabilities
+    }
+}

--- a/vantage-sql/src/postgres/vista/spec.rs
+++ b/vantage-sql/src/postgres/vista/spec.rs
@@ -1,0 +1,80 @@
+//! YAML-facing types for the PostgreSQL Vista driver.
+
+use serde::{Deserialize, Serialize};
+use vantage_vista::{NoExtras, VistaSpec};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresTableExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub postgres: Option<PostgresTableBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresTableBlock {
+    /// Override for the PostgreSQL table name. Defaults to the spec name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub table: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresColumnExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub postgres: Option<PostgresColumnBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresColumnBlock {
+    /// SQL column name when it differs from the spec column name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column: Option<String>,
+}
+
+pub type PostgresVistaSpec = VistaSpec<PostgresTableExtras, PostgresColumnExtras, NoExtras>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yaml_parses_into_postgres_vista_spec() {
+        let yaml = r#"
+name: client
+columns:
+  id:
+    type: int
+    flags: [id]
+  name:
+    type: string
+    flags: [title]
+postgres:
+  table: clients
+"#;
+        let spec: PostgresVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(spec.name, "client");
+        assert_eq!(
+            spec.driver
+                .postgres
+                .as_ref()
+                .and_then(|m| m.table.as_deref()),
+            Some("clients")
+        );
+    }
+
+    #[test]
+    fn yaml_rejects_unknown_postgres_block_field() {
+        let yaml = r#"
+name: client
+columns:
+  id: { type: int, flags: [id] }
+postgres:
+  table: clients
+  bogus: 1
+"#;
+        let err = serde_yaml_ng::from_str::<PostgresVistaSpec>(yaml).unwrap_err();
+        assert!(err.to_string().contains("bogus") || err.to_string().contains("unknown"));
+    }
+}

--- a/vantage-sql/src/sqlite/mod.rs
+++ b/vantage-sql/src/sqlite/mod.rs
@@ -6,6 +6,9 @@ pub(crate) mod row;
 pub mod statements;
 pub mod types;
 
+#[cfg(feature = "vista")]
+pub mod vista;
+
 use sqlx::sqlite::SqlitePool;
 
 pub use types::{AnySqliteType, SqliteType};

--- a/vantage-sql/src/sqlite/vista/factory.rs
+++ b/vantage-sql/src/sqlite/vista/factory.rs
@@ -1,0 +1,192 @@
+//! `SqliteVistaFactory` — typed-table and YAML entry points, plus the
+//! `VistaFactory` trait impl. SQLite advertises full read/write/count.
+
+use vantage_core::{Result, error};
+use vantage_table::column::core::Column as TableColumn;
+use vantage_table::column::flags::ColumnFlag;
+use vantage_table::table::Table;
+use vantage_table::traits::column_like::ColumnLike;
+use vantage_types::{EmptyEntity, Entity};
+use vantage_vista::{
+    Column as VistaColumn, NoExtras, Vista, VistaCapabilities, VistaFactory, VistaMetadata,
+    flags as vista_flags,
+};
+
+use crate::sqlite::SqliteDB;
+use crate::sqlite::types::AnySqliteType;
+use crate::sqlite::vista::source::SqliteTableShell;
+use crate::sqlite::vista::spec::{SqliteColumnExtras, SqliteTableExtras, SqliteVistaSpec};
+
+pub struct SqliteVistaFactory {
+    db: SqliteDB,
+}
+
+impl SqliteVistaFactory {
+    pub fn new(db: SqliteDB) -> Self {
+        Self { db }
+    }
+
+    /// Wrap a typed table as a Vista. Column metadata is harvested from the
+    /// table; CRUD goes through `Table`'s reading path.
+    pub fn from_table<E>(&self, table: Table<SqliteDB, E>) -> Result<Vista>
+    where
+        E: Entity<AnySqliteType> + 'static,
+    {
+        let name = table.table_name().to_string();
+        let any_table = table.into_entity::<EmptyEntity>();
+        Ok(self.wrap(any_table, name))
+    }
+
+    /// Single source-construction site shared by `from_table` and
+    /// `build_from_spec`. Keeps the capability set and `Vista::new` call in
+    /// one place so a future capability flip is a one-line edit.
+    fn wrap(&self, table: Table<SqliteDB, EmptyEntity>, name: String) -> Vista {
+        let metadata = metadata_from_table(&table);
+        let source = SqliteTableShell::new(
+            table,
+            VistaCapabilities {
+                can_count: true,
+                can_insert: true,
+                can_update: true,
+                can_delete: true,
+                ..VistaCapabilities::default()
+            },
+        );
+        Vista::new(name, Box::new(source), metadata)
+    }
+
+    /// Build a `Table<SqliteDB, EmptyEntity>` from a spec.
+    pub fn table_from_spec(&self, spec: &SqliteVistaSpec) -> Result<Table<SqliteDB, EmptyEntity>> {
+        let table_name = spec
+            .driver
+            .sqlite
+            .as_ref()
+            .and_then(|m| m.table.clone())
+            .unwrap_or_else(|| spec.name.clone());
+
+        let mut table = Table::<SqliteDB, EmptyEntity>::new(table_name, self.db.clone());
+
+        for (name, col_spec) in &spec.columns {
+            table.add_column(build_column(name, col_spec)?);
+            if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
+                table.add_title_field(name);
+            }
+        }
+
+        let id_column = resolve_id_column(spec);
+        if !table.columns().contains_key(&id_column) {
+            return Err(error!(
+                "id column not present in spec.columns",
+                id = id_column
+            ));
+        }
+        table.set_id_field(&id_column);
+
+        Ok(table)
+    }
+}
+
+impl VistaFactory for SqliteVistaFactory {
+    type TableExtras = SqliteTableExtras;
+    type ColumnExtras = SqliteColumnExtras;
+    type ReferenceExtras = NoExtras;
+
+    fn build_from_spec(&self, spec: SqliteVistaSpec) -> Result<Vista> {
+        let vista_name = spec.name.clone();
+        let table = self.table_from_spec(&spec)?;
+        let mut vista = self.wrap(table, vista_name.clone());
+        vista.set_name(vista_name);
+        Ok(vista)
+    }
+}
+
+pub(crate) fn resolve_id_column(spec: &SqliteVistaSpec) -> String {
+    if let Some(id) = &spec.id_column {
+        return id.clone();
+    }
+    for (name, col_spec) in &spec.columns {
+        if col_spec.flags.iter().any(|f| f == vista_flags::ID) {
+            return name.clone();
+        }
+    }
+    "id".to_string()
+}
+
+pub(crate) fn build_column(
+    name: &str,
+    col_spec: &vantage_vista::ColumnSpec<SqliteColumnExtras>,
+) -> Result<TableColumn<AnySqliteType>> {
+    let ty = col_spec.col_type.as_deref().unwrap_or("string");
+    let alias = col_spec
+        .driver
+        .sqlite
+        .as_ref()
+        .and_then(|b| b.column.clone())
+        .filter(|s| s != name);
+    let hidden = col_spec.flags.iter().any(|f| f == vista_flags::HIDDEN);
+
+    let mut col = column_for_type(name, ty)?;
+    if let Some(alias) = alias {
+        col = col.with_alias(alias);
+    }
+    if hidden {
+        col = col.with_flag(ColumnFlag::Hidden);
+    }
+    Ok(col)
+}
+
+/// YAML type alias → typed `Column` (then erased to `Column<AnySqliteType>`).
+pub(crate) fn column_for_type(name: &str, ty: &str) -> Result<TableColumn<AnySqliteType>> {
+    let col: TableColumn<AnySqliteType> = match ty {
+        "int" | "integer" | "i64" | "i32" => {
+            TableColumn::from_column(TableColumn::<i64>::new(name))
+        }
+        "float" | "double" | "f64" | "f32" => {
+            TableColumn::from_column(TableColumn::<f64>::new(name))
+        }
+        "bool" | "boolean" => TableColumn::from_column(TableColumn::<bool>::new(name)),
+        "string" | "text" | "str" => TableColumn::from_column(TableColumn::<String>::new(name)),
+        "decimal" | "numeric" => {
+            TableColumn::from_column(TableColumn::<rust_decimal::Decimal>::new(name))
+        }
+        "date" => TableColumn::from_column(TableColumn::<chrono::NaiveDate>::new(name)),
+        "time" => TableColumn::from_column(TableColumn::<chrono::NaiveTime>::new(name)),
+        "datetime" => TableColumn::from_column(TableColumn::<chrono::NaiveDateTime>::new(name)),
+        "timestamp" => {
+            TableColumn::from_column(TableColumn::<chrono::DateTime<chrono::Utc>>::new(name))
+        }
+        other => {
+            return Err(error!(
+                "Unknown YAML column type",
+                column = name,
+                ty = other.to_string()
+            ));
+        }
+    };
+    Ok(col)
+}
+
+pub(crate) fn metadata_from_table<T, E>(table: &Table<T, E>) -> VistaMetadata
+where
+    T: vantage_table::traits::table_source::TableSource,
+    E: Entity<T::Value>,
+    T::Column<T::AnyType>: ColumnLike<T::AnyType>,
+{
+    let mut metadata = VistaMetadata::new();
+    for (name, col) in table.columns() {
+        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+        if col.flags().contains(&ColumnFlag::Hidden) {
+            vc = vc.with_flag(vista_flags::HIDDEN);
+        }
+        metadata = metadata.with_column(vc);
+    }
+    if let Some(id_field) = table.id_field() {
+        metadata = metadata.with_id_column(id_field.name().to_string());
+    }
+    for title in table.title_fields() {
+        if let Some(col) = metadata.columns.get_mut(title) {
+            col.flags.push(vista_flags::TITLE.to_string());
+        }
+    }
+    metadata
+}

--- a/vantage-sql/src/sqlite/vista/mod.rs
+++ b/vantage-sql/src/sqlite/vista/mod.rs
@@ -1,0 +1,29 @@
+//! Vista bridge for the SQLite backend.
+//!
+//! Construct a `Vista` from a typed `Table<SqliteDB, E>` via
+//! `SqliteDB::vista_factory()`, or from a YAML spec via
+//! `SqliteVistaFactory::from_yaml`. The YAML path builds a
+//! `Table<SqliteDB, EmptyEntity>` first and then routes through `from_table` —
+//! one construction path, one reading path.
+//!
+//! `AnySqliteType` already wraps `ciborium::Value`, so the boundary
+//! translation is a passthrough; ids stringify (matching `TableSource::Id`).
+
+pub mod factory;
+pub mod source;
+pub mod spec;
+
+pub use factory::SqliteVistaFactory;
+pub use source::SqliteTableShell;
+pub use spec::{
+    SqliteColumnBlock, SqliteColumnExtras, SqliteTableBlock, SqliteTableExtras, SqliteVistaSpec,
+};
+
+use crate::sqlite::SqliteDB;
+
+impl SqliteDB {
+    /// Return a Vista factory bound to this SQLite data source.
+    pub fn vista_factory(&self) -> SqliteVistaFactory {
+        SqliteVistaFactory::new(self.clone())
+    }
+}

--- a/vantage-sql/src/sqlite/vista/source.rs
+++ b/vantage-sql/src/sqlite/vista/source.rs
@@ -1,0 +1,163 @@
+//! `SqliteTableShell` — owns the typed `Table<SqliteDB, EmptyEntity>` and
+//! exposes it through the `TableShell` boundary.
+//!
+//! `AnySqliteType` already wraps `ciborium::Value`, so the boundary is a
+//! straight unwrap/rewrap. `add_eq_condition` builds a typed
+//! `Column<AnySqliteType>::eq` comparison via the `SqliteOperation` trait
+//! and pushes it onto the wrapped table.
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_dataset::traits::{InsertableValueSet, ReadableValueSet, WritableValueSet};
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+use vantage_vista::{TableShell, Vista, VistaCapabilities};
+
+use crate::sqlite::SqliteDB;
+use crate::sqlite::operation::SqliteOperation;
+use crate::sqlite::types::AnySqliteType;
+
+pub struct SqliteTableShell {
+    pub(crate) table: Table<SqliteDB, EmptyEntity>,
+    pub(crate) capabilities: VistaCapabilities,
+}
+
+impl SqliteTableShell {
+    pub(crate) fn new(
+        table: Table<SqliteDB, EmptyEntity>,
+        capabilities: VistaCapabilities,
+    ) -> Self {
+        Self {
+            table,
+            capabilities,
+        }
+    }
+}
+
+fn to_cbor_record(record: Record<AnySqliteType>) -> Record<CborValue> {
+    record
+        .into_iter()
+        .map(|(k, v)| (k, v.into_value()))
+        .collect()
+}
+
+fn to_native_record(record: &Record<CborValue>) -> Record<AnySqliteType> {
+    record
+        .iter()
+        .map(|(k, v)| (k.clone(), AnySqliteType::untyped(v.clone())))
+        .collect()
+}
+
+#[async_trait]
+impl TableShell for SqliteTableShell {
+    async fn list_vista_values(
+        &self,
+        _vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        let raw = self.table.list_values().await?;
+        Ok(raw
+            .into_iter()
+            .map(|(id, record)| (id, to_cbor_record(record)))
+            .collect())
+    }
+
+    async fn get_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        let Some(record) = self.table.get_value(id).await? else {
+            return Ok(None);
+        };
+        Ok(Some(to_cbor_record(record)))
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        _vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        let Some((id, record)) = self.table.get_some_value().await? else {
+            return Ok(None);
+        };
+        Ok(Some((id, to_cbor_record(record))))
+    }
+
+    async fn get_vista_count(&self, _vista: &Vista) -> Result<i64> {
+        self.table.get_count().await
+    }
+
+    async fn insert_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let inserted = self
+            .table
+            .insert_value(id, &to_native_record(record))
+            .await?;
+        Ok(to_cbor_record(inserted))
+    }
+
+    async fn replace_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let replaced = self
+            .table
+            .replace_value(id, &to_native_record(record))
+            .await?;
+        Ok(to_cbor_record(replaced))
+    }
+
+    async fn patch_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        partial: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let patched = self
+            .table
+            .patch_value(id, &to_native_record(partial))
+            .await?;
+        Ok(to_cbor_record(patched))
+    }
+
+    async fn delete_vista_value(&self, _vista: &Vista, id: &String) -> Result<()> {
+        self.table.delete(id).await
+    }
+
+    async fn delete_vista_all_values(&self, _vista: &Vista) -> Result<()> {
+        self.table.delete_all().await
+    }
+
+    async fn insert_vista_return_id_value(
+        &self,
+        _vista: &Vista,
+        record: &Record<CborValue>,
+    ) -> Result<String> {
+        self.table
+            .insert_return_id_value(&to_native_record(record))
+            .await
+    }
+
+    fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
+        let column = self
+            .table
+            .columns()
+            .get(field)
+            .ok_or_else(|| error!("Unknown column for eq condition", field = field))?
+            .clone();
+        let sql_value = AnySqliteType::untyped(value.clone());
+        self.table.add_condition(column.eq(sql_value));
+        Ok(())
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.capabilities
+    }
+}

--- a/vantage-sql/src/sqlite/vista/spec.rs
+++ b/vantage-sql/src/sqlite/vista/spec.rs
@@ -1,0 +1,95 @@
+//! YAML-facing types for the SQLite Vista driver.
+
+use serde::{Deserialize, Serialize};
+use vantage_vista::{NoExtras, VistaSpec};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SqliteTableExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sqlite: Option<SqliteTableBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SqliteTableBlock {
+    /// Override for the SQLite table name. Defaults to the spec name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub table: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SqliteColumnExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sqlite: Option<SqliteColumnBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SqliteColumnBlock {
+    /// SQL column name when it differs from the spec column name. The vista
+    /// surfaces values under the spec name; on read the column is `SELECT`ed
+    /// via this name and aliased back to the spec column.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column: Option<String>,
+}
+
+pub type SqliteVistaSpec = VistaSpec<SqliteTableExtras, SqliteColumnExtras, NoExtras>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yaml_parses_into_sqlite_vista_spec() {
+        let yaml = r#"
+name: client
+columns:
+  id:
+    type: int
+    flags: [id]
+  name:
+    type: string
+    flags: [title, searchable]
+  is_paying_client:
+    type: bool
+sqlite:
+  table: clients
+"#;
+        let spec: SqliteVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(spec.name, "client");
+        assert_eq!(spec.columns.len(), 3);
+        assert_eq!(
+            spec.driver.sqlite.as_ref().and_then(|m| m.table.as_deref()),
+            Some("clients")
+        );
+        assert_eq!(spec.columns["id"].col_type.as_deref(), Some("int"));
+        assert!(spec.columns["name"].flags.contains(&"title".to_string()));
+    }
+
+    #[test]
+    fn yaml_rejects_unknown_sqlite_block_field() {
+        let yaml = r#"
+name: client
+columns:
+  id: { type: int, flags: [id] }
+sqlite:
+  table: clients
+  bogus: 1
+"#;
+        let err = serde_yaml_ng::from_str::<SqliteVistaSpec>(yaml).unwrap_err();
+        assert!(err.to_string().contains("bogus") || err.to_string().contains("unknown"));
+    }
+
+    #[test]
+    fn yaml_table_defaults_to_spec_name_when_block_omitted() {
+        let yaml = r#"
+name: clients
+columns:
+  id: { type: int, flags: [id] }
+"#;
+        let spec: SqliteVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(spec.driver.sqlite.is_none());
+    }
+}

--- a/vantage-sql/tests/mysql.rs
+++ b/vantage-sql/tests/mysql.rs
@@ -40,4 +40,7 @@ mod mysql {
     mod types_record;
     #[path = "1_types_round_trip.rs"]
     mod types_round_trip;
+    #[cfg(feature = "vista")]
+    #[path = "6_vista.rs"]
+    mod vista;
 }

--- a/vantage-sql/tests/mysql/6_vista.rs
+++ b/vantage-sql/tests/mysql/6_vista.rs
@@ -1,0 +1,189 @@
+//! Vista integration: typed `Table<MysqlDB, _>` → `Vista` and YAML → `Vista`.
+//!
+//! Requires a running MySQL on `mysql://vantage:vantage@localhost:3306/vantage`.
+//! Each test uses a uniquely-suffixed table to avoid collisions.
+
+#![cfg(feature = "vista")]
+
+use std::error::Error;
+
+use ciborium::Value as CborValue;
+use vantage_dataset::prelude::*;
+use vantage_sql::mysql::MysqlDB;
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+use vantage_vista::VistaFactory;
+
+type TestResult = std::result::Result<(), Box<dyn Error>>;
+
+const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
+
+async fn setup(suffix: &str) -> (MysqlDB, String) {
+    let db = MysqlDB::connect(MYSQL_URL).await.unwrap();
+    let table_name = format!("vista_product_{}", suffix);
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS `{}`", table_name))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE `{}` (
+            id VARCHAR(255) PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL,
+            is_deleted BOOLEAN NOT NULL DEFAULT 0
+        )",
+        table_name
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "INSERT INTO `{}` VALUES \
+         ('a', 'Alpha', 10, 0), \
+         ('b', 'Beta', 20, 1), \
+         ('c', 'Gamma', 30, 0)",
+        table_name
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    (db, table_name)
+}
+
+fn product_table(db: MysqlDB, name: &str) -> Table<MysqlDB, EmptyEntity> {
+    Table::<MysqlDB, EmptyEntity>::new(name, db)
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price")
+        .with_column_of::<bool>("is_deleted")
+}
+
+#[tokio::test]
+async fn vista_lists_typed_mysql_as_cbor() -> TestResult {
+    let (db, name) = setup("list").await;
+    let table = product_table(db.clone(), &name);
+    let vista = db.vista_factory().from_table(table)?;
+
+    assert_eq!(vista.name(), name);
+    assert_eq!(vista.get_id_column(), Some("id"));
+
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 3);
+
+    let alpha = rows.get("a").expect("row a");
+    assert_eq!(
+        alpha.get("name"),
+        Some(&CborValue::Text("Alpha".to_string()))
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_get_value_by_id() -> TestResult {
+    let (db, name) = setup("get").await;
+    let table = product_table(db.clone(), &name);
+    let vista = db.vista_factory().from_table(table)?;
+
+    let row = vista
+        .get_value(&"b".to_string())
+        .await?
+        .expect("row b exists");
+    assert_eq!(row.get("name"), Some(&CborValue::Text("Beta".to_string())));
+
+    let missing = vista.get_value(&"nope".to_string()).await?;
+    assert!(missing.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_count_with_eq_condition() -> TestResult {
+    let (db, name) = setup("count").await;
+    let table = product_table(db.clone(), &name);
+    let mut vista = db.vista_factory().from_table(table)?;
+
+    assert_eq!(vista.get_count().await?, 3);
+
+    vista.add_condition_eq("is_deleted", CborValue::Bool(false))?;
+    assert_eq!(vista.get_count().await?, 2);
+
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 2);
+    assert!(rows.contains_key("a"));
+    assert!(rows.contains_key("c"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_yaml_loads_table_and_columns() -> TestResult {
+    let (db, name) = setup("yaml").await;
+
+    let yaml = format!(
+        r#"
+name: product_view
+columns:
+  id:
+    type: string
+    flags: [id]
+  name:
+    type: string
+    flags: [title, searchable]
+  price:
+    type: int
+mysql:
+  table: {name}
+"#
+    );
+
+    let vista = db.vista_factory().from_yaml(&yaml)?;
+
+    assert_eq!(vista.name(), "product_view");
+    assert_eq!(vista.get_id_column(), Some("id"));
+    assert_eq!(vista.get_title_columns(), vec!["name"]);
+
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_writes_round_trip_via_cbor() -> TestResult {
+    let (db, name) = setup("write").await;
+    let table = product_table(db.clone(), &name);
+    let vista = db.vista_factory().from_table(table)?;
+
+    let record: Record<CborValue> = vec![
+        ("name".to_string(), CborValue::Text("Delta".into())),
+        ("price".to_string(), CborValue::Integer(99i64.into())),
+        ("is_deleted".to_string(), CborValue::Bool(false)),
+    ]
+    .into_iter()
+    .collect();
+
+    vista.insert_value(&"d".to_string(), &record).await?;
+
+    let fetched = vista.get_value(&"d".to_string()).await?.expect("inserted");
+    assert_eq!(fetched.get("name"), Some(&CborValue::Text("Delta".into())));
+
+    vista.delete(&"d".to_string()).await?;
+    assert!(vista.get_value(&"d".to_string()).await?.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_capabilities_advertise_read_write() -> TestResult {
+    let (db, name) = setup("caps").await;
+    let table = product_table(db.clone(), &name);
+    let vista = db.vista_factory().from_table(table)?;
+
+    let caps = vista.capabilities();
+    assert!(caps.can_count);
+    assert!(caps.can_insert);
+    assert!(caps.can_update);
+    assert!(caps.can_delete);
+    assert!(!caps.can_subscribe);
+    Ok(())
+}

--- a/vantage-sql/tests/postgres.rs
+++ b/vantage-sql/tests/postgres.rs
@@ -40,4 +40,7 @@ mod postgres {
     mod types_record;
     #[path = "1_types_round_trip.rs"]
     mod types_round_trip;
+    #[cfg(feature = "vista")]
+    #[path = "6_vista.rs"]
+    mod vista;
 }

--- a/vantage-sql/tests/postgres/6_vista.rs
+++ b/vantage-sql/tests/postgres/6_vista.rs
@@ -1,0 +1,189 @@
+//! Vista integration: typed `Table<PostgresDB, _>` → `Vista` and YAML → `Vista`.
+//!
+//! Requires a running PostgreSQL on `postgres://vantage:vantage@localhost:5433/vantage`.
+//! Each test uses a uniquely-suffixed table to avoid collisions.
+
+#![cfg(feature = "vista")]
+
+use std::error::Error;
+
+use ciborium::Value as CborValue;
+use vantage_dataset::prelude::*;
+use vantage_sql::postgres::PostgresDB;
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+use vantage_vista::VistaFactory;
+
+type TestResult = std::result::Result<(), Box<dyn Error>>;
+
+const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
+
+async fn setup(suffix: &str) -> (PostgresDB, String) {
+    let db = PostgresDB::connect(PG_URL).await.unwrap();
+    let table_name = format!("vista_product_{}", suffix);
+
+    sqlx::query(&format!("DROP TABLE IF EXISTS \"{}\"", table_name))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    sqlx::query(&format!(
+        "CREATE TABLE \"{}\" (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            price BIGINT NOT NULL,
+            is_deleted BOOLEAN NOT NULL DEFAULT false
+        )",
+        table_name
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(&format!(
+        "INSERT INTO \"{}\" VALUES \
+         ('a', 'Alpha', 10, false), \
+         ('b', 'Beta', 20, true), \
+         ('c', 'Gamma', 30, false)",
+        table_name
+    ))
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    (db, table_name)
+}
+
+fn product_table(db: PostgresDB, name: &str) -> Table<PostgresDB, EmptyEntity> {
+    Table::<PostgresDB, EmptyEntity>::new(name, db)
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price")
+        .with_column_of::<bool>("is_deleted")
+}
+
+#[tokio::test]
+async fn vista_lists_typed_postgres_as_cbor() -> TestResult {
+    let (db, name) = setup("list").await;
+    let table = product_table(db.clone(), &name);
+    let vista = db.vista_factory().from_table(table)?;
+
+    assert_eq!(vista.name(), name);
+    assert_eq!(vista.get_id_column(), Some("id"));
+
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 3);
+
+    let alpha = rows.get("a").expect("row a");
+    assert_eq!(
+        alpha.get("name"),
+        Some(&CborValue::Text("Alpha".to_string()))
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_get_value_by_id() -> TestResult {
+    let (db, name) = setup("get").await;
+    let table = product_table(db.clone(), &name);
+    let vista = db.vista_factory().from_table(table)?;
+
+    let row = vista
+        .get_value(&"b".to_string())
+        .await?
+        .expect("row b exists");
+    assert_eq!(row.get("name"), Some(&CborValue::Text("Beta".to_string())));
+
+    let missing = vista.get_value(&"nope".to_string()).await?;
+    assert!(missing.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_count_with_eq_condition() -> TestResult {
+    let (db, name) = setup("count").await;
+    let table = product_table(db.clone(), &name);
+    let mut vista = db.vista_factory().from_table(table)?;
+
+    assert_eq!(vista.get_count().await?, 3);
+
+    vista.add_condition_eq("is_deleted", CborValue::Bool(false))?;
+    assert_eq!(vista.get_count().await?, 2);
+
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 2);
+    assert!(rows.contains_key("a"));
+    assert!(rows.contains_key("c"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_yaml_loads_table_and_columns() -> TestResult {
+    let (db, name) = setup("yaml").await;
+
+    let yaml = format!(
+        r#"
+name: product_view
+columns:
+  id:
+    type: string
+    flags: [id]
+  name:
+    type: string
+    flags: [title, searchable]
+  price:
+    type: int
+postgres:
+  table: {name}
+"#
+    );
+
+    let vista = db.vista_factory().from_yaml(&yaml)?;
+
+    assert_eq!(vista.name(), "product_view");
+    assert_eq!(vista.get_id_column(), Some("id"));
+    assert_eq!(vista.get_title_columns(), vec!["name"]);
+
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 3);
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_writes_round_trip_via_cbor() -> TestResult {
+    let (db, name) = setup("write").await;
+    let table = product_table(db.clone(), &name);
+    let vista = db.vista_factory().from_table(table)?;
+
+    let record: Record<CborValue> = vec![
+        ("name".to_string(), CborValue::Text("Delta".into())),
+        ("price".to_string(), CborValue::Integer(99i64.into())),
+        ("is_deleted".to_string(), CborValue::Bool(false)),
+    ]
+    .into_iter()
+    .collect();
+
+    vista.insert_value(&"d".to_string(), &record).await?;
+
+    let fetched = vista.get_value(&"d".to_string()).await?.expect("inserted");
+    assert_eq!(fetched.get("name"), Some(&CborValue::Text("Delta".into())));
+
+    vista.delete(&"d".to_string()).await?;
+    assert!(vista.get_value(&"d".to_string()).await?.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_capabilities_advertise_read_write() -> TestResult {
+    let (db, name) = setup("caps").await;
+    let table = product_table(db.clone(), &name);
+    let vista = db.vista_factory().from_table(table)?;
+
+    let caps = vista.capabilities();
+    assert!(caps.can_count);
+    assert!(caps.can_insert);
+    assert!(caps.can_update);
+    assert!(caps.can_delete);
+    assert!(!caps.can_subscribe);
+    Ok(())
+}

--- a/vantage-sql/tests/sqlite.rs
+++ b/vantage-sql/tests/sqlite.rs
@@ -44,4 +44,7 @@ mod sqlite {
     mod types_record;
     #[path = "1_types_round_trip.rs"]
     mod types_round_trip;
+    #[cfg(feature = "vista")]
+    #[path = "6_vista.rs"]
+    mod vista;
 }

--- a/vantage-sql/tests/sqlite/6_vista.rs
+++ b/vantage-sql/tests/sqlite/6_vista.rs
@@ -1,0 +1,179 @@
+//! Vista integration: typed `Table<SqliteDB, _>` → `Vista` and YAML → `Vista`.
+//!
+//! Uses in-memory SQLite — no external setup required.
+
+#![cfg(feature = "vista")]
+
+use std::error::Error;
+
+use ciborium::Value as CborValue;
+use vantage_dataset::prelude::*;
+use vantage_sql::sqlite::SqliteDB;
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+use vantage_vista::VistaFactory;
+
+type TestResult = std::result::Result<(), Box<dyn Error>>;
+
+async fn setup() -> SqliteDB {
+    let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+
+    sqlx::query(
+        "CREATE TABLE product (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            price INTEGER NOT NULL,
+            is_deleted INTEGER NOT NULL DEFAULT 0
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO product VALUES \
+         ('a', 'Alpha', 10, 0), \
+         ('b', 'Beta', 20, 1), \
+         ('c', 'Gamma', 30, 0)",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    db
+}
+
+fn product_table(db: SqliteDB) -> Table<SqliteDB, EmptyEntity> {
+    Table::<SqliteDB, EmptyEntity>::new("product", db)
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price")
+        .with_column_of::<bool>("is_deleted")
+}
+
+#[tokio::test]
+async fn vista_lists_typed_sqlite_as_cbor() -> TestResult {
+    let db = setup().await;
+    let table = product_table(db.clone());
+    let vista = db.vista_factory().from_table(table)?;
+
+    assert_eq!(vista.name(), "product");
+    assert_eq!(vista.get_id_column(), Some("id"));
+
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 3);
+
+    let alpha = rows.get("a").expect("row a");
+    assert_eq!(
+        alpha.get("name"),
+        Some(&CborValue::Text("Alpha".to_string()))
+    );
+    assert_eq!(alpha.get("price"), Some(&CborValue::Integer(10i64.into())));
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_get_value_by_id() -> TestResult {
+    let db = setup().await;
+    let table = product_table(db.clone());
+    let vista = db.vista_factory().from_table(table)?;
+
+    let row = vista
+        .get_value(&"b".to_string())
+        .await?
+        .expect("row b exists");
+    assert_eq!(row.get("name"), Some(&CborValue::Text("Beta".to_string())));
+
+    let missing = vista.get_value(&"nope".to_string()).await?;
+    assert!(missing.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_count_with_eq_condition() -> TestResult {
+    let db = setup().await;
+    let table = product_table(db.clone());
+    let mut vista = db.vista_factory().from_table(table)?;
+
+    assert_eq!(vista.get_count().await?, 3);
+
+    vista.add_condition_eq("is_deleted", CborValue::Bool(false))?;
+    assert_eq!(vista.get_count().await?, 2);
+
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 2);
+    assert!(rows.contains_key("a"));
+    assert!(rows.contains_key("c"));
+    assert!(!rows.contains_key("b"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_yaml_loads_table_and_columns() -> TestResult {
+    let db = setup().await;
+
+    let yaml = r#"
+name: product_view
+columns:
+  id:
+    type: string
+    flags: [id]
+  name:
+    type: string
+    flags: [title, searchable]
+  price:
+    type: int
+sqlite:
+  table: product
+"#;
+
+    let vista = db.vista_factory().from_yaml(yaml)?;
+
+    assert_eq!(vista.name(), "product_view");
+    assert_eq!(vista.get_id_column(), Some("id"));
+    assert_eq!(vista.get_title_columns(), vec!["name"]);
+
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 3);
+    assert!(rows.contains_key("a"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_writes_round_trip_via_cbor() -> TestResult {
+    let db = setup().await;
+    let table = product_table(db.clone());
+    let vista = db.vista_factory().from_table(table)?;
+
+    let record: Record<CborValue> = vec![
+        ("name".to_string(), CborValue::Text("Delta".into())),
+        ("price".to_string(), CborValue::Integer(99i64.into())),
+        ("is_deleted".to_string(), CborValue::Bool(false)),
+    ]
+    .into_iter()
+    .collect();
+
+    vista.insert_value(&"d".to_string(), &record).await?;
+
+    let fetched = vista.get_value(&"d".to_string()).await?.expect("inserted");
+    assert_eq!(fetched.get("name"), Some(&CborValue::Text("Delta".into())));
+
+    vista.delete(&"d".to_string()).await?;
+    assert!(vista.get_value(&"d".to_string()).await?.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_capabilities_advertise_read_write() -> TestResult {
+    let db = setup().await;
+    let table = product_table(db.clone());
+    let vista = db.vista_factory().from_table(table)?;
+
+    let caps = vista.capabilities();
+    assert!(caps.can_count);
+    assert!(caps.can_insert);
+    assert!(caps.can_update);
+    assert!(caps.can_delete);
+    assert!(!caps.can_subscribe);
+    Ok(())
+}


### PR DESCRIPTION
SQLite, Postgres, and MySQL join CSV and MongoDB in the [Vista](https://docs.rs/vantage-vista/0.4.3/vantage_vista/struct.Vista.html) lineup. Same surface as #222 / #224 — typed table or YAML in, `Record<CborValue>` out:

```rust
let vista = db.vista_factory().from_table(table)?;
// or
let vista = db.vista_factory().from_yaml(yaml)?;
let rows = vista.list_values().await?;
```

Three backends, one pattern. Each ships its own `*VistaSpec` / `*VistaFactory` / `*TableShell` triple under `mysql::vista`, `postgres::vista`, `sqlite::vista`. The split isn't sugar — `Table<SqliteDB, _>`, `Table<PostgresDB, _>` and `Table<MysqlDB, _>` are distinct types and each carries its own `AnySqlType` / `*Operation` trait, so the shell that builds a `column.eq(value)` push-down has to be vendor-specific. The boundary itself is cheap: `AnySqliteType` / `AnyMysqlType` / `AnyPostgresType` already wrap `ciborium::Value`, so the conversion at the shell is a straight unwrap/rewrap. Capabilities advertise `can_count`, `can_insert`, `can_update`, `can_delete` for all three. Behind a `vista` cargo feature so non-vista users don't pull in `vantage-vista`.

### Backend-scoped overrides in YAML

A `sqlite:` / `postgres:` / `mysql:` block on the table or column lets you keep the spec name the application sees while the SQL targets a differently-named table or column. Useful when the schema is legacy and the spec is the friendly view.

```yaml
name: client
columns:
  id:
    type: int
    flags: [id]
  full_name:
    type: string
    flags: [title]
    sqlite: { column: fullName }
sqlite:
  table: clients
```

### `eq` filtering pushes down

`add_eq_condition` translates the CBOR pair into the vendor's typed `Column<AnySqlType>::eq` (via `SqliteOperation` / `PostgresOperation` / `MysqlOperation`) and pushes onto the wrapped `Table` — so a generic UI filter renders as `WHERE` server-side, not client-side.

### Versions

- `vantage-sql` 0.4.3 → 0.4.4 (new `vista` feature)

### Deferred

`subscribe` waits on a CDC story. Operator vocabulary beyond `eq` is the universal layer's next move, not a SQL-side concern.