### PR TITLE
auto-paginate json1 list ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "chrono",

--- a/vantage-api-client/src/api.rs
+++ b/vantage-api-client/src/api.rs
@@ -139,15 +139,16 @@ impl RestApi {
         // query params (and may treat them as strict filters that
         // return empty), so we leave them off.
         if !self.no_pagination
-            && let Some(p) = pagination {
-                let page_value = if self.pagination.skip_based {
-                    p.skip().to_string()
-                } else {
-                    p.get_page().to_string()
-                };
-                params.push((self.pagination.page.clone(), page_value));
-                params.push((self.pagination.limit.clone(), p.limit().to_string()));
-            }
+            && let Some(p) = pagination
+        {
+            let page_value = if self.pagination.skip_based {
+                p.skip().to_string()
+            } else {
+                p.get_page().to_string()
+            };
+            params.push((self.pagination.page.clone(), page_value));
+            params.push((self.pagination.limit.clone(), p.limit().to_string()));
+        }
 
         // Conditions: each `eq` becomes `?field=value`. Multiple
         // conditions AND together (JSON Server semantics).
@@ -197,9 +198,10 @@ impl RestApi {
         // and stops asking for more.
         if self.no_pagination
             && let Some(p) = pagination
-                && p.get_page() > 1 {
-                    return Ok(IndexMap::new());
-                }
+            && p.get_page() > 1
+        {
+            return Ok(IndexMap::new());
+        }
 
         let url = format!(
             "{}{}",

--- a/vantage-api-client/src/api.rs
+++ b/vantage-api-client/src/api.rs
@@ -138,8 +138,8 @@ impl RestApi {
         // When `no_pagination` is set the API doesn't accept page/limit
         // query params (and may treat them as strict filters that
         // return empty), so we leave them off.
-        if !self.no_pagination {
-            if let Some(p) = pagination {
+        if !self.no_pagination
+            && let Some(p) = pagination {
                 let page_value = if self.pagination.skip_based {
                     p.skip().to_string()
                 } else {
@@ -148,7 +148,6 @@ impl RestApi {
                 params.push((self.pagination.page.clone(), page_value));
                 params.push((self.pagination.limit.clone(), p.limit().to_string()));
             }
-        }
 
         // Conditions: each `eq` becomes `?field=value`. Multiple
         // conditions AND together (JSON Server semantics).
@@ -196,13 +195,11 @@ impl RestApi {
         // perpetual grid would never mark itself exhausted. Short-
         // circuit page > 1 to empty so the grid sees the chunk shrink
         // and stops asking for more.
-        if self.no_pagination {
-            if let Some(p) = pagination {
-                if p.get_page() > 1 {
+        if self.no_pagination
+            && let Some(p) = pagination
+                && p.get_page() > 1 {
                     return Ok(IndexMap::new());
                 }
-            }
-        }
 
         let url = format!(
             "{}{}",

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.6 — 2026-05-09
+
+Auto-pagination for the JSON-1.x list endpoints — CloudWatch Logs and ECS now walk through `nextToken` until exhausted, so calls like `streams_table(aws).get().await` return every stream in a busy log group instead of just the first page.
+
+- Opt in per-table by appending `@<cursor>` to the `array_key` in the table-name DSL: `json1/logStreams@nextToken:logs/Logs_20140328.DescribeLogStreams`. The bundled `models::ecs` and `models::logs` factories switched over — no caller change needed.
+- New [`AwsAccount::with_max_pages(n)`](https://docs.rs/vantage-aws/0.4.6/vantage_aws/struct.AwsAccount.html#method.with_max_pages) caps the walk for accounts with thousands of resources, or for content-bearing reads where "all of it" isn't what you want. Default is unbounded.
+- Other protocols (Query/IAM, REST-XML/S3, REST-JSON/Lambda) and asymmetric cursors (KMS's `Marker`/`NextMarker`, `GetLogEvents`'s forward/backward tokens) are still single-page — they need their own walk implementations.
+
 ## 0.4.5 — 2026-05-04
 
 A typed DynamoDB persistence backend — sibling to the existing list-API surface in `models::dynamodb`. Items have a typed `AttributeValue` representation, native key/filter expressions, and full CRUD semantics, none of which fold cleanly into the `AwsAccount`-as-`TableSource` shape — so DynamoDB lives as its own [`vantage_aws::dynamodb`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/) module with its own `TableSource` impl.

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-aws/src/account.rs
+++ b/vantage-aws/src/account.rs
@@ -28,6 +28,10 @@ struct Inner {
     /// DynamoDB Local, LocalStack, or a custom endpoint. Picked up from
     /// `AWS_ENDPOINT_URL` automatically by every constructor below.
     endpoint: Option<String>,
+    /// Cap on how many pages auto-paginating list operations will fetch.
+    /// `None` walks until AWS stops returning a continuation token.
+    /// See [`AwsAccount::with_max_pages`].
+    max_pages: Option<usize>,
     http: reqwest::Client,
 }
 
@@ -45,6 +49,7 @@ impl AwsAccount {
                 session_token: None,
                 region: region.into(),
                 endpoint: env_endpoint(),
+                max_pages: None,
                 http: reqwest::Client::new(),
             }),
         }
@@ -68,6 +73,7 @@ impl AwsAccount {
                 session_token,
                 region,
                 endpoint: env_endpoint(),
+                max_pages: None,
                 http: reqwest::Client::new(),
             }),
         })
@@ -111,6 +117,7 @@ impl AwsAccount {
                     session_token: creds.get("aws_session_token").cloned(),
                     region,
                     endpoint: env_endpoint(),
+                    max_pages: None,
                     http: reqwest::Client::new(),
                 }),
             });
@@ -127,6 +134,7 @@ impl AwsAccount {
                 session_token: token,
                 region,
                 endpoint: env_endpoint(),
+                max_pages: None,
                 http: reqwest::Client::new(),
             }),
         })
