### PR TITLE
add surrealdb vista driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-trait",
  "bakery_model3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4348,6 +4348,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
+ "serde_yaml_ng",
  "surreal-client",
  "thiserror 2.0.18",
  "tokio",
@@ -4357,6 +4358,7 @@ dependencies = [
  "vantage-expressions",
  "vantage-table",
  "vantage-types",
+ "vantage-vista",
 ]
 
 [[package]]

--- a/bakery_model3/CHANGELOG.md
+++ b/bakery_model3/CHANGELOG.md
@@ -1,7 +1,0 @@
-# Changelog
-
-## 0.4.1 — 2026-05-10
-
-- `cli-vista` example gains a `surreal` source, joining `csv`, `sqlite`, `postgres`, and `mongo`. Run e.g. `cargo run --example cli-vista -- surreal bakery list` against the v2 bakery database (or override with `SURREALDB_URL`).
-- `cli` example clarifies its role: it stays on `AnyTable` because it demonstrates `ref` traversal, which Vista doesn't surface yet. For Vista-backed work, prefer `cli-vista`.
-- Pulls in [`vantage-surrealdb 0.4.5`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/) with the `vista` feature enabled, so the bakery models work uniformly across every Vista driver in the workspace.

--- a/bakery_model3/CHANGELOG.md
+++ b/bakery_model3/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.4.1 — 2026-05-10
+
+- `cli-vista` example gains a `surreal` source, joining `csv`, `sqlite`, `postgres`, and `mongo`. Run e.g. `cargo run --example cli-vista -- surreal bakery list` against the v2 bakery database (or override with `SURREALDB_URL`).
+- `cli` example clarifies its role: it stays on `AnyTable` because it demonstrates `ref` traversal, which Vista doesn't surface yet. For Vista-backed work, prefer `cli-vista`.
+- Pulls in [`vantage-surrealdb 0.4.5`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/) with the `vista` feature enabled, so the bakery models work uniformly across every Vista driver in the workspace.

--- a/bakery_model3/Cargo.toml
+++ b/bakery_model3/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bakery_model3"
-version = "0.4.1"
+version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 vantage-core = { path = "../vantage-core" }

--- a/bakery_model3/Cargo.toml
+++ b/bakery_model3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bakery_model3"
-version = "0.1.0"
+version = "0.4.1"
 edition = "2024"
 
 [dependencies]

--- a/bakery_model3/Cargo.toml
+++ b/bakery_model3/Cargo.toml
@@ -14,7 +14,7 @@ vantage-types = { path = "../vantage-types" }
 vantage-sql = { path = "../vantage-sql", features = ["sqlite", "postgres", "vista"] }
 vantage-mongodb = { path = "../vantage-mongodb", features = ["vista"] }
 vantage-aws = { path = "../vantage-aws" }
-vantage-surrealdb = { path = "../vantage-surrealdb" }
+vantage-surrealdb = { path = "../vantage-surrealdb", features = ["vista"] }
 surreal-client = { path = "../surreal-client", features = ["decimal"] }
 bson = "2"
 serde_json = "1"

--- a/bakery_model3/examples/cli-vista.rs
+++ b/bakery_model3/examples/cli-vista.rs
@@ -2,7 +2,7 @@
 //!
 //! Usage: db-vista [--debug] <source> <entity> [command ...]
 //!
-//! Sources: csv, sqlite, postgres, mongo
+//! Sources: csv, sqlite, postgres, mongo, surreal
 //! Entities: bakery, client, product, order
 //!
 //! Commands:
@@ -14,6 +14,7 @@
 
 use bakery_model3::*;
 use clap::{Arg, Command};
+use surreal_client::SurrealConnection;
 use vantage_cli_util::render_records;
 use vantage_csv::Csv;
 use vantage_dataset::prelude::*;
@@ -161,9 +162,35 @@ async fn build_vista(source: &str, entity_name: &str) -> vantage_core::Result<Op
             };
             Ok(Some(vista))
         }
