### PR TITLE
various cleanups and fixes

### DIFF
--- a/.github/workflows/pr-version-check.yaml
+++ b/.github/workflows/pr-version-check.yaml
@@ -25,6 +25,9 @@ jobs:
           base_sha=$(git rev-parse "origin/${BASE_REF}")
           mapfile -t changed_files < <(git diff --name-only "${base_sha}"...HEAD)
 
+          # Legacy crates that are not under version-check governance.
+          ignored_crates=("vantage")
+
           # Map each changed file to the nearest ancestor dir with a publishable Cargo.toml.
           declare -A crate_set=()
           for f in "${changed_files[@]}"; do
@@ -33,6 +36,14 @@ jobs:
               if [ -f "$dir/Cargo.toml" ] && grep -q '^\[package\]' "$dir/Cargo.toml"; then
                 # Skip crates explicitly opted out of publishing.
                 if grep -qE '^publish\s*=\s*false' "$dir/Cargo.toml"; then
+                  break
+                fi
+                # Skip crates on the legacy ignore list.
+                skip=0
+                for ig in "${ignored_crates[@]}"; do
+                  if [ "$dir" = "$ig" ]; then skip=1; break; fi
+                done
+                if [ $skip -eq 1 ]; then
                   break
                 fi
                 crate_set[$dir]=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "bakery_model3",

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.8 — 2026-05-14
+
+- JSON-1.x `execute` now follows `nextToken` pagination directly (capped at 50 pages) — CloudWatch's `FilterLogEvents` and friends can return `events: []` plus a token while the log group is still being scanned, so a one-shot call would drop matches. Pages are merged under the operation's `array_key` and handed to `parse_records` as one synthesised response. Existing single-page protocols are unaffected. See [`vantage_aws::json1`](https://docs.rs/vantage-aws/0.4.8/vantage_aws/json1/index.html).
+- New [`vantage-aws/TODO.md`](https://github.com/romaninsh/vantage/blob/main/vantage-aws/TODO.md) documents the composite-key `get_value` gap on DynamoDB single-table designs (UI sheets on HASH+RANGE tables hit `ValidationException` today) along with the proposed `DynamoId` widening and condition-merge fix.
+
 ## 0.4.7 — 2026-05-09
 
 Auto-pagination for the JSON-1.x list endpoints — CloudWatch Logs and ECS now walk through `nextToken` until exhausted, so calls like `streams_table(aws).get().await` return every stream in a busy log group instead of just the first page. Behaviour-level breaking: anything that relied on first-page-only as an implicit cap should switch to `with_max_pages(1)`. ([#231](https://github.com/romaninsh/vantage/pull/231))

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-aws/TODO.md
+++ b/vantage-aws/TODO.md
@@ -1,0 +1,123 @@
+# TODO
+
+## Composite-key `get_value` for DynamoDB single-table designs
+
+`DynamoDB::get_table_value(id)` only builds a one-attribute `Key`
+(partition key), so it can't fetch items from tables with a composite
+primary key (HASH + RANGE). The fix is gated on giving `DynamoId` a
+sort-key half and teaching `get_table_value` to fill it from the
+table's pre-set conditions when present.
+
+### Symptom
+
+A `vantage-ui` page bound to a composite-key DynamoDB table loads the
+grid fine (Scan returns full items), but double-clicking a row to
+open the side sheet fails with:
+
+```
+ValidationException: The provided key element does not match the schema
+```
+
+Example from a real session (`cp_dynamo_subscriptions.yaml`):
+
+- Table: `ddb-odieplat-mercplat-dev-api`
+- Schema: HASH = `PK`, RANGE = `SK`
+- YAML pins `PK = "SUBSCRIPTION"` via `params:` and flags `SK` as the id
+- Grid passes the SK value to `get_value`; `get_value` sends
+  `{ SK: "USER#…SUB#…" }` as the Key — DynamoDB rejects it because the
+  partition key (`PK`) is missing.
+
+### Why the CLI doesn't hit it
+
+`vantage-cli-util::model_cli::run` (used by
+`examples/dynamo-single-table.rs`) never reaches `get_value`. For
+single-record mode (`subscription[0]`, `subscription id=…`) it adds
+an equality condition on the id field and calls `get_some_value()`,
+which does a `Scan` with `FilterExpression` and returns the first
+matching item. That sidesteps the key-shape issue but is O(table) per
+lookup — fine for a CLI, wrong for a UI sheet that fires on every
+double-click.
+
+### Current code shape
+
+- `src/dynamodb/id.rs` — `DynamoId(String)` carries only the partition
+  value; its module doc already calls out "Composite (partition + sort)
+  keys arrive in a follow-up."
+- `src/dynamodb/impls/table_source.rs:40-55` — `id_field_name` reads the
+  one `id_field` configured on the table; `key_for_id` builds a
+  one-entry `JsonMap`.
+- `src/dynamodb/impls/table_source.rs:163-183` — `get_table_value` calls
+  `key_for_id` directly with no awareness of the table's conditions.
+- `src/dynamodb/impls/table_source.rs` module header already documents
+  the limitation:
+  > Composite-key tables are partially supported: writes carry the full
+  > item, but `get_table_value` only knows the partition key (`DynamoId`
+  > is partition-only in v0). Sort-key tables work for Scan/Put/Delete
+  > when the caller hands in items containing both keys.
+
+### Proposed fix
+
+Two layers:
+
+1. **Widen `DynamoId`** to carry an optional sort-key half:
+   ```rust
+   pub struct DynamoId {
+       pub hash: AttributeValue,        // S or N today
+       pub range: Option<AttributeValue>,
+   }
+   ```
+   Keep `From<String>` / `Display` returning the hash-only shape so
+   existing callers don't break; add `with_range`, `hash_str`,
+   `range_str` accessors. `from_attr` returns just the hash half (the
+   call site at `item_to_record` doesn't know which attribute is the
+   range, so it stays single-half there).
+
+2. **Enrich the `Key` map in `get_table_value`** from the table's
+   `add_condition`-set equality conditions. When the table has an
+   `eq(field, value)` condition whose field isn't the id field, treat
+   the field as the partition-key counterpart and merge it into the
+   `Key` map. For the
+   `cp_dynamo_subscriptions.yaml` case this picks up
+   `PK = "SUBSCRIPTION"` automatically.
+
+   Sketch:
+   ```rust
+   async fn get_table_value(...) {
+       let id_field = id_field_name(table);
+       let mut key = key_for_id(&id_field, id)?;
+       for cond in table.conditions().iter() {
+           if let DynamoCondition::Eq { field, value } = cond {
+               if *field != id_field {
+                   key.insert(field.clone(), attr_to_json(value)?);
+               }
+           }
+       }
+       transport::get_item(self.aws(), table.table_name(), key).await
+   }
+   ```
+
+   This works for the common single-table-design pattern (`PK = constant,
+   SK = row id`) without forcing every caller to construct composite
+   `DynamoId`s. Tables with two genuinely-dynamic key halves still need
+   the wider `DynamoId` to round-trip the second half explicitly — call
+   that out in the function doc.
+
+### Tests to add
+
+`tests/dynamodb_live.rs` only covers a partition-key-only table
+(`vantage-demo-products`, `with_id_column("id")`). Add a second
+fixture that:
+
+- Provisions a composite-key table (HASH = `PK`, RANGE = `SK`).
+- Inserts an item with `PK = "TYPE#X"`, `SK = "ID#abc"`.
+- Builds the table with `with_id_column("SK")` + a static
+  `add_condition(eq("PK", "TYPE#X"))`.
+- Calls `get_value("ID#abc")` and asserts the item comes back.
+
+### Workaround until then
+
+UI code that needs the double-click sheet on a composite-key DynamoDB
+table can fall back to rendering whatever the grid already has loaded
+in memory (the row payload is the same shape as `GetItem` would
+return) rather than re-fetching by id. Tracked separately in
+`vantage-ui`.

--- a/vantage-aws/src/json1/mod.rs
+++ b/vantage-aws/src/json1/mod.rs
@@ -30,13 +30,69 @@ pub(crate) use transport::{json_aws_call, json1_call};
 /// Build the JSON-1.1 request body and post it. `target` is used
 /// verbatim as the `X-Amz-Target` header; `service` is both the SigV4
 /// service name and the URL hostname segment.
+///
+/// Follows `nextToken` pagination — CloudWatch's `FilterLogEvents`
+/// can hand back `events: []` plus a `nextToken` while it's still
+/// scanning the log group, so a single call isn't enough. We loop
+/// until the response has no `nextToken` (or empty), accumulating
+/// `op.array_key` entries from each page into one synthesised
+/// response that `parse_records` can fold as if it came back in one
+/// shot.
+///
+/// Cap at [`MAX_PAGES`] to avoid runaway loops if AWS keeps issuing
+/// tokens — that case shouldn't happen, but the safety belt is cheap.
 pub(crate) async fn execute(
     account: &AwsAccount,
     op: &OperationDescriptor<'_>,
     resolved: &[AwsCondition],
 ) -> Result<JsonValue> {
-    let body = build_json1_body(resolved)?;
-    json1_call(account, op.service, op.target, &JsonValue::Object(body)).await
+    const MAX_PAGES: usize = 50;
+    let base_body = build_json1_body(resolved)?;
+
+    let mut merged_array: Vec<JsonValue> = Vec::new();
+    let mut last_resp: Option<JsonValue> = None;
+    let mut next_token: Option<String> = None;
+
+    for page in 0..MAX_PAGES {
+        let mut body = base_body.clone();
+        if let Some(token) = &next_token {
+            body.insert("nextToken".to_string(), JsonValue::String(token.clone()));
+        }
+        let resp = json1_call(account, op.service, op.target, &JsonValue::Object(body)).await?;
+
+        if let Some(arr) = lookup_path(&resp, op.array_key).and_then(|v| v.as_array()) {
+            merged_array.extend(arr.iter().cloned());
+        }
+
+        let token = resp
+            .get("nextToken")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        last_resp = Some(resp);
+        match token {
+            Some(t) => next_token = Some(t),
+            None => break,
+        }
+        if page + 1 == MAX_PAGES {
+            eprintln!(
+                "vantage-aws: nextToken pagination hit max-page cap \
+                 ({MAX_PAGES} pages) for {}; truncating",
+                op.target
+            );
+        }
+    }
+
+    // Stitch the accumulated array back onto the last response so
+    // downstream `parse_records` reads the merged page set under
+    // `op.array_key`. The last response also carries any non-array
+    // metadata callers may want (search statistics, etc.).
+    let mut resp = last_resp.expect("loop ran at least once");
+    if let JsonValue::Object(ref mut map) = resp {
+        map.insert(op.array_key.to_string(), JsonValue::Array(merged_array));
+    }
+    Ok(resp)
 }
 
 /// Pull the configured array out of the response and build records

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.6 — 2026-05-14
+
+- Drop the `arbitrary_precision` feature flag from the `serde_json` dependency. It enabled a global mode that wraps numbers as `{"$serde_json::private::Number": "..."}` objects, which broke ad-hoc JSON inspection and forced every consumer of vantage-surrealdb's `serde_json::Value` outputs to opt into the same flag. `preserve_order` and `raw_value` are retained.
+
 ## 0.4.5 — 2026-05-10
 
 New opt-in [`vista`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/vista/struct.SurrealVistaFactory.html) feature: build a [`Vista`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html) from a typed `Table<SurrealDB, E>` or from YAML, with full read+write CRUD and server-side `eq` push-down.

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -28,11 +28,7 @@ ciborium = "0.2"
 hex = "0.4"
 indexmap = { version = "2.12.0", features = ["serde"] }
 paste = "1.0"
-serde_json = { version = "1", features = [
-    "preserve_order",
-    "raw_value",
-    "arbitrary_precision",
-] }
+serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1.48", features = ["full"] }

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.4.5"
+version = "0.4.6"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage/Cargo.toml
+++ b/vantage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage"
-version = "0.2.1"
+version = "0.2.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -19,7 +19,11 @@ rust_decimal = { version = "1", features = ["db-postgres"] }
 tokio-postgres = { version = "0.7.13", features = ["with-serde_json-1"] }
 indexmap = { version = "2.11.4", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
-serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
+serde_json = { version = "1", features = [
+    "preserve_order",
+    "raw_value",
+    "arbitrary_precision",
+] }
 serde = { version = "1", features = ["derive"] }
 anyhow = "1.0.100"
 futures = "0.3.31"

--- a/vantage/Cargo.toml
+++ b/vantage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage/Cargo.toml
+++ b/vantage/Cargo.toml
@@ -19,11 +19,7 @@ rust_decimal = { version = "1", features = ["db-postgres"] }
 tokio-postgres = { version = "0.7.13", features = ["with-serde_json-1"] }
 indexmap = { version = "2.11.4", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
-serde_json = { version = "1", features = [
-    "preserve_order",
-    "raw_value",
-    "arbitrary_precision",
-] }
+serde_json = { version = "1", features = ["preserve_order", "raw_value"] }
 serde = { version = "1", features = ["derive"] }
 anyhow = "1.0.100"
 futures = "0.3.31"


### PR DESCRIPTION
Three independent fixes from a cleanup pass.

`vantage-aws` JSON-1 pagination was dropping rows. CloudWatch's `FilterLogEvents` can return `events: []` plus a `nextToken` while it's still walking the log group, so a single round-trip would silently come back empty even when matches existed further on. The `execute` path now loops until the response carries no token (capped at 50 pages as a safety belt), accumulates entries under the operation's `array_key`, and hands the merged result to `parse_records` as one synthesised response. The `with_max_pages(n)` cap from 0.4.7 still applies at the `AwsAccount` level; this fixes the lower-level call that wasn't honouring tokens yet.

`vantage-surrealdb` and `vantage` drop the `arbitrary_precision` feature on `serde_json`. It's a *global* feature — enabling it anywhere in the build graph flips the behaviour everywhere — and it wraps numbers as `{"$serde_json::private::Number": "..."}` on `Value` output, which breaks `serde_json::to_string`, makes downstream `Value::is_number()` return false, and forced every transitive dependent to opt in. `preserve_order` and `raw_value` stay.

New [`vantage-aws/TODO.md`](https://github.com/romaninsh/vantage/blob/main/vantage-aws/TODO.md) documents the composite-key `get_value` gap on DynamoDB single-table designs — tables with `HASH + RANGE` keys fail `vantage-ui`'s double-click sheet today with `ValidationException: The provided key element does not match the schema` because `DynamoId` is partition-only. The TODO sketches the `DynamoId` widening plus condition-merge fix; tracked, not yet fixed.

### Versions

- `vantage-aws` 0.4.7 → 0.4.8 (CloudWatch pagination fix; TODO doc)
- `vantage-surrealdb` 0.4.5 → 0.4.6 (`arbitrary_precision` drop)
- `vantage` 0.2.0 → 0.2.1 (`arbitrary_precision` drop)