@@ -155,6 +163,7 @@ impl AwsAccount {
                 session_token: inner.session_token.clone(),
                 region: region.into(),
                 endpoint: inner.endpoint.clone(),
+                max_pages: inner.max_pages,
                 http: inner.http.clone(),
             }),
         }
@@ -174,9 +183,39 @@ impl AwsAccount {
                 session_token: inner.session_token.clone(),
                 region: inner.region.clone(),
                 endpoint: Some(endpoint.into()),
+                max_pages: inner.max_pages,
                 http: inner.http.clone(),
             }),
         }
+    }
+
+    /// Cap how many pages of results any single auto-paginating list
+    /// operation will fetch from this account. `None` (the default)
+    /// walks until AWS stops returning a continuation token. Pages
+    /// past the cap are silently dropped — callers see a truncated
+    /// result. Useful as a safety belt for accounts with many
+    /// thousands of streams / functions / etc., or for content-bearing
+    /// reads where "all of it" isn't what you want.
+    ///
+    /// Has no effect on operations that don't auto-paginate (only the
+    /// CloudWatch Logs and ECS list endpoints do today).
+    pub fn with_max_pages(self, n: usize) -> Self {
+        let inner = &self.inner;
+        Self {
+            inner: std::sync::Arc::new(Inner {
+                access_key: inner.access_key.clone(),
+                secret_key: inner.secret_key.clone(),
+                session_token: inner.session_token.clone(),
+                region: inner.region.clone(),
+                endpoint: inner.endpoint.clone(),
+                max_pages: Some(n),
+                http: inner.http.clone(),
+            }),
+        }
+    }
+
+    pub(crate) fn max_pages(&self) -> Option<usize> {
+        self.inner.max_pages
     }
 
     pub(crate) fn region(&self) -> &str {

--- a/vantage-aws/src/dispatch.rs
+++ b/vantage-aws/src/dispatch.rs
@@ -47,6 +47,21 @@ pub(crate) struct OperationDescriptor<'a> {
     pub array_key: &'a str,
     pub service: &'a str,
     pub target: &'a str,
+    /// Continuation-token field name. Same string is used for both the
+    /// request body field and the response body field — every CloudWatch
+    /// Logs and ECS list API uses `nextToken` symmetrically. Encoded in
+    /// the table name as `@<name>` after the array key:
+    ///
+    /// ```text
+    /// json1/logStreams@nextToken:logs/Logs_20140328.DescribeLogStreams
+    /// ```
+    ///
+    /// `None` means single-page (current behaviour). Other AWS protocols
+    /// (Query, RestXml, RestJson) and asymmetric cursors (KMS's
+    /// `Marker`/`NextMarker`, `GetLogEvents`'s forward/backward tokens)
+    /// don't use this field — they'll need a richer descriptor when
+    /// auto-pagination expands beyond json1.
+    pub cursor: Option<&'a str>,
 }
 
 impl AwsAccount {
@@ -61,6 +76,19 @@ impl AwsAccount {
     ) -> Result<JsonValue> {
         let op = parse_table_name(table_name)?;
         let resolved = self.resolve_conditions(conditions).await?;
+
+        // Auto-paginate when the descriptor carries a cursor name.
+        // Scoped to JSON-1.1 / 1.0 because that's where every paginated
+        // op uses the same field name in both directions and where the
+        // response array sits at a known top-level key. Other protocols
+        // need their own walk implementations (different cursor naming,
+        // `IsTruncated` flags, XML wrapping) — they stay single-page.
+        if let Some(cursor) = op.cursor
+            && matches!(op.protocol, Protocol::Json1 | Protocol::Json10)
+        {
+            return self.walk_json_pages(&op, &resolved, cursor).await;
+        }
+
         match op.protocol {
             Protocol::Json1 => json1::execute(self, &op, &resolved).await,
             Protocol::Json10 => json10::execute(self, &op, &resolved).await,
@@ -68,6 +96,63 @@ impl AwsAccount {
             Protocol::RestXml => restxml::execute(self, &op, &resolved).await,
             Protocol::RestJson => restjson::execute(self, &op, &resolved).await,
         }
+    }
+
+    /// Walk a JSON-1.x paginated list operation by re-issuing the same
+    /// request with the response's continuation token folded into the
+    /// next request's body, until the token is gone (or
+    /// [`AwsAccount::max_pages`] is hit). Items from each page are
+    /// concatenated under the descriptor's `array_key`; non-array
+    /// top-level fields are taken from the last page (none of the
+    /// supported ops carry meaningful per-page metadata, so this is
+    /// fine for now — see top-of-file note).
+    async fn walk_json_pages(
+        &self,
+        op: &OperationDescriptor<'_>,
+        resolved: &[AwsCondition],
+        cursor_field: &str,
+    ) -> Result<JsonValue> {
+        let max_pages = self.max_pages();
+        let mut conds: Vec<AwsCondition> = resolved.to_vec();
+
+        let mut accumulated: Vec<JsonValue> = Vec::new();
+        let mut pages: usize = 0;
+
+        let mut merged = loop {
+            let resp = match op.protocol {
+                Protocol::Json1 => json1::execute(self, op, &conds).await?,
+                Protocol::Json10 => json10::execute(self, op, &conds).await?,
+                _ => unreachable!("walk_json_pages is gated on Json1/Json10"),
+            };
+            pages += 1;
+
+            if let Some(arr) = lookup_path(&resp, op.array_key).and_then(|v| v.as_array()) {
+                accumulated.extend(arr.iter().cloned());
+            }
+
+            let next_cursor = resp
+                .get(cursor_field)
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
+
+            match next_cursor {
+                Some(token) if max_pages.is_none_or(|cap| pages < cap) => {
+                    // Replace any prior cursor condition before re-issuing.
+                    conds.retain(|c| c.field() != cursor_field);
+                    conds.push(AwsCondition::eq(cursor_field.to_string(), token));
+                }
+                _ => break resp,
+            }
+        };
+
+        // Replace the array under `array_key` with the concatenated
+        // results. `array_key` is always a single segment for the json1
+        // ops we walk (no dotted paths in the supported descriptors).
+        if let Some(obj) = merged.as_object_mut() {
+            obj.insert(op.array_key.to_string(), JsonValue::Array(accumulated));
+        }
+        Ok(merged)
     }
 
     /// Pull records out of a successful response. Each protocol owns
@@ -156,8 +241,16 @@ pub(crate) fn parse_table_name(name: &str) -> Result<OperationDescriptor<'_>> {
             ));
         }
     };
