### PR TITLE
add vantage-log-writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3839,6 +3839,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4117,6 +4127,29 @@ dependencies = [
  "vantage-redb",
  "vantage-table",
  "vantage-types",
+]
+
+[[package]]
+name = "vantage-log-writer"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "ciborium",
+ "indexmap",
+ "paste",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "ulid",
+ "vantage-core",
+ "vantage-dataset",
+ "vantage-expressions",
+ "vantage-table",
+ "vantage-types",
+ "vantage-vista",
 ]
 
 [[package]]
@@ -4444,6 +4477,16 @@ name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4131,7 +4131,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-log-writer"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "vantage-dataset",
     "vantage-table",
     "vantage-csv",
+    "vantage-log-writer",
     "vantage-api-client",
     "vantage-api-pool",
     "vantage-cli-util",

--- a/vantage-log-writer/CHANGELOG.md
+++ b/vantage-log-writer/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## 0.1.0 — 2026-05-04
+## 0.4.0 — 2026-05-04
 
-- Initial release. New [`LogWriter`](https://docs.rs/vantage-log-writer/0.1.0/vantage_log_writer/struct.LogWriter.html) data source: append-only JSONL files, one per table at `{base_dir}/{table_name}.jsonl`. Inserts are queued onto a background tokio task so callers see channel-send latency, not disk latency.
+- Initial release. New [`LogWriter`](https://docs.rs/vantage-log-writer/0.4.0/vantage_log_writer/struct.LogWriter.html) data source: append-only JSONL files, one per table at `{base_dir}/{table_name}.jsonl`. Inserts are queued onto a background tokio task so callers see channel-send latency, not disk latency.
 - Read methods (`list`, `get`, `count`, …) return [`ErrorKind::Unsupported`](https://docs.rs/vantage-core/0.4.1/vantage_core/enum.ErrorKind.html) — this is intentional. Pair a `LogWriter` table with a separate read-side store (Surreal, redb, …) when you need queries.
 - Fields not declared as columns on the `Table` are dropped on insert. Records are projected onto the column set, and an id column is filled from the record (string or number) or generated as a [ULID](https://github.com/ulid/spec) when absent. The id column name defaults to `"id"` and can be overridden via `LogWriter::with_id_column`.
-- Opt-in [`vista`](https://docs.rs/vantage-log-writer/0.1.0/vantage_log_writer/vista/index.html) feature: turn a typed `Table<LogWriter, E>` into a [`Vista`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html) via `writer.vista_factory().from_table(table)`, or build one from YAML via `from_yaml(...)`. Capabilities advertise `can_insert: true` only.
+- Opt-in [`vista`](https://docs.rs/vantage-log-writer/0.4.0/vantage_log_writer/vista/index.html) feature: turn a typed `Table<LogWriter, E>` into a [`Vista`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html) via `writer.vista_factory().from_table(table)`, or build one from YAML via `from_yaml(...)`. Capabilities advertise `can_insert: true` only.
 - YAML specs accept an optional `log_writer.filename` block to override the file stem when the spec's `name` differs from the on-disk filename.

--- a/vantage-log-writer/CHANGELOG.md
+++ b/vantage-log-writer/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.0 — 2026-05-04
+
+- Initial release. New [`LogWriter`](https://docs.rs/vantage-log-writer/0.1.0/vantage_log_writer/struct.LogWriter.html) data source: append-only JSONL files, one per table at `{base_dir}/{table_name}.jsonl`. Inserts are queued onto a background tokio task so callers see channel-send latency, not disk latency.
+- Read methods (`list`, `get`, `count`, …) return [`ErrorKind::Unsupported`](https://docs.rs/vantage-core/0.4.1/vantage_core/enum.ErrorKind.html) — this is intentional. Pair a `LogWriter` table with a separate read-side store (Surreal, redb, …) when you need queries.
+- Fields not declared as columns on the `Table` are dropped on insert. Records are projected onto the column set, and an id column is filled from the record (string or number) or generated as a [ULID](https://github.com/ulid/spec) when absent. The id column name defaults to `"id"` and can be overridden via `LogWriter::with_id_column`.
+- Opt-in [`vista`](https://docs.rs/vantage-log-writer/0.1.0/vantage_log_writer/vista/index.html) feature: turn a typed `Table<LogWriter, E>` into a [`Vista`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html) via `writer.vista_factory().from_table(table)`, or build one from YAML via `from_yaml(...)`. Capabilities advertise `can_insert: true` only.
+- YAML specs accept an optional `log_writer.filename` block to override the file stem when the spec's `name` differs from the on-disk filename.

--- a/vantage-log-writer/Cargo.toml
+++ b/vantage-log-writer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-log-writer"
-version = "0.1.0"
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for append-only log files (JSONL)"

--- a/vantage-log-writer/Cargo.toml
+++ b/vantage-log-writer/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+edition = "2024"
+name = "vantage-log-writer"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+authors = ["Romans Malinovskis <me@nearly.guru>"]
+description = "Vantage extension for append-only log files (JSONL)"
+homepage = "https://romaninsh.github.io/vantage"
+repository = "https://github.com/romaninsh/vantage"
+
+[features]
+default = []
+vista = ["dep:vantage-vista", "dep:ciborium", "dep:serde"]
+
+[dependencies]
+async-trait = "0.1"
+ciborium = { version = "0.2", features = ["std"], optional = true }
+indexmap = { version = "2", features = ["serde"] }
+paste = "1.0"
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1", features = ["preserve_order"] }
+tokio = { version = "1.48", features = ["rt", "fs", "sync", "io-util", "macros"] }
+tracing = "0.1"
+ulid = "1"
+vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
+vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-table = { version = "0.4.4", path = "../vantage-table" }
+vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
+vantage-vista = { version = "0.4.4", path = "../vantage-vista", optional = true }
+
+[dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml_ng = "0.10"
+tempfile = "3"
+tokio = { version = "1.48", features = ["full"] }
+vantage-vista = { version = "0.4.4", path = "../vantage-vista" }

--- a/vantage-log-writer/src/lib.rs
+++ b/vantage-log-writer/src/lib.rs
@@ -1,0 +1,17 @@
+//! Append-only persistence that writes JSONL records to files.
+//!
+//! See `docs4/src/new-persistence/` for the full guide; this crate is the
+//! POC implementation of step5 (insert-only TableSource) without the
+//! type system, expressions, or vista layers.
+
+mod log_writer;
+mod table_source;
+pub mod type_system;
+#[cfg(feature = "vista")]
+pub mod vista;
+mod writer_task;
+
+pub use log_writer::LogWriter;
+pub use type_system::{AnyJsonType, JsonType, JsonTypeVariants};
+#[cfg(feature = "vista")]
+pub use vista::{LogWriterTableShell, LogWriterVistaFactory};

--- a/vantage-log-writer/src/log_writer.rs
+++ b/vantage-log-writer/src/log_writer.rs
@@ -1,0 +1,72 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use crate::writer_task::{WRITE_QUEUE_CAPACITY, WriteOp, spawn};
+
+/// Append-only data source that writes JSONL records to files in `base_dir`.
+///
+/// Each table maps to one file: `{base_dir}/{table_name}.jsonl`. Inserts are
+/// queued on a background tokio task and the call returns as soon as the
+/// message lands on the channel — no fsync, no crash safety. Cloning shares
+/// the same channel and worker.
+#[derive(Clone)]
+pub struct LogWriter {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    base_dir: PathBuf,
+    id_column: String,
+    tx: mpsc::Sender<WriteOp>,
+}
+
+impl LogWriter {
+    pub fn new(base_dir: impl Into<PathBuf>) -> Self {
+        let (tx, rx) = mpsc::channel::<WriteOp>(WRITE_QUEUE_CAPACITY);
+        spawn(rx);
+        Self {
+            inner: Arc::new(Inner {
+                base_dir: base_dir.into(),
+                id_column: "id".to_string(),
+                tx,
+            }),
+        }
+    }
+
+    pub fn with_id_column(self, column: impl Into<String>) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                base_dir: self.inner.base_dir.clone(),
+                id_column: column.into(),
+                tx: self.inner.tx.clone(),
+            }),
+        }
+    }
+
+    pub fn base_dir(&self) -> &std::path::Path {
+        &self.inner.base_dir
+    }
+
+    pub fn id_column(&self) -> &str {
+        &self.inner.id_column
+    }
+
+    pub(crate) fn file_path(&self, table_name: &str) -> PathBuf {
+        self.inner.base_dir.join(format!("{}.jsonl", table_name))
+    }
+
+    pub(crate) fn sender(&self) -> &mpsc::Sender<WriteOp> {
+        &self.inner.tx
+    }
+}
+
+impl std::fmt::Debug for LogWriter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LogWriter")
+            .field("base_dir", &self.inner.base_dir)
+            .field("id_column", &self.inner.id_column)
+            .finish()
+    }
+}

--- a/vantage-log-writer/src/table_source.rs
+++ b/vantage-log-writer/src/table_source.rs
@@ -1,0 +1,323 @@
+use async_trait::async_trait;
+use indexmap::IndexMap;
+use serde_json::Value;
+use vantage_core::{Result, error};
+use vantage_expressions::Expression;
+use vantage_expressions::traits::associated_expressions::AssociatedExpression;
+use vantage_expressions::traits::datasource::{DataSource, ExprDataSource};
+use vantage_expressions::traits::expressive::{DeferredFn, ExpressiveEnum};
+use vantage_table::column::core::{Column, ColumnType};
+use vantage_table::table::Table;
+use vantage_table::traits::table_source::TableSource;
+use vantage_types::{Entity, Record};
+
+use crate::log_writer::LogWriter;
+use crate::type_system::AnyJsonType;
+use crate::writer_task::WriteOp;
+
+impl DataSource for LogWriter {}
+
+impl ExprDataSource<Value> for LogWriter {
+    async fn execute(&self, _expr: &Expression<Value>) -> Result<Value> {
+        Err(unsupported("execute"))
+    }
+
+    fn defer(&self, _expr: Expression<Value>) -> DeferredFn<Value>
+    where
+        Value: Clone + Send + Sync + 'static,
+    {
+        DeferredFn::new(move || {
+            Box::pin(async move { Err(unsupported("defer")) })
+        })
+    }
+}
+
+fn unsupported(method: &'static str) -> vantage_core::VantageError {
+    error!("log-writer is insert-only", method = method).is_unsupported()
+}
+
+#[async_trait]
+impl TableSource for LogWriter {
+    type Column<Type>
+        = Column<Type>
+    where
+        Type: ColumnType;
+    type AnyType = AnyJsonType;
+    type Value = Value;
+    type Id = String;
+    type Condition = Expression<Self::Value>;
+
+    fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
+        Column::new(name)
+    }
+
+    fn to_any_column<Type: ColumnType>(
+        &self,
+        column: Self::Column<Type>,
+    ) -> Self::Column<Self::AnyType> {
+        Column::from_column(column)
+    }
+
+    fn convert_any_column<Type: ColumnType>(
+        &self,
+        any_column: Self::Column<Self::AnyType>,
+    ) -> Option<Self::Column<Type>> {
+        Some(Column::from_column(any_column))
+    }
+
+    fn expr(
+        &self,
+        template: impl Into<String>,
+        parameters: Vec<ExpressiveEnum<Self::Value>>,
+    ) -> Expression<Self::Value> {
+        Expression::new(template, parameters)
+    }
+
+    fn search_table_condition<E>(
+        &self,
+        _table: &Table<Self, E>,
+        _search_value: &str,
+    ) -> Self::Condition
+    where
+        E: Entity<Self::Value>,
+    {
+        Expression::new("", vec![])
+    }
+
+    async fn list_table_values<E>(
+        &self,
+        _table: &Table<Self, E>,
+    ) -> Result<IndexMap<Self::Id, Record<Self::Value>>>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        Err(unsupported("list_table_values"))
+    }
+
+    async fn get_table_value<E>(
+        &self,
+        _table: &Table<Self, E>,
+        _id: &Self::Id,
+    ) -> Result<Option<Record<Self::Value>>>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        Err(unsupported("get_table_value"))
+    }
+
+    async fn get_table_some_value<E>(
+        &self,
+        _table: &Table<Self, E>,
+    ) -> Result<Option<(Self::Id, Record<Self::Value>)>>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        Err(unsupported("get_table_some_value"))
+    }
+
+    async fn get_table_count<E>(&self, _table: &Table<Self, E>) -> Result<i64>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        Err(unsupported("get_table_count"))
+    }
+
+    async fn get_table_sum<E>(
+        &self,
+        _table: &Table<Self, E>,
+        _column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        Err(unsupported("get_table_sum"))
+    }
+
+    async fn get_table_max<E>(
+        &self,
+        _table: &Table<Self, E>,
+        _column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        Err(unsupported("get_table_max"))
+    }
+
+    async fn get_table_min<E>(
+        &self,
+        _table: &Table<Self, E>,
+        _column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        Err(unsupported("get_table_min"))
+    }
+
+    async fn insert_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        record: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        let projected = project_record(table.columns().keys(), record, self.id_column(), id);
+        let line = serialize_line(&projected)?;
+        let path = self.file_path(table.table_name());
+        self.sender()
+            .send(WriteOp::Append { path, line })
+            .await
+            .map_err(|e| error!("log writer channel closed", detail = e.to_string()))?;
+        Ok(projected)
+    }
+
+    async fn replace_table_value<E>(
+        &self,
+        _table: &Table<Self, E>,
+        _id: &Self::Id,
+        _record: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        Err(unsupported("replace_table_value"))
+    }
+
+    async fn patch_table_value<E>(
+        &self,
+        _table: &Table<Self, E>,
+        _id: &Self::Id,
+        _partial: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        Err(unsupported("patch_table_value"))
+    }
+
+    async fn delete_table_value<E>(&self, _table: &Table<Self, E>, _id: &Self::Id) -> Result<()>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        Err(unsupported("delete_table_value"))
+    }
+
+    async fn delete_table_all_values<E>(&self, _table: &Table<Self, E>) -> Result<()>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        Err(unsupported("delete_table_all_values"))
+    }
+
+    async fn insert_table_return_id_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        record: &Record<Self::Value>,
+    ) -> Result<Self::Id>
+    where
+        E: Entity<Self::Value>,
+        Self: Sized,
+    {
+        let id = extract_or_generate_id(record, self.id_column());
+        let projected = project_record(table.columns().keys(), record, self.id_column(), &id);
+        let line = serialize_line(&projected)?;
+        let path = self.file_path(table.table_name());
+        self.sender()
+            .send(WriteOp::Append { path, line })
+            .await
+            .map_err(|e| error!("log writer channel closed", detail = e.to_string()))?;
+        Ok(id)
+    }
+
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        _target_field: &str,
+        _source_table: &Table<Self, SourceE>,
+        _source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized,
+    {
+        Expression::new("", vec![])
+    }
+
+    fn column_table_values_expr<'a, E, Type: ColumnType>(
+        &'a self,
+        _table: &Table<Self, E>,
+        _column: &Self::Column<Type>,
+    ) -> AssociatedExpression<'a, Self, Self::Value, Vec<Type>>
+    where
+        E: Entity<Self::Value> + 'static,
+        Self: Sized,
+    {
+        unimplemented!("log-writer is insert-only; column_table_values_expr is unreachable")
+    }
+}
+
+/// Project a record onto the table's declared column set, then attach the id.
+///
+/// Entity fields not declared as columns are dropped — this is the contract
+/// the user pinned down: "entity values with non-existent columns would be
+/// dropped".
+fn project_record<'a, I>(
+    column_names: I,
+    record: &Record<Value>,
+    id_column: &str,
+    id: &str,
+) -> Record<Value>
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    let mut out = Record::new();
+    let mut wrote_id = false;
+    for col in column_names {
+        if col == id_column {
+            out.insert(col.clone(), Value::String(id.to_string()));
+            wrote_id = true;
+        } else if let Some(v) = record.get(col) {
+            out.insert(col.clone(), v.clone());
+        }
+    }
+    if !wrote_id {
+        out.insert(id_column.to_string(), Value::String(id.to_string()));
+    }
+    out
+}
+
+fn serialize_line(record: &Record<Value>) -> Result<String> {
+    let map: serde_json::Map<String, Value> = record
+        .as_inner()
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    let mut s = serde_json::to_string(&Value::Object(map))
+        .map_err(|e| error!("failed to serialize record to JSON", detail = e.to_string()))?;
+    s.push('\n');
+    Ok(s)
+}
+
+fn extract_or_generate_id(record: &Record<Value>, id_column: &str) -> String {
+    if let Some(v) = record.get(id_column) {
+        match v {
+            Value::String(s) if !s.is_empty() => return s.clone(),
+            Value::Number(n) => return n.to_string(),
+            _ => {}
+        }
+    }
+    ulid::Ulid::new().to_string()
+}