+        "surreal" => {
+            let dsn = std::env::var("SURREALDB_URL")
+                .unwrap_or_else(|_| "cbor://root:root@localhost:8000/bakery/v2".to_string());
+            let client = SurrealConnection::dsn(&dsn)
+                .map_err(|e| {
+                    vantage_core::error!("Invalid SurrealDB DSN", details = e.to_string())
+                })?
+                .connect()
+                .await
+                .map_err(|e| {
+                    vantage_core::error!("Failed to connect to SurrealDB", details = e.to_string())
+                })?;
+            let db = SurrealDB::new(client);
+            let factory = db.vista_factory();
+            let vista = match entity_name {
+                "bakery" => factory.from_table(Bakery::surreal_table(db))?,
+                "client" => factory.from_table(Client::surreal_table(db))?,
+                "product" => factory.from_table(Product::surreal_table(db))?,
+                "order" => factory.from_table(Order::surreal_table(db))?,
+                _ => {
+                    println!("Unknown entity: {}", entity_name);
+                    return Ok(None);
+                }
+            };
+            Ok(Some(vista))
+        }
         _ => {
             println!(
-                "Unknown source: {}. Use: csv, sqlite, postgres, mongo",
+                "Unknown source: {}. Use: csv, sqlite, postgres, mongo, surreal",
                 source
             );
             Ok(None)
@@ -175,7 +202,7 @@ fn print_usage() {
     println!();
     println!("Usage: db-vista [--debug] <source> <entity> <command>");
     println!();
-    println!("Sources: csv, sqlite, postgres, mongo");
+    println!("Sources: csv, sqlite, postgres, mongo, surreal");
     println!();
     println!("Commands:");
     println!("  list              List all records");
@@ -189,6 +216,7 @@ fn print_usage() {
     println!("  db-vista csv bakery list");
     println!("  db-vista sqlite product list");
     println!("  db-vista mongo bakery count");
+    println!("  db-vista surreal bakery list");
     println!(r#"  db-vista postgres bakery add myid '{{"name":"Test","profit_margin":10}}'"#);
     println!("  db-vista postgres bakery delete myid");
 }

--- a/bakery_model3/examples/cli.rs
+++ b/bakery_model3/examples/cli.rs
@@ -1,4 +1,4 @@
-//! Multi-backend CLI for browsing and managing bakery data.
+//! Multi-backend AnyTable CLI for browsing bakery data with reference traversal.
 //!
 //! Usage: db [--debug] [--backend surreal|dynamodb] <entity> [command ...]
 //!
@@ -11,6 +11,11 @@
 //!   add <id> <json>   Insert a record
 //!   delete <id>       Delete a record by ID
 //!   ref <name>        Traverse a relationship and list the target table
+//!
+//! For backends with a Vista driver (csv, sqlite, postgres, mongo, surreal),
+//! prefer the `cli-vista` example — it exposes a uniform Vista surface and
+//! advertises capabilities. This example sticks with `AnyTable` so it can
+//! demonstrate `ref` traversal, which Vista doesn't surface yet.
 
 use bakery_model3::*;
 use clap::{Arg, Command};

--- a/bakery_model4/Cargo.toml
+++ b/bakery_model4/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bakery_model4"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 vantage-core = { path = "../vantage-core" }

--- a/cbor-test/Cargo.toml
+++ b/cbor-test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cbor-test"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 
 

--- a/learn-1/Cargo.toml
+++ b/learn-1/Cargo.toml
@@ -2,6 +2,7 @@
 name = "learn-1"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/learn-2/Cargo.toml
+++ b/learn-2/Cargo.toml
@@ -2,6 +2,7 @@
 name = "learn-2"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/learn-3/Cargo.toml
+++ b/learn-3/Cargo.toml
@@ -2,6 +2,7 @@
 name = "learn-3"
 version = "0.1.0"
 edition = "2024"
+publish = false
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.5 — 2026-05-10
+
+New opt-in [`vista`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/vista/struct.SurrealVistaFactory.html) feature: build a [`Vista`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html) from a typed `Table<SurrealDB, E>` or from YAML, with full read+write CRUD and server-side `eq` push-down.
+
+- `SurrealDB::vista_factory()` returns a [`SurrealVistaFactory`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/vista/struct.SurrealVistaFactory.html); `from_table` and `from_yaml` both produce a `Vista`. `from_table` preserves the entity type so `with_expression` closures still typecheck.
+- YAML `surreal:` block carries `table` (override the SurrealDB table name); per-column `surreal: { field }` aliases the field name. The `thing` / `record` column type maps to [`Thing`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/thing/struct.Thing.html); `datetime` and `decimal` round-trip via `AnySurrealType`.
+- Vista's string id boundary translates `"table:id"` straight to `Thing`; bare ids get prefixed with the wrapped table's name, so `vista.get_value("biff")` works the same as `vista.get_value("client:biff")`.
+- [`TableShell::add_eq_condition`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.add_eq_condition) translates `(field, CborValue)` into `column.eq(value)` and pushes onto the wrapped table — `WHERE` is server-side.
+- Capabilities: `can_count`, `can_insert`, `can_update`, `can_delete` all true. `can_subscribe` deferred to a later live-query pass.
+- Off by default; non-vista users still don't depend on `vantage-vista`.
+- Bug fix: `get_table_value` now treats `SELECT FROM ONLY ... NONE` (CBOR `Tag(6, _)`) as "no row" alongside the existing `Null` case, so missing-record lookups consistently return `None` instead of erroring downstream.
+
 ## 0.4.4 — 2026-05-09
 
 - Pins `vantage-types` to `>= 0.4.2` so cargo can't resolve back to a pre-`RichText` 0.4.x.

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -12,6 +12,7 @@ autoexamples = false
 [features]
 default = ["decimal"]
 decimal = ["surreal-client/decimal", "rust_decimal"]
+vista = ["dep:vantage-vista"]
 
 [dependencies]
 async-trait = "0.1"
@@ -20,6 +21,7 @@ vantage-expressions = { version = "0.4", path = "../vantage-expressions", featur
 vantage-table = { version = "0.4.2", path = "../vantage-table" }
 vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["serde"] }
+vantage-vista = { version = "0.4.4", path = "../vantage-vista", optional = true }
 surreal-client = { version = "0.4", path = "../surreal-client" }
 
 ciborium = "0.2"
@@ -85,6 +87,8 @@ test = false
 
 [dev-dependencies]
 bakery_model3 = { path = "../bakery_model3" }
+serde_yaml_ng = "0.10"
+vantage-vista = { version = "0.4.4", path = "../vantage-vista" }
 
 [[example]]
 name = "expr"

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.4.4"
+version = "0.4.5"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/lib.rs
+++ b/vantage-surrealdb/src/lib.rs
@@ -31,6 +31,9 @@ pub mod thing;
 // pub mod typed_expression;
 // pub mod variable;
 
+#[cfg(feature = "vista")]
+pub mod vista;
+
 // Re-export statement builders at crate root for convenience
 pub use statements::SurrealDelete;
 pub use statements::SurrealInsert;

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -177,9 +177,10 @@ impl TableSource for SurrealDB {
         let query = crate::surreal_expr!("SELECT * FROM ONLY {}", (id.clone()));
         let result = self.execute(&query).await?;
 
-        // `SELECT ... FROM ONLY` returns Null (in cbor) when no row matches.
+        // `SELECT ... FROM ONLY` returns NONE (Tag(6, _)) or plain Null when
+        // no row matches.
         let value = result.into_value();
-        if matches!(value, ciborium::Value::Null) {
+        if matches!(value, ciborium::Value::Null | ciborium::Value::Tag(6, _)) {
             return Ok(None);
         }
 

--- a/vantage-surrealdb/src/vista/factory.rs
+++ b/vantage-surrealdb/src/vista/factory.rs
@@ -1,0 +1,199 @@
+//! `SurrealVistaFactory` — typed-table and YAML entry points, plus the
+//! `VistaFactory` trait impl. SurrealDB advertises full read/write/count.
+
+use vantage_core::{Result, error};
+use vantage_table::column::core::Column as TableColumn;
+use vantage_table::column::flags::ColumnFlag;
+use vantage_table::table::Table;
+use vantage_table::traits::column_like::ColumnLike;
+use vantage_types::{EmptyEntity, Entity};
+use vantage_vista::{
+    Column as VistaColumn, NoExtras, Vista, VistaCapabilities, VistaFactory, VistaMetadata,
+    flags as vista_flags,
+};
+
+use crate::surrealdb::SurrealDB;
+use crate::thing::Thing;
+use crate::types::AnySurrealType;
+use crate::vista::source::SurrealTableShell;
+use crate::vista::spec::{SurrealColumnExtras, SurrealTableExtras, SurrealVistaSpec};
+
+pub struct SurrealVistaFactory {
+    db: SurrealDB,
+}
+
+impl SurrealVistaFactory {
+    pub fn new(db: SurrealDB) -> Self {
+        Self { db }
+    }
+
+    /// Wrap a typed table as a Vista. Column metadata is harvested from the
+    /// table; CRUD goes through `Table`'s reading path. The original entity
+    /// type is preserved so `with_expression` closures remain typecheckable.
+    pub fn from_table<E>(&self, table: Table<SurrealDB, E>) -> Result<Vista>
+    where
+        E: Entity<AnySurrealType> + 'static,
+    {
+        let name = table.table_name().to_string();
+        Ok(self.wrap(table, name))
+    }
+
+    /// Single source-construction site shared by `from_table` and
+    /// `build_from_spec`.
+    fn wrap<E>(&self, table: Table<SurrealDB, E>, name: String) -> Vista
+    where
+        E: Entity<AnySurrealType> + 'static,
+    {
+        let metadata = metadata_from_table(&table);
+        let source = SurrealTableShell::new(
+            table,
+            VistaCapabilities {
+                can_count: true,
+                can_insert: true,
+                can_update: true,
+                can_delete: true,
+                ..VistaCapabilities::default()
+            },
+        );
+        Vista::new(name, Box::new(source), metadata)
+    }
+
+    /// Build a `Table<SurrealDB, EmptyEntity>` from a spec.
+    pub fn table_from_spec(
+        &self,
+        spec: &SurrealVistaSpec,
+    ) -> Result<Table<SurrealDB, EmptyEntity>> {
+        let table_name = spec
+            .driver
+            .surreal
+            .as_ref()
+            .and_then(|m| m.table.clone())
+            .unwrap_or_else(|| spec.name.clone());
+
+        let mut table = Table::<SurrealDB, EmptyEntity>::new(table_name, self.db.clone());
+
+        for (name, col_spec) in &spec.columns {
+            table.add_column(build_column(name, col_spec)?);
+            if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
+                table.add_title_field(name);
+            }
+        }
+
+        let id_column = resolve_id_column(spec);
+        if !table.columns().contains_key(&id_column) {
+            return Err(error!(
+                "id column not present in spec.columns",
+                id = id_column
+            ));
+        }
+        table.set_id_field(&id_column);
+
+        Ok(table)
+    }
+}
+
+impl VistaFactory for SurrealVistaFactory {
+    type TableExtras = SurrealTableExtras;
+    type ColumnExtras = SurrealColumnExtras;
+    type ReferenceExtras = NoExtras;
+
+    fn build_from_spec(&self, spec: SurrealVistaSpec) -> Result<Vista> {
+        let vista_name = spec.name.clone();
+        let table = self.table_from_spec(&spec)?;
+        let mut vista = self.wrap(table, vista_name.clone());
+        vista.set_name(vista_name);
+        Ok(vista)
+    }
+}
+
+pub(crate) fn resolve_id_column(spec: &SurrealVistaSpec) -> String {
+    if let Some(id) = &spec.id_column {
+        return id.clone();
+    }
+    for (name, col_spec) in &spec.columns {
+        if col_spec.flags.iter().any(|f| f == vista_flags::ID) {
+            return name.clone();
+        }
+    }
+    "id".to_string()
+}
+
+pub(crate) fn build_column(
+    name: &str,
+    col_spec: &vantage_vista::ColumnSpec<SurrealColumnExtras>,
+) -> Result<TableColumn<AnySurrealType>> {
+    let ty = col_spec.col_type.as_deref().unwrap_or("string");
+    let alias = col_spec
+        .driver
+        .surreal
+        .as_ref()
+        .and_then(|b| b.field.clone())
+        .filter(|s| s != name);
+    let hidden = col_spec.flags.iter().any(|f| f == vista_flags::HIDDEN);
+
+    let mut col = column_for_type(name, ty)?;
+    if let Some(alias) = alias {
+        col = col.with_alias(alias);
+    }
+    if hidden {
+        col = col.with_flag(ColumnFlag::Hidden);
+    }
+    Ok(col)
+}
+
+/// YAML type alias → typed `Column` (then erased to `Column<AnySurrealType>`).
+pub(crate) fn column_for_type(name: &str, ty: &str) -> Result<TableColumn<AnySurrealType>> {
+    let col: TableColumn<AnySurrealType> = match ty {
+        "int" | "integer" | "i64" | "i32" => {
+            TableColumn::from_column(TableColumn::<i64>::new(name))
+        }
+        "float" | "double" | "f64" | "f32" => {
+            TableColumn::from_column(TableColumn::<f64>::new(name))
+        }
+        "bool" | "boolean" => TableColumn::from_column(TableColumn::<bool>::new(name)),
+        "string" | "text" | "str" => TableColumn::from_column(TableColumn::<String>::new(name)),
+        "thing" | "record" | "record_id" => {
+            TableColumn::from_column(TableColumn::<Thing>::new(name))
+        }
+        "datetime" => {
+            TableColumn::from_column(TableColumn::<chrono::DateTime<chrono::Utc>>::new(name))
+        }
+        #[cfg(feature = "decimal")]
+        "decimal" | "numeric" => {
+            TableColumn::from_column(TableColumn::<rust_decimal::Decimal>::new(name))
+        }
+        other => {
+            return Err(error!(
+                "Unknown YAML column type",
+                column = name,
+                ty = other.to_string()
+            ));
+        }
+    };
+    Ok(col)
+}
+
+pub(crate) fn metadata_from_table<T, E>(table: &Table<T, E>) -> VistaMetadata
+where
+    T: vantage_table::traits::table_source::TableSource,
+    E: Entity<T::Value>,
+    T::Column<T::AnyType>: ColumnLike<T::AnyType>,
+{
+    let mut metadata = VistaMetadata::new();
+    for (name, col) in table.columns() {
+        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+        if col.flags().contains(&ColumnFlag::Hidden) {
+            vc = vc.with_flag(vista_flags::HIDDEN);
+        }
+        metadata = metadata.with_column(vc);
+    }
+    if let Some(id_field) = table.id_field() {
+        metadata = metadata.with_id_column(id_field.name().to_string());
+    }
+    for title in table.title_fields() {
+        if let Some(col) = metadata.columns.get_mut(title) {
+            col.flags.push(vista_flags::TITLE.to_string());
+        }
+    }
+    metadata
+}

--- a/vantage-surrealdb/src/vista/mod.rs
+++ b/vantage-surrealdb/src/vista/mod.rs
@@ -1,0 +1,30 @@
+//! Vista bridge for the SurrealDB backend.
+//!
+//! Construct a `Vista` from a typed `Table<SurrealDB, E>` via
+//! `SurrealDB::vista_factory()`, or from a YAML spec via
+//! `SurrealVistaFactory::from_yaml`. The YAML path builds a
+//! `Table<SurrealDB, EmptyEntity>` first and then routes through `from_table` —
+//! one construction path, one reading path.
+//!
+//! `AnySurrealType` already wraps `ciborium::Value`, so the boundary
+//! translation is a passthrough; `Thing` ids stringify as `"table:id"`.
+
+pub mod factory;
+pub mod source;
+pub mod spec;
+
+pub use factory::SurrealVistaFactory;
+pub use source::SurrealTableShell;
+pub use spec::{
+    SurrealColumnBlock, SurrealColumnExtras, SurrealTableBlock, SurrealTableExtras,
+    SurrealVistaSpec,
+};
+
+use crate::surrealdb::SurrealDB;
+
+impl SurrealDB {
+    /// Return a Vista factory bound to this SurrealDB data source.
+    pub fn vista_factory(&self) -> SurrealVistaFactory {
+        SurrealVistaFactory::new(self.clone())
+    }
+}

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -1,0 +1,201 @@
+//! `SurrealTableShell` — owns the typed `Table<SurrealDB, E>` and exposes it
+//! through the `TableShell` boundary.
+//!
+//! The shell is generic in `E` so `with_expression` closures (parameterized
+//! over `E`) survive the wrap; `Vista` erases `E` once at the
+//! `Box<dyn TableShell>` boundary.
+//!
+//! Vista exposes ids as `String`. SurrealDB's native id is `Thing`
+//! (`table:id`). The shell stringifies via `Thing::to_string()` on the way
+//! out and parses back via `String::contains(':')` on the way in — bare ids
+//! get prefixed with the wrapped table's name.
+//!
+//! `AnySurrealType` already wraps `ciborium::Value`, so the value boundary
+//! is a straight unwrap/rewrap.
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_dataset::traits::{InsertableValueSet, ReadableValueSet, WritableValueSet};
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Entity, Record};
+use vantage_vista::{TableShell, Vista, VistaCapabilities};
+
+use crate::operation::SurrealOperation;
+use crate::surrealdb::SurrealDB;
+use crate::thing::Thing;
+use crate::types::AnySurrealType;
+
+pub struct SurrealTableShell<E = EmptyEntity>
+where
+    E: Entity<AnySurrealType>,
+{
+    pub(crate) table: Table<SurrealDB, E>,
+    pub(crate) capabilities: VistaCapabilities,
+}
+
+impl<E> SurrealTableShell<E>
+where
+    E: Entity<AnySurrealType>,
+{
+    pub(crate) fn new(table: Table<SurrealDB, E>, capabilities: VistaCapabilities) -> Self {
+        Self {
+            table,
+            capabilities,
+        }
+    }
+
+    /// Resolve a Vista-side string id into a SurrealDB `Thing`. A `table:id`
+    /// pair is parsed verbatim; a bare id gets prefixed with the wrapped
+    /// table's name so `vista.get_value("biff")` works the same as
+    /// `vista.get_value("client:biff")`.
+    fn parse_id(&self, id: &str) -> Thing {
+        if id.contains(':') {
+            id.parse::<Thing>()
+                .unwrap_or_else(|_| Thing::new(self.table.table_name(), id))
+        } else {
+            Thing::new(self.table.table_name(), id)
+        }
+    }
+}
+
+fn to_cbor_record(record: Record<AnySurrealType>) -> Record<CborValue> {
+    record
+        .into_iter()
+        .map(|(k, v)| (k, v.into_value()))
+        .collect()
+}
+
+fn to_native_record(record: &Record<CborValue>) -> Record<AnySurrealType> {
+    record
+        .iter()
+        .map(|(k, v)| (k.clone(), AnySurrealType::from(v.clone())))
+        .collect()
+}
+
+#[async_trait]
+impl<E> TableShell for SurrealTableShell<E>
+where
+    E: Entity<AnySurrealType> + 'static,
+{
+    async fn list_vista_values(
+        &self,
+        _vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        let raw = self.table.list_values().await?;
+        Ok(raw
+            .into_iter()
+            .map(|(thing, record)| (thing.to_string(), to_cbor_record(record)))
+            .collect())
+    }
+
+    async fn get_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        let thing = self.parse_id(id);
+        let Some(record) = self.table.get_value(&thing).await? else {
+            return Ok(None);
+        };
+        Ok(Some(to_cbor_record(record)))
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        _vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        let Some((thing, record)) = self.table.get_some_value().await? else {
+            return Ok(None);
+        };
+        Ok(Some((thing.to_string(), to_cbor_record(record))))
+    }
+
+    async fn get_vista_count(&self, _vista: &Vista) -> Result<i64> {
+        self.table.get_count().await
+    }
+
+    async fn insert_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let thing = self.parse_id(id);
+        let inserted = self
+            .table
+            .insert_value(&thing, &to_native_record(record))
+            .await?;
+        Ok(to_cbor_record(inserted))
+    }
+
+    async fn replace_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let thing = self.parse_id(id);
+        let replaced = self
+            .table
+            .replace_value(&thing, &to_native_record(record))
+            .await?;
+        Ok(to_cbor_record(replaced))
+    }
+
+    async fn patch_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        partial: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let thing = self.parse_id(id);
+        let patched = self
+            .table
+            .patch_value(&thing, &to_native_record(partial))
+            .await?;
+        Ok(to_cbor_record(patched))
+    }
+
+    async fn delete_vista_value(&self, _vista: &Vista, id: &String) -> Result<()> {
+        let thing = self.parse_id(id);
+        self.table.delete(&thing).await
+    }
+
+    async fn delete_vista_all_values(&self, _vista: &Vista) -> Result<()> {
+        self.table.delete_all().await
+    }
+
+    async fn insert_vista_return_id_value(
+        &self,
+        _vista: &Vista,
+        record: &Record<CborValue>,
+    ) -> Result<String> {
+        let thing = self
+            .table
+            .insert_return_id_value(&to_native_record(record))
+            .await?;
+        Ok(thing.to_string())
+    }
+
+    fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
+        let column = self
+            .table
+            .columns()
+            .get(field)
+            .ok_or_else(|| error!("Unknown column for eq condition", field = field))?
+            .clone();
+        let surreal_value = AnySurrealType::from(value.clone());
+        self.table.add_condition(column.eq(surreal_value));
+        Ok(())
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.capabilities
+    }
+
+    fn driver_name(&self) -> &'static str {
+        "surrealdb"
+    }
+}