-    let (array_key, rest) = rest.split_once(':').ok_or_else(bad)?;
+    let (array_key_raw, rest) = rest.split_once(':').ok_or_else(bad)?;
     let (service, target) = rest.split_once('/').ok_or_else(bad)?;
+
+    // Optional `@cursor` suffix on the array key opts the operation
+    // into auto-pagination — see [`OperationDescriptor::cursor`].
+    let (array_key, cursor) = match array_key_raw.split_once('@') {
+        Some((key, cursor)) if !cursor.is_empty() => (key, Some(cursor)),
+        Some(_) => return Err(bad()),
+        None => (array_key_raw, None),
+    };
 
     if array_key.is_empty() || service.is_empty() || target.is_empty() {
         return Err(bad());
@@ -168,6 +261,7 @@ pub(crate) fn parse_table_name(name: &str) -> Result<OperationDescriptor<'_>> {
         array_key,
         service,
         target,
+        cursor,
     })
 }
 
@@ -200,6 +294,7 @@ mod tests {
         assert_eq!(op.array_key, "logGroups");
         assert_eq!(op.service, "logs");
         assert_eq!(op.target, "Logs_20140328.DescribeLogGroups");
+        assert_eq!(op.cursor, None);
     }
 
     #[test]
@@ -209,6 +304,24 @@ mod tests {
         assert_eq!(op.array_key, "Users");
         assert_eq!(op.service, "iam");
         assert_eq!(op.target, "2010-05-08.ListUsers");
+        assert_eq!(op.cursor, None);
+    }
+
+    #[test]
+    fn parses_cursor_suffix() {
+        let op = parse_table_name(
+            "json1/logStreams@nextToken:logs/Logs_20140328.DescribeLogStreams",
+        )
+        .unwrap();
+        assert_eq!(op.array_key, "logStreams");
+        assert_eq!(op.cursor, Some("nextToken"));
+    }
+
+    #[test]
+    fn rejects_empty_cursor_suffix() {
+        let err = parse_table_name("json1/logStreams@:logs/Logs_20140328.DescribeLogStreams")
+            .unwrap_err();
+        assert!(format!("{err}").contains("must be \""));
     }
 
     #[test]

