### PR TITLE
Re-release crates, due to ripples after vantage-type 0.4.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-pool"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4213,7 +4213,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-live"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4262,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-trait",
  "bson",
@@ -4308,7 +4308,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bakery_model3",

--- a/vantage-api-pool/CHANGELOG.md
+++ b/vantage-api-pool/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3 — 2026-05-09
+
+- Pins `vantage-types` to `>= 0.4.2`.
+
 ## 0.1.2 — 2026-05-03
 
 - HTTP worker pool, request/response matcher, and all paginator variants now wrap their spawned futures with `tracing::Instrument::in_current_span()` so the caller's span follows the future across the `tokio::spawn` boundary. Any tracing layer the consumer installs sees background-task events as descendants of the originating request.

--- a/vantage-api-pool/Cargo.toml
+++ b/vantage-api-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "vantage-api-pool"
-version = "0.1.2"
+version = "0.1.3"
 license = "MIT OR Apache-2.0"
 description = "Paginated REST API client pool for Vantage"
 
@@ -23,7 +23,7 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.4.2", path = "../vantage-table" }
-vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
+vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["serde"] }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/vantage-csv/CHANGELOG.md
+++ b/vantage-csv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.9 — 2026-05-09
+
+- Pins `vantage-types` to `>= 0.4.2`. The `AnyCsvType` `TerminalRender` impl returns `RichText` and needs the trait shape from `vantage-types 0.4.2`.
+
 ## 0.4.8 — 2026-05-04
 
 - Implements [`TableShell::driver_name`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.driver_name) — `Vista::driver()` reports `"csv"` for tables wrapped through `csv.vista_factory()`.

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.4.8"
+version = "0.4.9"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"
@@ -24,7 +24,7 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.4.4", path = "../vantage-table" }
-vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
+vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.4.4", path = "../vantage-vista", optional = true }
 
 [dev-dependencies]

--- a/vantage-live/CHANGELOG.md
+++ b/vantage-live/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.6 — 2026-05-09
+
+- Pins `vantage-types` to `>= 0.4.2` so cargo can't resolve back to the pre-`RichText` trait shape.
+
 ## 0.4.5 — 2026-05-03
 
 - The write-queue worker and live-event consumer wrap their spawned futures with `tracing::Instrument::in_current_span()` so the caller's span follows the future across the `tokio::spawn` boundary. With a tracing layer installed (e.g. `sentry-tracing`, `tracing-opentelemetry`), worker errors and panics stitch into the same trace as the originating write request rather than appearing as orphans.

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-live"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-types = { version = "0.4", path = "../vantage-types" }
+vantage-types = { version = "0.4.2", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
 vantage-table = { version = "0.4.8", path = "../vantage-table" }

--- a/vantage-mongodb/CHANGELOG.md
+++ b/vantage-mongodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.8 — 2026-05-09
+
+- Pins `vantage-types` to `>= 0.4.2` for consistency with the other backends after the `TerminalRender → RichText` migration.
+
 ## 0.4.7 — 2026-05-04
 
 - Implements [`TableShell::driver_name`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.driver_name) — `Vista::driver()` reports `"mongodb"` for collections wrapped through `MongoDB::vista_factory()`.

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"
@@ -12,7 +12,7 @@ vista = ["dep:vantage-vista"]
 
 [dependencies]
 vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-types = { version = "0.4", path = "../vantage-types" }
+vantage-types = { version = "0.4.2", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.4.4", path = "../vantage-table" }
 vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.5 — 2026-05-09
+
+- Pins `vantage-types` to `>= 0.4.2`. The `RichText`-returning `TerminalRender` impls landed in 0.4.4 alongside `vantage-types 0.4.2`; without an explicit floor, cargo could resolve `vantage-types` to 0.4.0/0.4.1 and fail to compile against the old trait shape.
+
 ## 0.4.4 — 2026-05-04
 
 - New optional `vista` feature wires SQLite, Postgres, and MySQL into [`vantage-vista`](https://docs.rs/vantage-vista). Call `db.vista_factory().from_table(table)` to expose any typed `Table<…>` as a `Vista`, or load a YAML spec via `build_from_spec` for config-driven setups.

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -18,7 +18,7 @@ vista = ["dep:vantage-vista"]
 
 [dependencies]
 vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
+vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["serde"] }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 paste = "1.0"
 

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+## 0.4.4 — 2026-05-09
+
+- Pins `vantage-types` to `>= 0.4.2` so cargo can't resolve back to a pre-`RichText` 0.4.x.
+
 ## 0.4.3 — 2026-05-09
 
-- `TerminalRender for AnySurrealType` now returns `vantage_types::RichText` (with semantic `Style::Muted` / `Success` / `Error`) instead of `String` + a separate `color_hint()`, tracking the [`vantage-types 0.4.2`](https://docs.rs/vantage-types/0.4.2/) trait change.
+- `TerminalRender for AnySurrealType` now returns `vantage_types::RichText` (with semantic
+  `Style::Muted` / `Success` / `Error`) instead of `String` + a separate `color_hint()`, tracking
+  the [`vantage-types 0.4.2`](https://docs.rs/vantage-types/0.4.2/) trait change.
 
 ## 0.4.2 — 2026-04-19
 

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.4.3"
+version = "0.4.4"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"
@@ -19,7 +19,7 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions", features = ["chrono"] }
 vantage-table = { version = "0.4.2", path = "../vantage-table" }
 vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
-vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
+vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["serde"] }
 surreal-client = { version = "0.4", path = "../surreal-client" }
 
 ciborium = "0.2"


### PR DESCRIPTION
nothing to see here- just compatibility release.