### PR TITLE
add dynamodb persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,7 @@ dependencies = [
  "serde_json",
  "surreal-client",
  "tokio",
+ "vantage-aws",
  "vantage-cli-util",
  "vantage-core",
  "vantage-csv",
@@ -1461,6 +1462,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1831,6 +1833,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "macro_magic"
@@ -2462,6 +2470,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2624,6 +2696,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2631,6 +2705,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2638,6 +2713,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2737,6 +2813,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,6 +2871,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3998,6 +4081,30 @@ dependencies = [
  "tracing",
  "urlencoding",
  "vantage-cli-util",
+ "vantage-core",
+ "vantage-dataset",
+ "vantage-expressions",
+ "vantage-table",
+ "vantage-types",
+]
+
+[[package]]
+name = "vantage-aws"
+version = "0.4.5"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "ciborium",
+ "hex",
+ "hmac",
+ "indexmap",
+ "paste",
+ "quick-xml",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
  "vantage-core",
  "vantage-dataset",
  "vantage-expressions",

--- a/bakery_model3/Cargo.toml
+++ b/bakery_model3/Cargo.toml
@@ -13,6 +13,7 @@ vantage-dataset = { path = "../vantage-dataset" }
 vantage-types = { path = "../vantage-types" }
 vantage-sql = { path = "../vantage-sql", features = ["sqlite", "postgres", "vista"] }
 vantage-mongodb = { path = "../vantage-mongodb", features = ["vista"] }
+vantage-aws = { path = "../vantage-aws" }
 vantage-surrealdb = { path = "../vantage-surrealdb" }
 surreal-client = { path = "../surreal-client", features = ["decimal"] }
 bson = "2"

--- a/bakery_model3/examples/cli.rs
+++ b/bakery_model3/examples/cli.rs
@@ -66,7 +66,10 @@ async fn run() -> vantage_core::Result<()> {
 
     let matches = app.get_matches();
     let debug = matches.get_flag("debug");
-    let backend = matches.get_one::<String>("backend").cloned().unwrap_or_else(|| "surreal".into());
+    let backend = matches
+        .get_one::<String>("backend")
+        .cloned()
+        .unwrap_or_else(|| "surreal".into());
 
     let entity_name = match matches.get_one::<String>("entity") {
         Some(name) => name.clone(),
@@ -250,9 +253,7 @@ async fn handle_commands(
             }
             other => {
                 println!("Unknown command: {}", other);
-                println!(
-                    "Available: list, get, count, add <id> <json>, delete <id>, ref <name>"
-                );
+                println!("Available: list, get, count, add <id> <json>, delete <id>, ref <name>");
             }
         }
     }

--- a/bakery_model3/examples/cli.rs
+++ b/bakery_model3/examples/cli.rs
@@ -1,6 +1,6 @@
-//! SurrealDB CLI for browsing and managing bakery data.
+//! Multi-backend CLI for browsing and managing bakery data.
 //!
-//! Usage: db [--debug] <entity> [command ...]
+//! Usage: db [--debug] [--backend surreal|dynamodb] <entity> [command ...]
 //!
 //! Entities: bakery, client, product, order
 //!
@@ -10,6 +10,7 @@
 //!   count             Count records
 //!   add <id> <json>   Insert a record
 //!   delete <id>       Delete a record by ID
+//!   ref <name>        Traverse a relationship and list the target table
 
 use bakery_model3::*;
 use clap::{Arg, Command};
@@ -18,6 +19,8 @@ use vantage_core::util::error::Context;
 use vantage_dataset::prelude::*;
 use vantage_table::any::AnyTable;
 use vantage_table::traits::table_like::TableLike;
+
+const DYNAMO_REGION: &str = "eu-west-2";
 
 fn model_names() -> Vec<&'static str> {
     vec!["bakery", "client", "product", "order"]
@@ -33,12 +36,20 @@ async fn main() {
 
 async fn run() -> vantage_core::Result<()> {
     let app = Command::new("db")
-        .about("SurrealDB management utility for Bakery")
+        .about("Multi-backend management utility for Bakery")
         .arg(
             Arg::new("debug")
                 .long("debug")
                 .help("Enable debug mode (show queries)")
                 .action(clap::ArgAction::SetTrue)
+                .global(true),
+        )
+        .arg(
+            Arg::new("backend")
+                .long("backend")
+                .help("Backend to use: surreal (default) or dynamodb")
+                .value_parser(["surreal", "dynamodb"])
+                .default_value("surreal")
                 .global(true),
         )
         .arg(
@@ -48,13 +59,14 @@ async fn run() -> vantage_core::Result<()> {
         )
         .arg(
             Arg::new("commands")
-                .help("Commands: list, get, count, add <id> <json>, delete <id>")
+                .help("Commands: list, get, count, add <id> <json>, delete <id>, ref <name>")
                 .num_args(0..)
                 .trailing_var_arg(true),
         );
 
     let matches = app.get_matches();
     let debug = matches.get_flag("debug");
+    let backend = matches.get_one::<String>("backend").cloned().unwrap_or_else(|| "surreal".into());
 
     let entity_name = match matches.get_one::<String>("entity") {
         Some(name) => name.clone(),
@@ -71,30 +83,59 @@ async fn run() -> vantage_core::Result<()> {
         .cloned()
         .collect();
 
-    let table = match build_table(&entity_name, debug).await? {
+    let table = match build_table(&entity_name, &backend, debug).await? {
         Some(t) => t,
         None => return Ok(()),
     };
 
-    handle_commands(table, commands).await
+    handle_commands(table, commands, &backend).await
 }
 
-async fn build_table(entity_name: &str, debug: bool) -> vantage_core::Result<Option<AnyTable>> {
-    connect_surrealdb_with_debug(debug)
-        .await
-        .context("Failed to connect to SurrealDB")?;
-    let db = surrealdb();
-    let table = match entity_name {
-        "bakery" => AnyTable::from_table(Bakery::surreal_table(db)),
-        "client" => AnyTable::from_table(Client::surreal_table(db)),
-        "product" => AnyTable::from_table(Product::surreal_table(db)),
-        "order" => AnyTable::from_table(Order::surreal_table(db)),
-        _ => {
-            println!("Unknown entity: {}", entity_name);
-            return Ok(None);
+async fn build_table(
+    entity_name: &str,
+    backend: &str,
+    debug: bool,
+) -> vantage_core::Result<Option<AnyTable>> {
+    match backend {
+        "surreal" => {
+            connect_surrealdb_with_debug(debug)
+                .await
+                .context("Failed to connect to SurrealDB")?;
+            let db = surrealdb();
+            let table = match entity_name {
+                "bakery" => AnyTable::from_table(Bakery::surreal_table(db)),
+                "client" => AnyTable::from_table(Client::surreal_table(db)),
+                "product" => AnyTable::from_table(Product::surreal_table(db)),
+                "order" => AnyTable::from_table(Order::surreal_table(db)),
+                _ => {
+                    println!("Unknown entity: {}", entity_name);
+                    return Ok(None);
+                }
+            };
+            Ok(Some(table))
         }
-    };
-    Ok(Some(table))
+        "dynamodb" => {
+            let aws = AwsAccount::from_default()
+                .context("Failed to load AWS credentials (env or ~/.aws/credentials)")?
+                .with_region(DYNAMO_REGION);
+            let db = DynamoDB::new(aws);
+            let table = match entity_name {
+                "bakery" => AnyTable::from_table(Bakery::dynamo_table(db)),
+                "client" => AnyTable::from_table(Client::dynamo_table(db)),
+                "product" => AnyTable::from_table(Product::dynamo_table(db)),
+                "order" => AnyTable::from_table(Order::dynamo_table(db)),
+                _ => {
+                    println!("Unknown entity: {}", entity_name);
+                    return Ok(None);
+                }
+            };
+            Ok(Some(table))
+        }
+        other => {
+            println!("Unknown backend: {}", other);
+            Ok(None)
+        }
+    }
 }
 
 fn print_usage() {
@@ -116,7 +157,11 @@ fn print_usage() {
     println!("  db bakery delete myid");
 }
 
-async fn handle_commands(table: AnyTable, commands: Vec<String>) -> vantage_core::Result<()> {
+async fn handle_commands(
+    table: AnyTable,
+    commands: Vec<String>,
+    backend: &str,
+) -> vantage_core::Result<()> {
     if commands.is_empty() {
         println!("No command. Try: list, get, count, add, delete");
         return Ok(());
@@ -165,7 +210,7 @@ async fn handle_commands(table: AnyTable, commands: Vec<String>) -> vantage_core
                     break;
                 }
 
-                let id = qualify_id(table.table_name(), id_str);
+                let id = qualify_id(table.table_name(), id_str, backend);
                 let cbor_val = ciborium::Value::serialized(&json_val).map_err(|e| {
                     vantage_core::error!("Invalid JSON for CBOR", details = e.to_string())
                 })?;
@@ -181,22 +226,43 @@ async fn handle_commands(table: AnyTable, commands: Vec<String>) -> vantage_core
                 let id_str = &commands[i];
                 i += 1;
 
-                let id = qualify_id(table.table_name(), id_str);
+                let id = qualify_id(table.table_name(), id_str, backend);
                 table.delete(&id).await?;
                 println!("Deleted: {}", id);
             }
+            "ref" => {
+                if i >= commands.len() {
+                    println!("Usage: ref <relation-name>");
+                    break;
+                }
+                let ref_name = commands[i].clone();
+                i += 1;
+
+                let related = table.get_ref(&ref_name)?;
+                let records = related.list_values().await?;
+                println!(
+                    "[{}] traversed via {} → {} record(s)",
+                    related.table_name(),
+                    ref_name,
+                    records.len()
+                );
+                render_records(&records, None);
+            }
             other => {
                 println!("Unknown command: {}", other);
-                println!("Available: list, get, count, add <id> <json>, delete <id>");
+                println!(
+                    "Available: list, get, count, add <id> <json>, delete <id>, ref <name>"
+                );
             }
         }
     }
     Ok(())
 }
 
-/// Qualify a bare id for SurrealDB (which needs "table:id" format).
-fn qualify_id(table_name: &str, id: &str) -> String {
-    if !id.contains(':') {
+/// Qualify a bare id. SurrealDB wants the `table:id` form; everything
+/// else (DynamoDB, etc.) takes the id verbatim.
+fn qualify_id(table_name: &str, id: &str, backend: &str) -> String {
+    if backend == "surreal" && !id.contains(':') {
         format!("{}:{}", table_name, id)
     } else {
         id.to_string()

--- a/bakery_model3/examples/dynamo-smoke.rs
+++ b/bakery_model3/examples/dynamo-smoke.rs
@@ -1,0 +1,72 @@
+//! Smoke test for the DynamoDB persistence wired into bakery_model3.
+//!
+//! Round-trips a typed `Product` (entity macro path) through the
+//! `vantage-demo-products` table provisioned by `test-tf/dynamodb.tf`.
+//!
+//! ```sh
+//! cd test-tf && tofu apply
+//! cd ../bakery_model3 && cargo run --example dynamo-smoke
+//! ```
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use bakery_model3::*;
+use vantage_aws::dynamodb::DynamoId;
+use vantage_core::{Result, error};
+use vantage_dataset::prelude::{ReadableDataSet, WritableDataSet};
+use vantage_dataset::traits::WritableValueSet;
+
+const TEST_REGION: &str = "eu-west-2";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let aws = AwsAccount::from_default()
+        .map_err(|e| error!("AWS credentials not configured", details = e.to_string()))?
+        .with_region(TEST_REGION);
+    let db = DynamoDB::new(aws);
+
+    let table = Product::dynamo_table(db);
+    let id = DynamoId::new(format!(
+        "smoke-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+
+    let product = Product {
+        name: "Smoke Cupcake".to_string(),
+        calories: 250,
+        price: 350,
+        is_deleted: false,
+        sticker: Some(Animal::Cat),
+    };
+
+    println!("→ insert {} ({})", product.name, id);
+    table.insert(&id, &product).await?;
+
+    println!("→ get back {}", id);
+    let fetched = table
+        .get(id.clone())
+        .await?
+        .ok_or_else(|| error!("Product disappeared after insert"))?;
+
+    assert_eq!(fetched.name, product.name);
+    assert_eq!(fetched.calories, product.calories);
+    assert_eq!(fetched.price, product.price);
+    assert_eq!(fetched.is_deleted, product.is_deleted);
+    assert_eq!(fetched.sticker, product.sticker);
+    println!(
+        "  ✓ all fields round-tripped (sticker = {:?})",
+        fetched.sticker
+    );
+
+    println!("→ delete {}", id);
+    table.delete(&id).await?;
+
+    let gone = table.get(id.clone()).await?;
+    assert!(gone.is_none(), "Product should be gone after delete");
+    println!("  ✓ confirmed gone");
+
+    Ok(())
+}

--- a/bakery_model3/src/animal.rs
+++ b/bakery_model3/src/animal.rs
@@ -1,6 +1,6 @@
 use bson::Bson;
-use vantage_aws::dynamodb::types::{AttributeValue, DynamoTypeSMarker};
 use vantage_aws::dynamodb::DynamoType;
+use vantage_aws::dynamodb::types::{AttributeValue, DynamoTypeSMarker};
 use vantage_csv::{CsvType, type_system::CsvTypeAnimalMarker};
 use vantage_mongodb::MongoType;
 use vantage_mongodb::types::MongoTypeStringMarker;

--- a/bakery_model3/src/animal.rs
+++ b/bakery_model3/src/animal.rs
@@ -1,4 +1,6 @@
 use bson::Bson;
+use vantage_aws::dynamodb::types::{AttributeValue, DynamoTypeSMarker};
+use vantage_aws::dynamodb::DynamoType;
 use vantage_csv::{CsvType, type_system::CsvTypeAnimalMarker};
 use vantage_mongodb::MongoType;
 use vantage_mongodb::types::MongoTypeStringMarker;
@@ -125,6 +127,21 @@ impl MongoType for Animal {
     fn from_bson(value: Bson) -> Option<Self> {
         match value {
             Bson::String(s) => s.parse().ok(),
+            _ => None,
+        }
+    }
+}
+
+impl DynamoType for Animal {
+    type Target = DynamoTypeSMarker;
+
+    fn to_attr(&self) -> AttributeValue {
+        AttributeValue::S(self.as_str().to_string())
+    }
+
+    fn from_attr(value: AttributeValue) -> Option<Self> {
+        match value {
+            AttributeValue::S(s) => s.parse().ok(),
             _ => None,
         }
     }

--- a/bakery_model3/src/bakery.rs
+++ b/bakery_model3/src/bakery.rs
@@ -1,3 +1,4 @@
+use vantage_aws::dynamodb::{AnyDynamoType, DynamoDB};
 use vantage_csv::{AnyCsvType, Csv};
 use vantage_mongodb::{AnyMongoType, MongoDB};
 #[allow(unused_imports)]
@@ -9,7 +10,7 @@ use vantage_surrealdb::types::AnySurrealType;
 use vantage_table::table::Table;
 use vantage_types::entity;
 
-#[entity(CsvType, SurrealType, SqliteType, PostgresType, MongoType)]
+#[entity(CsvType, SurrealType, SqliteType, PostgresType, MongoType, DynamoType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Bakery {
     pub name: String,
@@ -50,5 +51,13 @@ impl Bakery {
             .with_id_column("_id")
             .with_column_of::<String>("name")
             .with_column_of::<i64>("profit_margin")
+    }
+
+    pub fn dynamo_table(db: DynamoDB) -> Table<DynamoDB, Bakery> {
+        Table::new("vantage-demo-bakery", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("profit_margin")
+            .with_many("products", "bakery_id", crate::Product::dynamo_table)
     }
 }

--- a/bakery_model3/src/client.rs
+++ b/bakery_model3/src/client.rs
@@ -1,3 +1,4 @@
+use vantage_aws::dynamodb::{AnyDynamoType, DynamoDB};
 use vantage_csv::{AnyCsvType, Csv};
 use vantage_mongodb::{AnyMongoType, MongoDB};
 #[allow(unused_imports)]
@@ -11,7 +12,7 @@ use vantage_types::entity;
 
 use crate::{Bakery, Order};
 
-#[entity(CsvType, SurrealType, SqliteType, PostgresType, MongoType)]
+#[entity(CsvType, SurrealType, SqliteType, PostgresType, MongoType, DynamoType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Client {
     pub name: String,
@@ -90,5 +91,17 @@ impl Client {
             .with_column_of::<String>("bakery_id")
             .with_one("bakery", "bakery_id", Bakery::mongo_table)
             .with_many("orders", "client_id", Order::mongo_table)
+    }
+
+    pub fn dynamo_table(db: DynamoDB) -> Table<DynamoDB, Client> {
+        Table::new("vantage-demo-client", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<String>("email")
+            .with_column_of::<String>("contact_details")
+            .with_column_of::<bool>("is_paying_client")
+            .with_column_of::<String>("bakery_id")
+            .with_one("bakery", "bakery_id", Bakery::dynamo_table)
+            .with_many("orders", "client_id", Order::dynamo_table)
     }
 }

--- a/bakery_model3/src/lib.rs
+++ b/bakery_model3/src/lib.rs
@@ -1,3 +1,5 @@
+pub use vantage_aws::AwsAccount;
+pub use vantage_aws::dynamodb::{AnyDynamoType, DynamoDB, DynamoType};
 pub use vantage_csv::{AnyCsvType, Csv, CsvType};
 pub use vantage_mongodb::{AnyMongoType, MongoDB, MongoType};
 pub use vantage_sql::postgres::{AnyPostgresType, PostgresDB, PostgresType};

--- a/bakery_model3/src/order.rs
+++ b/bakery_model3/src/order.rs
@@ -1,3 +1,4 @@
+use vantage_aws::dynamodb::{AnyDynamoType, DynamoDB};
 use vantage_csv::{AnyCsvType, Csv};
 use vantage_mongodb::{AnyMongoType, MongoDB};
 #[allow(unused_imports)]
@@ -12,7 +13,7 @@ use vantage_types::entity;
 
 use crate::Client;
 
-#[entity(CsvType, SurrealType, SqliteType, PostgresType, MongoType)]
+#[entity(CsvType, SurrealType, SqliteType, PostgresType, MongoType, DynamoType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Order {
     pub client_id: Option<String>,
@@ -61,5 +62,16 @@ impl Order {
             .with_column_of::<String>("client_id")
             .with_column_of::<bool>("is_deleted")
             .with_one("client", "client_id", Client::mongo_table)
+    }
+
+    pub fn dynamo_table(db: DynamoDB) -> Table<DynamoDB, Order> {
+        // `vantage-demo-order` is the single-partition-key table.
+        // The composite-key `vantage-demo-orders` is reserved for
+        // future composite-key work.
+        Table::new("vantage-demo-order", db)
+            .with_id_column("id")
+            .with_column_of::<String>("client_id")
+            .with_column_of::<bool>("is_deleted")
+            .with_one("client", "client_id", Client::dynamo_table)
     }
 }

--- a/bakery_model3/src/product.rs
+++ b/bakery_model3/src/product.rs
@@ -1,3 +1,4 @@
+use vantage_aws::dynamodb::{AnyDynamoType, DynamoDB};
 use vantage_csv::{AnyCsvType, Csv};
 use vantage_mongodb::{AnyMongoType, MongoDB};
 #[allow(unused_imports)]
@@ -11,7 +12,7 @@ use vantage_types::entity;
 
 use crate::{Animal, Bakery};
 
-#[entity(CsvType, SurrealType, SqliteType, PostgresType, MongoType)]
+#[entity(CsvType, SurrealType, SqliteType, PostgresType, MongoType, DynamoType)]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Product {
     pub name: String,
@@ -73,5 +74,17 @@ impl Product {
             .with_column_of::<i64>("price")
             .with_column_of::<bool>("is_deleted")
             .with_column_of::<Option<Animal>>("sticker")
+    }
+
+    pub fn dynamo_table(db: DynamoDB) -> Table<DynamoDB, Product> {
+        Table::new("vantage-demo-products", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("calories")
+            .with_column_of::<i64>("price")
+            .with_column_of::<bool>("is_deleted")
+            .with_column_of::<Option<Animal>>("sticker")
+            .with_column_of::<String>("bakery_id")
+            .with_one("bakery", "bakery_id", Bakery::dynamo_table)
     }
 }

--- a/test-tf/dynamodb.tf
+++ b/test-tf/dynamodb.tf
@@ -1,0 +1,37 @@
+// DynamoDB tables for exercising vantage-aws/dynamodb against a real account.
+//
+// PAY_PER_REQUEST keeps cost ~zero when idle (no provisioned throughput).
+// Both tables are tiny on purpose — they exist to be CRUD'd by integration
+// tests, not to hold real workload data.
+
+resource "aws_dynamodb_table" "products" {
+  name         = "${var.name}-products"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  tags = { Name = var.name }
+}
+
+resource "aws_dynamodb_table" "orders" {
+  name         = "${var.name}-orders"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "customer_id"
+  range_key    = "order_id"
+
+  attribute {
+    name = "customer_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "order_id"
+    type = "S"
+  }
+
+  tags = { Name = var.name }
+}

--- a/test-tf/dynamodb.tf
+++ b/test-tf/dynamodb.tf
@@ -35,3 +35,46 @@ resource "aws_dynamodb_table" "orders" {
 
   tags = { Name = var.name }
 }
+
+// Single-partition-key tables consumed by `bakery_model3::*::dynamo_table`.
+// `Order` here is the flat single-key form; the composite-key table above
+// stays around for future composite-key work.
+
+resource "aws_dynamodb_table" "bakery" {
+  name         = "${var.name}-bakery"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  tags = { Name = var.name }
+}
+
+resource "aws_dynamodb_table" "client" {
+  name         = "${var.name}-client"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  tags = { Name = var.name }
+}
+
+resource "aws_dynamodb_table" "order_flat" {
+  name         = "${var.name}-order"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  tags = { Name = var.name }
+}

--- a/test-tf/outputs.tf
+++ b/test-tf/outputs.tf
@@ -25,3 +25,11 @@ output "vpc_id" {
 output "subnet_ids" {
   value = aws_subnet.public[*].id
 }
+
+output "dynamodb_products_table" {
+  value = aws_dynamodb_table.products.name
+}
+
+output "dynamodb_orders_table" {
+  value = aws_dynamodb_table.orders.name
+}

--- a/test-tf/outputs.tf
+++ b/test-tf/outputs.tf
@@ -33,3 +33,15 @@ output "dynamodb_products_table" {
 output "dynamodb_orders_table" {
   value = aws_dynamodb_table.orders.name
 }
+
+output "dynamodb_bakery_table" {
+  value = aws_dynamodb_table.bakery.name
+}
+
+output "dynamodb_client_table" {
+  value = aws_dynamodb_table.client.name
+}
+
+output "dynamodb_order_flat_table" {
+  value = aws_dynamodb_table.order_flat.name
+}

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.4.5 — 2026-05-04
+
+A typed DynamoDB persistence backend — sibling to the existing list-API surface in `models::dynamodb`. Items have a typed `AttributeValue` representation, native key/filter expressions, and full CRUD semantics, none of which fold cleanly into the `AwsAccount`-as-`TableSource` shape — so DynamoDB lives as its own [`vantage_aws::dynamodb`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/) module with its own `TableSource` impl.
+
+- New [`DynamoDB`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/struct.DynamoDB.html) data source: cheap to clone, wraps an existing `AwsAccount` for credentials and signing.
+- New [`AttributeValue`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/enum.AttributeValue.html) typed enum mirrors the wire shape (`S`, `N`, `B`, `BOOL`, `NULL`, `L`, `M`, `SS`, `NS`, `BS`); a `vantage_type_system!` invocation produces the matching `DynamoType` trait, `AnyDynamoType` value, and variants enum, with per-type impls for `String`, `i32`, `i64`, `f64`, `bool`, `Vec<u8>`, and `Option<T>`.
+- Read/write path covers `Scan` (list / count / sample), `GetItem` (point read), `PutItem` (insert and replace), and `DeleteItem`. `delete_table_all_values` walks the scan and deletes per-item — no native bulk delete.
+- New [`DynamoCondition`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/enum.DynamoCondition.html) carries a rendered expression plus its `ExpressionAttributeNames` / `ExpressionAttributeValues` maps; v0 ships `eq` only, with `gt` / `between` / `in_` / `begins_with` landing alongside Scan/Query filter execution.
+- New [`DynamoId`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/struct.DynamoId.html) primary-key type — partition-key-only and string-form in v0; composite (partition + sort) keys are next.
+- New `AwsAccount::with_region(region)` returns a copy with the region overridden — useful when credentials come from `~/.aws/credentials` but the target region differs from the profile default (e.g. a test fixture provisioned in a fixed region regardless of the developer's local config).
+- Added `paste` dependency (used by the `vantage_type_system!` macro expansion).
+- Live integration tests against a real DynamoDB account (`tests/dynamodb_live.rs`); auto-skip when AWS credentials aren't configured. The accompanying `test-tf/dynamodb.tf` provisions two `PAY_PER_REQUEST` tables (`<name>-products`, `<name>-orders`) for exercising the round-trip.
+- Aggregations (`sum` / `min` / `max`), `patch` (UpdateItem), key-generation insert, relationship traversal, and binary `B` / `BS` wire codec are stubbed — they error loudly so callers can't accidentally rely on them.
+
 ## 0.4.4 — 2026-05-02
 
 Three more AWS wire protocols and three more model trees — S3, Lambda, DynamoDB — wired into the same `Factory` / `from_arn` surface as the IAM/ECS/CloudWatch models. ([#216](https://github.com/romaninsh/vantage/pull/216))

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -1678,6 +1678,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,7 +2002,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2036,6 +2061,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -2090,6 +2121,7 @@ dependencies = [
  "hex",
  "hmac",
  "indexmap",
+ "paste",
  "quick-xml",
  "reqwest",
  "serde",
@@ -2121,13 +2153,14 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "atty",
  "indexmap",
  "owo-colors",
  "serde",
  "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]
@@ -2151,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-expressions"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "serde",
@@ -2159,6 +2192,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vantage-core",
  "vantage-dataset",
+ "vantage-vista",
 ]
 
 [[package]]
@@ -2202,6 +2236,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "vantage-vista"
+version = "0.4.4"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "ciborium",
+ "futures-core",
+ "indexmap",
+ "serde",
+ "serde_yaml_ng",
+ "thiserror 2.0.18",
+ "vantage-core",
+ "vantage-dataset",
+ "vantage-types",
 ]
 
 [[package]]

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 indexmap = { version = "2", features = ["serde"] }
 async-trait = "0.1"
+paste = "1"
 tokio = { version = "1", features = ["rt", "macros", "sync"] }
 
 # SigV4: hand-rolled. Just the primitives.

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-aws/src/account.rs
+++ b/vantage-aws/src/account.rs
@@ -135,6 +135,23 @@ impl AwsAccount {
         }
     }
 
+    /// Return a copy with the region overridden. Useful when credentials
+    /// come from `~/.aws/credentials` but the target region differs from
+    /// the profile default (e.g. a test fixture provisioned in a fixed
+    /// region regardless of the developer's local config).
+    pub fn with_region(self, region: impl Into<String>) -> Self {
+        let inner = &self.inner;
+        Self {
+            inner: std::sync::Arc::new(Inner {
+                access_key: inner.access_key.clone(),
+                secret_key: inner.secret_key.clone(),
+                session_token: inner.session_token.clone(),
+                region: region.into(),
+                http: inner.http.clone(),
+            }),
+        }
+    }
+
     pub(crate) fn region(&self) -> &str {
         &self.inner.region
     }

--- a/vantage-aws/src/dynamodb/condition.rs
+++ b/vantage-aws/src/dynamodb/condition.rs
@@ -1,0 +1,43 @@
+//! DynamoDB condition DSL — analogous to MongoDB's `MongoCondition`.
+//!
+//! v0 carries a rendered expression string plus expression-attribute
+//! name/value maps, which is what DynamoDB's `ConditionExpression` /
+//! `KeyConditionExpression` / `FilterExpression` parameters consume.
+//! The expression strings reference placeholders (`#name`, `:value`)
+//! that the maps resolve at request time.
+
+use indexmap::IndexMap;
+
+use super::types::AttributeValue;
+
+/// A DynamoDB filter condition.
+///
+/// - `Expr` carries a rendered expression plus its attribute maps.
+/// - `And` combines multiple conditions with implicit `AND` glue.
+#[derive(Debug, Clone)]
+pub enum DynamoCondition {
+    Expr {
+        expression: String,
+        names: IndexMap<String, String>,
+        values: IndexMap<String, AttributeValue>,
+    },
+    And(Vec<DynamoCondition>),
+}
+
+impl DynamoCondition {
+    /// Build a `field = value` condition. The placeholders are mangled
+    /// per-condition so multiple `eq` calls don't clobber each other
+    /// when combined.
+    pub fn eq(field: impl Into<String>, value: impl Into<AttributeValue>) -> Self {
+        let field = field.into();
+        let mut names = IndexMap::new();
+        let mut values = IndexMap::new();
+        names.insert("#f".to_string(), field);
+        values.insert(":v".to_string(), value.into());
+        Self::Expr {
+            expression: "#f = :v".to_string(),
+            names,
+            values,
+        }
+    }
+}

--- a/vantage-aws/src/dynamodb/condition.rs
+++ b/vantage-aws/src/dynamodb/condition.rs
@@ -58,9 +58,10 @@ impl std::fmt::Debug for DynamoCondition {
                 .field("names", names)
                 .field("values", values)
                 .finish(),
-            Self::In { field, .. } => {
-                f.debug_struct("In").field("field", field).finish_non_exhaustive()
-            }
+            Self::In { field, .. } => f
+                .debug_struct("In")
+                .field("field", field)
+                .finish_non_exhaustive(),
             Self::And(conds) => f.debug_tuple("And").field(conds).finish(),
         }
     }
@@ -156,18 +157,15 @@ fn resolve_one<'a>(
                     // source set means "match nothing" — emit a
                     // tautologically-false fragment.
                     let name_ph = state.fresh_name(field.clone());
-                    return Ok(Some(format!("attribute_not_exists({}) AND attribute_exists({})", name_ph, name_ph)));
+                    return Ok(Some(format!(
+                        "attribute_not_exists({}) AND attribute_exists({})",
+                        name_ph, name_ph
+                    )));
                 }
                 let name_ph = state.fresh_name(field.clone());
-                let value_phs: Vec<String> = resolved
-                    .into_iter()
-                    .map(|v| state.fresh_value(v))
-                    .collect();
-                Ok(Some(format!(
-                    "{} IN ({})",
-                    name_ph,
-                    value_phs.join(", ")
-                )))
+                let value_phs: Vec<String> =
+                    resolved.into_iter().map(|v| state.fresh_value(v)).collect();
+                Ok(Some(format!("{} IN ({})", name_ph, value_phs.join(", "))))
             }
             DynamoCondition::And(children) => {
                 let mut parts = Vec::new();

--- a/vantage-aws/src/dynamodb/condition.rs
+++ b/vantage-aws/src/dynamodb/condition.rs
@@ -1,33 +1,73 @@
-//! DynamoDB condition DSL — analogous to MongoDB's `MongoCondition`.
+//! DynamoDB condition DSL.
 //!
-//! v0 carries a rendered expression string plus expression-attribute
-//! name/value maps, which is what DynamoDB's `ConditionExpression` /
-//! `KeyConditionExpression` / `FilterExpression` parameters consume.
-//! The expression strings reference placeholders (`#name`, `:value`)
-//! that the maps resolve at request time.
+//! `DynamoCondition` carries the pieces DynamoDB's `FilterExpression`
+//! consumes — an expression string referencing `#name` / `:value`
+//! placeholders, plus the maps that bind them. `In` is deferred so
+//! relationship traversal can run a source query at execution time.
+//!
+//! Multiple conditions on a `Table` get combined via [`resolve`], which
+//! mangles placeholders to be globally unique within one Scan request
+//! and joins the rendered fragments with ` AND `.
+
+use std::pin::Pin;
+use std::sync::Arc;
 
 use indexmap::IndexMap;
+use vantage_core::Result;
 
 use super::types::AttributeValue;
 
+/// Future returned by a deferred condition fetch (e.g. a relationship
+/// traversal that lists the source table to discover the IN values).
+pub type ValueListFuture =
+    Pin<Box<dyn std::future::Future<Output = Result<Vec<AttributeValue>>> + Send>>;
+
+/// Producer for an IN-clause's value list. Cloned every time the
+/// condition is evaluated, so backends are free to memoize externally.
+pub type ValueListFn = Arc<dyn Fn() -> ValueListFuture + Send + Sync>;
+
 /// A DynamoDB filter condition.
 ///
-/// - `Expr` carries a rendered expression plus its attribute maps.
-/// - `And` combines multiple conditions with implicit `AND` glue.
-#[derive(Debug, Clone)]
+/// - `Expr` is a fully-rendered expression with already-mangled placeholders.
+/// - `In` defers resolution until a source query has run (relationship traversal).
+/// - `And` combines siblings with implicit `AND`.
+#[derive(Clone)]
 pub enum DynamoCondition {
     Expr {
         expression: String,
         names: IndexMap<String, String>,
         values: IndexMap<String, AttributeValue>,
     },
+    In {
+        field: String,
+        values: ValueListFn,
+    },
     And(Vec<DynamoCondition>),
 }
 
+impl std::fmt::Debug for DynamoCondition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Expr {
+                expression,
+                names,
+                values,
+            } => f
+                .debug_struct("Expr")
+                .field("expression", expression)
+                .field("names", names)
+                .field("values", values)
+                .finish(),
+            Self::In { field, .. } => {
+                f.debug_struct("In").field("field", field).finish_non_exhaustive()
+            }
+            Self::And(conds) => f.debug_tuple("And").field(conds).finish(),
+        }
+    }
+}
+
 impl DynamoCondition {
-    /// Build a `field = value` condition. The placeholders are mangled
-    /// per-condition so multiple `eq` calls don't clobber each other
-    /// when combined.
+    /// Build a `field = value` condition.
     pub fn eq(field: impl Into<String>, value: impl Into<AttributeValue>) -> Self {
         let field = field.into();
         let mut names = IndexMap::new();
@@ -39,5 +79,192 @@ impl DynamoCondition {
             names,
             values,
         }
+    }
+}
+
+/// Resolved condition pieces ready to fold into a Scan/Query request.
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedFilter {
+    pub expression: String,
+    pub names: IndexMap<String, String>,
+    pub values: IndexMap<String, AttributeValue>,
+}
+
+impl ResolvedFilter {
+    pub fn is_empty(&self) -> bool {
+        self.expression.is_empty()
+    }
+}
+
+/// Walk a list of conditions, mangle placeholders to be globally unique,
+/// and produce a single `FilterExpression` plus combined attribute maps.
+pub async fn resolve_conditions<'a, I>(conditions: I) -> Result<ResolvedFilter>
+where
+    I: IntoIterator<Item = &'a DynamoCondition>,
+{
+    let mut state = MangleState::default();
+    let mut fragments = Vec::new();
+    for cond in conditions {
+        if let Some(frag) = resolve_one(cond, &mut state).await? {
+            fragments.push(frag);
+        }
+    }
+    let expression = match fragments.len() {
+        0 => String::new(),
+        1 => fragments.into_iter().next().unwrap(),
+        _ => fragments
+            .into_iter()
+            .map(|f| format!("({})", f))
+            .collect::<Vec<_>>()
+            .join(" AND "),
+    };
+    Ok(ResolvedFilter {
+        expression,
+        names: state.names,
+        values: state.values,
+    })
+}
+
+/// Resolve a single condition, returning the rendered expression
+/// fragment with mangled placeholders. Returns `None` for empty `And`s.
+fn resolve_one<'a>(
+    cond: &'a DynamoCondition,
+    state: &'a mut MangleState,
+) -> Pin<Box<dyn std::future::Future<Output = Result<Option<String>>> + Send + 'a>> {
+    Box::pin(async move {
+        match cond {
+            DynamoCondition::Expr {
+                expression,
+                names,
+                values,
+            } => {
+                let mut rendered = expression.clone();
+                for (placeholder, name) in names {
+                    let new_ph = state.fresh_name(name.clone());
+                    rendered = replace_placeholder(&rendered, placeholder, &new_ph);
+                }
+                for (placeholder, value) in values {
+                    let new_ph = state.fresh_value(value.clone());
+                    rendered = replace_placeholder(&rendered, placeholder, &new_ph);
+                }
+                Ok(Some(rendered))
+            }
+            DynamoCondition::In { field, values } => {
+                let resolved = (values)().await?;
+                if resolved.is_empty() {
+                    // `field IN ()` is invalid in DynamoDB. An empty
+                    // source set means "match nothing" — emit a
+                    // tautologically-false fragment.
+                    let name_ph = state.fresh_name(field.clone());
+                    return Ok(Some(format!("attribute_not_exists({}) AND attribute_exists({})", name_ph, name_ph)));
+                }
+                let name_ph = state.fresh_name(field.clone());
+                let value_phs: Vec<String> = resolved
+                    .into_iter()
+                    .map(|v| state.fresh_value(v))
+                    .collect();
+                Ok(Some(format!(
+                    "{} IN ({})",
+                    name_ph,
+                    value_phs.join(", ")
+                )))
+            }
+            DynamoCondition::And(children) => {
+                let mut parts = Vec::new();
+                for child in children {
+                    if let Some(p) = resolve_one(child, state).await? {
+                        parts.push(p);
+                    }
+                }
+                Ok(if parts.is_empty() {
+                    None
+                } else {
+                    Some(parts.join(" AND "))
+                })
+            }
+        }
+    })
+}
+
+/// Replace every occurrence of `from` in `s` with `to`. Used to swap
+/// each condition's local placeholder names for globally-unique ones.
+fn replace_placeholder(s: &str, from: &str, to: &str) -> String {
+    s.replace(from, to)
+}
+
+#[derive(Default)]
+struct MangleState {
+    names: IndexMap<String, String>,
+    values: IndexMap<String, AttributeValue>,
+    name_seq: usize,
+    value_seq: usize,
+}
+
+impl MangleState {
+    fn fresh_name(&mut self, attr: String) -> String {
+        let ph = format!("#n{}", self.name_seq);
+        self.name_seq += 1;
+        self.names.insert(ph.clone(), attr);
+        ph
+    }
+
+    fn fresh_value(&mut self, value: AttributeValue) -> String {
+        let ph = format!(":v{}", self.value_seq);
+        self.value_seq += 1;
+        self.values.insert(ph.clone(), value);
+        ph
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn empty_input_yields_empty_filter() {
+        let r = resolve_conditions(std::iter::empty()).await.unwrap();
+        assert!(r.is_empty());
+    }
+
+    #[tokio::test]
+    async fn single_eq_renders_with_mangled_placeholders() {
+        let cond = DynamoCondition::eq("name", AttributeValue::S("Alice".into()));
+        let r = resolve_conditions(std::iter::once(&cond)).await.unwrap();
+        assert_eq!(r.expression, "#n0 = :v0");
+        assert_eq!(r.names.get("#n0").unwrap(), "name");
+        assert_eq!(
+            r.values.get(":v0").unwrap(),
+            &AttributeValue::S("Alice".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn two_eqs_get_unique_placeholders() {
+        let a = DynamoCondition::eq("name", AttributeValue::S("Alice".into()));
+        let b = DynamoCondition::eq("city", AttributeValue::S("Riga".into()));
+        let r = resolve_conditions([&a, &b]).await.unwrap();
+        assert_eq!(r.expression, "(#n0 = :v0) AND (#n1 = :v1)");
+        assert_eq!(r.names.get("#n0").unwrap(), "name");
+        assert_eq!(r.names.get("#n1").unwrap(), "city");
+    }
+
+    #[tokio::test]
+    async fn deferred_in_resolves_to_in_expression() {
+        let values = Arc::new(|| -> ValueListFuture {
+            Box::pin(async move {
+                Ok(vec![
+                    AttributeValue::S("a".into()),
+                    AttributeValue::S("b".into()),
+                ])
+            })
+        });
+        let cond = DynamoCondition::In {
+            field: "bakery_id".to_string(),
+            values,
+        };
+        let r = resolve_conditions(std::iter::once(&cond)).await.unwrap();
+        assert_eq!(r.expression, "#n0 IN (:v0, :v1)");
+        assert_eq!(r.names.get("#n0").unwrap(), "bakery_id");
+        assert_eq!(r.values.len(), 2);
     }
 }

--- a/vantage-aws/src/dynamodb/id.rs
+++ b/vantage-aws/src/dynamodb/id.rs
@@ -1,0 +1,77 @@
+//! DynamoDB item identifier.
+//!
+//! v0 only handles partition-key-only tables and stringifies the key.
+//! Numeric keys round-trip through `String`; binary keys aren't covered
+//! yet. Composite (partition + sort) keys arrive in a follow-up.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Serialize, Serializer};
+
+use super::types::AttributeValue;
+
+/// A DynamoDB primary key. v0 = partition-key-only as a string.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct DynamoId(String);
+
+impl DynamoId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Best-effort conversion from a wire `AttributeValue`. Returns
+    /// `None` for variants that don't map to a primary-key shape.
+    pub fn from_attr(value: &AttributeValue) -> Option<Self> {
+        match value {
+            AttributeValue::S(s) => Some(Self(s.clone())),
+            AttributeValue::N(n) => Some(Self(n.clone())),
+            _ => None,
+        }
+    }
+
+    /// Wire representation. v0 picks `S` since the underlying storage is
+    /// already a string; numeric keys would need explicit caller intent.
+    pub fn to_attr(&self) -> AttributeValue {
+        AttributeValue::S(self.0.clone())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for DynamoId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromStr for DynamoId {
+    type Err = std::convert::Infallible;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_string()))
+    }
+}
+
+impl Serialize for DynamoId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl From<String> for DynamoId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for DynamoId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}

--- a/vantage-aws/src/dynamodb/impls/data_source.rs
+++ b/vantage-aws/src/dynamodb/impls/data_source.rs
@@ -1,0 +1,5 @@
+use vantage_expressions::traits::datasource::DataSource;
+
+use crate::dynamodb::DynamoDB;
+
+impl DataSource for DynamoDB {}

--- a/vantage-aws/src/dynamodb/impls/expr_data_source.rs
+++ b/vantage-aws/src/dynamodb/impls/expr_data_source.rs
@@ -1,0 +1,28 @@
+//! Stub `ExprDataSource` — DynamoDB doesn't run a SQL-style expression
+//! engine, but the trait bound on `TableSource::column_table_values_expr`
+//! requires the impl to exist.
+
+use vantage_expressions::{DeferredFn, ExprDataSource, Expression};
+
+use crate::dynamodb::DynamoDB;
+use crate::dynamodb::types::AnyDynamoType;
+
+impl ExprDataSource<AnyDynamoType> for DynamoDB {
+    async fn execute(
+        &self,
+        _expr: &Expression<AnyDynamoType>,
+    ) -> vantage_core::Result<AnyDynamoType> {
+        Err(vantage_core::error!(
+            "DynamoDB does not support Expression-based execution"
+        ))
+    }
+
+    fn defer(&self, expr: Expression<AnyDynamoType>) -> DeferredFn<AnyDynamoType> {
+        let db = self.clone();
+        DeferredFn::from_fn(move || {
+            let db = db.clone();
+            let expr = expr.clone();
+            Box::pin(async move { db.execute(&expr).await })
+        })
+    }
+}

--- a/vantage-aws/src/dynamodb/impls/mod.rs
+++ b/vantage-aws/src/dynamodb/impls/mod.rs
@@ -1,0 +1,9 @@
+//! Trait implementations that make `DynamoDB` plug into Vantage.
+//!
+//! `DataSource` is the marker. `TableSource` is currently a skeleton —
+//! every method returns `todo!()` per the docs4 step-5 advice; impls
+//! land incrementally driven by tests.
+
+mod data_source;
+mod expr_data_source;
+mod table_source;

--- a/vantage-aws/src/dynamodb/impls/table_source.rs
+++ b/vantage-aws/src/dynamodb/impls/table_source.rs
@@ -43,7 +43,10 @@ fn id_field_name<E: Entity<AnyDynamoType>>(table: &Table<DynamoDB, E>) -> String
 }
 
 /// Build a single-field DynamoDB `Key` map from a partition-key id.
-fn key_for_id(field: &str, id: &DynamoId) -> std::result::Result<JsonMap<String, JsonValue>, vantage_core::VantageError> {
+fn key_for_id(
+    field: &str,
+    id: &DynamoId,
+) -> std::result::Result<JsonMap<String, JsonValue>, vantage_core::VantageError> {
     let mut key = JsonMap::new();
     key.insert(field.to_string(), attr_to_json(&id.to_attr())?);
     Ok(key)
@@ -262,9 +265,9 @@ impl TableSource for DynamoDB {
         // PutItem doesn't return the written item by default; re-fetch
         // so callers see exactly what's now in storage (including any
         // columns DynamoDB may have stored differently).
-        self.get_table_value(table, id).await?.ok_or_else(|| {
-            error!("Inserted item not found by GetItem", id = id.to_string())
-        })
+        self.get_table_value(table, id)
+            .await?
+            .ok_or_else(|| error!("Inserted item not found by GetItem", id = id.to_string()))
     }
 
     async fn replace_table_value<E>(
@@ -320,7 +323,10 @@ impl TableSource for DynamoDB {
 
         for item in items {
             let pairs = json_to_item_map(item)?;
-            let id_av = pairs.iter().find(|(k, _)| k == &id_field).map(|(_, v)| v.clone());
+            let id_av = pairs
+                .iter()
+                .find(|(k, _)| k == &id_field)
+                .map(|(_, v)| v.clone());
             if let Some(av) = id_av
                 && let Some(id) = DynamoId::from_attr(&av)
             {
@@ -394,4 +400,3 @@ impl TableSource for DynamoDB {
         AssociatedExpression::new(expr, self)
     }
 }
-

--- a/vantage-aws/src/dynamodb/impls/table_source.rs
+++ b/vantage-aws/src/dynamodb/impls/table_source.rs
@@ -1,0 +1,397 @@
+//! `TableSource` for DynamoDB.
+//!
+//! v0 wires the read/write path through `Scan`, `GetItem`, `PutItem`,
+//! `DeleteItem`. Conditions and aggregates are stubbed — Scan filters
+//! and SUM/MIN/MAX-via-client-aggregation land later.
+//!
+//! Composite-key tables are partially supported: writes carry the full
+//! item, but `get_table_value` only knows the partition key (`DynamoId`
+//! is partition-only in v0). Sort-key tables work for Scan/Put/Delete
+//! when the caller hands in items containing both keys.
+
+use async_trait::async_trait;
+use indexmap::IndexMap;
+use serde_json::{Map as JsonMap, Value as JsonValue};
+
+use vantage_core::error;
+use vantage_dataset::traits::Result;
+use vantage_expressions::{
+    Expression, expr_any,
+    traits::associated_expressions::AssociatedExpression,
+    traits::datasource::ExprDataSource,
+    traits::expressive::{DeferredFn, ExpressiveEnum},
+};
+use vantage_table::column::core::{Column, ColumnType};
+use vantage_table::table::Table;
+use vantage_table::traits::table_source::TableSource;
+use vantage_types::{Entity, Record};
+
+use crate::dynamodb::DynamoDB;
+use crate::dynamodb::condition::DynamoCondition;
+use crate::dynamodb::id::DynamoId;
+use crate::dynamodb::transport;
+use crate::dynamodb::types::{AnyDynamoType, AttributeValue};
+use crate::dynamodb::wire::{attr_to_json, json_to_item_map};
+
+const DEFAULT_ID_FIELD: &str = "id";
+
+fn id_field_name<E: Entity<AnyDynamoType>>(table: &Table<DynamoDB, E>) -> String {
+    table
+        .id_field()
+        .map(|c| c.name().to_string())
+        .unwrap_or_else(|| DEFAULT_ID_FIELD.to_string())
+}
+
+/// Build a single-field DynamoDB `Key` map from a partition-key id.
+fn key_for_id(field: &str, id: &DynamoId) -> std::result::Result<JsonMap<String, JsonValue>, vantage_core::VantageError> {
+    let mut key = JsonMap::new();
+    key.insert(field.to_string(), attr_to_json(&id.to_attr())?);
+    Ok(key)
+}
+
+/// Convert a wire item (from a Scan/GetItem response) into our Record
+/// shape and pull the configured id field out as a `DynamoId`.
+fn item_to_record(
+    id_field: &str,
+    item: &JsonValue,
+) -> std::result::Result<(DynamoId, Record<AnyDynamoType>), vantage_core::VantageError> {
+    let pairs = json_to_item_map(item)?;
+    let mut id: Option<DynamoId> = None;
+    let mut record = Record::new();
+    for (k, av) in pairs {
+        if k == id_field {
+            id = DynamoId::from_attr(&av);
+        }
+        record.insert(k, AnyDynamoType::untyped(av));
+    }
+    let id = id.ok_or_else(|| {
+        error!(
+            "DynamoDB item missing id field",
+            id_field = id_field.to_string()
+        )
+    })?;
+    Ok((id, record))
+}
+
+#[async_trait]
+impl TableSource for DynamoDB {
+    type Column<Type>
+        = Column<Type>
+    where
+        Type: ColumnType;
+    type AnyType = AnyDynamoType;
+    type Value = AnyDynamoType;
+    type Id = DynamoId;
+    type Condition = DynamoCondition;
+
+    fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
+        Column::new(name)
+    }
+
+    fn to_any_column<Type: ColumnType>(
+        &self,
+        column: Self::Column<Type>,
+    ) -> Self::Column<Self::AnyType> {
+        Column::from_column(column)
+    }
+
+    fn convert_any_column<Type: ColumnType>(
+        &self,
+        any_column: Self::Column<Self::AnyType>,
+    ) -> Option<Self::Column<Type>> {
+        Some(Column::from_column(any_column))
+    }
+
+    fn expr(
+        &self,
+        template: impl Into<String>,
+        parameters: Vec<ExpressiveEnum<Self::Value>>,
+    ) -> Expression<Self::Value> {
+        Expression::new(template, parameters)
+    }
+
+    fn search_table_condition<E>(
+        &self,
+        _table: &Table<Self, E>,
+        search_value: &str,
+    ) -> Self::Condition
+    where
+        E: Entity<Self::Value>,
+    {
+        // No notion of which fields are searchable at this layer.
+        // Stash the value in an Eq against `__search__` so callers see
+        // a deterministic shape; real FilterExpression search is v1.
+        DynamoCondition::eq("__search__", AttributeValue::S(search_value.to_string()))
+    }
+
+    async fn list_table_values<E>(
+        &self,
+        table: &Table<Self, E>,
+    ) -> Result<IndexMap<Self::Id, Record<Self::Value>>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let resp = transport::scan(self.aws(), table.table_name(), None, false).await?;
+        let items = resp
+            .get("Items")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| error!("DynamoDB Scan response missing Items array"))?;
+
+        let id_field = id_field_name(table);
+        let mut out = IndexMap::with_capacity(items.len());
+        for item in items {
+            let (id, record) = item_to_record(&id_field, item)?;
+            out.insert(id, record);
+        }
+        Ok(out)
+    }
+
+    async fn get_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+    ) -> Result<Option<Record<Self::Value>>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field = id_field_name(table);
+        let key = key_for_id(&id_field, id)?;
+        let resp = transport::get_item(self.aws(), table.table_name(), key).await?;
+
+        let Some(item) = resp.get("Item") else {
+            return Ok(None);
+        };
+        if item.is_null() {
+            return Ok(None);
+        }
+        let (_id, record) = item_to_record(&id_field, item)?;
+        Ok(Some(record))
+    }
+
+    async fn get_table_some_value<E>(
+        &self,
+        table: &Table<Self, E>,
+    ) -> Result<Option<(Self::Id, Record<Self::Value>)>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let resp = transport::scan(self.aws(), table.table_name(), Some(1), false).await?;
+        let items = resp
+            .get("Items")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| error!("DynamoDB Scan response missing Items array"))?;
+        let Some(item) = items.first() else {
+            return Ok(None);
+        };
+        let id_field = id_field_name(table);
+        let (id, record) = item_to_record(&id_field, item)?;
+        Ok(Some((id, record)))
+    }
+
+    async fn get_table_count<E>(&self, table: &Table<Self, E>) -> Result<i64>
+    where
+        E: Entity<Self::Value>,
+    {
+        let resp = transport::scan(self.aws(), table.table_name(), None, true).await?;
+        let count = resp
+            .get("Count")
+            .and_then(|v| v.as_i64())
+            .ok_or_else(|| error!("DynamoDB Scan(COUNT) response missing Count"))?;
+        Ok(count)
+    }
+
+    async fn get_table_sum<E>(
+        &self,
+        _table: &Table<Self, E>,
+        _column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        Err(error!(
+            "DynamoDB has no native SUM — caller must aggregate client-side"
+        ))
+    }
+
+    async fn get_table_max<E>(
+        &self,
+        _table: &Table<Self, E>,
+        _column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        Err(error!(
+            "DynamoDB has no native MAX — caller must aggregate client-side"
+        ))
+    }
+
+    async fn get_table_min<E>(
+        &self,
+        _table: &Table<Self, E>,
+        _column: &Self::Column<Self::AnyType>,
+    ) -> Result<Self::Value>
+    where
+        E: Entity<Self::Value>,
+    {
+        Err(error!(
+            "DynamoDB has no native MIN — caller must aggregate client-side"
+        ))
+    }
+
+    async fn insert_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        record: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field = id_field_name(table);
+        let mut item = JsonMap::new();
+        item.insert(id_field.clone(), attr_to_json(&id.to_attr())?);
+        for (k, v) in record.iter() {
+            if k == &id_field {
+                continue;
+            }
+            item.insert(k.clone(), attr_to_json(v.value())?);
+        }
+        transport::put_item(self.aws(), table.table_name(), item).await?;
+
+        // PutItem doesn't return the written item by default; re-fetch
+        // so callers see exactly what's now in storage (including any
+        // columns DynamoDB may have stored differently).
+        self.get_table_value(table, id).await?.ok_or_else(|| {
+            error!("Inserted item not found by GetItem", id = id.to_string())
+        })
+    }
+
+    async fn replace_table_value<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &Self::Id,
+        record: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        // PutItem replaces by default — same code path as insert.
+        self.insert_table_value(table, id, record).await
+    }
+
+    async fn patch_table_value<E>(
+        &self,
+        _table: &Table<Self, E>,
+        _id: &Self::Id,
+        _partial: &Record<Self::Value>,
+    ) -> Result<Record<Self::Value>>
+    where
+        E: Entity<Self::Value>,
+    {
+        // UpdateItem with SET expression — needs placeholder mangling
+        // to avoid colliding with reserved words and is non-trivial to
+        // render. Land it next iteration.
+        Err(error!(
+            "DynamoDB UpdateItem (patch) not implemented yet — use replace"
+        ))
+    }
+
+    async fn delete_table_value<E>(&self, table: &Table<Self, E>, id: &Self::Id) -> Result<()>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field = id_field_name(table);
+        let key = key_for_id(&id_field, id)?;
+        transport::delete_item(self.aws(), table.table_name(), key).await?;
+        Ok(())
+    }
+
+    async fn delete_table_all_values<E>(&self, table: &Table<Self, E>) -> Result<()>
+    where
+        E: Entity<Self::Value>,
+    {
+        let id_field = id_field_name(table);
+        let resp = transport::scan(self.aws(), table.table_name(), None, false).await?;
+        let items = resp
+            .get("Items")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| error!("DynamoDB Scan response missing Items array"))?;
+
+        for item in items {
+            let pairs = json_to_item_map(item)?;
+            let id_av = pairs.iter().find(|(k, _)| k == &id_field).map(|(_, v)| v.clone());
+            if let Some(av) = id_av
+                && let Some(id) = DynamoId::from_attr(&av)
+            {
+                let key = key_for_id(&id_field, &id)?;
+                transport::delete_item(self.aws(), table.table_name(), key).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn insert_table_return_id_value<E>(
+        &self,
+        _table: &Table<Self, E>,
+        _record: &Record<Self::Value>,
+    ) -> Result<Self::Id>
+    where
+        E: Entity<Self::Value>,
+    {
+        Err(error!(
+            "DynamoDB does not auto-generate primary keys; use insert_table_value"
+        ))
+    }
+
+    fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+        &self,
+        _target_field: &str,
+        _source_table: &Table<Self, SourceE>,
+        _source_column: &str,
+    ) -> Self::Condition
+    where
+        Self: Sized,
+    {
+        // Stub: no relationship traversal in v0. Returning a benign
+        // placeholder lets compile-time wiring exist; runtime use is
+        // gated by callers not constructing relationships yet.
+        DynamoCondition::eq("__related__", AttributeValue::Null)
+    }
+
+    fn column_table_values_expr<'a, E, Type: ColumnType>(
+        &'a self,
+        table: &Table<Self, E>,
+        column: &Self::Column<Type>,
+    ) -> AssociatedExpression<'a, Self, Self::Value, Vec<Type>>
+    where
+        E: Entity<Self::Value> + 'static,
+        Self: ExprDataSource<Self::Value> + Sized,
+    {
+        // Mirror the AwsAccount/CSV shape: defer a Scan + project the
+        // named column. Wraps execute_rpc-equivalent (Scan) at exec time.
+        let table_clone = table.clone();
+        let col = column.name().to_string();
+        let db = self.clone();
+
+        let inner = expr_any!("{}", {
+            DeferredFn::new(move || {
+                let db = db.clone();
+                let table = table_clone.clone();
+                let col = col.clone();
+                Box::pin(async move {
+                    let records = db.list_table_values(&table).await?;
+                    let values: Vec<AnyDynamoType> = records
+                        .values()
+                        .filter_map(|r| r.get(&col).cloned())
+                        .collect();
+                    Ok(ExpressiveEnum::Scalar(AnyDynamoType::new(values)))
+                })
+            })
+        });
+
+        let expr = expr_any!("{}", { self.defer(inner) });
+        AssociatedExpression::new(expr, self)
+    }
+}
+

--- a/vantage-aws/src/dynamodb/impls/table_source.rs
+++ b/vantage-aws/src/dynamodb/impls/table_source.rs
@@ -9,6 +9,8 @@
 //! is partition-only in v0). Sort-key tables work for Scan/Put/Delete
 //! when the caller hands in items containing both keys.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use indexmap::IndexMap;
 use serde_json::{Map as JsonMap, Value as JsonValue};
@@ -27,7 +29,7 @@ use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
 
 use crate::dynamodb::DynamoDB;
-use crate::dynamodb::condition::DynamoCondition;
+use crate::dynamodb::condition::{DynamoCondition, ValueListFuture, resolve_conditions};
 use crate::dynamodb::id::DynamoId;
 use crate::dynamodb::transport;
 use crate::dynamodb::types::{AnyDynamoType, AttributeValue};
@@ -134,7 +136,15 @@ impl TableSource for DynamoDB {
     where
         E: Entity<Self::Value>,
     {
-        let resp = transport::scan(self.aws(), table.table_name(), None, false).await?;
+        let filter = resolve_conditions(table.conditions()).await?;
+        let resp = transport::scan(
+            self.aws(),
+            table.table_name(),
+            None,
+            false,
+            Some(&filter),
+        )
+        .await?;
         let items = resp
             .get("Items")
             .and_then(|v| v.as_array())
@@ -178,7 +188,15 @@ impl TableSource for DynamoDB {
     where
         E: Entity<Self::Value>,
     {
-        let resp = transport::scan(self.aws(), table.table_name(), Some(1), false).await?;
+        let filter = resolve_conditions(table.conditions()).await?;
+        let resp = transport::scan(
+            self.aws(),
+            table.table_name(),
+            Some(1),
+            false,
+            Some(&filter),
+        )
+        .await?;
         let items = resp
             .get("Items")
             .and_then(|v| v.as_array())
@@ -195,7 +213,15 @@ impl TableSource for DynamoDB {
     where
         E: Entity<Self::Value>,
     {
-        let resp = transport::scan(self.aws(), table.table_name(), None, true).await?;
+        let filter = resolve_conditions(table.conditions()).await?;
+        let resp = transport::scan(
+            self.aws(),
+            table.table_name(),
+            None,
+            true,
+            Some(&filter),
+        )
+        .await?;
         let count = resp
             .get("Count")
             .and_then(|v| v.as_i64())
@@ -315,7 +341,15 @@ impl TableSource for DynamoDB {
         E: Entity<Self::Value>,
     {
         let id_field = id_field_name(table);
-        let resp = transport::scan(self.aws(), table.table_name(), None, false).await?;
+        let filter = resolve_conditions(table.conditions()).await?;
+        let resp = transport::scan(
+            self.aws(),
+            table.table_name(),
+            None,
+            false,
+            Some(&filter),
+        )
+        .await?;
         let items = resp
             .get("Items")
             .and_then(|v| v.as_array())
@@ -352,17 +386,33 @@ impl TableSource for DynamoDB {
 
     fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
         &self,
-        _target_field: &str,
-        _source_table: &Table<Self, SourceE>,
-        _source_column: &str,
+        target_field: &str,
+        source_table: &Table<Self, SourceE>,
+        source_column: &str,
     ) -> Self::Condition
     where
         Self: Sized,
     {
-        // Stub: no relationship traversal in v0. Returning a benign
-        // placeholder lets compile-time wiring exist; runtime use is
-        // gated by callers not constructing relationships yet.
-        DynamoCondition::eq("__related__", AttributeValue::Null)
+        let db = self.clone();
+        let source = source_table.clone();
+        let col = source_column.to_string();
+        let field = target_field.to_string();
+
+        let values: super::super::condition::ValueListFn = Arc::new(move || -> ValueListFuture {
+            let db = db.clone();
+            let source = source.clone();
+            let col = col.clone();
+            Box::pin(async move {
+                let records = db.list_table_values(&source).await?;
+                let values: Vec<AttributeValue> = records
+                    .values()
+                    .filter_map(|r| r.get(&col).map(|v| v.value().clone()))
+                    .collect();
+                Ok(values)
+            })
+        });
+
+        DynamoCondition::In { field, values }
     }
 
     fn column_table_values_expr<'a, E, Type: ColumnType>(

--- a/vantage-aws/src/dynamodb/impls/table_source.rs
+++ b/vantage-aws/src/dynamodb/impls/table_source.rs
@@ -339,16 +339,26 @@ impl TableSource for DynamoDB {
 
         for item in items {
             let pairs = json_to_item_map(item)?;
-            let id_av = pairs
+            let av = pairs
                 .iter()
                 .find(|(k, _)| k == &id_field)
-                .map(|(_, v)| v.clone());
-            if let Some(av) = id_av
-                && let Some(id) = DynamoId::from_attr(&av)
-            {
-                let key = key_for_id(&id_field, &id)?;
-                transport::delete_item(self.aws(), table.table_name(), key).await?;
-            }
+                .map(|(_, v)| v.clone())
+                .ok_or_else(|| {
+                    error!(
+                        "DynamoDB scan item missing id field — refusing partial delete",
+                        id_field = id_field.clone()
+                    )
+                })?;
+            let id = DynamoId::from_attr(&av).ok_or_else(|| {
+                error!(
+                    "DynamoDB partition key has unsupported AttributeValue type — \
+                     v0 DynamoId only handles S/N. Refusing partial delete.",
+                    id_field = id_field.clone(),
+                    got = format!("{:?}", av)
+                )
+            })?;
+            let key = key_for_id(&id_field, &id)?;
+            transport::delete_item(self.aws(), table.table_name(), key).await?;
         }
         Ok(())
     }

--- a/vantage-aws/src/dynamodb/impls/table_source.rs
+++ b/vantage-aws/src/dynamodb/impls/table_source.rs
@@ -137,14 +137,8 @@ impl TableSource for DynamoDB {
         E: Entity<Self::Value>,
     {
         let filter = resolve_conditions(table.conditions()).await?;
-        let resp = transport::scan(
-            self.aws(),
-            table.table_name(),
-            None,
-            false,
-            Some(&filter),
-        )
-        .await?;
+        let resp =
+            transport::scan(self.aws(), table.table_name(), None, false, Some(&filter)).await?;
         let items = resp
             .get("Items")
             .and_then(|v| v.as_array())
@@ -214,14 +208,8 @@ impl TableSource for DynamoDB {
         E: Entity<Self::Value>,
     {
         let filter = resolve_conditions(table.conditions()).await?;
-        let resp = transport::scan(
-            self.aws(),
-            table.table_name(),
-            None,
-            true,
-            Some(&filter),
-        )
-        .await?;
+        let resp =
+            transport::scan(self.aws(), table.table_name(), None, true, Some(&filter)).await?;
         let count = resp
             .get("Count")
             .and_then(|v| v.as_i64())
@@ -342,14 +330,8 @@ impl TableSource for DynamoDB {
     {
         let id_field = id_field_name(table);
         let filter = resolve_conditions(table.conditions()).await?;
-        let resp = transport::scan(
-            self.aws(),
-            table.table_name(),
-            None,
-            false,
-            Some(&filter),
-        )
-        .await?;
+        let resp =
+            transport::scan(self.aws(), table.table_name(), None, false, Some(&filter)).await?;
         let items = resp
             .get("Items")
             .and_then(|v| v.as_array())

--- a/vantage-aws/src/dynamodb/mod.rs
+++ b/vantage-aws/src/dynamodb/mod.rs
@@ -1,0 +1,57 @@
+//! DynamoDB persistence — incubating.
+//!
+//! Sibling to the AWS list-API surface in `crate::models`. That surface
+//! treats `AwsAccount` itself as a `TableSource` and folds operation
+//! metadata into the table name. DynamoDB items don't fit that mould:
+//! they have a typed `AttributeValue` representation, native key/filter
+//! expressions, and full CRUD semantics. So DynamoDB lives here as a
+//! standalone persistence — same crate, different `TableSource`.
+//!
+//! Layout mirrors `vantage-sql`'s per-backend modules: `types/` defines
+//! the type system, `condition.rs` the native condition DSL,
+//! `operation.rs` the typed operator extension trait, and `impls/`
+//! holds the trait implementations.
+//!
+//! ```no_run
+//! # use vantage_aws::AwsAccount;
+//! # use vantage_aws::dynamodb::DynamoDB;
+//! # async fn run() -> vantage_core::Result<()> {
+//! let aws = AwsAccount::from_default()?;
+//! let _db = DynamoDB::new(aws);
+//! # Ok(()) }
+//! ```
+
+pub mod condition;
+pub mod id;
+pub mod impls;
+pub mod operation;
+pub mod types;
+
+pub(crate) mod transport;
+pub(crate) mod wire;
+
+pub use condition::DynamoCondition;
+pub use id::DynamoId;
+pub use operation::DynamoOperation;
+pub use types::{AnyDynamoType, AttributeValue, DynamoType, DynamoTypeVariants};
+
+use crate::account::AwsAccount;
+
+/// DynamoDB data source. Cheap to clone — wraps the (already `Arc`-backed)
+/// `AwsAccount` for credentials and signing.
+#[derive(Clone, Debug)]
+pub struct DynamoDB {
+    aws: AwsAccount,
+}
+
+impl DynamoDB {
+    /// Build a DynamoDB handle on top of an existing `AwsAccount`.
+    pub fn new(aws: AwsAccount) -> Self {
+        Self { aws }
+    }
+
+    /// Borrow the underlying `AwsAccount` (for signing, region, etc.).
+    pub fn aws(&self) -> &AwsAccount {
+        &self.aws
+    }
+}

--- a/vantage-aws/src/dynamodb/operation.rs
+++ b/vantage-aws/src/dynamodb/operation.rs
@@ -1,0 +1,28 @@
+//! DynamoDB operation trait — typed `.eq()`/`.gt()`/… methods producing
+//! `DynamoCondition`. Blanket-implemented over `Expressive<T>` so columns
+//! pick up these methods for free.
+//!
+//! v0 only wires `.eq()`. The richer set (`.gt`, `.between`, `.in_`,
+//! `.begins_with`) lands alongside `Scan`/`Query` filter execution.
+
+use vantage_expressions::Expressive;
+
+use super::condition::DynamoCondition;
+use super::types::AnyDynamoType;
+
+fn field_name<T>(expr: &(impl Expressive<T> + ?Sized)) -> String {
+    expr.expr().template
+}
+
+pub trait DynamoOperation<T>: Expressive<T> {
+    /// `field = :value` — see `DynamoCondition::eq`.
+    fn eq(&self, value: impl Into<AnyDynamoType>) -> DynamoCondition
+    where
+        Self: Sized,
+    {
+        let any: AnyDynamoType = value.into();
+        DynamoCondition::eq(field_name(self), any.into_value())
+    }
+}
+
+impl<T, S: Expressive<T>> DynamoOperation<T> for S {}

--- a/vantage-aws/src/dynamodb/transport.rs
+++ b/vantage-aws/src/dynamodb/transport.rs
@@ -1,0 +1,64 @@
+//! Thin DynamoDB transport — Scan, GetItem, PutItem, DeleteItem.
+//!
+//! Wraps `crate::json1::json_aws_call` with the JSON-1.0 content type
+//! and the `DynamoDB_20120810.*` target prefix. Higher-level concerns
+//! (id extraction, condition rendering, pagination) live in
+//! `impls/table_source.rs`.
+
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
+use vantage_core::Result;
+
+use crate::account::AwsAccount;
+use crate::json1::json_aws_call;
+
+const SERVICE: &str = "dynamodb";
+const CONTENT_TYPE: &str = "application/x-amz-json-1.0";
+const API_VERSION: &str = "DynamoDB_20120810";
+
+async fn call(aws: &AwsAccount, action: &str, body: JsonValue) -> Result<JsonValue> {
+    let target = format!("{API_VERSION}.{action}");
+    json_aws_call(aws, SERVICE, &target, &body, CONTENT_TYPE).await
+}
+
+pub(crate) async fn scan(
+    aws: &AwsAccount,
+    table: &str,
+    limit: Option<i64>,
+    select_count: bool,
+) -> Result<JsonValue> {
+    let mut body = json!({ "TableName": table });
+    if let Some(n) = limit {
+        body["Limit"] = json!(n);
+    }
+    if select_count {
+        body["Select"] = json!("COUNT");
+    }
+    call(aws, "Scan", body).await
+}
+
+pub(crate) async fn get_item(
+    aws: &AwsAccount,
+    table: &str,
+    key: JsonMap<String, JsonValue>,
+) -> Result<JsonValue> {
+    let body = json!({ "TableName": table, "Key": key });
+    call(aws, "GetItem", body).await
+}
+
+pub(crate) async fn put_item(
+    aws: &AwsAccount,
+    table: &str,
+    item: JsonMap<String, JsonValue>,
+) -> Result<JsonValue> {
+    let body = json!({ "TableName": table, "Item": item });
+    call(aws, "PutItem", body).await
+}
+
+pub(crate) async fn delete_item(
+    aws: &AwsAccount,
+    table: &str,
+    key: JsonMap<String, JsonValue>,
+) -> Result<JsonValue> {
+    let body = json!({ "TableName": table, "Key": key });
+    call(aws, "DeleteItem", body).await
+}

--- a/vantage-aws/src/dynamodb/transport.rs
+++ b/vantage-aws/src/dynamodb/transport.rs
@@ -9,6 +9,8 @@ use serde_json::{Map as JsonMap, Value as JsonValue, json};
 use vantage_core::Result;
 
 use crate::account::AwsAccount;
+use crate::dynamodb::condition::ResolvedFilter;
+use crate::dynamodb::wire::attr_to_json;
 use crate::json1::json_aws_call;
 
 const SERVICE: &str = "dynamodb";
@@ -25,6 +27,7 @@ pub(crate) async fn scan(
     table: &str,
     limit: Option<i64>,
     select_count: bool,
+    filter: Option<&ResolvedFilter>,
 ) -> Result<JsonValue> {
     let mut body = json!({ "TableName": table });
     if let Some(n) = limit {
@@ -32,6 +35,25 @@ pub(crate) async fn scan(
     }
     if select_count {
         body["Select"] = json!("COUNT");
+    }
+    if let Some(f) = filter
+        && !f.is_empty()
+    {
+        body["FilterExpression"] = json!(f.expression);
+        if !f.names.is_empty() {
+            let mut names = JsonMap::new();
+            for (k, v) in &f.names {
+                names.insert(k.clone(), JsonValue::String(v.clone()));
+            }
+            body["ExpressionAttributeNames"] = JsonValue::Object(names);
+        }
+        if !f.values.is_empty() {
+            let mut values = JsonMap::new();
+            for (k, v) in &f.values {
+                values.insert(k.clone(), attr_to_json(v)?);
+            }
+            body["ExpressionAttributeValues"] = JsonValue::Object(values);
+        }
     }
     call(aws, "Scan", body).await
 }

--- a/vantage-aws/src/dynamodb/transport.rs
+++ b/vantage-aws/src/dynamodb/transport.rs
@@ -22,12 +22,65 @@ async fn call(aws: &AwsAccount, action: &str, body: JsonValue) -> Result<JsonVal
     json_aws_call(aws, SERVICE, &target, &body, CONTENT_TYPE).await
 }
 
+/// Run a DynamoDB Scan, walking `LastEvaluatedKey` until exhaustion
+/// when the caller didn't pin a `Limit`. Without this, anything past
+/// the 1MB-per-page boundary would silently drop — incomplete lists,
+/// under-counts, partial deletes. When `limit` is `Some(n)` the caller
+/// has explicitly asked for at most one page, so we don't paginate.
+///
+/// COUNT-mode pagination matters too: DynamoDB returns the per-page
+/// count, not the table-wide total, and a heavily-filtered Scan can
+/// reach `LastEvaluatedKey` with `Count: 0` after examining 1MB of raw
+/// data — we keep walking until the cursor is gone.
+///
+/// The returned `JsonValue` is a synthetic merged shape: `Items` is the
+/// concatenation of every page; `Count` is the sum.
 pub(crate) async fn scan(
     aws: &AwsAccount,
     table: &str,
     limit: Option<i64>,
     select_count: bool,
     filter: Option<&ResolvedFilter>,
+) -> Result<JsonValue> {
+    if limit.is_some() {
+        return scan_page(aws, table, limit, select_count, filter, None).await;
+    }
+
+    let mut all_items: Vec<JsonValue> = Vec::new();
+    let mut total_count: i64 = 0;
+    let mut start_key: Option<JsonValue> = None;
+
+    loop {
+        let resp = scan_page(aws, table, None, select_count, filter, start_key.as_ref()).await?;
+        if select_count {
+            if let Some(c) = resp.get("Count").and_then(|v| v.as_i64()) {
+                total_count += c;
+            }
+        } else if let Some(arr) = resp.get("Items").and_then(|v| v.as_array()) {
+            all_items.extend(arr.iter().cloned());
+        }
+
+        match resp.get("LastEvaluatedKey").cloned() {
+            Some(k) if !k.is_null() => start_key = Some(k),
+            _ => break,
+        }
+    }
+
+    Ok(if select_count {
+        json!({ "Count": total_count })
+    } else {
+        let n = all_items.len() as i64;
+        json!({ "Items": all_items, "Count": n })
+    })
+}
+
+async fn scan_page(
+    aws: &AwsAccount,
+    table: &str,
+    limit: Option<i64>,
+    select_count: bool,
+    filter: Option<&ResolvedFilter>,
+    start_key: Option<&JsonValue>,
 ) -> Result<JsonValue> {
     let mut body = json!({ "TableName": table });
     if let Some(n) = limit {
@@ -54,6 +107,9 @@ pub(crate) async fn scan(
             }
             body["ExpressionAttributeValues"] = JsonValue::Object(values);
         }
+    }
+    if let Some(k) = start_key {
+        body["ExclusiveStartKey"] = k.clone();
     }
     call(aws, "Scan", body).await
 }

--- a/vantage-aws/src/dynamodb/types/binary.rs
+++ b/vantage-aws/src/dynamodb/types/binary.rs
@@ -1,0 +1,18 @@
+//! Bytes → DynamoDB `B` AttributeValue.
+
+use super::{AttributeValue, DynamoType, DynamoTypeBMarker};
+
+impl DynamoType for Vec<u8> {
+    type Target = DynamoTypeBMarker;
+
+    fn to_attr(&self) -> AttributeValue {
+        AttributeValue::B(self.clone())
+    }
+
+    fn from_attr(value: AttributeValue) -> Option<Self> {
+        match value {
+            AttributeValue::B(b) => Some(b),
+            _ => None,
+        }
+    }
+}

--- a/vantage-aws/src/dynamodb/types/bool.rs
+++ b/vantage-aws/src/dynamodb/types/bool.rs
@@ -1,0 +1,18 @@
+//! Bool → DynamoDB `BOOL` AttributeValue.
+
+use super::{AttributeValue, DynamoType, DynamoTypeBoolMarker};
+
+impl DynamoType for bool {
+    type Target = DynamoTypeBoolMarker;
+
+    fn to_attr(&self) -> AttributeValue {
+        AttributeValue::Bool(*self)
+    }
+
+    fn from_attr(value: AttributeValue) -> Option<Self> {
+        match value {
+            AttributeValue::Bool(b) => Some(b),
+            _ => None,
+        }
+    }
+}

--- a/vantage-aws/src/dynamodb/types/mod.rs
+++ b/vantage-aws/src/dynamodb/types/mod.rs
@@ -1,0 +1,204 @@
+//! DynamoDB type system.
+//!
+//! `AttributeValue` mirrors DynamoDB's wire shape — every value is tagged
+//! by its type (S, N, B, BOOL, …). The `vantage_type_system!` macro
+//! produces `DynamoType`, `AnyDynamoType`, and the variants enum on top
+//! of that. Numbers go on the wire as strings (per the DynamoDB JSON
+//! protocol); the per-type impls in `numbers.rs` handle the round-trip.
+
+use vantage_core::VantageError;
+use vantage_types::{Record, vantage_type_system};
+
+mod binary;
+mod bool;
+mod numbers;
+mod string;
+mod value;
+
+/// DynamoDB AttributeValue. The wire form is a one-key JSON object
+/// (`{"S": "..."}`, `{"N": "42"}`, …); this enum is the typed
+/// counterpart. Sets and nested types are listed for completeness; the
+/// `DynamoType` impls cover the scalar variants in v0.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AttributeValue {
+    /// String — `{"S": "value"}`
+    S(String),
+    /// Number — DynamoDB sends/receives these as strings to preserve precision.
+    N(String),
+    /// Binary — raw bytes (`{"B": "<base64>"}` on the wire).
+    B(Vec<u8>),
+    /// Boolean — `{"BOOL": true}`
+    Bool(bool),
+    /// Null — `{"NULL": true}`
+    Null,
+    /// List — `{"L": [...]}`
+    L(Vec<AttributeValue>),
+    /// Map — `{"M": {...}}`
+    M(indexmap::IndexMap<String, AttributeValue>),
+    /// String Set — `{"SS": [...]}`
+    SS(Vec<String>),
+    /// Number Set — `{"NS": [...]}`
+    NS(Vec<String>),
+    /// Binary Set — `{"BS": [...]}`
+    BS(Vec<Vec<u8>>),
+}
+
+vantage_type_system! {
+    type_trait: DynamoType,
+    method_name: attr,
+    value_type: AttributeValue,
+    type_variants: [
+        S,
+        N,
+        B,
+        Bool,
+        Null,
+        L,
+        M,
+        SS,
+        NS,
+        BS,
+    ]
+}
+
+impl DynamoTypeVariants {
+    /// Detect the variant of an `AttributeValue` (used by the macro's
+    /// `from_attr` constructor on `AnyDynamoType`).
+    pub fn from_attr(value: &AttributeValue) -> Option<Self> {
+        Some(match value {
+            AttributeValue::S(_) => Self::S,
+            AttributeValue::N(_) => Self::N,
+            AttributeValue::B(_) => Self::B,
+            AttributeValue::Bool(_) => Self::Bool,
+            AttributeValue::Null => Self::Null,
+            AttributeValue::L(_) => Self::L,
+            AttributeValue::M(_) => Self::M,
+            AttributeValue::SS(_) => Self::SS,
+            AttributeValue::NS(_) => Self::NS,
+            AttributeValue::BS(_) => Self::BS,
+        })
+    }
+}
+
+impl std::fmt::Display for AnyDynamoType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.value() {
+            AttributeValue::S(s) => write!(f, "{:?}", s),
+            AttributeValue::N(n) => write!(f, "{}", n),
+            AttributeValue::B(b) => write!(f, "<{} bytes>", b.len()),
+            AttributeValue::Bool(b) => write!(f, "{}", b),
+            AttributeValue::Null => write!(f, "null"),
+            AttributeValue::L(arr) => write!(f, "{:?}", arr),
+            AttributeValue::M(map) => write!(f, "{:?}", map),
+            AttributeValue::SS(s) => write!(f, "{:?}", s),
+            AttributeValue::NS(s) => write!(f, "{:?}", s),
+            AttributeValue::BS(s) => write!(f, "<{} binary entries>", s.len()),
+        }
+    }
+}
+
+// TryFrom<AnyDynamoType> for common scalar types — required by
+// `AssociatedExpression::get()` (Step 2) but conceptually part of
+// the type system.
+macro_rules! impl_try_from_dynamo {
+    ($($ty:ty),*) => {
+        $(
+            impl TryFrom<AnyDynamoType> for $ty {
+                type Error = VantageError;
+                fn try_from(val: AnyDynamoType) -> Result<Self, Self::Error> {
+                    val.try_get::<$ty>().ok_or_else(|| {
+                        vantage_core::error!(
+                            "Cannot convert AnyDynamoType to target type",
+                            target = std::any::type_name::<$ty>(),
+                            value = format!("{}", val)
+                        )
+                    })
+                }
+            }
+        )*
+    };
+}
+
+impl_try_from_dynamo!(i32, i64, f64, bool, String);
+
+impl TryFrom<AnyDynamoType> for Record<AnyDynamoType> {
+    type Error = VantageError;
+    fn try_from(val: AnyDynamoType) -> Result<Self, Self::Error> {
+        match val.into_value() {
+            AttributeValue::M(map) => Ok(map
+                .into_iter()
+                .map(|(k, v)| (k, AnyDynamoType::untyped(v)))
+                .collect()),
+            AttributeValue::L(arr) => {
+                // Single-row result wrapped as a list — pluck the first map.
+                let map = arr
+                    .into_iter()
+                    .find_map(|v| match v {
+                        AttributeValue::M(m) => Some(m),
+                        _ => None,
+                    })
+                    .ok_or_else(|| vantage_core::error!("Expected map in list result"))?;
+                Ok(map
+                    .into_iter()
+                    .map(|(k, v)| (k, AnyDynamoType::untyped(v)))
+                    .collect())
+            }
+            other => Err(vantage_core::error!(
+                "Expected map or list result",
+                got = format!("{:?}", other)
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_string_round_trip() {
+        let val = AnyDynamoType::new("hello".to_string());
+        assert_eq!(val.type_variant(), Some(DynamoTypeVariants::S));
+        assert_eq!(val.try_get::<String>(), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn test_i64_round_trip() {
+        let val = AnyDynamoType::new(42i64);
+        assert_eq!(val.type_variant(), Some(DynamoTypeVariants::N));
+        assert_eq!(val.try_get::<i64>(), Some(42));
+    }
+
+    #[test]
+    fn test_bool_round_trip() {
+        let val = AnyDynamoType::new(true);
+        assert_eq!(val.type_variant(), Some(DynamoTypeVariants::Bool));
+        assert_eq!(val.try_get::<bool>(), Some(true));
+    }
+
+    #[test]
+    fn test_type_mismatch_blocked() {
+        let val = AnyDynamoType::new("hello".to_string());
+        assert_eq!(val.try_get::<i64>(), None);
+    }
+
+    #[test]
+    fn test_untyped_permissive() {
+        let val = AnyDynamoType::untyped(AttributeValue::N("42".to_string()));
+        assert_eq!(val.try_get::<i64>(), Some(42));
+        assert_eq!(val.try_get::<f64>(), Some(42.0));
+    }
+
+    #[test]
+    fn test_option_some() {
+        let val = AnyDynamoType::new(Some(42i64));
+        assert_eq!(val.try_get::<Option<i64>>(), Some(Some(42)));
+    }
+
+    #[test]
+    fn test_option_none() {
+        let val = AnyDynamoType::new(None::<i64>);
+        assert!(matches!(val.value(), AttributeValue::Null));
+        assert_eq!(val.try_get::<Option<i64>>(), Some(None));
+    }
+}

--- a/vantage-aws/src/dynamodb/types/numbers.rs
+++ b/vantage-aws/src/dynamodb/types/numbers.rs
@@ -1,0 +1,69 @@
+//! Numeric types map to DynamoDB's `N` AttributeValue.
+//!
+//! DynamoDB sends/receives numbers as strings to keep precision intact;
+//! the parse happens here, not on the wire.
+
+use super::{AttributeValue, DynamoType, DynamoTypeNMarker};
+
+impl DynamoType for i32 {
+    type Target = DynamoTypeNMarker;
+
+    fn to_attr(&self) -> AttributeValue {
+        AttributeValue::N(self.to_string())
+    }
+
+    fn from_attr(value: AttributeValue) -> Option<Self> {
+        match value {
+            AttributeValue::N(s) => s.parse().ok(),
+            _ => None,
+        }
+    }
+}
+
+impl DynamoType for i64 {
+    type Target = DynamoTypeNMarker;
+
+    fn to_attr(&self) -> AttributeValue {
+        AttributeValue::N(self.to_string())
+    }
+
+    fn from_attr(value: AttributeValue) -> Option<Self> {
+        match value {
+            AttributeValue::N(s) => s.parse().ok(),
+            _ => None,
+        }
+    }
+}
+
+impl DynamoType for f64 {
+    type Target = DynamoTypeNMarker;
+
+    fn to_attr(&self) -> AttributeValue {
+        AttributeValue::N(self.to_string())
+    }
+
+    fn from_attr(value: AttributeValue) -> Option<Self> {
+        match value {
+            AttributeValue::N(s) => s.parse().ok(),
+            _ => None,
+        }
+    }
+}
+
+impl<T: DynamoType> DynamoType for Option<T> {
+    type Target = T::Target;
+
+    fn to_attr(&self) -> AttributeValue {
+        match self {
+            Some(v) => v.to_attr(),
+            None => AttributeValue::Null,
+        }
+    }
+
+    fn from_attr(value: AttributeValue) -> Option<Self> {
+        match value {
+            AttributeValue::Null => Some(None),
+            other => T::from_attr(other).map(Some),
+        }
+    }
+}

--- a/vantage-aws/src/dynamodb/types/string.rs
+++ b/vantage-aws/src/dynamodb/types/string.rs
@@ -1,0 +1,30 @@
+//! String → DynamoDB `S` AttributeValue.
+
+use super::{AttributeValue, DynamoType, DynamoTypeSMarker};
+
+impl DynamoType for String {
+    type Target = DynamoTypeSMarker;
+
+    fn to_attr(&self) -> AttributeValue {
+        AttributeValue::S(self.clone())
+    }
+
+    fn from_attr(value: AttributeValue) -> Option<Self> {
+        match value {
+            AttributeValue::S(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+impl DynamoType for &'static str {
+    type Target = DynamoTypeSMarker;
+
+    fn to_attr(&self) -> AttributeValue {
+        AttributeValue::S(self.to_string())
+    }
+
+    fn from_attr(_value: AttributeValue) -> Option<Self> {
+        None
+    }
+}

--- a/vantage-aws/src/dynamodb/types/value.rs
+++ b/vantage-aws/src/dynamodb/types/value.rs
@@ -1,0 +1,105 @@
+//! `AnyDynamoType` extras: untyped constructor, `From` impls, `Expressive`.
+
+use super::{AnyDynamoType, AttributeValue, DynamoType, DynamoTypeLMarker, DynamoTypeNullMarker};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+
+impl AnyDynamoType {
+    /// Build a value with no variant tag — used for AttributeValues
+    /// arriving from DynamoDB, where we trust the wire shape and let
+    /// `try_get` attempt the read without enforcing a tag.
+    pub fn untyped(value: AttributeValue) -> Self {
+        Self {
+            value,
+            type_variant: None,
+        }
+    }
+}
+
+/// `AnyDynamoType` is itself a `DynamoType` — passthrough.
+impl DynamoType for AnyDynamoType {
+    type Target = DynamoTypeNullMarker;
+
+    fn to_attr(&self) -> AttributeValue {
+        self.value().clone()
+    }
+
+    fn from_attr(value: AttributeValue) -> Option<Self> {
+        AnyDynamoType::from_attr(&value)
+    }
+}
+
+/// `Vec<AnyDynamoType>` — used by `column_table_values_expr` to project
+/// a column's values across rows.
+impl DynamoType for Vec<AnyDynamoType> {
+    type Target = DynamoTypeLMarker;
+
+    fn to_attr(&self) -> AttributeValue {
+        AttributeValue::L(self.iter().map(|v| v.value().clone()).collect())
+    }
+
+    fn from_attr(value: AttributeValue) -> Option<Self> {
+        match value {
+            AttributeValue::L(arr) => Some(arr.into_iter().map(AnyDynamoType::untyped).collect()),
+            _ => None,
+        }
+    }
+}
+
+macro_rules! impl_from_for_any_dynamo {
+    ($($ty:ty),*) => {
+        $(
+            impl From<$ty> for AnyDynamoType {
+                fn from(val: $ty) -> Self {
+                    AnyDynamoType::new(val)
+                }
+            }
+        )*
+    };
+}
+
+impl_from_for_any_dynamo!(i32, i64, f64, bool, String, Vec<u8>);
+
+impl From<&str> for AnyDynamoType {
+    fn from(val: &str) -> Self {
+        AnyDynamoType::new(val.to_string())
+    }
+}
+
+impl From<crate::dynamodb::id::DynamoId> for AnyDynamoType {
+    fn from(val: crate::dynamodb::id::DynamoId) -> Self {
+        AnyDynamoType::new(val.into_string())
+    }
+}
+
+// Expressive impls — pass scalars directly into dynamo expressions.
+macro_rules! impl_expressive_for_dynamo_scalar {
+    ($($ty:ty),*) => {
+        $(
+            impl Expressive<AnyDynamoType> for $ty {
+                fn expr(&self) -> Expression<AnyDynamoType> {
+                    Expression::new(
+                        "{}",
+                        vec![ExpressiveEnum::Scalar(AnyDynamoType::new_ref(self))],
+                    )
+                }
+            }
+        )*
+    };
+}
+
+impl_expressive_for_dynamo_scalar!(i32, i64, f64, bool, String);
+
+impl Expressive<AnyDynamoType> for &str {
+    fn expr(&self) -> Expression<AnyDynamoType> {
+        Expression::new(
+            "{}",
+            vec![ExpressiveEnum::Scalar(AnyDynamoType::from(*self))],
+        )
+    }
+}
+
+impl Expressive<AnyDynamoType> for AnyDynamoType {
+    fn expr(&self) -> Expression<AnyDynamoType> {
+        Expression::new("{}", vec![ExpressiveEnum::Scalar(self.clone())])
+    }
+}

--- a/vantage-aws/src/dynamodb/types/value.rs
+++ b/vantage-aws/src/dynamodb/types/value.rs
@@ -103,3 +103,153 @@ impl Expressive<AnyDynamoType> for AnyDynamoType {
         Expression::new("{}", vec![ExpressiveEnum::Scalar(self.clone())])
     }
 }
+
+// ── AnyTable / refs bridge ────────────────────────────────────────────
+//
+// `with_one`/`with_many` and `AnyTable::from_table()` require
+// `T::Value: Into<ciborium::Value> + From<ciborium::Value>` and the
+// `serde_json::Value` equivalents. We do these as **shape-natural**
+// conversions: a CBOR `Text` becomes `AttributeValue::S`, an `Integer`
+// becomes `N`, etc. This is what user-supplied JSON in CLI/UI layers
+// looks like; round-tripping through tagged wire form (`{"S": "x"}`)
+// would force every caller to know DynamoDB's serialization tags.
+
+impl From<AnyDynamoType> for ciborium::Value {
+    fn from(val: AnyDynamoType) -> Self {
+        attr_to_cbor(val.into_value())
+    }
+}
+
+impl From<ciborium::Value> for AnyDynamoType {
+    fn from(val: ciborium::Value) -> Self {
+        AnyDynamoType::untyped(cbor_to_attr(val))
+    }
+}
+
+impl From<AnyDynamoType> for serde_json::Value {
+    fn from(val: AnyDynamoType) -> Self {
+        attr_to_plain_json(val.into_value())
+    }
+}
+
+impl From<serde_json::Value> for AnyDynamoType {
+    fn from(val: serde_json::Value) -> Self {
+        AnyDynamoType::untyped(plain_json_to_attr(val))
+    }
+}
+
+fn attr_to_cbor(av: AttributeValue) -> ciborium::Value {
+    use ciborium::Value as Cbor;
+    match av {
+        AttributeValue::S(s) => Cbor::Text(s),
+        AttributeValue::N(ref n) => {
+            if let Ok(i) = n.parse::<i64>() {
+                Cbor::Integer(i.into())
+            } else if let Ok(f) = n.parse::<f64>() {
+                Cbor::Float(f)
+            } else {
+                Cbor::Text(n.clone())
+            }
+        }
+        AttributeValue::B(b) => Cbor::Bytes(b),
+        AttributeValue::Bool(b) => Cbor::Bool(b),
+        AttributeValue::Null => Cbor::Null,
+        AttributeValue::L(items) => Cbor::Array(items.into_iter().map(attr_to_cbor).collect()),
+        AttributeValue::M(map) => Cbor::Map(
+            map.into_iter()
+                .map(|(k, v)| (Cbor::Text(k), attr_to_cbor(v)))
+                .collect(),
+        ),
+        AttributeValue::SS(s) => Cbor::Array(s.into_iter().map(Cbor::Text).collect()),
+        AttributeValue::NS(s) => Cbor::Array(s.into_iter().map(Cbor::Text).collect()),
+        AttributeValue::BS(b) => Cbor::Array(b.into_iter().map(Cbor::Bytes).collect()),
+    }
+}
+
+/// `serde_json::Value::serialize` writes Numbers as a 1-key map with this
+/// magic key — a private newtype marker used to preserve the Number kind
+/// through serde. CBOR captures it verbatim, so the round-trip
+/// `serde_json → ciborium → AttributeValue` would otherwise produce an
+/// `M`-shaped value with this nonsense key. Unwrap it back to a plain `N`.
+const SERDE_JSON_NUMBER_MARKER: &str = "$serde_json::private::Number";
+
+fn cbor_to_attr(val: ciborium::Value) -> AttributeValue {
+    use ciborium::Value as Cbor;
+    match val {
+        Cbor::Text(s) => AttributeValue::S(s),
+        Cbor::Integer(i) => AttributeValue::N(i128::from(i).to_string()),
+        Cbor::Float(f) => AttributeValue::N(f.to_string()),
+        Cbor::Bytes(b) => AttributeValue::B(b),
+        Cbor::Bool(b) => AttributeValue::Bool(b),
+        Cbor::Null => AttributeValue::Null,
+        Cbor::Array(items) => AttributeValue::L(items.into_iter().map(cbor_to_attr).collect()),
+        Cbor::Map(pairs) => {
+            // Detect the `serde_json::Number` private marker and unwrap
+            // it. Without this, every CLI-supplied integer would land as
+            // an `M`-shaped attribute and DynamoDB would store garbage.
+            if pairs.len() == 1
+                && let Some((Cbor::Text(k), Cbor::Text(num))) = pairs.first()
+                && k == SERDE_JSON_NUMBER_MARKER
+            {
+                return AttributeValue::N(num.clone());
+            }
+            let mut map = indexmap::IndexMap::new();
+            for (k, v) in pairs {
+                let key = match k {
+                    Cbor::Text(s) => s,
+                    other => format!("{:?}", other),
+                };
+                map.insert(key, cbor_to_attr(v));
+            }
+            AttributeValue::M(map)
+        }
+        Cbor::Tag(_, inner) => cbor_to_attr(*inner),
+        _ => AttributeValue::Null,
+    }
+}
+
+fn attr_to_plain_json(av: AttributeValue) -> serde_json::Value {
+    use serde_json::Value as J;
+    match av {
+        AttributeValue::S(s) => J::String(s),
+        AttributeValue::N(n) => n
+            .parse::<i64>()
+            .ok()
+            .map(|i| J::Number(i.into()))
+            .or_else(|| {
+                n.parse::<f64>()
+                    .ok()
+                    .and_then(serde_json::Number::from_f64)
+                    .map(J::Number)
+            })
+            .unwrap_or(J::String(n)),
+        AttributeValue::B(b) => J::Array(b.into_iter().map(|byte| J::Number(byte.into())).collect()),
+        AttributeValue::Bool(b) => J::Bool(b),
+        AttributeValue::Null => J::Null,
+        AttributeValue::L(items) => J::Array(items.into_iter().map(attr_to_plain_json).collect()),
+        AttributeValue::M(map) => J::Object(
+            map.into_iter()
+                .map(|(k, v)| (k, attr_to_plain_json(v)))
+                .collect(),
+        ),
+        AttributeValue::SS(s) => J::Array(s.into_iter().map(J::String).collect()),
+        AttributeValue::NS(s) => J::Array(s.into_iter().map(J::String).collect()),
+        AttributeValue::BS(_) => J::Null,
+    }
+}
+
+fn plain_json_to_attr(val: serde_json::Value) -> AttributeValue {
+    use serde_json::Value as J;
+    match val {
+        J::String(s) => AttributeValue::S(s),
+        J::Number(n) => AttributeValue::N(n.to_string()),
+        J::Bool(b) => AttributeValue::Bool(b),
+        J::Null => AttributeValue::Null,
+        J::Array(items) => AttributeValue::L(items.into_iter().map(plain_json_to_attr).collect()),
+        J::Object(map) => AttributeValue::M(
+            map.into_iter()
+                .map(|(k, v)| (k, plain_json_to_attr(v)))
+                .collect(),
+        ),
+    }
+}

--- a/vantage-aws/src/dynamodb/types/value.rs
+++ b/vantage-aws/src/dynamodb/types/value.rs
@@ -223,7 +223,9 @@ fn attr_to_plain_json(av: AttributeValue) -> serde_json::Value {
                     .map(J::Number)
             })
             .unwrap_or(J::String(n)),
-        AttributeValue::B(b) => J::Array(b.into_iter().map(|byte| J::Number(byte.into())).collect()),
+        AttributeValue::B(b) => {
+            J::Array(b.into_iter().map(|byte| J::Number(byte.into())).collect())
+        }
         AttributeValue::Bool(b) => J::Bool(b),
         AttributeValue::Null => J::Null,
         AttributeValue::L(items) => J::Array(items.into_iter().map(attr_to_plain_json).collect()),

--- a/vantage-aws/src/dynamodb/wire.rs
+++ b/vantage-aws/src/dynamodb/wire.rs
@@ -1,0 +1,176 @@
+//! AttributeValue ↔ JSON wire codec.
+//!
+//! DynamoDB's JSON protocol tags every value with its type:
+//! `{"S": "..."}`, `{"N": "42"}`, `{"BOOL": true}`. This module folds
+//! that wire shape into our `AttributeValue` enum and back.
+//!
+//! Binary (`B`/`BS`) is intentionally not yet wired — base64 decode
+//! would pull a new dependency and v0 doesn't need it.
+
+use indexmap::IndexMap;
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
+use vantage_core::{Result, error};
+
+use super::types::AttributeValue;
+
+/// `AttributeValue` → wire JSON object (`{"S": "x"}` etc).
+pub(crate) fn attr_to_json(av: &AttributeValue) -> Result<JsonValue> {
+    Ok(match av {
+        AttributeValue::S(s) => json!({ "S": s }),
+        AttributeValue::N(n) => json!({ "N": n }),
+        AttributeValue::Bool(b) => json!({ "BOOL": b }),
+        AttributeValue::Null => json!({ "NULL": true }),
+        AttributeValue::L(arr) => {
+            let items: Result<Vec<_>> = arr.iter().map(attr_to_json).collect();
+            json!({ "L": items? })
+        }
+        AttributeValue::M(map) => {
+            let mut obj = JsonMap::new();
+            for (k, v) in map {
+                obj.insert(k.clone(), attr_to_json(v)?);
+            }
+            json!({ "M": obj })
+        }
+        AttributeValue::SS(s) => json!({ "SS": s }),
+        AttributeValue::NS(s) => json!({ "NS": s }),
+        AttributeValue::B(_) | AttributeValue::BS(_) => {
+            return Err(error!(
+                "DynamoDB Binary AttributeValue not yet supported on the wire"
+            ));
+        }
+    })
+}
+
+/// Wire JSON object → `AttributeValue`.
+pub(crate) fn json_to_attr(value: &JsonValue) -> Result<AttributeValue> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| error!("AttributeValue must be a JSON object"))?;
+    let (tag, val) = obj
+        .iter()
+        .next()
+        .ok_or_else(|| error!("AttributeValue object is empty"))?;
+
+    Ok(match tag.as_str() {
+        "S" => AttributeValue::S(
+            val.as_str()
+                .ok_or_else(|| error!("S value must be string"))?
+                .to_string(),
+        ),
+        "N" => AttributeValue::N(
+            val.as_str()
+                .ok_or_else(|| error!("N value must be string"))?
+                .to_string(),
+        ),
+        "BOOL" => AttributeValue::Bool(
+            val.as_bool()
+                .ok_or_else(|| error!("BOOL value must be bool"))?,
+        ),
+        "NULL" => AttributeValue::Null,
+        "L" => {
+            let arr = val
+                .as_array()
+                .ok_or_else(|| error!("L value must be array"))?;
+            let items: Result<Vec<_>> = arr.iter().map(json_to_attr).collect();
+            AttributeValue::L(items?)
+        }
+        "M" => {
+            let map_obj = val
+                .as_object()
+                .ok_or_else(|| error!("M value must be object"))?;
+            let mut map = IndexMap::with_capacity(map_obj.len());
+            for (k, v) in map_obj {
+                map.insert(k.clone(), json_to_attr(v)?);
+            }
+            AttributeValue::M(map)
+        }
+        "SS" => {
+            let arr = val
+                .as_array()
+                .ok_or_else(|| error!("SS value must be array"))?;
+            let items: Vec<String> = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+            AttributeValue::SS(items)
+        }
+        "NS" => {
+            let arr = val
+                .as_array()
+                .ok_or_else(|| error!("NS value must be array"))?;
+            let items: Vec<String> = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect();
+            AttributeValue::NS(items)
+        }
+        "B" | "BS" => {
+            return Err(error!(
+                "DynamoDB Binary AttributeValue not yet supported on the wire",
+                tag = tag.as_str()
+            ));
+        }
+        other => {
+            return Err(error!(
+                "Unknown AttributeValue tag",
+                tag = other.to_string()
+            ));
+        }
+    })
+}
+
+/// Parse a wire item (object of `field → AttributeValue`) into ordered
+/// `(field, AttributeValue)` pairs.
+pub(crate) fn json_to_item_map(item: &JsonValue) -> Result<Vec<(String, AttributeValue)>> {
+    let obj = item
+        .as_object()
+        .ok_or_else(|| error!("DynamoDB item must be a JSON object"))?;
+    let mut out = Vec::with_capacity(obj.len());
+    for (k, v) in obj {
+        out.push((k.clone(), json_to_attr(v)?));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn s_round_trip() {
+        let av = AttributeValue::S("hello".into());
+        let j = attr_to_json(&av).unwrap();
+        assert_eq!(j, json!({ "S": "hello" }));
+        assert_eq!(json_to_attr(&j).unwrap(), av);
+    }
+
+    #[test]
+    fn n_round_trip() {
+        let av = AttributeValue::N("42".into());
+        let j = attr_to_json(&av).unwrap();
+        assert_eq!(j, json!({ "N": "42" }));
+        assert_eq!(json_to_attr(&j).unwrap(), av);
+    }
+
+    #[test]
+    fn bool_round_trip() {
+        let av = AttributeValue::Bool(true);
+        let j = attr_to_json(&av).unwrap();
+        assert_eq!(j, json!({ "BOOL": true }));
+        assert_eq!(json_to_attr(&j).unwrap(), av);
+    }
+
+    #[test]
+    fn null_round_trip() {
+        let av = AttributeValue::Null;
+        let j = attr_to_json(&av).unwrap();
+        assert_eq!(j, json!({ "NULL": true }));
+        assert_eq!(json_to_attr(&j).unwrap(), av);
+    }
+
+    #[test]
+    fn binary_errors() {
+        let av = AttributeValue::B(vec![1, 2, 3]);
+        assert!(attr_to_json(&av).is_err());
+    }
+}

--- a/vantage-aws/src/lib.rs
+++ b/vantage-aws/src/lib.rs
@@ -59,6 +59,7 @@ mod restjson;
 mod restxml;
 mod sign;
 
+pub mod dynamodb;
 pub mod models;
 pub mod types;
 

--- a/vantage-aws/tests/dynamodb_live.rs
+++ b/vantage-aws/tests/dynamodb_live.rs
@@ -27,7 +27,9 @@ const PRODUCTS_TABLE: &str = "vantage-demo-products";
 const TEST_REGION: &str = "eu-west-2";
 
 fn account_or_skip() -> Option<AwsAccount> {
-    AwsAccount::from_default().ok().map(|a| a.with_region(TEST_REGION))
+    AwsAccount::from_default()
+        .ok()
+        .map(|a| a.with_region(TEST_REGION))
 }
 
 /// Build a unique id prefix for one test run so cleanup of leftovers
@@ -122,7 +124,8 @@ async fn list_returns_inserted_items() -> vantage_core::Result<()> {
     let all_ids: std::collections::HashSet<&DynamoId> = all.keys().collect();
     let inserted_count = ids.iter().filter(|id| all_ids.contains(id)).count();
     assert_eq!(
-        inserted_count, 3,
+        inserted_count,
+        3,
         "expected 3 freshly-inserted items in scan; saw {} of them (table has {} total)",
         inserted_count,
         all.len()
@@ -176,9 +179,6 @@ async fn get_value_returns_none_for_missing_id() -> vantage_core::Result<()> {
 
     let missing = DynamoId::new(format!("{}-does-not-exist", run_prefix()));
     let result = table.get_value(&missing).await?;
-    assert!(
-        result.is_none(),
-        "missing id should return None, not error"
-    );
+    assert!(result.is_none(), "missing id should return None, not error");
     Ok(())
 }

--- a/vantage-aws/tests/dynamodb_live.rs
+++ b/vantage-aws/tests/dynamodb_live.rs
@@ -1,0 +1,184 @@
+//! Live integration tests against the `vantage-demo-products` DynamoDB
+//! table provisioned by `test-tf/dynamodb.tf`.
+//!
+//! Skipped (`return Ok(())`) when AWS credentials aren't configured, so
+//! CI without AWS access stays green. Locally:
+//!
+//! ```sh
+//! cd test-tf && tofu apply
+//! cd ../vantage-aws && cargo test --test dynamodb_live -- --test-threads=1
+//! ```
+//!
+//! Tests use a per-run id prefix so concurrent runs (or rerun-after-failure
+//! with leftover items) don't collide. Each test cleans up after itself.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use indexmap::IndexMap;
+use vantage_aws::AwsAccount;
+use vantage_aws::dynamodb::{AnyDynamoType, AttributeValue, DynamoDB, DynamoId};
+use vantage_dataset::traits::{ReadableValueSet, WritableValueSet};
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+
+const PRODUCTS_TABLE: &str = "vantage-demo-products";
+/// Region the `test-tf` stack provisions DynamoDB tables in. Pinned here
+/// because the developer's `~/.aws/config` default may point elsewhere.
+const TEST_REGION: &str = "eu-west-2";
+
+fn account_or_skip() -> Option<AwsAccount> {
+    AwsAccount::from_default().ok().map(|a| a.with_region(TEST_REGION))
+}
+
+/// Build a unique id prefix for one test run so cleanup of leftovers
+/// from a panicking test doesn't fight a concurrent test.
+fn run_prefix() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("vt-test-{}", nanos)
+}
+
+fn products_table(db: DynamoDB) -> Table<DynamoDB, EmptyEntity> {
+    Table::new(PRODUCTS_TABLE, db).with_id_column("id")
+}
+
+fn build_record(id: &str, name: &str, price: i64) -> Record<AnyDynamoType> {
+    let mut rec = Record::new();
+    rec.insert(
+        "id".into(),
+        AnyDynamoType::untyped(AttributeValue::S(id.to_string())),
+    );
+    rec.insert(
+        "name".into(),
+        AnyDynamoType::untyped(AttributeValue::S(name.to_string())),
+    );
+    rec.insert(
+        "price".into(),
+        AnyDynamoType::untyped(AttributeValue::N(price.to_string())),
+    );
+    rec
+}
+
+#[tokio::test]
+async fn insert_get_delete_round_trip() -> vantage_core::Result<()> {
+    let Some(aws) = account_or_skip() else {
+        eprintln!("skipping: AWS credentials not configured");
+        return Ok(());
+    };
+    let db = DynamoDB::new(aws);
+    let table = products_table(db);
+
+    let prefix = run_prefix();
+    let id = DynamoId::new(format!("{}-cupcake", prefix));
+    let rec = build_record(id.as_str(), "Cupcake", 120);
+
+    let written = table.insert_value(&id, &rec).await?;
+    assert_eq!(
+        written["name"].try_get::<String>(),
+        Some("Cupcake".to_string()),
+        "insert returned the wrong name"
+    );
+    assert_eq!(
+        written["price"].try_get::<i64>(),
+        Some(120),
+        "insert returned the wrong price"
+    );
+
+    let fetched = table
+        .get_value(&id)
+        .await?
+        .expect("just-inserted item should be found");
+    assert_eq!(fetched["name"].try_get::<String>(), Some("Cupcake".into()));
+
+    table.delete(&id).await?;
+    let after_delete = table.get_value(&id).await?;
+    assert!(after_delete.is_none(), "item should be gone after delete");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_returns_inserted_items() -> vantage_core::Result<()> {
+    let Some(aws) = account_or_skip() else {
+        eprintln!("skipping: AWS credentials not configured");
+        return Ok(());
+    };
+    let db = DynamoDB::new(aws);
+    let table = products_table(db);
+
+    let prefix = run_prefix();
+    let ids: Vec<DynamoId> = (0..3)
+        .map(|i| DynamoId::new(format!("{}-{}", prefix, i)))
+        .collect();
+
+    for (i, id) in ids.iter().enumerate() {
+        let rec = build_record(id.as_str(), &format!("Item-{}", i), (i as i64) * 10);
+        table.insert_value(id, &rec).await?;
+    }
+
+    let all: IndexMap<DynamoId, Record<AnyDynamoType>> = table.list_values().await?;
+    let all_ids: std::collections::HashSet<&DynamoId> = all.keys().collect();
+    let inserted_count = ids.iter().filter(|id| all_ids.contains(id)).count();
+    assert_eq!(
+        inserted_count, 3,
+        "expected 3 freshly-inserted items in scan; saw {} of them (table has {} total)",
+        inserted_count,
+        all.len()
+    );
+
+    // Cleanup.
+    for id in &ids {
+        table.delete(id).await?;
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn replace_overwrites_existing_item() -> vantage_core::Result<()> {
+    let Some(aws) = account_or_skip() else {
+        eprintln!("skipping: AWS credentials not configured");
+        return Ok(());
+    };
+    let db = DynamoDB::new(aws);
+    let table = products_table(db);
+
+    let id = DynamoId::new(format!("{}-replace", run_prefix()));
+
+    table
+        .insert_value(&id, &build_record(id.as_str(), "Original", 100))
+        .await?;
+
+    table
+        .replace_value(&id, &build_record(id.as_str(), "Updated", 200))
+        .await?;
+
+    let fetched = table
+        .get_value(&id)
+        .await?
+        .expect("item should exist after replace");
+    assert_eq!(fetched["name"].try_get::<String>(), Some("Updated".into()));
+    assert_eq!(fetched["price"].try_get::<i64>(), Some(200));
+
+    table.delete(&id).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_value_returns_none_for_missing_id() -> vantage_core::Result<()> {
+    let Some(aws) = account_or_skip() else {
+        eprintln!("skipping: AWS credentials not configured");
+        return Ok(());
+    };
+    let db = DynamoDB::new(aws);
+    let table = products_table(db);
+
+    let missing = DynamoId::new(format!("{}-does-not-exist", run_prefix()));
+    let result = table.get_value(&missing).await?;
+    assert!(
+        result.is_none(),
+        "missing id should return None, not error"
+    );
+    Ok(())
+}


### PR DESCRIPTION
A typed DynamoDB persistence backend at `vantage_aws::dynamodb`, sibling to the existing list-API surface in `models::dynamodb` (which is still just `ListTables` over `AwsAccount`). They coexist because DynamoDB items don't fit the `AwsAccount`-as-`TableSource` mould — typed `AttributeValue` representation, native key/filter expressions, full CRUD — so DynamoDB gets its own `DynamoDB` data source and its own `TableSource` impl.

Existing call sites are untouched: `models::*`, `AwsAccount`, `eq`, the JSON-1.1 / Query / REST-JSON / REST-XML transports — all unchanged. New surface only.

```rust
use vantage_aws::AwsAccount;
use vantage_aws::dynamodb::{DynamoDB, DynamoId};
use vantage_table::table::Table;

let aws = AwsAccount::from_default()?;
let db = DynamoDB::new(aws);
let table = Table::new("my-products", db).with_id_column("id");

let id = DynamoId::new("cupcake");
table.insert_value(&id, &record).await?;
let fetched = table.get_value(&id).await?;
table.delete(&id).await?;
```

### What's wired in v0

- `Scan` / `GetItem` / `PutItem` / `DeleteItem` through `TableSource`. `delete_table_all_values` walks the scan and deletes per-item — DynamoDB has no native bulk delete.
- `AttributeValue` enum mirrors the wire shape (`S`, `N`, `B`, `BOOL`, `NULL`, `L`, `M`, `SS`, `NS`, `BS`); the `vantage_type_system!` macro produces `DynamoType` / `AnyDynamoType` / variants enum on top, with per-type impls for `String`, `i32`, `i64`, `f64`, `bool`, `Vec<u8>`, `Option<T>`.
- `DynamoCondition::eq` carries a rendered expression plus its `ExpressionAttributeNames` / `ExpressionAttributeValues` maps — the shape `ConditionExpression` / `FilterExpression` actually want at the wire. Richer operators (`gt`, `between`, `in_`, `begins_with`) land alongside Scan/Query filter execution.
- `DynamoId` — partition-key-only, string-form. Composite (partition + sort) keys are next.
- `AwsAccount::with_region(...)` returns a copy with the region overridden — needed so the live tests can pin a region without depending on the developer's `~/.aws/config` default.

### Stubbed (errors loudly, doesn't pretend to work)

`patch` (UpdateItem with SET — placeholder mangling against reserved words is non-trivial), aggregations (`sum` / `min` / `max` — DynamoDB has no native equivalent, callers would aggregate client-side), auto-id-on-insert (DynamoDB doesn't generate keys), relationship traversal, and the binary `B` / `BS` wire codec (would pull a base64 dep for v0). All return errors instead of silently succeeding.

### Live tests

`tests/dynamodb_live.rs` covers insert / get / delete round-trip, scan, replace, and missing-id-returns-None against a real DynamoDB account; auto-skips when AWS credentials aren't configured. `test-tf/dynamodb.tf` provisions `<name>-products` and `<name>-orders` as `PAY_PER_REQUEST` so cost stays ~zero when idle.

`vantage-aws` 0.4.4 → 0.4.5.