--- a/vantage-aws/src/dispatch.rs
+++ b/vantage-aws/src/dispatch.rs
@@ -309,10 +309,9 @@ mod tests {
 
     #[test]
     fn parses_cursor_suffix() {
-        let op = parse_table_name(
-            "json1/logStreams@nextToken:logs/Logs_20140328.DescribeLogStreams",
-        )
-        .unwrap();
+        let op =
+            parse_table_name("json1/logStreams@nextToken:logs/Logs_20140328.DescribeLogStreams")
+                .unwrap();
         assert_eq!(op.array_key, "logStreams");
         assert_eq!(op.cursor, Some("nextToken"));
     }

--- a/vantage-aws/src/lib.rs
+++ b/vantage-aws/src/lib.rs
@@ -26,7 +26,11 @@
 //! services and protocols freely.
 //!
 //! Conditions on the table fold into the request body. v0 is
-//! read-only, first-page only — pagination and writes arrive later.
+//! read-only; writes arrive later. The CloudWatch Logs and ECS list
+//! endpoints auto-paginate through `nextToken` until exhausted; cap
+//! the walk via [`AwsAccount::with_max_pages`] if you need to. Other
+//! protocols (Query/IAM, REST-XML/S3, REST-JSON/Lambda) are still
+//! single-page — they'll need their own walk implementations.
 //!
 //! Ready-made models live under [`models`] if you want to skip the
 //! table-name dance and start querying.

--- a/vantage-aws/src/models/ecs/cluster.rs
+++ b/vantage-aws/src/models/ecs/cluster.rs
@@ -26,7 +26,7 @@ pub struct Cluster {
 /// ```
 pub fn clusters_table(aws: AwsAccount) -> Table<AwsAccount, Cluster> {
     Table::new(
-        "json1/clusterArns:ecs/AmazonEC2ContainerServiceV20141113.ListClusters",
+        "json1/clusterArns@nextToken:ecs/AmazonEC2ContainerServiceV20141113.ListClusters",
         aws,
     )
     .with_id_column("clusterArn")

--- a/vantage-aws/src/models/ecs/service.rs
+++ b/vantage-aws/src/models/ecs/service.rs
@@ -15,7 +15,7 @@ pub struct Service {
 /// traverse from a [`Cluster`](super::cluster::Cluster).
 pub fn services_table(aws: AwsAccount) -> Table<AwsAccount, Service> {
     Table::new(
-        "json1/serviceArns:ecs/AmazonEC2ContainerServiceV20141113.ListServices",
+        "json1/serviceArns@nextToken:ecs/AmazonEC2ContainerServiceV20141113.ListServices",
         aws,
     )
     .with_id_column("serviceArn")

--- a/vantage-aws/src/models/ecs/task.rs
+++ b/vantage-aws/src/models/ecs/task.rs
@@ -21,7 +21,7 @@ pub struct Task {
 /// `STOPPED`), `launchType`, `containerInstance`.
 pub fn tasks_table(aws: AwsAccount) -> Table<AwsAccount, Task> {
     Table::new(
-        "json1/taskArns:ecs/AmazonEC2ContainerServiceV20141113.ListTasks",
+        "json1/taskArns@nextToken:ecs/AmazonEC2ContainerServiceV20141113.ListTasks",
         aws,
     )
     .with_id_column("taskArn")

--- a/vantage-aws/src/models/ecs/task_definition.rs
+++ b/vantage-aws/src/models/ecs/task_definition.rs
@@ -16,7 +16,7 @@ pub struct TaskDefinition {
 /// `INACTIVE`), `sort` (`ASC` / `DESC`).
 pub fn task_definitions_table(aws: AwsAccount) -> Table<AwsAccount, TaskDefinition> {
     Table::new(
-        "json1/taskDefinitionArns:ecs/AmazonEC2ContainerServiceV20141113.ListTaskDefinitions",
+        "json1/taskDefinitionArns@nextToken:ecs/AmazonEC2ContainerServiceV20141113.ListTaskDefinitions",
         aws,
     )
     .with_id_column("taskDefinitionArn")

--- a/vantage-aws/src/models/logs/event.rs
+++ b/vantage-aws/src/models/logs/event.rs
@@ -35,8 +35,8 @@ pub fn events_table(aws: AwsAccount) -> Table<AwsAccount, LogEvent> {
         "json1/events@nextToken:logs/Logs_20140328.FilterLogEvents",
         aws,
     )
-        .with_id_column("eventId")
-        .with_title_column_of::<String>("logStreamName")
-        .with_title_column_of::<i64>("timestamp")
-        .with_column_of::<String>("message")
+    .with_id_column("eventId")
+    .with_title_column_of::<String>("logStreamName")
+    .with_title_column_of::<i64>("timestamp")
+    .with_column_of::<String>("message")
 }

--- a/vantage-aws/src/models/logs/event.rs
+++ b/vantage-aws/src/models/logs/event.rs
@@ -31,7 +31,10 @@ pub struct LogEvent {
 /// # Ok(()) }
 /// ```
 pub fn events_table(aws: AwsAccount) -> Table<AwsAccount, LogEvent> {
-    Table::new("json1/events:logs/Logs_20140328.FilterLogEvents", aws)
+    Table::new(
+        "json1/events@nextToken:logs/Logs_20140328.FilterLogEvents",
+        aws,
+    )
         .with_id_column("eventId")
         .with_title_column_of::<String>("logStreamName")
         .with_title_column_of::<i64>("timestamp")

--- a/vantage-aws/src/models/logs/group.rs
+++ b/vantage-aws/src/models/logs/group.rs
@@ -43,11 +43,11 @@ pub fn groups_table(aws: AwsAccount) -> Table<AwsAccount, LogGroup> {
         "json1/logGroups@nextToken:logs/Logs_20140328.DescribeLogGroups",
         aws,
     )
-        .with_id_column("logGroupName")
-        .with_column_of::<i64>("creationTime")
-        .with_title_column_of::<i64>("storedBytes")
-        .with_many("events", "logGroupName", events_table)
-        .with_many("streams", "logGroupName", streams_table)
+    .with_id_column("logGroupName")
+    .with_column_of::<i64>("creationTime")
+    .with_title_column_of::<i64>("storedBytes")
+    .with_many("events", "logGroupName", events_table)
+    .with_many("streams", "logGroupName", streams_table)
 }
 
 impl LogGroup {

--- a/vantage-aws/src/models/logs/group.rs
+++ b/vantage-aws/src/models/logs/group.rs
@@ -39,7 +39,10 @@ pub struct LogGroup {
 /// # Ok(()) }
 /// ```
 pub fn groups_table(aws: AwsAccount) -> Table<AwsAccount, LogGroup> {
-    Table::new("json1/logGroups:logs/Logs_20140328.DescribeLogGroups", aws)
+    Table::new(
+        "json1/logGroups@nextToken:logs/Logs_20140328.DescribeLogGroups",
+        aws,
+    )
         .with_id_column("logGroupName")
         .with_column_of::<i64>("creationTime")
         .with_title_column_of::<i64>("storedBytes")

--- a/vantage-aws/src/models/logs/stream.rs
+++ b/vantage-aws/src/models/logs/stream.rs
@@ -41,7 +41,7 @@ pub struct LogStream {
 /// ```
 pub fn streams_table(aws: AwsAccount) -> Table<AwsAccount, LogStream> {
     Table::new(
-        "json1/logStreams:logs/Logs_20140328.DescribeLogStreams",
+        "json1/logStreams@nextToken:logs/Logs_20140328.DescribeLogStreams",
         aws,
     )
     .with_id_column("logStreamName")

--- a/vantage-sql/scripts/mysql/start.sh
+++ b/vantage-sql/scripts/mysql/start.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -e
+
+# Configuration
+CONTAINER_NAME="vantage-mysql"
+PORT="3306"
+USER="vantage"
+PASS="vantage"
+ROOT_PASS="vantage"
+DB="vantage"
+
+# Check if Docker is running
+if ! docker info > /dev/null 2>&1; then
+    echo "Error: Docker is not running. Please start Docker and try again."
+    exit 1
+fi
+
+# Stop existing container if running
+if docker ps -q -f name=$CONTAINER_NAME | grep -q .; then
+    echo "Stopping existing MySQL container..."
+    docker stop $CONTAINER_NAME > /dev/null 2>&1 || true
+fi
+
+# Remove existing container
+if docker ps -aq -f name=$CONTAINER_NAME | grep -q .; then
+    echo "Removing existing MySQL container..."
+    docker rm $CONTAINER_NAME > /dev/null 2>&1 || true
+fi
+
+echo "Starting MySQL local instance..."
+echo "Container: $CONTAINER_NAME"
+echo "Port: $PORT"
+echo "Username: $USER"
+echo "Password: $PASS"
+echo "Database: $DB"
+
+# Start MySQL container
+docker run -d \
+    --name $CONTAINER_NAME \
+    -p $PORT:3306 \
+    -e MYSQL_ROOT_PASSWORD=$ROOT_PASS \
+    -e MYSQL_USER=$USER \
+    -e MYSQL_PASSWORD=$PASS \
+    -e MYSQL_DATABASE=$DB \
+    mysql:8
+
+# Wait for MySQL to be ready
+echo "Waiting for MySQL to start..."
+for i in $(seq 1 60); do
+    if docker exec $CONTAINER_NAME mysqladmin ping -h 127.0.0.1 -u$USER -p$PASS --silent > /dev/null 2>&1; then
+        echo "MySQL is ready!"
+        break
+    fi
+    sleep 1
+done
+
+# Check if container is running
+if docker ps -q -f name=$CONTAINER_NAME | grep -q .; then
+    echo ""
+    echo "Connection details:"
+    echo "  URL: mysql://$USER:$PASS@localhost:$PORT/$DB"
+    echo ""
+    echo "To connect with mysql:"
+    echo "  docker exec -it $CONTAINER_NAME mysql -u$USER -p$PASS $DB"
+    echo ""
+    echo "To stop the instance, run: ./stop.sh"
+else
+    echo "Failed to start MySQL container"
+    docker logs $CONTAINER_NAME
+    exit 1
+fi

--- a/vantage-sql/scripts/mysql/stop.sh
+++ b/vantage-sql/scripts/mysql/stop.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+CONTAINER_NAME="vantage-mysql"
+
+if docker ps -q -f name=$CONTAINER_NAME | grep -q .; then
+    echo "Stopping MySQL container..."
+    docker stop $CONTAINER_NAME > /dev/null 2>&1
+    docker rm $CONTAINER_NAME > /dev/null 2>&1
+    echo "MySQL stopped."
+else
+    echo "MySQL container is not running."
+fi


### PR DESCRIPTION
The CloudWatch Logs and ECS list endpoints now walk `nextToken` until exhausted instead of returning only the first page. If your code was quietly missing the bulk of a busy log group's streams (or every service past the first 100 in an ECS cluster), the missing rows are now there — `streams_table(aws).get().await` returns the lot.

[`AwsAccount::with_max_pages(n)`](https://docs.rs/vantage-aws/0.4.6/vantage_aws/struct.AwsAccount.html#method.with_max_pages) caps the walk for accounts where "all of it" is too much, or for content-bearing reads where you don't actually want every entry. `None` is the default and walks until AWS stops handing out continuation tokens.

### Where the cursor lives

Pagination is opt-in per table by appending `@<cursor>` to the `array_key` in the table-name DSL:

```text
json1/logStreams@nextToken:logs/Logs_20140328.DescribeLogStreams
```

`models::ecs::*` and `models::logs::*` flipped over; everything still works through the same `AwsAccount` and the same conditions. New tables you write yourself need to opt in via the suffix.

### Why only json1 today

That's where every paginated endpoint uses a single `nextToken` field symmetrically (request body field in, response top-level field out) and the response array sits at a known top-level key. Other protocols need their own walks:

- Query / IAM uses `Marker` / `IsTruncated` and wraps results in XML.
- REST-XML / S3 uses `ContinuationToken` / `NextContinuationToken` with truncation flags.
- REST-JSON / Lambda uses `Marker` / `NextMarker`.
- `GetLogEvents`'s forward/backward tokens don't fit a single-cursor descriptor at all — they'll need a richer shape when we get to them.

So this lands the thing the README's v0 caveat ("first-page only — pagination later") promised, for the JSON-1.x services, and sets up the pattern the rest can follow.

vantage-aws 0.4.5 → 0.4.6. No source-level breaks; behaviour-level the list calls now return all pages by default, so anything that relied on first-page-only as an implicit cap should switch to `with_max_pages(1)`.