### PR TITLE
automate per-crate publish on merge

### DIFF
--- a/.github/workflows/pr-version-check.yaml
+++ b/.github/workflows/pr-version-check.yaml
@@ -1,0 +1,115 @@
+name: PR version check
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find changed crates and verify version + changelog
+        id: check
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          base_sha=$(git rev-parse "origin/${BASE_REF}")
+          mapfile -t changed_files < <(git diff --name-only "${base_sha}"...HEAD)
+
+          # Map each changed file to the nearest ancestor dir with a publishable Cargo.toml.
+          declare -A crate_set=()
+          for f in "${changed_files[@]}"; do
+            dir=$(dirname "$f")
+            while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+              if [ -f "$dir/Cargo.toml" ] && grep -q '^\[package\]' "$dir/Cargo.toml"; then
+                # Skip crates explicitly opted out of publishing.
+                if grep -qE '^publish\s*=\s*false' "$dir/Cargo.toml"; then
+                  break
+                fi
+                crate_set[$dir]=1
+                break
+              fi
+              dir=$(dirname "$dir")
+            done
+          done
+
+          if [ ${#crate_set[@]} -eq 0 ]; then
+            echo "No publishable-crate changes — skipping version checks."
+            echo "labels=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          fail=0
+          labels=()
+          for crate in "${!crate_set[@]}"; do
+            name=$(awk -F'"' '/^name = "/ {print $2; exit}' "$crate/Cargo.toml")
+            new_ver=$(awk -F'"' '/^version = "/ {print $2; exit}' "$crate/Cargo.toml")
+            old_ver=$(git show "${base_sha}:${crate}/Cargo.toml" 2>/dev/null \
+                       | awk -F'"' '/^version = "/ {print $2; exit}' || true)
+
+            echo "::group::${name} (${crate})"
+            echo "  base version: ${old_ver:-<new crate>}"
+            echo "  head version: ${new_ver}"
+
+            if [ -n "${old_ver}" ] && [ "${old_ver}" = "${new_ver}" ]; then
+              echo "::error file=${crate}/Cargo.toml::${name} has changes but version is still ${new_ver} — bump it (patch is fine)."
+              fail=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ ! -f "${crate}/CHANGELOG.md" ]; then
+              echo "::error file=${crate}::${name} is missing CHANGELOG.md."
+              fail=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            if ! grep -qE "^## ${new_ver}( |\$)" "${crate}/CHANGELOG.md"; then
+              echo "::error file=${crate}/CHANGELOG.md::${name} CHANGELOG.md has no entry for ${new_ver} (need a '## ${new_ver}' heading)."
+              fail=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            echo "  ok — will publish ${name} ${new_ver} on merge"
+            labels+=("release:${name}")
+            echo "::endgroup::"
+          done
+
+          {
+            echo "labels<<EOF"
+            printf '%s\n' "${labels[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ $fail -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Sync release labels on PR
+        if: always() && steps.check.outputs.labels != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          NEW_LABELS: ${{ steps.check.outputs.labels }}
+        run: |
+          set -euo pipefail
+          # Drop any stale release:* labels first so the PR reflects the current diff.
+          existing=$(gh pr view "$PR" --json labels --jq '.labels[].name' | grep '^release:' || true)
+          for l in $existing; do
+            gh pr edit "$PR" --remove-label "$l" >/dev/null || true
+          done
+          for l in $NEW_LABELS; do
+            gh label create "$l" --color "0e8a16" --description "Crate release on merge" 2>/dev/null || true
+            gh pr edit "$PR" --add-label "$l" >/dev/null
+          done

--- a/.github/workflows/publish-on-merge.yaml
+++ b/.github/workflows/publish-on-merge.yaml
@@ -1,0 +1,77 @@
+name: Publish on merge
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: publish
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Detect crates whose version changed
+        id: detect
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+          # Skip the empty-before case (initial push, branch create, force-push to a new sha that has no parent on main).
+          if [ "${BEFORE}" = "0000000000000000000000000000000000000000" ] || [ -z "${BEFORE}" ]; then
+            echo "No before-sha — skipping."
+            echo "crates=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          mapfile -t toml_changes < <(git diff --name-only "${BEFORE}" "${AFTER}" -- '**/Cargo.toml' | sort -u)
+
+          crates=()
+          for f in "${toml_changes[@]}"; do
+            dir=$(dirname "$f")
+            [ "$dir" = "." ] && continue
+            grep -q '^\[package\]' "$f" || continue
+            grep -qE '^publish\s*=\s*false' "$f" && continue
+            new_ver=$(awk -F'"' '/^version = "/ {print $2; exit}' "$f")
+            old_ver=$(git show "${BEFORE}:$f" 2>/dev/null \
+                       | awk -F'"' '/^version = "/ {print $2; exit}' || true)
+            if [ -n "${new_ver}" ] && [ "${new_ver}" != "${old_ver}" ]; then
+              crates+=("$dir")
+            fi
+          done
+
+          if [ ${#crates[@]} -eq 0 ]; then
+            echo "No version bumps in this push."
+            echo "crates=" >> "$GITHUB_OUTPUT"
+          else
+            printf 'Will publish: %s\n' "${crates[@]}"
+            {
+              echo "crates<<EOF"
+              printf '%s\n' "${crates[@]}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: cargo login
+        if: steps.detect.outputs.crates != ''
+        run: cargo login "${{ secrets.CRATES_IO_API_TOKEN }}"
+
+      - name: Publish each bumped crate
+        if: steps.detect.outputs.crates != ''
+        env:
+          CRATES: ${{ steps.detect.outputs.crates }}
+        run: |
+          set -euo pipefail
+          for crate in $CRATES; do
+            echo "::group::Publishing $crate"
+            (cd "$crate" && cargo publish --no-verify)
+            echo "::endgroup::"
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,7 +4045,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "async-trait",
  "chrono",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.3 — 2026-05-09
+
+Opt-in [`RestApiBuilder::no_pagination()`](https://docs.rs/vantage-api-client/0.1.3/vantage_api_client/struct.RestApiBuilder.html#method.no_pagination) for APIs that don't paginate. ([#230](https://github.com/romaninsh/vantage/pull/230))
+
+```rust
+let api = RestApi::builder(base_url).no_pagination().build();
+```
+
+FastAPI / Pydantic services often treat unknown query params as strict filters and silently return empty rows, so adding `_page=1&_limit=50` makes the response empty. Setting this stops vantage from sending those params, and a perpetual grid asking for page > 1 short-circuits to an empty result so it actually marks itself exhausted instead of looping. Default behaviour is unchanged.
+
 ## 0.1.2 — 2026-04-26
 
 `RestApi::builder` now configures response shape and pagination convention, so the same client works against APIs with different conventions:

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.1.2"
+version = "0.1.3"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST API backends"

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,12 +1,23 @@
 # Changelog
 
-## 0.4.6 — 2026-05-09
+## 0.4.7 — 2026-05-09
 
-Auto-pagination for the JSON-1.x list endpoints — CloudWatch Logs and ECS now walk through `nextToken` until exhausted, so calls like `streams_table(aws).get().await` return every stream in a busy log group instead of just the first page.
+Auto-pagination for the JSON-1.x list endpoints — CloudWatch Logs and ECS now walk through `nextToken` until exhausted, so calls like `streams_table(aws).get().await` return every stream in a busy log group instead of just the first page. Behaviour-level breaking: anything that relied on first-page-only as an implicit cap should switch to `with_max_pages(1)`. ([#231](https://github.com/romaninsh/vantage/pull/231))
 
 - Opt in per-table by appending `@<cursor>` to the `array_key` in the table-name DSL: `json1/logStreams@nextToken:logs/Logs_20140328.DescribeLogStreams`. The bundled `models::ecs` and `models::logs` factories switched over — no caller change needed.
-- New [`AwsAccount::with_max_pages(n)`](https://docs.rs/vantage-aws/0.4.6/vantage_aws/struct.AwsAccount.html#method.with_max_pages) caps the walk for accounts with thousands of resources, or for content-bearing reads where "all of it" isn't what you want. Default is unbounded.
+- New [`AwsAccount::with_max_pages(n)`](https://docs.rs/vantage-aws/0.4.7/vantage_aws/struct.AwsAccount.html#method.with_max_pages) caps the walk for accounts with thousands of resources, or for content-bearing reads where "all of it" isn't what you want. Default is unbounded; pages past the cap are silently dropped, so a caller can lean on it as a safety belt without changing error-handling.
 - Other protocols (Query/IAM, REST-XML/S3, REST-JSON/Lambda) and asymmetric cursors (KMS's `Marker`/`NextMarker`, `GetLogEvents`'s forward/backward tokens) are still single-page — they need their own walk implementations.
+
+## 0.4.6 — 2026-05-09
+
+`AwsAccount` finally respects `AWS_PROFILE` and SSO; DynamoDB picks up `begins_with` plus a fix for `find_some` with filters. ([#230](https://github.com/romaninsh/vantage/pull/230))
+
+- `AwsAccount::from_credentials_file()` reads `AWS_PROFILE` (default `"default"`) instead of always taking `[default]`. For profiles whose creds don't live in `~/.aws/credentials` it shells out to `aws configure export-credentials --format env`, which is the AWS CLI's stable handover format and knows how to materialise SSO tokens, assumed-role chains, and `credential_process` output. So `AWS_PROFILE=<sso-profile> cargo run` works as long as `aws sso login` is current. New [`AwsAccount::from_profile(name)`](https://docs.rs/vantage-aws/0.4.6/vantage_aws/struct.AwsAccount.html#method.from_profile) lets you pick a profile without touching env vars. The README's "no AWS_PROFILE / SSO / assume-role" v0 caveat is now stale.
+- `mise.toml` pins `aws` as a tool dep because of the shell-out — install it via `mise install` if you don't already have it.
+- New [`DynamoCondition::begins_with(field, prefix)`](https://docs.rs/vantage-aws/0.4.6/vantage_aws/dynamodb/enum.DynamoCondition.html#variant.BeginsWith) for sort-key prefix filtering — needed for any single-table design that scopes entities by `SK` prefix.
+- Bug: `find_some` was passing `Limit=1` even when a filter was set. DynamoDB applies `FilterExpression` *after* `Limit`, so `Scan(Limit=1)` with a filter routinely returned zero items even when matches existed further down the partition. Fixed by dropping the limit when a filter is present and letting `transport::scan` paginate; the first match is still consumed.
+- New `vantage-aws/examples/dynamo-single-table.rs` — a worked CLI over one DynamoDB table holding seven logical entities (`product`, `version`, `deployment`, `environment`, `team`, `subscription`, `dataport`) distinguished by `PK` / `SK` prefix conventions. Drives the same `model_cli` runner as `aws-cli`. `vantage-aws/examples/aws-dynamo.rs` is a smaller list-and-scan walker for any DynamoDB account.
+- `DynamoId` is partition-key-only in v0, so listing per-product entities globally collapses entries into the same `IndexMap` key. Traversing through a parent (`product[N] :versions`) narrows scope and the collapse stops mattering. Composite-key `DynamoId` is next.
 
 ## 0.4.5 — 2026-05-04
 

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]


### PR DESCRIPTION
PRs that touch a publishable crate now have to bump its version and add a `## <version>` heading to its `CHANGELOG.md`. The new `pr-version-check` workflow walks the diff vs the base branch, maps each changed file to its nearest crate, and fails the check if either is missing. It stamps a `release:<crate>` label on the PR so reviewers can see at a glance what's about to ship.

After merge, `publish-on-merge` re-reads the same crate set from the push diff and runs `cargo publish --no-verify` per bumped crate. Crates whose versions didn't change are skipped. No tags, no `cargo release publish --workspace`, no silent "already published" warnings to sift past to find a real publish failure.

`vantage-aws` 0.4.5 → 0.4.6 and `vantage-api-client` 0.1.2 → 0.1.3 are backfilled here for the AWS_PROFILE / SSO + DynamoDB `begins_with` work that landed in [#230](https://github.com/romaninsh/vantage/pull/230) without their own bumps. `vantage-aws` 0.4.7 retitles the json-1 pagination entry from [#231](https://github.com/romaninsh/vantage/pull/231) under the new version. So this PR also dogfoods the check.

`publish = false` crates are skipped. Both the `vantage` umbrella crate and `vantage-aws` are excluded from the workspace but each has its own `[package]`, so the workflow still catches changes to them — that's intended; `cargo release --workspace` couldn't see them either.