--- a/vantage-surrealdb/src/vista/spec.rs
+++ b/vantage-surrealdb/src/vista/spec.rs
@@ -1,0 +1,98 @@
+//! YAML-facing types for the SurrealDB Vista driver.
+
+use serde::{Deserialize, Serialize};
+use vantage_vista::{NoExtras, VistaSpec};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SurrealTableExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub surreal: Option<SurrealTableBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SurrealTableBlock {
+    /// Override for the SurrealDB table name. Defaults to the spec name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub table: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SurrealColumnExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub surreal: Option<SurrealColumnBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SurrealColumnBlock {
+    /// SurrealDB field name when it differs from the spec column name.
+    /// The vista surfaces values under the spec name; the underlying field
+    /// is read/written under this alias.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+}
+
+pub type SurrealVistaSpec = VistaSpec<SurrealTableExtras, SurrealColumnExtras, NoExtras>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yaml_parses_into_surreal_vista_spec() {
+        let yaml = r#"
+name: client
+columns:
+  id:
+    type: thing
+    flags: [id]
+  name:
+    type: string
+    flags: [title, searchable]
+  is_paying_client:
+    type: bool
+surreal:
+  table: clients
+"#;
+        let spec: SurrealVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(spec.name, "client");
+        assert_eq!(spec.columns.len(), 3);
+        assert_eq!(
+            spec.driver
+                .surreal
+                .as_ref()
+                .and_then(|m| m.table.as_deref()),
+            Some("clients")
+        );
+        assert_eq!(spec.columns["id"].col_type.as_deref(), Some("thing"));
+        assert!(spec.columns["name"].flags.contains(&"title".to_string()));
+    }
+
+    #[test]
+    fn yaml_rejects_unknown_surreal_block_field() {
+        let yaml = r#"
+name: client
+columns:
+  id: { type: thing, flags: [id] }
+surreal:
+  table: clients
+  bogus: 1
+"#;
+        let err = serde_yaml_ng::from_str::<SurrealVistaSpec>(yaml).unwrap_err();
+        assert!(err.to_string().contains("bogus") || err.to_string().contains("unknown"));
+    }
+
+    #[test]
+    fn yaml_table_defaults_to_spec_name_when_block_omitted() {
+        let yaml = r#"
+name: clients
+columns:
+  id: { type: thing, flags: [id] }
+"#;
+        let spec: SurrealVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(spec.driver.surreal.is_none());
+    }
+}