--- a/vantage-log-writer/src/table_source.rs
+++ b/vantage-log-writer/src/table_source.rs
@@ -26,9 +26,7 @@ impl ExprDataSource<Value> for LogWriter {
     where
         Value: Clone + Send + Sync + 'static,
     {
-        DeferredFn::new(move || {
-            Box::pin(async move { Err(unsupported("defer")) })
-        })
+        DeferredFn::new(move || Box::pin(async move { Err(unsupported("defer")) }))
     }
 }
 

--- a/vantage-log-writer/src/type_system.rs
+++ b/vantage-log-writer/src/type_system.rs
@@ -1,0 +1,157 @@
+use serde_json::Value;
+use vantage_types::vantage_type_system;
+
+vantage_type_system! {
+    type_trait: JsonType,
+    method_name: json,
+    value_type: serde_json::Value,
+    type_variants: [String, Int, Float, Bool, Object, Array, Null]
+}
+
+impl JsonTypeVariants {
+    pub fn from_json(value: &serde_json::Value) -> Option<Self> {
+        match value {
+            Value::Null => Some(JsonTypeVariants::Null),
+            Value::Bool(_) => Some(JsonTypeVariants::Bool),
+            Value::Number(n) if n.is_i64() || n.is_u64() => Some(JsonTypeVariants::Int),
+            Value::Number(_) => Some(JsonTypeVariants::Float),
+            Value::String(_) => Some(JsonTypeVariants::String),
+            Value::Array(_) => Some(JsonTypeVariants::Array),
+            Value::Object(_) => Some(JsonTypeVariants::Object),
+        }
+    }
+}
+
+impl JsonType for String {
+    type Target = JsonTypeStringMarker;
+
+    fn to_json(&self) -> Value {
+        Value::String(self.clone())
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::String(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+impl JsonType for i64 {
+    type Target = JsonTypeIntMarker;
+
+    fn to_json(&self) -> Value {
+        Value::Number(serde_json::Number::from(*self))
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_i64(),
+            _ => None,
+        }
+    }
+}
+
+impl JsonType for f64 {
+    type Target = JsonTypeFloatMarker;
+
+    fn to_json(&self) -> Value {
+        serde_json::Number::from_f64(*self)
+            .map(Value::Number)
+            .unwrap_or(Value::Null)
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Number(n) => n.as_f64(),
+            _ => None,
+        }
+    }
+}
+
+impl JsonType for bool {
+    type Target = JsonTypeBoolMarker;
+
+    fn to_json(&self) -> Value {
+        Value::Bool(*self)
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Bool(b) => Some(b),
+            _ => None,
+        }
+    }
+}
+
+impl JsonType for serde_json::Value {
+    type Target = JsonTypeObjectMarker;
+
+    fn to_json(&self) -> Value {
+        self.clone()
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        Some(value)
+    }
+}
+
+impl<T> JsonType for Option<T>
+where
+    T: JsonType,
+{
+    type Target = T::Target;
+
+    fn to_json(&self) -> Value {
+        match self {
+            Some(v) => v.to_json(),
+            None => Value::Null,
+        }
+    }
+
+    fn from_json(value: Value) -> Option<Self> {
+        match value {
+            Value::Null => Some(None),
+            other => T::from_json(other).map(Some),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_string() {
+        let any = AnyJsonType::new("hello".to_string());
+        assert_eq!(any.type_variant(), Some(JsonTypeVariants::String));
+        assert_eq!(any.try_get::<String>(), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn roundtrip_int() {
+        let any = AnyJsonType::new(42_i64);
+        assert_eq!(any.type_variant(), Some(JsonTypeVariants::Int));
+        assert_eq!(any.try_get::<i64>(), Some(42));
+    }
+
+    #[test]
+    fn variant_detection_from_json() {
+        assert_eq!(
+            JsonTypeVariants::from_json(&Value::Null),
+            Some(JsonTypeVariants::Null)
+        );
+        assert_eq!(
+            JsonTypeVariants::from_json(&Value::Bool(true)),
+            Some(JsonTypeVariants::Bool)
+        );
+        assert_eq!(
+            JsonTypeVariants::from_json(&serde_json::json!(7)),
+            Some(JsonTypeVariants::Int)
+        );
+        assert_eq!(
+            JsonTypeVariants::from_json(&serde_json::json!(7.5)),
+            Some(JsonTypeVariants::Float)
+        );
+    }
+}

--- a/vantage-log-writer/src/vista/factory.rs
+++ b/vantage-log-writer/src/vista/factory.rs
@@ -1,0 +1,160 @@
+use vantage_core::{Result, error};
+use vantage_table::column::core::Column as TableColumn;
+use vantage_table::column::flags::ColumnFlag;
+use vantage_table::table::Table;
+use vantage_table::traits::column_like::ColumnLike;
+use vantage_types::{EmptyEntity, Entity};
+use vantage_vista::{
+    Column as VistaColumn, NoExtras, Vista, VistaCapabilities, VistaFactory, VistaMetadata,
+    flags as vista_flags,
+};
+
+use crate::log_writer::LogWriter;
+use crate::type_system::AnyJsonType;
+use crate::vista::source::LogWriterTableShell;
+use crate::vista::spec::{LogWriterTableExtras, LogWriterVistaSpec};
+
+pub struct LogWriterVistaFactory {
+    log_writer: LogWriter,
+}
+
+impl LogWriterVistaFactory {
+    pub fn new(log_writer: LogWriter) -> Self {
+        Self { log_writer }
+    }
+
+    pub fn from_table<E>(&self, table: Table<LogWriter, E>) -> Result<Vista>
+    where
+        E: Entity<serde_json::Value> + 'static,
+    {
+        let metadata = metadata_from_table(&table);
+        let name = table.table_name().to_string();
+        let any_table = table.into_entity::<EmptyEntity>();
+
+        let source = LogWriterTableShell::new(
+            any_table,
+            VistaCapabilities {
+                can_insert: true,
+                ..VistaCapabilities::default()
+            },
+        );
+        Ok(Vista::new(name, Box::new(source), metadata))
+    }
+
+    pub fn table_from_spec(&self, spec: &LogWriterVistaSpec) -> Result<Table<LogWriter, EmptyEntity>> {
+        let table_name = spec
+            .driver
+            .log_writer
+            .as_ref()
+            .and_then(|b| b.filename.clone())
+            .unwrap_or_else(|| spec.name.clone());
+
+        let id_column = resolve_id_column(spec);
+        let log_writer = self.log_writer.clone().with_id_column(&id_column);
+        let mut table = Table::<LogWriter, EmptyEntity>::new(table_name, log_writer);
+
+        for (name, col_spec) in &spec.columns {
+            table.add_column(build_column(name, col_spec)?);
+            if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
+                table.add_title_field(name);
+            }
+        }
+
+        if !table.columns().contains_key(&id_column) {
+            return Err(error!(
+                "id column not present in spec.columns",
+                id = id_column
+            ));
+        }
+        table.set_id_field(&id_column);
+
+        Ok(table)
+    }
+}
+
+impl VistaFactory for LogWriterVistaFactory {
+    type TableExtras = LogWriterTableExtras;
+    type ColumnExtras = NoExtras;
+    type ReferenceExtras = NoExtras;
+
+    fn build_from_spec(&self, spec: LogWriterVistaSpec) -> Result<Vista> {
+        let vista_name = spec.name.clone();
+        let table = self.table_from_spec(&spec)?;
+        let mut vista = self.from_table(table)?;
+        vista.set_name(vista_name);
+        Ok(vista)
+    }
+}
+
+fn resolve_id_column(spec: &LogWriterVistaSpec) -> String {
+    if let Some(id) = &spec.id_column {
+        return id.clone();
+    }
+    for (name, col_spec) in &spec.columns {
+        if col_spec.flags.iter().any(|f| f == vista_flags::ID) {
+            return name.clone();
+        }
+    }
+    "id".to_string()
+}
+
+fn build_column(
+    name: &str,
+    col_spec: &vantage_vista::ColumnSpec<NoExtras>,
+) -> Result<TableColumn<AnyJsonType>> {
+    let ty = col_spec.col_type.as_deref().unwrap_or("string");
+    let hidden = col_spec.flags.iter().any(|f| f == vista_flags::HIDDEN);
+
+    let mut col = column_for_type(name, ty)?;
+    if hidden {
+        col = col.with_flag(ColumnFlag::Hidden);
+    }
+    Ok(col)
+}
+
+fn column_for_type(name: &str, ty: &str) -> Result<TableColumn<AnyJsonType>> {
+    let col: TableColumn<AnyJsonType> = match ty {
+        "int" | "integer" | "i64" | "i32" => TableColumn::from_column(TableColumn::<i64>::new(name)),
+        "float" | "double" | "f64" | "f32" => {
+            TableColumn::from_column(TableColumn::<f64>::new(name))
+        }
+        "bool" | "boolean" => TableColumn::from_column(TableColumn::<bool>::new(name)),
+        "string" | "text" | "str" => TableColumn::from_column(TableColumn::<String>::new(name)),
+        "json" | "object" | "array" => {
+            TableColumn::from_column(TableColumn::<serde_json::Value>::new(name))
+        }
+        other => {
+            return Err(error!(
+                "Unknown YAML column type",
+                column = name,
+                ty = other.to_string()
+            ));
+        }
+    };
+    Ok(col)
+}
+
+fn metadata_from_table<T, E>(table: &Table<T, E>) -> VistaMetadata
+where
+    T: vantage_table::traits::table_source::TableSource,
+    E: Entity<T::Value>,
+    T::Column<T::AnyType>: ColumnLike<T::AnyType>,
+{
+    let mut metadata = VistaMetadata::new();
+    for (name, col) in table.columns() {
+        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+        if col.flags().contains(&ColumnFlag::Hidden) {
+            vc = vc.with_flag(vista_flags::HIDDEN);
+        }
+        metadata = metadata.with_column(vc);
+    }
+    if let Some(id_field) = table.id_field() {
+        metadata = metadata.with_id_column(id_field.name().to_string());
+    }
+    for title in table.title_fields() {
+        if let Some(col) = metadata.columns.get_mut(title) {
+            col.flags.push(vista_flags::TITLE.to_string());
+        }
+    }
+    metadata
+}

--- a/vantage-log-writer/src/vista/factory.rs
+++ b/vantage-log-writer/src/vista/factory.rs
@@ -41,7 +41,10 @@ impl LogWriterVistaFactory {
         Ok(Vista::new(name, Box::new(source), metadata))
     }
 
-    pub fn table_from_spec(&self, spec: &LogWriterVistaSpec) -> Result<Table<LogWriter, EmptyEntity>> {
+    pub fn table_from_spec(
+        &self,
+        spec: &LogWriterVistaSpec,
+    ) -> Result<Table<LogWriter, EmptyEntity>> {
         let table_name = spec
             .driver
             .log_writer
@@ -114,7 +117,9 @@ fn build_column(
 
 fn column_for_type(name: &str, ty: &str) -> Result<TableColumn<AnyJsonType>> {
     let col: TableColumn<AnyJsonType> = match ty {
-        "int" | "integer" | "i64" | "i32" => TableColumn::from_column(TableColumn::<i64>::new(name)),
+        "int" | "integer" | "i64" | "i32" => {
+            TableColumn::from_column(TableColumn::<i64>::new(name))
+        }
         "float" | "double" | "f64" | "f32" => {
             TableColumn::from_column(TableColumn::<f64>::new(name))
         }

--- a/vantage-log-writer/src/vista/mod.rs
+++ b/vantage-log-writer/src/vista/mod.rs
@@ -1,0 +1,20 @@
+//! Vista bridge for the log-writer backend.
+//!
+//! Insert-only: `can_insert: true`, all other capability flags false. Read
+//! methods return `ErrorKind::Unsupported` via the trait's `default_error`.
+
+pub mod factory;
+pub mod source;
+pub mod spec;
+
+pub use factory::LogWriterVistaFactory;
+pub use source::LogWriterTableShell;
+pub use spec::{LogWriterBlock, LogWriterTableExtras, LogWriterVistaSpec};
+
+use crate::log_writer::LogWriter;
+
+impl LogWriter {
+    pub fn vista_factory(&self) -> LogWriterVistaFactory {
+        LogWriterVistaFactory::new(self.clone())
+    }
+}

--- a/vantage-log-writer/src/vista/source.rs
+++ b/vantage-log-writer/src/vista/source.rs
@@ -1,0 +1,103 @@
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use serde_json::Value;
+use vantage_core::{Result, error};
+use vantage_dataset::traits::InsertableValueSet;
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+use vantage_vista::{TableShell, Vista, VistaCapabilities};
+
+use crate::log_writer::LogWriter;
+
+pub struct LogWriterTableShell {
+    pub(crate) table: Table<LogWriter, EmptyEntity>,
+    pub(crate) capabilities: VistaCapabilities,
+}
+
+impl LogWriterTableShell {
+    pub(crate) fn new(table: Table<LogWriter, EmptyEntity>, capabilities: VistaCapabilities) -> Self {
+        Self {
+            table,
+            capabilities,
+        }
+    }
+}
+
+fn cbor_record_to_json(record: &Record<CborValue>) -> Record<Value> {
+    record
+        .iter()
+        .map(|(k, v)| {
+            let json = serde_json::to_value(v).unwrap_or(Value::Null);
+            (k.clone(), json)
+        })
+        .collect()
+}
+
+#[async_trait]
+impl TableShell for LogWriterTableShell {
+    async fn list_vista_values(
+        &self,
+        vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        Err(self.default_error("list_vista_values", "can_count", vista))
+    }
+
+    async fn get_vista_value(
+        &self,
+        vista: &Vista,
+        _id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        Err(self.default_error("get_vista_value", "can_count", vista))
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        Err(self.default_error("get_vista_some_value", "can_count", vista))
+    }
+
+    async fn get_vista_count(&self, vista: &Vista) -> Result<i64> {
+        Err(self.default_error("get_vista_count", "can_count", vista))
+    }
+
+    async fn insert_vista_return_id_value(
+        &self,
+        _vista: &Vista,
+        record: &Record<CborValue>,
+    ) -> Result<String> {
+        let json_record = cbor_record_to_json(record);
+        self.table.insert_return_id_value(&json_record).await
+    }
+
+    async fn insert_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        use vantage_dataset::traits::WritableValueSet;
+        let json_record = cbor_record_to_json(record);
+        let stored = self.table.insert_value(id, &json_record).await?;
+        Ok(stored
+            .into_iter()
+            .map(|(k, v)| {
+                let cbor = ciborium::Value::serialized(&v).unwrap_or(ciborium::Value::Null);
+                (k, cbor)
+            })
+            .collect())
+    }
+
+    fn add_eq_condition(&mut self, _field: &str, _value: &CborValue) -> Result<()> {
+        Err(error!("log-writer is insert-only; conditions are not supported").is_unsupported())
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.capabilities
+    }
+
+    fn driver_name(&self) -> &'static str {
+        "log-writer"
+    }
+}

--- a/vantage-log-writer/src/vista/source.rs
+++ b/vantage-log-writer/src/vista/source.rs
@@ -16,7 +16,10 @@ pub struct LogWriterTableShell {
 }
 
 impl LogWriterTableShell {
-    pub(crate) fn new(table: Table<LogWriter, EmptyEntity>, capabilities: VistaCapabilities) -> Self {
+    pub(crate) fn new(
+        table: Table<LogWriter, EmptyEntity>,
+        capabilities: VistaCapabilities,
+    ) -> Self {
         Self {
             table,
             capabilities,

--- a/vantage-log-writer/src/vista/spec.rs
+++ b/vantage-log-writer/src/vista/spec.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+use vantage_vista::{NoExtras, VistaSpec};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LogWriterTableExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_writer: Option<LogWriterBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LogWriterBlock {
+    /// Override the file stem; defaults to `spec.name`. The full path is
+    /// `{base_dir}/{filename}.jsonl`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+}
+
+pub type LogWriterVistaSpec = VistaSpec<LogWriterTableExtras, NoExtras, NoExtras>;

--- a/vantage-log-writer/src/writer_task.rs
+++ b/vantage-log-writer/src/writer_task.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use tokio::fs::{File, OpenOptions};
+use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::warn;
+
+pub(crate) enum WriteOp {
+    Append { path: PathBuf, line: String },
+}
+
+pub(crate) const WRITE_QUEUE_CAPACITY: usize = 256;
+
+pub(crate) fn spawn(mut rx: mpsc::Receiver<WriteOp>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut handles: HashMap<PathBuf, BufWriter<File>> = HashMap::new();
+        while let Some(op) = rx.recv().await {
+            match op {
+                WriteOp::Append { path, line } => {
+                    let writer = match get_or_open(&mut handles, &path).await {
+                        Ok(w) => w,
+                        Err(e) => {
+                            warn!(target: "vantage_log_writer", path = %path.display(), error = %e, "open failed");
+                            continue;
+                        }
+                    };
+                    if let Err(e) = writer.write_all(line.as_bytes()).await {
+                        warn!(target: "vantage_log_writer", path = %path.display(), error = %e, "write failed");
+                        handles.remove(&path);
+                        continue;
+                    }
+                    if let Err(e) = writer.flush().await {
+                        warn!(target: "vantage_log_writer", path = %path.display(), error = %e, "flush failed");
+                    }
+                }
+            }
+        }
+        for (path, mut writer) in handles {
+            if let Err(e) = writer.flush().await {
+                warn!(target: "vantage_log_writer", path = %path.display(), error = %e, "final flush failed");
+            }
+        }
+    })
+}
+
+async fn get_or_open<'a>(
+    handles: &'a mut HashMap<PathBuf, BufWriter<File>>,
+    path: &PathBuf,
+) -> std::io::Result<&'a mut BufWriter<File>> {
+    if !handles.contains_key(path) {
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await.ok();
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+        handles.insert(path.clone(), BufWriter::new(file));
+    }
+    Ok(handles.get_mut(path).unwrap())
+}

--- a/vantage-log-writer/src/writer_task.rs
+++ b/vantage-log-writer/src/writer_task.rs
@@ -33,6 +33,7 @@ pub(crate) fn spawn(mut rx: mpsc::Receiver<WriteOp>) -> JoinHandle<()> {
                     }
                     if let Err(e) = writer.flush().await {
                         warn!(target: "vantage_log_writer", path = %path.display(), error = %e, "flush failed");
+                        handles.remove(&path);
                     }
                 }
             }

--- a/vantage-log-writer/tests/insert.rs
+++ b/vantage-log-writer/tests/insert.rs
@@ -110,8 +110,8 @@ async fn read_methods_return_unsupported() {
 async fn insert_with_explicit_id_uses_it() {
     let dir = tempdir().unwrap();
     let writer = LogWriter::new(dir.path());
-    let table = Table::<LogWriter, EmptyEntity>::new("events", writer)
-        .with_column_of::<String>("name");
+    let table =
+        Table::<LogWriter, EmptyEntity>::new("events", writer).with_column_of::<String>("name");
 
     use vantage_dataset::traits::WritableValueSet;
     let mut record = vantage_types::Record::<serde_json::Value>::new();

--- a/vantage-log-writer/tests/insert.rs
+++ b/vantage-log-writer/tests/insert.rs
@@ -1,0 +1,130 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tempfile::tempdir;
+use tokio::time::sleep;
+use vantage_dataset::traits::{InsertableDataSet, ReadableValueSet};
+use vantage_log_writer::LogWriter;
+use vantage_table::table::Table;
+use vantage_types::EmptyEntity;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Event {
+    name: String,
+    user_id: i64,
+    is_admin: bool,
+    extra: String,
+}
+
+async fn read_lines(path: &std::path::Path) -> Vec<serde_json::Value> {
+    let text = tokio::fs::read_to_string(path).await.unwrap();
+    text.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect()
+}
+
+#[tokio::test]
+async fn insert_writes_jsonl_line() {
+    let dir = tempdir().unwrap();
+    let writer = LogWriter::new(dir.path());
+    let table = Table::<LogWriter, Event>::new("events", writer.clone())
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("user_id")
+        .with_column_of::<bool>("is_admin");
+
+    let event = Event {
+        name: "login".into(),
+        user_id: 42,
+        is_admin: true,
+        extra: "should be dropped".into(),
+    };
+
+    let id = table.insert_return_id(&event).await.unwrap();
+    assert_eq!(id.len(), 26, "ULID is 26 chars: {}", id);
+
+    sleep(Duration::from_millis(100)).await;
+
+    let path = dir.path().join("events.jsonl");
+    let rows = read_lines(&path).await;
+    assert_eq!(rows.len(), 1);
+
+    let row = &rows[0];
+    assert_eq!(row["name"], "login");
+    assert_eq!(row["user_id"], 42);
+    assert_eq!(row["is_admin"], true);
+    assert_eq!(row["id"], id);
+    assert!(
+        row.get("extra").is_none(),
+        "fields not in column list must be dropped"
+    );
+}
+
+#[tokio::test]
+async fn cloned_table_shares_writer() {
+    let dir = tempdir().unwrap();
+    let writer = LogWriter::new(dir.path());
+    let t1 = Table::<LogWriter, Event>::new("events", writer.clone())
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("user_id")
+        .with_column_of::<bool>("is_admin");
+    let t2 = t1.clone();
+
+    let e = Event {
+        name: "x".into(),
+        user_id: 1,
+        is_admin: false,
+        extra: "".into(),
+    };
+    let _ = t1.insert_return_id(&e).await.unwrap();
+    let _ = t2.insert_return_id(&e).await.unwrap();
+
+    sleep(Duration::from_millis(100)).await;
+
+    let rows = read_lines(&dir.path().join("events.jsonl")).await;
+    assert_eq!(rows.len(), 2);
+}
+
+#[tokio::test]
+async fn read_methods_return_unsupported() {
+    let dir = tempdir().unwrap();
+    let writer = LogWriter::new(dir.path());
+    let table = Table::<LogWriter, EmptyEntity>::new("events", writer);
+
+    let res = table.list_values().await;
+    assert!(res.is_err());
+    assert_eq!(
+        res.unwrap_err().kind(),
+        vantage_core::ErrorKind::Unsupported
+    );
+
+    let res = table.get_value(&"any".to_string()).await;
+    assert!(res.is_err());
+    assert_eq!(
+        res.unwrap_err().kind(),
+        vantage_core::ErrorKind::Unsupported
+    );
+}
+
+#[tokio::test]
+async fn insert_with_explicit_id_uses_it() {
+    let dir = tempdir().unwrap();
+    let writer = LogWriter::new(dir.path());
+    let table = Table::<LogWriter, EmptyEntity>::new("events", writer)
+        .with_column_of::<String>("name");
+
+    use vantage_dataset::traits::WritableValueSet;
+    let mut record = vantage_types::Record::<serde_json::Value>::new();
+    record.insert("name".into(), serde_json::Value::String("hello".into()));
+    let stored = WritableValueSet::insert_value(&table, &"my-id".to_string(), &record)
+        .await
+        .unwrap();
+    assert_eq!(stored["id"], "my-id");
+
+    sleep(Duration::from_millis(100)).await;
+
+    let rows = read_lines(&dir.path().join("events.jsonl")).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], "my-id");
+    assert_eq!(rows[0]["name"], "hello");
+}

--- a/vantage-log-writer/tests/vista.rs
+++ b/vantage-log-writer/tests/vista.rs
@@ -1,0 +1,195 @@
+#![cfg(feature = "vista")]
+
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use serde::{Deserialize, Serialize};
+use tempfile::tempdir;
+use tokio::time::sleep;
+use vantage_dataset::traits::InsertableValueSet;
+use vantage_log_writer::LogWriter;
+use vantage_table::table::Table;
+use vantage_types::Record;
+use vantage_vista::VistaFactory;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Event {
+    name: String,
+    user_id: i64,
+}
+
+async fn read_lines(path: &std::path::Path) -> Vec<serde_json::Value> {
+    let text = tokio::fs::read_to_string(path).await.unwrap();
+    text.lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect()
+}
+
+#[tokio::test]
+async fn capabilities_advertise_insert_only() {
+    let dir = tempdir().unwrap();
+    let writer = LogWriter::new(dir.path());
+    let table = Table::<LogWriter, Event>::new("events", writer.clone())
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("user_id");
+
+    let vista = writer.vista_factory().from_table(table).unwrap();
+    let caps = vista.capabilities();
+    assert!(caps.can_insert);
+    assert!(!caps.can_count);
+    assert!(!caps.can_update);
+    assert!(!caps.can_delete);
+    assert!(!caps.can_subscribe);
+    assert_eq!(vista.driver(), "log-writer");
+}
+
+#[tokio::test]
+async fn from_table_insert_via_cbor_writes_jsonl() {
+    let dir = tempdir().unwrap();
+    let writer = LogWriter::new(dir.path());
+    let table = Table::<LogWriter, Event>::new("events", writer.clone())
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("user_id");
+
+    let vista = writer.vista_factory().from_table(table).unwrap();
+
+    let mut record = Record::<CborValue>::new();
+    record.insert("name".into(), CborValue::Text("login".into()));
+    record.insert("user_id".into(), CborValue::Integer(42.into()));
+    record.insert("extra".into(), CborValue::Text("dropped".into()));
+
+    let id = vista.insert_return_id_value(&record).await.unwrap();
+    assert_eq!(id.len(), 26);
+
+    sleep(Duration::from_millis(100)).await;
+
+    let rows = read_lines(&dir.path().join("events.jsonl")).await;
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row["name"], "login");
+    assert_eq!(row["user_id"], 42);
+    assert_eq!(row["id"], id);
+    assert!(row.get("extra").is_none(), "out-of-column field must drop");
+}
+
+#[tokio::test]
+async fn read_methods_return_unsupported() {
+    use vantage_dataset::traits::ReadableValueSet;
+
+    let dir = tempdir().unwrap();
+    let writer = LogWriter::new(dir.path());
+    let table = Table::<LogWriter, Event>::new("events", writer.clone())
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("user_id");
+
+    let vista = writer.vista_factory().from_table(table).unwrap();
+
+    let res = vista.list_values().await;
+    assert!(res.is_err());
+    assert_eq!(
+        res.unwrap_err().kind(),
+        vantage_core::ErrorKind::Unsupported
+    );
+
+    let res = vista.get_value(&"any".to_string()).await;
+    assert!(res.is_err());
+    assert_eq!(
+        res.unwrap_err().kind(),
+        vantage_core::ErrorKind::Unsupported
+    );
+
+    let res = vista.get_count().await;
+    assert!(res.is_err());
+    assert_eq!(
+        res.unwrap_err().kind(),
+        vantage_core::ErrorKind::Unsupported
+    );
+}
+
+#[tokio::test]
+async fn build_from_spec_yaml_round_trip() {
+    let dir = tempdir().unwrap();
+    let writer = LogWriter::new(dir.path());
+
+    let yaml = r#"
+name: events
+columns:
+  id:
+    type: string
+    flags: [id]
+  name:
+    type: string
+    flags: [title]
+  user_id:
+    type: int
+"#;
+
+    let vista = writer.vista_factory().from_yaml(yaml).unwrap();
+    assert_eq!(vista.name(), "events");
+    assert_eq!(vista.get_id_column(), Some("id"));
+
+    let mut record = Record::<CborValue>::new();
+    record.insert("name".into(), CborValue::Text("hello".into()));
+    record.insert("user_id".into(), CborValue::Integer(7.into()));
+
+    let id = vista.insert_return_id_value(&record).await.unwrap();
+    sleep(Duration::from_millis(100)).await;
+
+    let rows = read_lines(&dir.path().join("events.jsonl")).await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["name"], "hello");
+    assert_eq!(rows[0]["user_id"], 7);
+    assert_eq!(rows[0]["id"], id);
+}
+
+#[tokio::test]
+async fn yaml_filename_override_redirects_file() {
+    let dir = tempdir().unwrap();
+    let writer = LogWriter::new(dir.path());
+
+    let yaml = r#"
+name: prod_events
+columns:
+  id: { type: string, flags: [id] }
+  name: { type: string }
+log_writer:
+  filename: events_v2
+"#;
+
+    let vista = writer.vista_factory().from_yaml(yaml).unwrap();
+    assert_eq!(vista.name(), "prod_events");
+
+    let mut record = Record::<CborValue>::new();
+    record.insert("name".into(), CborValue::Text("x".into()));
+    let _ = vista.insert_return_id_value(&record).await.unwrap();
+    sleep(Duration::from_millis(100)).await;
+
+    assert!(dir.path().join("events_v2.jsonl").exists());
+    assert!(!dir.path().join("prod_events.jsonl").exists());
+}
+
+#[tokio::test]
+async fn unknown_yaml_field_errors() {
+    let dir = tempdir().unwrap();
+    let writer = LogWriter::new(dir.path());
+
+    let yaml = r#"
+name: events
+columns:
+  id: { type: string, flags: [id] }
+log_writer:
+  filename: events
+  bogus: 1
+"#;
+
+    let result = writer.vista_factory().from_yaml(yaml);
+    let err = match result {
+        Ok(_) => panic!("expected unknown-field error"),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        err.contains("bogus") || err.contains("unknown"),
+        "got: {err}"
+    );
+}


### PR DESCRIPTION
A new `vantage-log-writer` crate for the case where you want a `Table` to spool events to disk and nothing else — audit logs, telemetry, append-only event streams. Inserts go to `{base_dir}/{table_name}.jsonl`, one line per record, queued onto a background tokio task so callers see channel-send latency, not disk latency.

```rust
let writer = LogWriter::new("./logs");
let table = Table::<LogWriter, Event>::new("events", writer)
    .with_column_of::<String>("name")
    .with_column_of::<i64>("user_id");
table.insert_return_id(&event).await?;
```

Insert-only by design. `list`, `get`, `count`, ... return `ErrorKind::Unsupported`; pair the writer with a separate read-side store (Surreal, redb, ...) when you need queries.

Records are projected onto the table's declared columns — entity fields outside the column set are dropped on the way down. The id column (default `"id"`, configurable via `with_id_column`) is filled from the record (string or number) or generated as a [ULID](https://github.com/ulid/spec) when absent.

### Why a new crate instead of redb / a SQL backend

Both work, but both demand a schema and a query engine you don't use. JSONL is what people actually reach for when they want grep-able event logs that survive crashes well enough and don't need a process to read. The vista bridge keeps it composable with the rest of vantage — the same `Vista` handle a Surreal- or CSV-backed table exposes.

### Vista feature

Behind a `vista` cargo feature: `writer.vista_factory().from_table(table)` or `from_yaml(...)`. Capabilities advertise `can_insert: true` only; `Vista::driver()` reports `"log-writer"`. YAML specs accept an optional `log_writer.filename` block to override the file stem when the spec's `name` differs from the on-disk file.

### Rough edges

No fsync, no rotation, no compaction. One tokio worker per `LogWriter`; clones share the same channel. Lose power between flush and disk and you lose the tail. Fine for telemetry; not fine for ledgers.