--- a/vantage-surrealdb/tests/6_vista.rs
+++ b/vantage-surrealdb/tests/6_vista.rs
@@ -1,0 +1,269 @@
+//! Vista integration: typed `Table<SurrealDB, _>` → `Vista` and YAML → `Vista`.
+//!
+//! Requires a running SurrealDB. Set `SURREALDB_URL` (defaults to
+//! `cbor://root:root@localhost:8000/bakery/v2`). Each test runs in a fresh
+//! randomised database so parallel runs don't trigger transaction conflicts.
+
+#![cfg(feature = "vista")]
+
+use std::error::Error;
+
+use ciborium::Value as CborValue;
+use uuid::Uuid;
+use vantage_dataset::prelude::*;
+use vantage_expressions::ExprDataSource;
+use vantage_surrealdb::surreal_expr;
+use vantage_surrealdb::surrealdb::SurrealDB;
+use vantage_surrealdb::thing::Thing;
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+use vantage_vista::VistaFactory;
+
+use surreal_client::SurrealConnection;
+
+type TestResult = std::result::Result<(), Box<dyn Error>>;
+
+/// Build a per-test DSN with an isolated database name. The base DSN comes
+/// from `SURREALDB_URL` (root auth + host); each test substitutes its own
+/// database to avoid transaction conflicts between parallel runs.
+fn surreal_dsn(database: &str) -> String {
+    let base = std::env::var("SURREALDB_URL")
+        .unwrap_or_else(|_| "cbor://root:root@localhost:8000/bakery/v2".to_string());
+    let (prefix, _) = base.rsplit_once('/').unwrap_or((&base, ""));
+    format!("{}/{}", prefix, database)
+}
+
+async fn setup() -> (SurrealDB, String) {
+    let database = format!("vista_{}", Uuid::new_v4().simple());
+    let client = SurrealConnection::dsn(surreal_dsn(&database))
+        .expect("Invalid SURREALDB_URL DSN")
+        .connect()
+        .await
+        .expect("Failed to connect to SurrealDB");
+    let db = SurrealDB::new(client);
+    let table = format!("product_{}", Uuid::new_v4().simple());
+    (db, table)
+}
+
+fn product_table(db: SurrealDB, table_name: &str) -> Table<SurrealDB, EmptyEntity> {
+    Table::<SurrealDB, EmptyEntity>::new(table_name, db)
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price")
+        .with_column_of::<bool>("is_deleted")
+}
+
+async fn seed_row(
+    db: &SurrealDB,
+    table_name: &str,
+    id: &str,
+    name: &str,
+    price: i64,
+    is_deleted: bool,
+) -> std::result::Result<Thing, Box<dyn Error>> {
+    let record = format!("{}:{}", table_name, id);
+    let name_owned = name.to_string();
+    db.execute(&surreal_expr!(
+        &format!(
+            "CREATE {} SET name = {{}}, price = {{}}, is_deleted = {{}}",
+            record
+        ),
+        name_owned,
+        price,
+        is_deleted
+    ))
+    .await?;
+    Ok(Thing::new(table_name, id))
+}
+
+#[tokio::test]
+async fn vista_lists_typed_surreal_as_cbor() -> TestResult {
+    let (db, table_name) = setup().await;
+    seed_row(&db, &table_name, "alpha", "Alpha", 10, false).await?;
+    seed_row(&db, &table_name, "beta", "Beta", 20, true).await?;
+
+    let table = product_table(db.clone(), &table_name);
+    let vista = db.vista_factory().from_table(table)?;
+
+    assert_eq!(vista.name(), table_name);
+    assert_eq!(vista.get_id_column(), Some("id"));
+
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 2);
+
+    let alpha_key = format!("{}:alpha", table_name);
+    let alpha = rows.get(&alpha_key).expect("row alpha");
+    assert_eq!(
+        alpha.get("name"),
+        Some(&CborValue::Text("Alpha".to_string()))
+    );
+    assert_eq!(alpha.get("price"), Some(&CborValue::Integer(10i64.into())));
+    assert_eq!(alpha.get("is_deleted"), Some(&CborValue::Bool(false)));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_get_value_by_id() -> TestResult {
+    let (db, table_name) = setup().await;
+    seed_row(&db, &table_name, "alpha", "Alpha", 10, false).await?;
+
+    let table = product_table(db.clone(), &table_name);
+    let vista = db.vista_factory().from_table(table)?;
+
+    // Bare id — shell prefixes with table name.
+    let row = vista.get_value(&"alpha".to_string()).await?.expect("found");
+    assert_eq!(row.get("name"), Some(&CborValue::Text("Alpha".to_string())));
+
+    // Full record id also works.
+    let full = format!("{}:alpha", table_name);
+    let row2 = vista.get_value(&full).await?.expect("found");
+    assert_eq!(
+        row2.get("name"),
+        Some(&CborValue::Text("Alpha".to_string()))
+    );
+
+    let missing = vista.get_value(&"nope".to_string()).await?;
+    assert!(missing.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_count_with_eq_condition() -> TestResult {
+    let (db, table_name) = setup().await;
+    seed_row(&db, &table_name, "a", "A", 10, false).await?;
+    seed_row(&db, &table_name, "b", "B", 20, true).await?;
+    seed_row(&db, &table_name, "c", "C", 30, false).await?;
+
+    let table = product_table(db.clone(), &table_name);
+    let mut vista = db.vista_factory().from_table(table)?;
+
+    assert_eq!(vista.get_count().await?, 3);
+
+    vista.add_condition_eq("is_deleted", CborValue::Bool(false))?;
+    assert_eq!(vista.get_count().await?, 2);
+
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_yaml_loads_table_and_columns() -> TestResult {
+    let (db, table_name) = setup().await;
+    seed_row(&db, &table_name, "biff", "Biff", 99, false).await?;
+
+    let yaml = format!(
+        r#"
+name: product_view
+columns:
+  id:
+    type: thing
+    flags: [id]
+  name:
+    type: string
+    flags: [title, searchable]
+  price:
+    type: int
+surreal:
+  table: {}
+"#,
+        table_name
+    );
+
+    let vista = db.vista_factory().from_yaml(&yaml)?;
+
+    assert_eq!(vista.name(), "product_view");
+    assert_eq!(vista.get_id_column(), Some("id"));
+    assert_eq!(vista.get_title_columns(), vec!["name"]);
+
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 1);
+    let (_, row) = rows.into_iter().next().unwrap();
+    assert_eq!(row.get("name"), Some(&CborValue::Text("Biff".to_string())));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_writes_round_trip_via_cbor() -> TestResult {
+    let (db, table_name) = setup().await;
+    let table = product_table(db.clone(), &table_name);
+    let vista = db.vista_factory().from_table(table)?;
+
+    let record: Record<CborValue> = vec![
+        ("name".to_string(), CborValue::Text("Delta".into())),
+        ("price".to_string(), CborValue::Integer(99i64.into())),
+        ("is_deleted".to_string(), CborValue::Bool(false)),
+    ]
+    .into_iter()
+    .collect();
+
+    vista.insert_value(&"delta".to_string(), &record).await?;
+
+    let fetched = vista
+        .get_value(&"delta".to_string())
+        .await?
+        .expect("inserted");
+    assert_eq!(fetched.get("name"), Some(&CborValue::Text("Delta".into())));
+    assert_eq!(
+        fetched.get("price"),
+        Some(&CborValue::Integer(99i64.into()))
+    );
+
+    vista.delete(&"delta".to_string()).await?;
+    assert!(vista.get_value(&"delta".to_string()).await?.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_capabilities_advertise_read_write() -> TestResult {
+    let (db, table_name) = setup().await;
+    let table = product_table(db.clone(), &table_name);
+    let vista = db.vista_factory().from_table(table)?;
+
+    let caps = vista.capabilities();
+    assert!(caps.can_count);
+    assert!(caps.can_insert);
+    assert!(caps.can_update);
+    assert!(caps.can_delete);
+    assert!(!caps.can_subscribe);
+    assert_eq!(vista.driver(), "surrealdb");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_eq_condition_with_typed_value() -> TestResult {
+    let (db, table_name) = setup().await;
+    seed_row(&db, &table_name, "a", "Match", 10, false).await?;
+    seed_row(&db, &table_name, "b", "Other", 20, false).await?;
+
+    let table = product_table(db.clone(), &table_name);
+    let mut vista = db.vista_factory().from_table(table)?;
+
+    vista.add_condition_eq("name", CborValue::Text("Match".into()))?;
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 1);
+    let (_, row) = rows.into_iter().next().unwrap();
+    assert_eq!(row.get("name"), Some(&CborValue::Text("Match".into())));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_unknown_field_eq_errors() -> TestResult {
+    let (db, table_name) = setup().await;
+    let table = product_table(db.clone(), &table_name);
+    let mut vista = db.vista_factory().from_table(table)?;
+
+    let err = vista
+        .add_condition_eq("nonexistent", CborValue::Bool(true))
+        .expect_err("should reject unknown field");
+    assert!(err.to_string().contains("nonexistent"));
+
+    Ok(())
+}


### PR DESCRIPTION
SurrealDB is the fourth driver to slot into `Vista`, joining csv / sqlite-postgres / mongo from the earlier rounds of stage-4 rollout. Opt in with `features = ["vista"]`; non-vista users keep their existing dependency footprint.

```rust
let vista = db.vista_factory().from_table(Client::surreal_table(db.clone()))?;
let rows = vista.list_values().await?;       // CBOR records, "table:id" keys
vista.add_condition_eq("name", CborValue::Text("Biff".into()))?; // server-side WHERE
```

YAML loads through `from_yaml` with the same `surreal:` block / per-column `surreal: { field }` shape established by the Mongo driver. The `thing` / `record` column type maps to [`Thing`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/thing/struct.Thing.html); `datetime` and `decimal` round-trip through `AnySurrealType`. Bare ids passed to `get_value` get prefixed with the wrapped table's name, so `vista.get_value("biff")` works the same as `vista.get_value("client:biff")`.

### Typed shell preserves `with_expression`

`SurrealVistaFactory::from_table` is generic in `E` and the shell stores `Table<SurrealDB, E>` rather than erasing to `EmptyEntity` immediately. `with_expression` closures parameterised over `E` survive the wrap; erasure happens once at the `Box<dyn TableShell>` boundary inside `Vista::new`. The YAML path builds an `EmptyEntity` table first and then routes through the same `from_table`, so there's one construction path and one reading path.

### Capabilities and a small bug fix

`can_count`, `can_insert`, `can_update`, `can_delete` all true; `can_subscribe` waits for the live-query pass. [`TableShell::add_eq_condition`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.add_eq_condition) translates `(field, CborValue)` into `column.eq(value)` and pushes onto the wrapped table — `WHERE` is server-side.

While in `surrealdb/impls/table_source.rs`: `get_table_value` was treating only CBOR `Null` as "no row", but `SELECT FROM ONLY ... NONE` actually comes back as `Tag(6, _)`. Missing-record lookups were erroring downstream instead of returning `None`. Now both shapes resolve to `Ok(None)`.

The `bakery_model3` `cli-vista` example gains a `surreal` source so `db-vista surreal bakery list` works the same as the other backends.

### Versions

- `vantage-surrealdb` 0.4.4 → 0.4.5 (additive: new opt-in `vista` feature; bug fix for `get_table_value`)