### PR TITLE
switch rest-api to ciborium and add vista bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4046,7 +4046,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4117,7 +4117,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4415,7 +4415,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,6 +4050,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
+ "ciborium",
  "indexmap",
  "reqwest",
  "serde",
@@ -4062,6 +4063,7 @@ dependencies = [
  "vantage-expressions",
  "vantage-table",
  "vantage-types",
+ "vantage-vista",
 ]
 
 [[package]]
@@ -4126,6 +4128,7 @@ dependencies = [
  "vantage-dataset",
  "vantage-table",
  "vantage-types",
+ "vantage-vista",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-live"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.4 — 2026-05-14
+
+REST API now speaks [`ciborium::Value`](https://docs.rs/ciborium/) end-to-end and bridges into the universal [`Vista`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html) surface.
+
+- **Breaking**: `RestApi::Value` is now `ciborium::Value` instead of `serde_json::Value`. `eq_condition(field, value)` accepts anything that implements `Into<CborValue>` — so `eq_condition("userId", 1i64)` and `eq_condition("name", "Alice")` work without a wrapper macro. Existing callers passing `json!(...)` need to switch to the matching CBOR variant. Records returned from `list_values` carry `Record<CborValue>` now, which means master tables wrap into `AnyTable::from_table` directly — no JSON↔CBOR adapter boilerplate at the call site.
+- URI templates in table names get substituted from eq-conditions at request time. Declare a child table as `Table::new("users/{userId}/albums", api)` and a parent's `id=1` condition lowers to `GET /users/1/albums`, with `userId` peeled out of the query string. Lets `with_many` / `with_one` traversal hit nested REST endpoints natively.
+- [`related_in_condition`](https://docs.rs/vantage-api-client/0.1.4/vantage_api_client/struct.RestApi.html) is implemented: `with_many` re-keys an existing eq-condition onto the child's FK field, and `with_one` resolves the parent record on demand through a deferred condition that's executed at fetch time. No more `unimplemented!()` panic for REST API references.
+- New [`vista_factory`](https://docs.rs/vantage-api-client/0.1.4/vantage_api_client/struct.RestApi.html#method.vista_factory) method returns a `RestApiVistaFactory` that wraps a typed `Table<RestApi, E>` as a `Vista`. Columns, id field, title fields, and references are harvested up front; the original entity stays attached for reference traversal.
+- New `examples/jsonplaceholder.rs` demo — model-driven CLI over <https://jsonplaceholder.typicode.com> using the new Vista bridge and the `vista_cli` runner from [`vantage-cli-util 0.4.2`](https://docs.rs/vantage-cli-util/0.4.2/vantage_cli_util/). Run `cargo run --example jsonplaceholder -- users id=1 :albums`.
+
 ## 0.1.3 — 2026-05-09
 
 Opt-in [`RestApiBuilder::no_pagination()`](https://docs.rs/vantage-api-client/0.1.3/vantage_api_client/struct.RestApiBuilder.html#method.no_pagination) for APIs that don't paginate. ([#230](https://github.com/romaninsh/vantage/pull/230))

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.1.3"
+version = "0.1.4"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST API backends"
@@ -19,7 +19,7 @@ vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.4.2", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.4", path = "../vantage-vista" }
+vantage-vista = { version = "0.4.5", path = "../vantage-vista" }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -8,6 +8,7 @@ description = "Vantage extension for REST API backends"
 
 [dependencies]
 async-trait = "0.1"
+ciborium = "0.2"
 indexmap = { version = "2", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -18,6 +19,7 @@ vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.4.2", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
+vantage-vista = { version = "0.4", path = "../vantage-vista" }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/vantage-api-client/examples/jsonplaceholder.rs
+++ b/vantage-api-client/examples/jsonplaceholder.rs
@@ -1,0 +1,309 @@
+//! `jsonplaceholder` — model-driven CLI over the public
+//! <https://jsonplaceholder.typicode.com> demo API.
+//!
+//! Three typed entities live behind it: User, Album, Photo. Albums
+//! belong to a User; Photos belong to an Album. The factory wires each
+//! parent's `with_many` reference to a child table built around a URI
+//! template — for example, traversing `users id=1 :albums` lowers to
+//! `GET /users/1/albums`, with `userId` peeled out of the conditions
+//! and substituted into the URL path.
+//!
+//! Usage:
+//!
+//! ```sh
+//! cargo run --example jsonplaceholder -- users
+//! cargo run --example jsonplaceholder -- users id=1
+//! cargo run --example jsonplaceholder -- users id=1 :albums
+//! cargo run --example jsonplaceholder -- users id=1 :albums[0] :photos
+//! cargo run --example jsonplaceholder -- albums userId=1
+//! ```
+//!
+//! Token grammar matches `vantage_cli_util::vista_cli`: model name,
+//! `field=value` filters, `[N]` index selectors, `:relation`
+//! traversals. The first token must be a model name.
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use vantage_api_client::{RestApi, ResponseShape};
+use vantage_cli_util::vista_cli::{self, Mode, ModelFactory, Renderer};
+use vantage_table::table::Table;
+use vantage_types::Record;
+use vantage_vista::Vista;
+
+const BASE_URL: &str = "https://jsonplaceholder.typicode.com";
+
+// ── Entity types ─────────────────────────────────────────────────────────
+//
+// jsonplaceholder returns one JSON object per record. Each field is
+// either present (with a concrete value) or missing — we model with
+// `Option<...>` to keep `TryFromRecord` lenient against future schema
+// drift. Field names match the API verbatim (camelCase) so id-based
+// joins and URI templating line up without aliasing.
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct User {
+    pub id: Option<i64>,
+    pub name: Option<String>,
+    pub username: Option<String>,
+    pub email: Option<String>,
+    pub phone: Option<String>,
+    pub website: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Album {
+    pub id: Option<i64>,
+    #[serde(rename = "userId")]
+    pub user_id: Option<i64>,
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Photo {
+    pub id: Option<i64>,
+    #[serde(rename = "albumId")]
+    pub album_id: Option<i64>,
+    pub title: Option<String>,
+    pub url: Option<String>,
+    #[serde(rename = "thumbnailUrl")]
+    pub thumbnail_url: Option<String>,
+}
+
+// ── Table factories ──────────────────────────────────────────────────────
+//
+// Each model exposes two factories:
+//   * the top-level table — `users`, `albums`, `photos` — used when the
+//     entity is queried in its own right;
+//   * a URI-template variant — `users/{userId}/albums`,
+//     `albums/{albumId}/photos` — used as a `with_many` build target
+//     so traversing from a parent narrows directly to the nested
+//     endpoint.
+//
+// The condition produced by RestApi's `related_in_condition`
+// (`userId = <parent_id>`) is consumed by the template's `{userId}`
+// substitution at request time; nothing leaks into the query string.
+
+impl User {
+    pub fn api_table(api: RestApi) -> Table<RestApi, User> {
+        Table::new("users", api)
+            .with_id_column("id")
+            .with_title_column_of::<Option<String>>("name")
+            .with_column_of::<Option<String>>("username")
+            .with_column_of::<Option<String>>("email")
+            .with_column_of::<Option<String>>("phone")
+            .with_column_of::<Option<String>>("website")
+            .with_many("albums", "userId", Album::api_table_for_user)
+    }
+}
+
+impl Album {
+    pub fn api_table(api: RestApi) -> Table<RestApi, Album> {
+        Self::columns(Table::new("albums", api))
+    }
+
+    /// Nested form used when traversing from a User. The `{userId}`
+    /// placeholder is resolved by `RestApi`'s template substitution at
+    /// request time from the eq-condition wired up by `with_many`.
+    pub fn api_table_for_user(api: RestApi) -> Table<RestApi, Album> {
+        Self::columns(Table::new("users/{userId}/albums", api))
+    }
+
+    fn columns(t: Table<RestApi, Album>) -> Table<RestApi, Album> {
+        t.with_id_column("id")
+            .with_title_column_of::<Option<String>>("title")
+            .with_column_of::<Option<i64>>("userId")
+            .with_one("user", "userId", User::api_table)
+            .with_many("photos", "albumId", Photo::api_table_for_album)
+    }
+}
+
+impl Photo {
+    pub fn api_table(api: RestApi) -> Table<RestApi, Photo> {
+        Self::columns(Table::new("photos", api))
+    }
+
+    pub fn api_table_for_album(api: RestApi) -> Table<RestApi, Photo> {
+        Self::columns(Table::new("albums/{albumId}/photos", api))
+    }
+
+    fn columns(t: Table<RestApi, Photo>) -> Table<RestApi, Photo> {
+        t.with_id_column("id")
+            .with_title_column_of::<Option<String>>("title")
+            .with_column_of::<Option<i64>>("albumId")
+            .with_column_of::<Option<String>>("url")
+            .with_column_of::<Option<String>>("thumbnailUrl")
+            .with_one("album", "albumId", Album::api_table)
+    }
+}
+
+// ── Factory + renderer for the vista_cli runner ─────────────────────────
+
+struct JsonPlaceholderFactory {
+    api: RestApi,
+}
+
+impl JsonPlaceholderFactory {
+    fn new(api: RestApi) -> Self {
+        Self { api }
+    }
+
+    fn vista_for(&self, name: &str) -> Option<Vista> {
+        let factory = self.api.vista_factory();
+        match name {
+            "user" | "users" => factory.from_table(User::api_table(self.api.clone())).ok(),
+            "album" | "albums" => factory.from_table(Album::api_table(self.api.clone())).ok(),
+            "photo" | "photos" => factory.from_table(Photo::api_table(self.api.clone())).ok(),
+            _ => None,
+        }
+    }
+}
+
+impl ModelFactory for JsonPlaceholderFactory {
+    fn for_name(&self, name: &str) -> Option<(Vista, Mode)> {
+        let mode = match name {
+            "user" | "album" | "photo" => Mode::Single,
+            "users" | "albums" | "photos" => Mode::List,
+            _ => return None,
+        };
+        self.vista_for(name).map(|v| (v, mode))
+    }
+}
+
+const KNOWN_MODELS: &[&str] = &[
+    "user", "users", "album", "albums", "photo", "photos",
+];
+
+struct CborRenderer;
+
+impl Renderer for CborRenderer {
+    fn render_list(
+        &self,
+        vista: &Vista,
+        records: &IndexMap<String, Record<CborValue>>,
+        column_override: Option<&[String]>,
+    ) {
+        let id_field = vista.get_id_column().unwrap_or("id").to_string();
+        let title_fields: Vec<String> = vista
+            .get_title_columns()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let columns: Vec<String> = if let Some(cols) = column_override {
+            cols.iter()
+                .map(|c| {
+                    if c == "id" {
+                        id_field.clone()
+                    } else {
+                        c.clone()
+                    }
+                })
+                .collect()
+        } else if !title_fields.is_empty() {
+            title_fields
+        } else {
+            // Fall back to the first three non-id columns from the
+            // declared schema — keeps the table tidy on noisy APIs.
+            vista
+                .get_column_names()
+                .into_iter()
+                .filter(|c| *c != id_field)
+                .take(3)
+                .map(|s| s.to_string())
+                .collect()
+        };
+
+        let mut header = vec![id_field.clone()];
+        header.extend(columns.iter().cloned());
+        println!("{}", header.join("\t"));
+
+        for (id, rec) in records {
+            let mut row = vec![id.clone()];
+            for c in &columns {
+                row.push(rec.get(c).map(cbor_short).unwrap_or_default());
+            }
+            println!("{}", row.join("\t"));
+        }
+        println!(
+            "\n({} record{})",
+            records.len(),
+            if records.len() == 1 { "" } else { "s" }
+        );
+    }
+
+    fn render_record(
+        &self,
+        vista: &Vista,
+        id: &str,
+        record: &Record<CborValue>,
+        relations: &[String],
+    ) {
+        let id_field = vista.get_id_column().unwrap_or("id");
+        println!("{}: {}", id_field, id);
+        let title_fields: Vec<&str> = vista.get_title_columns();
+        for tf in &title_fields {
+            if *tf == id_field {
+                continue;
+            }
+            if let Some(v) = record.get(*tf) {
+                println!("{}: {}", tf, cbor_short(v));
+            }
+        }
+        println!("--------");
+        for (k, v) in record.iter() {
+            if k == id_field || title_fields.iter().any(|t| t == k) {
+                continue;
+            }
+            println!("{}: {}", k, cbor_short(v));
+        }
+        if !relations.is_empty() {
+            println!();
+            println!("Relations:");
+            for r in relations {
+                println!("  :{r}");
+            }
+        }
+    }
+}
+
+fn cbor_short(v: &CborValue) -> String {
+    use ciborium::Value as C;
+    match v {
+        C::Text(s) => s.clone(),
+        C::Integer(i) => i128::from(*i).to_string(),
+        C::Float(f) => f.to_string(),
+        C::Bool(b) => b.to_string(),
+        C::Null => "null".to_string(),
+        C::Bytes(b) => format!("<{} bytes>", b.len()),
+        other => format!("{other:?}"),
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!(
+            "usage: jsonplaceholder <model> [field=value ...] [[N]] [:relation ...]"
+        );
+        eprintln!("\nKnown models:");
+        for n in KNOWN_MODELS {
+            eprintln!("  {n}");
+        }
+        std::process::exit(2);
+    }
+
+    // jsonplaceholder returns bare JSON arrays and supports the
+    // JSON-Server `_page` / `_limit` conventions out of the box.
+    let api = RestApi::builder(BASE_URL)
+        .response_shape(ResponseShape::BareArray)
+        .build();
+
+    let factory = JsonPlaceholderFactory::new(api);
+    let renderer = CborRenderer;
+    vista_cli::run(&factory, &renderer, &args)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(())
+}

--- a/vantage-api-client/examples/jsonplaceholder.rs
+++ b/vantage-api-client/examples/jsonplaceholder.rs
@@ -25,7 +25,7 @@
 use ciborium::Value as CborValue;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use vantage_api_client::{RestApi, ResponseShape};
+use vantage_api_client::{ResponseShape, RestApi};
 use vantage_cli_util::vista_cli::{self, Mode, ModelFactory, Renderer};
 use vantage_table::table::Table;
 use vantage_types::Record;
@@ -170,9 +170,7 @@ impl ModelFactory for JsonPlaceholderFactory {
     }
 }
 
-const KNOWN_MODELS: &[&str] = &[
-    "user", "users", "album", "albums", "photo", "photos",
-];
+const KNOWN_MODELS: &[&str] = &["user", "users", "album", "albums", "photo", "photos"];
 
 struct CborRenderer;
 
@@ -284,9 +282,7 @@ fn cbor_short(v: &CborValue) -> String {
 async fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     if args.is_empty() {
-        eprintln!(
-            "usage: jsonplaceholder <model> [field=value ...] [[N]] [:relation ...]"
-        );
+        eprintln!("usage: jsonplaceholder <model> [field=value ...] [[N]] [:relation ...]");
         eprintln!("\nKnown models:");
         for n in KNOWN_MODELS {
             eprintln!("  {n}");

--- a/vantage-api-client/src/api.rs
+++ b/vantage-api-client/src/api.rs
@@ -1,8 +1,9 @@
+use ciborium::Value as CborValue;
 use indexmap::IndexMap;
-use serde_json::Value;
 use vantage_core::error;
 use vantage_dataset::traits::Result;
 use vantage_expressions::Expression;
+use vantage_expressions::traits::expressive::ExpressiveEnum;
 use vantage_table::pagination::Pagination;
 use vantage_types::Record;
 
@@ -117,20 +118,68 @@ impl RestApi {
         self
     }
 
-    /// Build the endpoint URL for a given table name. No query string.
-    fn endpoint_url(&self, table_name: &str) -> String {
-        format!("{}/{}", self.base_url, table_name)
+    /// Build the endpoint path for `table_name`, substituting any
+    /// `{placeholder}` segments from matching eq-conditions.
+    ///
+    /// Returns the absolute URL up to (but excluding) the query string,
+    /// alongside the indices of conditions consumed by the substitution
+    /// — those are dropped from the query string by `build_query_string`.
+    ///
+    /// Tables that don't use templates (no `{}` in the name) pass
+    /// through unchanged and consume no conditions.
+    fn endpoint_url(
+        &self,
+        table_name: &str,
+        conditions: &[&Expression<CborValue>],
+    ) -> Result<(String, Vec<usize>)> {
+        let mut consumed = Vec::new();
+        let mut path = String::with_capacity(table_name.len());
+        let mut rest = table_name;
+        while let Some(open) = rest.find('{') {
+            path.push_str(&rest[..open]);
+            let after = &rest[open + 1..];
+            let close = after.find('}').ok_or_else(|| {
+                error!(
+                    "Unclosed `{` in table name URI template",
+                    table_name = table_name
+                )
+            })?;
+            let placeholder = &after[..close];
+            let (idx, value) = conditions
+                .iter()
+                .enumerate()
+                .find_map(|(i, cond)| {
+                    if consumed.contains(&i) {
+                        return None;
+                    }
+                    let (field, value) = crate::condition_to_query_param(cond)?;
+                    (field == placeholder).then_some((i, value))
+                })
+                .ok_or_else(|| {
+                    error!(
+                        "No eq-condition provided for URI placeholder",
+                        placeholder = placeholder,
+                        table_name = table_name
+                    )
+                })?;
+            consumed.push(idx);
+            path.push_str(&urlencode(&value));
+            rest = &after[close + 1..];
+        }
+        path.push_str(rest);
+        Ok((format!("{}/{}", self.base_url, path), consumed))
     }
 
     /// Build the combined query-string from pagination + conditions.
-    /// Conditions that don't peel cleanly into eq pairs are skipped (we
-    /// could fail loudly here, but silently ignoring matches the v1
-    /// "best effort" stance — the caller still gets correct data, just
-    /// with less efficient filtering).
-    fn build_query_string<'a>(
+    /// `consumed` lists condition indices already baked into the URI
+    /// path; those don't appear in the query string. Conditions that
+    /// don't peel cleanly into eq pairs are skipped — same "best effort"
+    /// stance as before.
+    fn build_query_string(
         &self,
         pagination: Option<&Pagination>,
-        conditions: impl IntoIterator<Item = &'a Expression<Value>>,
+        conditions: &[&Expression<CborValue>],
+        consumed: &[usize],
     ) -> String {
         let mut params: Vec<(String, String)> = Vec::new();
 
@@ -152,7 +201,10 @@ impl RestApi {
 
         // Conditions: each `eq` becomes `?field=value`. Multiple
         // conditions AND together (JSON Server semantics).
-        for cond in conditions {
+        for (i, cond) in conditions.iter().enumerate() {
+            if consumed.contains(&i) {
+                continue;
+            }
             if let Some((field, value)) = crate::condition_to_query_param(cond) {
                 params.push((field, value));
             }
@@ -189,8 +241,8 @@ impl RestApi {
         table_name: &str,
         id_field: Option<&str>,
         pagination: Option<&Pagination>,
-        conditions: impl IntoIterator<Item = &'a Expression<Value>>,
-    ) -> Result<IndexMap<String, Record<serde_json::Value>>> {
+        conditions: impl IntoIterator<Item = &'a Expression<CborValue>>,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
         // Non-paginating endpoints return the whole list on page 1; a
         // page-2 fetch would just re-deliver the same rows and the
         // perpetual grid would never mark itself exhausted. Short-
@@ -203,11 +255,19 @@ impl RestApi {
             return Ok(IndexMap::new());
         }
 
-        let url = format!(
-            "{}{}",
-            self.endpoint_url(table_name),
-            self.build_query_string(pagination, conditions)
-        );
+        // Conditions may carry `DeferredFn` values — typically from
+        // `related_in_condition` for `with_one`-style traversals where
+        // the FK lives in a parent record we haven't fetched yet.
+        // Resolve them once, up front, so the rest of the pipeline
+        // sees only sync, peelable scalars.
+        let raw: Vec<&Expression<CborValue>> = conditions.into_iter().collect();
+        let mut resolved: Vec<Expression<CborValue>> = Vec::with_capacity(raw.len());
+        for cond in raw {
+            resolved.push(resolve_deferreds(cond.clone()).await?);
+        }
+        let conds: Vec<&Expression<CborValue>> = resolved.iter().collect();
+        let (endpoint, consumed) = self.endpoint_url(table_name, &conds)?;
+        let url = format!("{}{}", endpoint, self.build_query_string(pagination, &conds, &consumed));
 
         let mut request = self.client.get(&url);
         if let Some(ref auth) = self.auth_header {
@@ -250,8 +310,20 @@ impl RestApi {
                 })
                 .unwrap_or_else(|| row_idx.to_string());
 
-            let record: Record<serde_json::Value> =
-                obj.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+            // The HTTP body parses as JSON for free; convert to CBOR
+            // at this single boundary so the rest of the pipeline
+            // (Table, Vista, AnyTable) sees the universal carrier.
+            let mut record: Record<CborValue> = Record::new();
+            for (k, v) in obj {
+                let cbor = CborValue::serialized(v).map_err(|e| {
+                    error!(
+                        "JSON → CBOR conversion failed",
+                        field = k.clone(),
+                        detail = e.to_string()
+                    )
+                })?;
+                record.insert(k.clone(), cbor);
+            }
 
             records.insert(id, record);
         }
@@ -262,6 +334,33 @@ impl RestApi {
 
 fn urlencode(s: &str) -> String {
     urlencoding::encode(s).into_owned()
+}
+
+/// Walk an `Expression`'s parameter tree and force any `Deferred`
+/// branches to their resolved form. Used at the `fetch_records`
+/// boundary so the URL builder only sees sync scalars.
+///
+/// Recursion lives on the heap (boxed) because the future's body
+/// contains another `async` call of the same shape — Rust can't size
+/// a directly-recursive `async fn` without indirection.
+fn resolve_deferreds(
+    mut expr: Expression<CborValue>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Expression<CborValue>>> + Send>> {
+    Box::pin(async move {
+        for param in expr.parameters.iter_mut() {
+            match param {
+                ExpressiveEnum::Deferred(deferred) => {
+                    *param = deferred.call().await?;
+                }
+                ExpressiveEnum::Nested(inner) => {
+                    let resolved = resolve_deferreds(inner.clone()).await?;
+                    *inner = resolved;
+                }
+                ExpressiveEnum::Scalar(_) => {}
+            }
+        }
+        Ok(expr)
+    })
 }
 
 impl RestApi {

--- a/vantage-api-client/src/api.rs
+++ b/vantage-api-client/src/api.rs
@@ -267,7 +267,11 @@ impl RestApi {
         }
         let conds: Vec<&Expression<CborValue>> = resolved.iter().collect();
         let (endpoint, consumed) = self.endpoint_url(table_name, &conds)?;
-        let url = format!("{}{}", endpoint, self.build_query_string(pagination, &conds, &consumed));
+        let url = format!(
+            "{}{}",
+            endpoint,
+            self.build_query_string(pagination, &conds, &consumed)
+        );
 
         let mut request = self.client.get(&url);
         if let Some(ref auth) = self.auth_header {

--- a/vantage-api-client/src/lib.rs
+++ b/vantage-api-client/src/lib.rs
@@ -1,7 +1,11 @@
 mod api;
 mod operation;
 mod table_source;
+pub mod vista;
 
 pub use api::{PaginationParams, ResponseShape, RestApi, RestApiBuilder};
 pub(crate) use operation::condition_to_query_param;
 pub use operation::eq_condition;
+pub use vista::{
+    AnyTableShell, NoApiExtras, RestApiTableShell, RestApiVistaFactory, RestApiVistaSpec,
+};

--- a/vantage-api-client/src/operation.rs
+++ b/vantage-api-client/src/operation.rs
@@ -2,63 +2,42 @@
 //! peel them apart at the `list_values` boundary into URL query params.
 //!
 //! Why not the standard `Operation::eq` from `vantage-table`? That trait
-//! is blanket-implemented for all `Expressive<T>`, but we can't provide
-//! the *value-side* `Expressive<serde_json::Value>` impls for primitive
-//! types — orphan rule (both `Expressive` and `serde_json::Value` are
-//! foreign to this crate). A future refactor wrapping the value type in
-//! a local newtype would unlock the full `Operation` surface; for now
-//! we provide an `eq_condition(field, value)` free function that builds
-//! the same expression shape directly.
+//! is blanket-implemented for all `Expressive<T>`, but the value-side
+//! `Expressive<ciborium::Value>` impls for primitive types live in
+//! foreign crates — we can't add them ourselves. So we ship a focused
+//! `eq_condition` helper that produces the same expression shape
+//! directly.
 
-use serde_json::Value;
+use ciborium::Value as CborValue;
 use vantage_expressions::Expression;
 use vantage_expressions::traits::expressive::ExpressiveEnum;
 
-/// Build an `eq` condition `field = value` for use with `Table<RestApi,
-/// _>::add_condition`. Produces the same shape as
-/// `vantage_table::operation::Operation::eq` would for backends that
-/// support it.
+/// Build an `eq` condition `field = value` for `Table<RestApi, _>`.
 ///
-/// ```ignore
-/// use vantage_api_client::eq_condition;
-/// use serde_json::json;
-///
-/// let mut comments = Table::<RestApi, EmptyEntity>::new("comments", api);
-/// comments.add_condition(eq_condition("postId", json!(1)));
-/// ```
-pub fn eq_condition(field: &str, value: Value) -> Expression<Value> {
+/// `value` is accepted as anything that converts into `CborValue` —
+/// most scalars (`i64`, `f64`, `bool`, `&str`, `String`) implement
+/// this directly through ciborium's `From` impls, so the call site
+/// stays readable: `eq_condition("userId", 1i64)`.
+pub fn eq_condition(field: &str, value: impl Into<CborValue>) -> Expression<CborValue> {
     Expression::new(
         "{} = {}",
         vec![
-            // Field side: bare identifier expression.
             ExpressiveEnum::Nested(Expression::new(field.to_string(), vec![])),
-            // Value side: scalar wrapped in a `{}` expression so it
-            // matches the layout `Operation::eq` produces.
-            ExpressiveEnum::Nested(Expression::new("{}", vec![ExpressiveEnum::Scalar(value)])),
+            ExpressiveEnum::Nested(Expression::new(
+                "{}",
+                vec![ExpressiveEnum::Scalar(value.into())],
+            )),
         ],
     )
 }
 
 /// Try to peel an `eq`-shaped condition into `(field_name, value_string)`
-/// suitable for a URL query parameter.
-///
-/// Recognised shape — same one `eq_condition` (and
-/// `vantage_table::Operation::eq` for compatible value types) produces:
-///
-/// ```text
-/// Expression {
-///     template: "{} = {}",
-///     parameters: [
-///         Nested(Expression { template: <field_name>, parameters: [] }),
-///         Nested(Expression { template: "{}", parameters: [Scalar(value)] }),
-///     ],
-/// }
-/// ```
-///
-/// Returns `None` for anything that doesn't match — non-eq operators,
-/// nested column-on-column comparisons, deferred values, etc. The caller
-/// decides what to do (skip silently is the v1 stance).
-pub(crate) fn condition_to_query_param(cond: &Expression<Value>) -> Option<(String, String)> {
+/// suitable for a URL query parameter. Returns `None` for anything
+/// that doesn't match — non-eq operators, compound values, nested
+/// column-on-column comparisons, deferred values, etc.
+pub(crate) fn condition_to_query_param(
+    cond: &Expression<CborValue>,
+) -> Option<(String, String)> {
     if cond.template != "{} = {}" || cond.parameters.len() != 2 {
         return None;
     }
@@ -71,62 +50,66 @@ pub(crate) fn condition_to_query_param(cond: &Expression<Value>) -> Option<(Stri
     let value = match &cond.parameters[1] {
         ExpressiveEnum::Nested(e) if e.template == "{}" && e.parameters.len() == 1 => {
             match &e.parameters[0] {
-                ExpressiveEnum::Scalar(v) => json_to_query_string(v)?,
+                ExpressiveEnum::Scalar(v) => cbor_to_query_string(v)?,
                 _ => return None,
             }
         }
-        ExpressiveEnum::Scalar(v) => json_to_query_string(v)?,
+        ExpressiveEnum::Scalar(v) => cbor_to_query_string(v)?,
         _ => return None,
     };
 
     Some((field, value))
 }
 
-fn json_to_query_string(v: &Value) -> Option<String> {
+/// Render a scalar CBOR value as the string form expected in a URL
+/// query parameter. Compound values (arrays, maps) have no single-key
+/// representation, so they fall through as `None` and the condition
+/// is dropped from the query string.
+fn cbor_to_query_string(v: &CborValue) -> Option<String> {
     match v {
-        Value::Bool(b) => Some(b.to_string()),
-        Value::Number(n) => Some(n.to_string()),
-        Value::String(s) => Some(s.clone()),
-        Value::Null | Value::Array(_) | Value::Object(_) => None,
+        CborValue::Bool(b) => Some(b.to_string()),
+        CborValue::Integer(i) => Some(i128::from(*i).to_string()),
+        CborValue::Float(f) => Some(f.to_string()),
+        CborValue::Text(s) => Some(s.clone()),
+        CborValue::Null | CborValue::Array(_) | CborValue::Map(_) | CborValue::Bytes(_) => None,
+        _ => None,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn eq_condition_round_trips_int() {
-        let cond = eq_condition("userId", json!(1));
+        let cond = eq_condition("userId", 1i64);
         let pair = condition_to_query_param(&cond).expect("eq parses");
         assert_eq!(pair, ("userId".into(), "1".into()));
     }
 
     #[test]
     fn eq_condition_round_trips_string() {
-        let cond = eq_condition("name", json!("Alice"));
+        let cond = eq_condition("name", "Alice");
         let pair = condition_to_query_param(&cond).expect("eq parses");
         assert_eq!(pair, ("name".into(), "Alice".into()));
     }
 
     #[test]
     fn eq_condition_round_trips_bool() {
-        let cond = eq_condition("completed", json!(true));
+        let cond = eq_condition("completed", true);
         let pair = condition_to_query_param(&cond).expect("eq parses");
         assert_eq!(pair, ("completed".into(), "true".into()));
     }
 
     #[test]
     fn raw_expression_with_unknown_template_returns_none() {
-        let cond = Expression::<Value>::new("CUSTOM SQL", vec![]);
+        let cond = Expression::<CborValue>::new("CUSTOM SQL", vec![]);
         assert!(condition_to_query_param(&cond).is_none());
     }
 
     #[test]
     fn array_value_returns_none() {
-        let cond = eq_condition("tags", json!(["a", "b"]));
-        // Arrays don't map to a single query-param string.
+        let cond = eq_condition("tags", vec![CborValue::Text("a".into())]);
         assert!(condition_to_query_param(&cond).is_none());
     }
 }

--- a/vantage-api-client/src/operation.rs
+++ b/vantage-api-client/src/operation.rs
@@ -35,9 +35,7 @@ pub fn eq_condition(field: &str, value: impl Into<CborValue>) -> Expression<Cbor
 /// suitable for a URL query parameter. Returns `None` for anything
 /// that doesn't match — non-eq operators, compound values, nested
 /// column-on-column comparisons, deferred values, etc.
-pub(crate) fn condition_to_query_param(
-    cond: &Expression<CborValue>,
-) -> Option<(String, String)> {
+pub(crate) fn condition_to_query_param(cond: &Expression<CborValue>) -> Option<(String, String)> {
     if cond.template != "{} = {}" || cond.parameters.len() != 2 {
         return None;
     }

--- a/vantage-api-client/src/table_source.rs
+++ b/vantage-api-client/src/table_source.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
+use ciborium::Value as CborValue;
 use indexmap::IndexMap;
-use serde_json::Value;
 use vantage_core::error;
-use vantage_dataset::traits::Result;
+use vantage_dataset::traits::{ReadableValueSet, Result};
 use vantage_expressions::Expression;
 use vantage_expressions::traits::associated_expressions::AssociatedExpression;
 use vantage_expressions::traits::datasource::DataSource;
@@ -18,20 +18,20 @@ use vantage_expressions::traits::expressive::DeferredFn;
 use crate::RestApi;
 
 /// Extract the id field name from a table's column flags.
-fn id_field_name<E: Entity<Value>>(table: &Table<RestApi, E>) -> Option<String> {
+fn id_field_name<E: Entity<CborValue>>(table: &Table<RestApi, E>) -> Option<String> {
     table.id_field().map(|col| col.name().to_string())
 }
 
-impl ExprDataSource<Value> for RestApi {
-    async fn execute(&self, expr: &Expression<Value>) -> vantage_core::Result<Value> {
+impl ExprDataSource<CborValue> for RestApi {
+    async fn execute(&self, expr: &Expression<CborValue>) -> vantage_core::Result<CborValue> {
         if expr.parameters.is_empty() {
-            Ok(Value::String(expr.template.clone()))
+            Ok(CborValue::Text(expr.template.clone()))
         } else {
-            Ok(Value::Null)
+            Ok(CborValue::Null)
         }
     }
 
-    fn defer(&self, expr: Expression<Value>) -> DeferredFn<Value> {
+    fn defer(&self, expr: Expression<CborValue>) -> DeferredFn<CborValue> {
         let api = self.clone();
         DeferredFn::new(move || {
             let api = api.clone();
@@ -52,10 +52,19 @@ impl TableSource for RestApi {
         = Column<Type>
     where
         Type: ColumnType;
-    type AnyType = Value;
-    type Value = Value;
+    type AnyType = CborValue;
+    type Value = CborValue;
     type Id = String;
     type Condition = vantage_expressions::Expression<Self::Value>;
+
+    /// Build a stringy `field == value` eq-condition. Stringy callers
+    /// (the model-driven CLI) only have text on hand; values arrive as
+    /// `String` and become CBOR text scalars here. The peeling code
+    /// in `condition_to_query_param` renders all scalar variants the
+    /// same way so the URL still reads correctly.
+    fn eq_condition(field: &str, value: &str) -> Result<Self::Condition> {
+        Ok(crate::eq_condition(field, value.to_string()))
+    }
 
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         Column::new(name)
@@ -269,16 +278,83 @@ impl TableSource for RestApi {
         Err(error!("REST API is a read-only data source"))
     }
 
+    /// Build a child condition for `with_many` / `with_one` traversal.
+    ///
+    /// REST APIs can't run subqueries, so this resolves on two paths:
+    ///
+    /// * **Sync peek** — if the parent already carries an eq-condition
+    ///   on `source_column`, we re-key its value onto `target_field`
+    ///   and we're done. Covers the common `with_many` case where
+    ///   `source_column` is the parent's id field (narrowed via
+    ///   `id=N` or `[N]`).
+    /// * **Deferred read** — otherwise (the `with_one` case, where
+    ///   `source_column` is a foreign-key field that lives in the
+    ///   parent's record, not its conditions), we wrap the resolution
+    ///   in a `DeferredFn` that fetches the parent at request time and
+    ///   pulls the field out of the row. `fetch_records` resolves
+    ///   deferreds before peeling conditions into query params.
     fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
         &self,
-        _target_field: &str,
-        _source_table: &Table<Self, SourceE>,
-        _source_column: &str,
+        target_field: &str,
+        source_table: &Table<Self, SourceE>,
+        source_column: &str,
     ) -> Self::Condition
     where
         Self: Sized,
     {
-        unimplemented!("related_in_condition not yet supported for REST API")
+        for cond in source_table.conditions() {
+            if let Some((field, value)) = crate::condition_to_query_param(cond)
+                && field == source_column
+            {
+                let cbor_value: CborValue = if let Ok(i) = value.parse::<i64>() {
+                    CborValue::Integer(i.into())
+                } else if let Ok(f) = value.parse::<f64>() {
+                    CborValue::Float(f)
+                } else {
+                    CborValue::Text(value)
+                };
+                return crate::eq_condition(target_field, cbor_value);
+            }
+        }
+
+        // Deferred fallback. Clone the parent table into the closure
+        // so it stays valid past this stack frame; at fetch time we
+        // list its values, take the first, and pull `source_column`.
+        let parent = source_table.clone();
+        let column = source_column.to_string();
+        let parent_name = source_table.table_name().to_string();
+        let deferred = DeferredFn::new(move || {
+            let parent = parent.clone();
+            let column = column.clone();
+            let parent_name = parent_name.clone();
+            Box::pin(async move {
+                let records = parent.list_values().await?;
+                let value = records
+                    .values()
+                    .next()
+                    .and_then(|r| r.get(&column))
+                    .cloned()
+                    .ok_or_else(|| {
+                        error!(
+                            "Deferred FK resolve: parent yielded no row or column missing",
+                            table = parent_name,
+                            column = column
+                        )
+                    })?;
+                Ok(ExpressiveEnum::Scalar(value))
+            })
+        });
+
+        Expression::new(
+            "{} = {}",
+            vec![
+                ExpressiveEnum::Nested(Expression::new(target_field.to_string(), vec![])),
+                ExpressiveEnum::Nested(Expression::new(
+                    "{}",
+                    vec![ExpressiveEnum::Deferred(deferred)],
+                )),
+            ],
+        )
     }
 
     fn column_table_values_expr<'a, E, Type: ColumnType>(

--- a/vantage-api-client/src/vista/any_shell.rs
+++ b/vantage-api-client/src/vista/any_shell.rs
@@ -1,0 +1,145 @@
+//! Generic `TableShell` adapter over `AnyTable`.
+//!
+//! When a typed `Table::get_ref(...)` returns a related table it comes
+//! back type-erased as `AnyTable` — the static `E2` is hidden by the
+//! reference machinery. To keep the Vista driver path uniform we wrap
+//! that `AnyTable` in `AnyTableShell` and harvest the metadata it
+//! already exposes (column names + types, id field, title fields).
+//!
+//! The shell forwards everything to `AnyTable`. `AnyTable` itself uses
+//! the CBOR adapter when its inner table doesn't natively use
+//! `CborValue`, so `RestApi` (which is JSON-native) round-trips
+//! through CBOR transparently here.
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_table::any::AnyTable;
+use vantage_table::traits::table_like::TableLike;
+use vantage_types::Record;
+use vantage_vista::{
+    Column as VistaColumn, TableShell, Vista, VistaCapabilities, VistaMetadata,
+    flags as vista_flags,
+};
+
+pub struct AnyTableShell {
+    table: AnyTable,
+    capabilities: VistaCapabilities,
+}
+
+impl AnyTableShell {
+    pub fn new(table: AnyTable, capabilities: VistaCapabilities) -> Self {
+        Self {
+            table,
+            capabilities,
+        }
+    }
+
+    /// Build a `Vista` from an `AnyTable`, harvesting metadata
+    /// (columns, id field, title fields) from the table itself.
+    ///
+    /// Capabilities default to `can_count` only — REST API is the
+    /// initial caller and is read-only. Callers needing different
+    /// capabilities should build the shell explicitly via `new`.
+    pub fn into_vista(table: AnyTable) -> Result<Vista> {
+        let caps = VistaCapabilities {
+            can_count: true,
+            ..VistaCapabilities::default()
+        };
+        Self::into_vista_with(table, caps)
+    }
+
+    pub fn into_vista_with(table: AnyTable, capabilities: VistaCapabilities) -> Result<Vista> {
+        let name = table.table_name().to_string();
+        let metadata = metadata_from_any_table(&table);
+        let shell = Self::new(table, capabilities);
+        Ok(Vista::new(name, Box::new(shell), metadata))
+    }
+}
+
+fn metadata_from_any_table(table: &AnyTable) -> VistaMetadata {
+    let mut metadata = VistaMetadata::new();
+    let types = table.column_types();
+    let id_field = table.id_field_name();
+    let title_fields = table.title_field_names();
+    for (name, ty) in types {
+        let mut col = VistaColumn::new(name.clone(), ty.to_string());
+        if Some(name.as_str()) == id_field.as_deref() {
+            col = col.with_flag(vista_flags::ID);
+        }
+        if title_fields.iter().any(|t| t == &name) {
+            col = col.with_flag(vista_flags::TITLE);
+        }
+        metadata = metadata.with_column(col);
+    }
+    if let Some(id) = id_field {
+        metadata = metadata.with_id_column(id);
+    }
+    metadata
+}
+
+#[async_trait]
+impl TableShell for AnyTableShell {
+    async fn list_vista_values(
+        &self,
+        _vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        self.table.list_values().await
+    }
+
+    async fn get_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        self.table.get_value(id).await
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        _vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        self.table.get_some_value().await
+    }
+
+    async fn get_vista_count(&self, _vista: &Vista) -> Result<i64> {
+        self.table.get_count().await
+    }
+
+    fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
+        // AnyTable only accepts stringy filters at this layer; coerce
+        // scalar CBOR values into their natural string form. Compound
+        // values (arrays, maps) can't be expressed as a flat eq, so
+        // we refuse them rather than silently truncating.
+        let s = match value {
+            CborValue::Text(s) => s.clone(),
+            CborValue::Integer(i) => i128::from(*i).to_string(),
+            CborValue::Float(f) => f.to_string(),
+            CborValue::Bool(b) => b.to_string(),
+            CborValue::Null => String::new(),
+            other => {
+                return Err(error!(
+                    "AnyTableShell: eq value must be a scalar",
+                    field = field,
+                    value = format!("{:?}", other)
+                ));
+            }
+        };
+        self.table.add_condition_eq(field, &s)
+    }
+
+    fn get_ref(&self, relation: &str) -> Result<Vista> {
+        let any_table = self.table.get_ref(relation)?;
+        AnyTableShell::into_vista(any_table)
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.capabilities
+    }
+
+    fn driver_name(&self) -> &'static str {
+        "any-table"
+    }
+}

--- a/vantage-api-client/src/vista/factory.rs
+++ b/vantage-api-client/src/vista/factory.rs
@@ -1,0 +1,104 @@
+//! `RestApiVistaFactory` — typed-table entry point and `VistaFactory`
+//! trait impl. REST API is read-only at this stage, so the factory
+//! advertises only `can_count`.
+
+use ciborium::Value as CborValue;
+use vantage_core::Result;
+use vantage_table::column::flags::ColumnFlag;
+use vantage_table::table::Table;
+use vantage_table::traits::column_like::ColumnLike;
+use vantage_types::Entity;
+use vantage_vista::{
+    Column as VistaColumn, Reference as VistaReference, ReferenceKind, Vista, VistaCapabilities,
+    VistaFactory, VistaMetadata, flags as vista_flags,
+};
+
+use crate::RestApi;
+use crate::vista::source::RestApiTableShell;
+use crate::vista::spec::{NoApiExtras, RestApiVistaSpec};
+
+pub struct RestApiVistaFactory {
+    api: RestApi,
+}
+
+impl RestApiVistaFactory {
+    pub fn new(api: RestApi) -> Self {
+        Self { api }
+    }
+
+    pub fn api(&self) -> &RestApi {
+        &self.api
+    }
+
+    /// Wrap a typed `Table<RestApi, E>` as a `Vista`. Column metadata,
+    /// id field, title fields, and references are harvested up front;
+    /// the table itself is stored as `Box<dyn TableLike>` so the
+    /// original `E` stays attached for reference traversal.
+    pub fn from_table<E>(&self, table: Table<RestApi, E>) -> Result<Vista>
+    where
+        E: Entity<CborValue> + 'static,
+    {
+        let metadata = metadata_from_table(&table);
+        let name = table.table_name().to_string();
+
+        let source = RestApiTableShell::new(
+            Box::new(table),
+            VistaCapabilities {
+                can_count: true,
+                ..VistaCapabilities::default()
+            },
+        );
+        Ok(Vista::new(name, Box::new(source), metadata))
+    }
+}
+
+impl VistaFactory for RestApiVistaFactory {
+    type TableExtras = NoApiExtras;
+    type ColumnExtras = NoApiExtras;
+    type ReferenceExtras = NoApiExtras;
+
+    fn build_from_spec(&self, _spec: RestApiVistaSpec) -> Result<Vista> {
+        Err(vantage_core::error!(
+            "YAML spec construction not yet implemented for RestApiVistaFactory"
+        ))
+    }
+}
+
+fn metadata_from_table<E>(table: &Table<RestApi, E>) -> VistaMetadata
+where
+    E: Entity<CborValue> + 'static,
+{
+    let mut metadata = VistaMetadata::new();
+    for (name, col) in table.columns() {
+        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+        if col.flags().contains(&ColumnFlag::Hidden) {
+            vc = vc.with_flag(vista_flags::HIDDEN);
+        }
+        metadata = metadata.with_column(vc);
+    }
+    if let Some(id_field) = table.id_field() {
+        let id = id_field.name().to_string();
+        metadata = metadata.with_id_column(id.clone());
+        if let Some(col) = metadata.columns.get_mut(&id) {
+            col.flags.push(vista_flags::ID.to_string());
+        }
+    }
+    for title in table.title_fields() {
+        if let Some(col) = metadata.columns.get_mut(title) {
+            col.flags.push(vista_flags::TITLE.to_string());
+        }
+    }
+    for relation in table.references() {
+        metadata = metadata.with_reference(VistaReference::new(
+            relation.clone(),
+            // Target / foreign-key metadata are driver-internal for
+            // REST API (the typed table's reference closure owns the
+            // child build); surface a placeholder so the universal
+            // shape stays populated.
+            "",
+            ReferenceKind::HasMany,
+            "",
+        ));
+    }
+    metadata
+}

--- a/vantage-api-client/src/vista/mod.rs
+++ b/vantage-api-client/src/vista/mod.rs
@@ -1,0 +1,29 @@
+//! Vista bridge for the REST API backend.
+//!
+//! Construct a `Vista` from a typed `Table<RestApi, E>` via
+//! `RestApi::vista_factory().from_table(...)`. The factory harvests
+//! schema metadata (columns, id field, references) and wraps the
+//! erased table in a `RestApiTableShell` that the universal Vista
+//! surface drives.
+//!
+//! REST APIs are read-only at this stage — the shell advertises only
+//! `can_count`.
+
+pub mod any_shell;
+pub mod factory;
+pub mod source;
+pub mod spec;
+
+pub use any_shell::AnyTableShell;
+pub use factory::RestApiVistaFactory;
+pub use source::RestApiTableShell;
+pub use spec::{NoApiExtras, RestApiVistaSpec};
+
+use crate::RestApi;
+
+impl RestApi {
+    /// Return a Vista factory bound to this REST API data source.
+    pub fn vista_factory(&self) -> RestApiVistaFactory {
+        RestApiVistaFactory::new(self.clone())
+    }
+}

--- a/vantage-api-client/src/vista/source.rs
+++ b/vantage-api-client/src/vista/source.rs
@@ -1,0 +1,100 @@
+//! `RestApiTableShell` — owns the typed `Table<RestApi, E>` behind a
+//! `dyn TableLike` so the original entity type stays attached for
+//! reference traversal.
+//!
+//! `RestApi` already speaks `ciborium::Value` natively (the HTTP body
+//! is converted at the fetch boundary), so the shell is a pass-through
+//! with no per-record translation.
+//!
+//! Why `Box<dyn TableLike>` and not `Table<RestApi, EmptyEntity>`?
+//! `with_many` / `with_one` register references whose `SourceE` is the
+//! original entity (`User`, `Album`, …). At traversal time
+//! `HasMany::resolve_as_any` downcasts `Table<T, SourceE>` against the
+//! stored value; erasing the entity to `EmptyEntity` would break that
+//! downcast.
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::Result;
+use vantage_table::traits::table_like::TableLike;
+use vantage_types::Record;
+use vantage_vista::{TableShell, Vista, VistaCapabilities};
+
+use super::any_shell::AnyTableShell;
+
+pub struct RestApiTableShell {
+    pub(crate) table: Box<dyn TableLike<Value = CborValue, Id = String>>,
+    pub(crate) capabilities: VistaCapabilities,
+}
+
+impl RestApiTableShell {
+    pub(crate) fn new(
+        table: Box<dyn TableLike<Value = CborValue, Id = String>>,
+        capabilities: VistaCapabilities,
+    ) -> Self {
+        Self {
+            table,
+            capabilities,
+        }
+    }
+}
+
+#[async_trait]
+impl TableShell for RestApiTableShell {
+    async fn list_vista_values(
+        &self,
+        _vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        self.table.list_values().await
+    }
+
+    async fn get_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        let mut data = self.table.list_values().await?;
+        Ok(data.shift_remove(id))
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        _vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        let data = self.table.list_values().await?;
+        Ok(data.into_iter().next())
+    }
+
+    async fn get_vista_count(&self, _vista: &Vista) -> Result<i64> {
+        self.table.get_count().await
+    }
+
+    fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
+        // Build a typed `Expression<CborValue>` and hand it through
+        // the type-erased `add_condition` API — `Table::add_condition`
+        // downcasts it back to `RestApi::Condition` on the other side.
+        let condition = crate::eq_condition(field, value.clone());
+        self.table.add_condition(Box::new(condition))
+    }
+
+    fn get_ref(&self, relation: &str) -> Result<Vista> {
+        // `TableLike::get_ref` delegates to `Table<T, E>::get_ref`,
+        // which uses the typed-table reference machinery. The result
+        // already carries the right conditions (parent-narrowing eq
+        // translated by `related_in_condition`) and the right table
+        // name (possibly a URI template, since the child factory
+        // chose one). Wrap it in a Vista so generic code can keep
+        // driving it.
+        let any_table = self.table.get_ref(relation)?;
+        AnyTableShell::into_vista(any_table)
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.capabilities
+    }
+
+    fn driver_name(&self) -> &'static str {
+        "rest-api"
+    }
+}

--- a/vantage-api-client/src/vista/spec.rs
+++ b/vantage-api-client/src/vista/spec.rs
@@ -1,0 +1,11 @@
+//! YAML-facing types for the REST-API Vista driver.
+//!
+//! REST APIs carry no driver-specific blocks for now, so all three
+//! extension types use `NoExtras`. Kept as separate typedefs so we can
+//! grow a per-table/per-column block later (e.g. response-shape
+//! overrides) without breaking callers.
+
+use vantage_vista::{NoExtras, VistaSpec};
+
+pub type NoApiExtras = NoExtras;
+pub type RestApiVistaSpec = VistaSpec<NoApiExtras, NoApiExtras, NoApiExtras>;

--- a/vantage-cli-util/CHANGELOG.md
+++ b/vantage-cli-util/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.2 — 2026-05-14
+
+- New [`vista_cli`](https://docs.rs/vantage-cli-util/0.4.2/vantage_cli_util/vista_cli/index.html) module — the [`Vista`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html) equivalent of `model_cli`. Same token grammar (`<model> [field=value ...] [[N]] [:relation ...] [=col1,col2]`), same `ModelFactory` / `Renderer` traits, but drives a `Vista` end-to-end so traversal goes through [`Vista::get_ref`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html#method.get_ref) and condition pushdown reaches the driver's native condition type. Use this when you've migrated a CLI to the universal Vista surface; `model_cli` stays as the `AnyTable`-flavoured path.
+- Pins `vantage-vista = "0.4.5"` for `Vista::get_ref` and `TableShell::get_ref`.
+
 ## 0.4.1 — 2026-04-30
 
 - New `model_cli` module — generic, model-driven CLI runner over any `AnyTable`. Argv shape: `<model | arn> [field=value ...] [[N]] [:relation [[N]] ...] [=col1,col2 ...]`. Singular vs plural model names drive list/single mode; `id=value` is sugar that resolves to the table's id field and forces single-record mode; `[N]` selects the Nth record and switches into single-record mode by adding `eq(id_field, that_id)`; `:relation` traverses a registered `with_many` / `with_one`; `=col1,col2` overrides the visible columns in list mode. Glued forms (`users[0]`, `:members[0]`, `name=foo[0]`, `=msg,timestamp[0]`) split into a base token plus an index selector.

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -17,3 +17,4 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
 vantage-table = { version = "0.4.8", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
+vantage-vista = { version = "0.4", path = "../vantage-vista" }

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-cli-util"
-version = "0.4.1"
+version = "0.4.2"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "CLI utilities for Vantage data framework"
@@ -17,4 +17,4 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
 vantage-table = { version = "0.4.8", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
-vantage-vista = { version = "0.4", path = "../vantage-vista" }
+vantage-vista = { version = "0.4.5", path = "../vantage-vista" }

--- a/vantage-cli-util/src/lib.rs
+++ b/vantage-cli-util/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod model_cli;
 mod table_display;
+pub mod vista_cli;
 
 pub use model_cli::{Mode, ModelFactory, Renderer};
 pub use table_display::{

--- a/vantage-cli-util/src/vista_cli.rs
+++ b/vantage-cli-util/src/vista_cli.rs
@@ -258,8 +258,11 @@ pub async fn run<F: ModelFactory, R: Renderer>(
                 .get_some_value()
                 .await?
                 .ok_or_else(|| error!("No record found"))?;
-            let relations: Vec<String> =
-                vista.get_references().iter().map(|s| s.to_string()).collect();
+            let relations: Vec<String> = vista
+                .get_references()
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
             renderer.render_record(&vista, &id, &record, &relations);
         }
     }

--- a/vantage-cli-util/src/vista_cli.rs
+++ b/vantage-cli-util/src/vista_cli.rs
@@ -1,0 +1,331 @@
+//! Generic model-driven CLI runner, Vista edition.
+//!
+//! Mirrors [`crate::model_cli`] but drives a [`Vista`] instead of an
+//! `AnyTable`. The token shapes and flow are identical (`model_name`,
+//! `field=value`, `[N]`, `:relation`, `=col1,col2`) — only the
+//! underlying type changes.
+//!
+//! See `model_cli` for the full token-shape reference; this module
+//! repeats only the behaviour notes that differ for Vista.
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_types::Record;
+use vantage_vista::Vista;
+
+/// Whether the current state is a list of records or a single record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    List,
+    Single,
+}
+
+/// Resolves model identifiers (singular/plural names, ARNs) to
+/// `Vista`s. Implemented per-backend.
+pub trait ModelFactory {
+    /// Resolve a model name (e.g. `users` or `user`).
+    /// Singular names should return [`Mode::Single`], plural
+    /// [`Mode::List`]. Returns `None` for unknown names.
+    fn for_name(&self, name: &str) -> Option<(Vista, Mode)>;
+
+    /// Resolve an ARN to a single-record `Vista` with any required
+    /// conditions already applied. Backends without an ARN syntax
+    /// can leave the default `None`.
+    fn for_arn(&self, _arn: &str) -> Option<Vista> {
+        None
+    }
+}
+
+/// Backend hook for printing list and single-record results.
+pub trait Renderer {
+    fn render_list(
+        &self,
+        vista: &Vista,
+        records: &IndexMap<String, Record<CborValue>>,
+        column_override: Option<&[String]>,
+    );
+    fn render_record(
+        &self,
+        vista: &Vista,
+        id: &str,
+        record: &Record<CborValue>,
+        relations: &[String],
+    );
+}
+
+#[derive(Debug)]
+enum Token {
+    ModelName(String, Option<usize>),
+    Arn(String),
+    Condition(String, String, Option<usize>),
+    Relation(String, Option<usize>),
+    Index(usize),
+    Columns(Vec<String>, Option<usize>),
+}
+
+fn split_index_suffix(s: &str) -> (&str, Option<usize>) {
+    if let Some(stripped) = s.strip_suffix(']')
+        && let Some(open) = stripped.rfind('[')
+    {
+        let inner = &stripped[open + 1..];
+        if !inner.is_empty()
+            && inner.chars().all(|c| c.is_ascii_digit())
+            && let Ok(n) = inner.parse::<usize>()
+        {
+            return (&stripped[..open], Some(n));
+        }
+    }
+    (s, None)
+}
+
+fn parse_token(arg: &str) -> Result<Token> {
+    if arg.is_empty() {
+        return Err(error!("Empty argument"));
+    }
+    if arg.starts_with("arn:") {
+        return Ok(Token::Arn(arg.to_string()));
+    }
+    if let Some(rest) = arg.strip_prefix(':') {
+        let (rel, idx) = split_index_suffix(rest);
+        if rel.is_empty() {
+            return Err(error!(format!("Empty relation name in token `{arg}`")));
+        }
+        return Ok(Token::Relation(rel.to_string(), idx));
+    }
+    if arg.starts_with('[') {
+        let (_, idx) = split_index_suffix(arg);
+        let idx = idx.ok_or_else(|| error!(format!("Invalid index token `{arg}`")))?;
+        return Ok(Token::Index(idx));
+    }
+    if let Some(rest) = arg.strip_prefix('=') {
+        let (cols_part, idx) = split_index_suffix(rest);
+        if cols_part.is_empty() {
+            return Err(error!(format!(
+                "Empty column list in token `{arg}` — write `=col1,col2`"
+            )));
+        }
+        let cols: Vec<String> = cols_part
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if cols.is_empty() {
+            return Err(error!(format!("Empty column list in token `{arg}`")));
+        }
+        return Ok(Token::Columns(cols, idx));
+    }
+    if let Some(eq_pos) = arg.find('=') {
+        let field = arg[..eq_pos].to_string();
+        if field.is_empty() {
+            return Err(error!(format!("Empty field name in token `{arg}`")));
+        }
+        let value_part = &arg[eq_pos + 1..];
+        let (value, idx) =
+            if value_part.starts_with('"') && value_part.ends_with('"') && value_part.len() >= 2 {
+                (value_part[1..value_part.len() - 1].to_string(), None)
+            } else {
+                let (v, i) = split_index_suffix(value_part);
+                (v.to_string(), i)
+            };
+        return Ok(Token::Condition(field, value, idx));
+    }
+    let (name, idx) = split_index_suffix(arg);
+    Ok(Token::ModelName(name.to_string(), idx))
+}
+
+/// Run a Vista-backed model-driven CLI.
+///
+/// `args` is the list of positional arguments after any global flags
+/// have been stripped out.
+pub async fn run<F: ModelFactory, R: Renderer>(
+    factory: &F,
+    renderer: &R,
+    args: &[String],
+) -> Result<()> {
+    if args.is_empty() {
+        return Err(error!(
+            "No model specified — pass a model name (e.g. `users`) or an ARN"
+        ));
+    }
+
+    let mut tokens: Vec<Token> = args.iter().map(|s| parse_token(s)).collect::<Result<_>>()?;
+    let first = tokens.remove(0);
+    let mut column_override: Option<Vec<String>> = None;
+
+    let (mut vista, mut mode) = match first {
+        Token::ModelName(name, idx) => {
+            let (v, m) = factory
+                .for_name(&name)
+                .ok_or_else(|| error!(format!("Unknown model `{name}`")))?;
+            if let Some(i) = idx {
+                apply_index(v, i).await?
+            } else {
+                (v, m)
+            }
+        }
+        Token::Arn(arn) => {
+            let v = factory
+                .for_arn(&arn)
+                .ok_or_else(|| error!(format!("Cannot resolve ARN `{arn}`")))?;
+            (v, Mode::Single)
+        }
+        Token::Condition(_, _, _)
+        | Token::Relation(_, _)
+        | Token::Index(_)
+        | Token::Columns(_, _) => {
+            return Err(error!(format!(
+                "First argument must be a model name or ARN, got `{}`",
+                args[0]
+            )));
+        }
+    };
+
+    for token in tokens {
+        match token {
+            Token::Condition(field, value, idx) => {
+                // `id=value` is a sugared "fetch this specific record":
+                // resolve to the actual id field and force single-record
+                // mode. Anything else is just a regular eq filter.
+                let is_id_alias = field == "id";
+                let resolved_field = if is_id_alias {
+                    vista.get_id_column().map(str::to_string).ok_or_else(|| {
+                        error!(format!(
+                            "`id=` used but vista `{}` has no id column",
+                            vista.name()
+                        ))
+                    })?
+                } else {
+                    field.clone()
+                };
+                vista.add_condition_eq(&resolved_field, string_to_cbor(&value))?;
+                if is_id_alias {
+                    mode = Mode::Single;
+                }
+                if let Some(i) = idx {
+                    let (v, m) = apply_index(vista, i).await?;
+                    vista = v;
+                    mode = m;
+                }
+            }
+            Token::Index(i) => {
+                let (v, m) = apply_index(vista, i).await?;
+                vista = v;
+                mode = m;
+            }
+            Token::Relation(rel, idx) => {
+                if mode != Mode::Single {
+                    return Err(error!(format!(
+                        "Cannot traverse `:{rel}` from list mode — narrow to a single record first (add a filter or `[N]`)"
+                    )));
+                }
+                vista = vista.get_ref(&rel)?;
+                mode = Mode::List;
+                // A new vista means the column override no longer
+                // applies — drop it so the child renders with its own
+                // default columns until a new override appears.
+                column_override = None;
+                if let Some(i) = idx {
+                    let (v, m) = apply_index(vista, i).await?;
+                    vista = v;
+                    mode = m;
+                }
+            }
+            Token::Columns(cols, idx) => {
+                column_override = Some(cols);
+                if let Some(i) = idx {
+                    let (v, m) = apply_index(vista, i).await?;
+                    vista = v;
+                    mode = m;
+                }
+            }
+            Token::ModelName(_, _) | Token::Arn(_) => {
+                return Err(error!(
+                    "Model name or ARN may only appear as the first argument"
+                ));
+            }
+        }
+    }
+
+    match mode {
+        Mode::List => {
+            let records = vista.list_values().await?;
+            renderer.render_list(&vista, &records, column_override.as_deref());
+        }
+        Mode::Single => {
+            let (id, record) = vista
+                .get_some_value()
+                .await?
+                .ok_or_else(|| error!("No record found"))?;
+            let relations: Vec<String> =
+                vista.get_references().iter().map(|s| s.to_string()).collect();
+            renderer.render_record(&vista, &id, &record, &relations);
+        }
+    }
+
+    Ok(())
+}
+
+/// CLI tokens carry filter values as plain strings. Coerce them into
+/// the cheapest matching CBOR scalar: integer if it parses, else
+/// float, else booleans, else text. Drivers translate further at
+/// their own boundary.
+fn string_to_cbor(value: &str) -> CborValue {
+    if let Ok(i) = value.parse::<i64>() {
+        CborValue::Integer(i.into())
+    } else if let Ok(f) = value.parse::<f64>() {
+        CborValue::Float(f)
+    } else if value == "true" {
+        CborValue::Bool(true)
+    } else if value == "false" {
+        CborValue::Bool(false)
+    } else {
+        CborValue::Text(value.to_string())
+    }
+}
+
+/// List the vista, take the Nth row, narrow the vista to that row by
+/// adding `eq(id_field, that_id)`. Returns the narrowed vista in
+/// single-record mode so subsequent traversals see one parent.
+async fn apply_index(mut vista: Vista, index: usize) -> Result<(Vista, Mode)> {
+    let records = vista.list_values().await?;
+    let total = records.len();
+    let (id, _record) = records.into_iter().nth(index).ok_or_else(|| {
+        error!(format!(
+            "Index [{index}] out of bounds — only {total} record(s) match"
+        ))
+    })?;
+    let id_field = vista.get_id_column().map(str::to_string).ok_or_else(|| {
+        error!(format!(
+            "Cannot apply index — vista `{}` has no id column",
+            vista.name()
+        ))
+    })?;
+    vista.add_condition_eq(&id_field, string_to_cbor(&id))?;
+    Ok((vista, Mode::Single))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_split_index_suffix() {
+        assert_eq!(split_index_suffix("users"), ("users", None));
+        assert_eq!(split_index_suffix("users[0]"), ("users", Some(0)));
+        assert_eq!(split_index_suffix("[3]"), ("", Some(3)));
+        assert_eq!(split_index_suffix("foo[bar]"), ("foo[bar]", None));
+    }
+
+    #[test]
+    fn token_parse_relation() {
+        match parse_token(":albums[2]").unwrap() {
+            Token::Relation(r, i) => {
+                assert_eq!(r, "albums");
+                assert_eq!(i, Some(2));
+            }
+            t => panic!("expected Relation, got {t:?}"),
+        }
+    }
+}

--- a/vantage-live/CHANGELOG.md
+++ b/vantage-live/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.7 — 2026-05-14
+
+- `live_demo` drops the in-example `JsonToCborAdapter` and wraps `Table<RestApi, _>` straight through `AnyTable::from_table`, now that [`vantage-api-client`](https://docs.rs/vantage-api-client) speaks `ciborium::Value` natively.
+- Pins `vantage-api-client = "0.1.4"` for the new value type.
+
 ## 0.4.6 — 2026-05-09
 
 - Pins `vantage-types` to `>= 0.4.2` so cargo can't resolve back to the pre-`RichText` trait shape.

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-live"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-live/Cargo.toml
+++ b/vantage-live/Cargo.toml
@@ -35,7 +35,7 @@ clap = { version = "4", features = ["derive"] }
 serde_json = "1"
 # vantage-redb only used in tests for the master fixture and the demo CLI.
 vantage-redb = { version = "0.4", path = "../vantage-redb" }
-vantage-api-client = { version = "0.1.2", path = "../vantage-api-client" }
+vantage-api-client = { version = "0.1.4", path = "../vantage-api-client" }
 
 [[example]]
 name = "live_demo"

--- a/vantage-live/examples/live_demo.rs
+++ b/vantage-live/examples/live_demo.rs
@@ -232,13 +232,9 @@ fn open_local_typed(path: &Path) -> Table<Redb, EmptyEntity> {
 
 // ── API master ────────────────────────────────────────────────────────────
 //
-// `RestApi::Value = serde_json::Value`, but `AnyTable` carries
-// `ciborium::Value`. There's no `Into<CborValue> + From<CborValue>` impl
-// for `serde_json::Value` (both are foreign types), so `from_table` rejects
-// `Table<RestApi, _>` directly. Wrap in a tiny adapter that implements
-// `TableLike<Value = CborValue, Id = String>` and converts on the fly via
-// serde round-trip. This is demo code — vantage-api-client could grow a
-// proper bridge as a follow-up.
+// `RestApi` now speaks `ciborium::Value` natively, so we can drop the
+// JSON↔CBOR adapter that used to live here and wrap the typed table
+// straight into `AnyTable::from_table`.
 
 fn open_api_master(resource: &str, filter: Option<&(String, String)>) -> AnyTable {
     use vantage_api_client::eq_condition;
@@ -253,19 +249,19 @@ fn open_api_master(resource: &str, filter: Option<&(String, String)>) -> AnyTabl
         // a string. JSON Server is type-permissive in URL params, so
         // this mostly works regardless, but `?completed=true` for a
         // boolean field is more conventional than `?completed="true"`.
-        let json_value = if let Ok(n) = value.parse::<i64>() {
-            serde_json::Value::Number(n.into())
+        let cbor_value: CborValue = if let Ok(n) = value.parse::<i64>() {
+            CborValue::Integer(n.into())
         } else if value == "true" {
-            serde_json::Value::Bool(true)
+            CborValue::Bool(true)
         } else if value == "false" {
-            serde_json::Value::Bool(false)
+            CborValue::Bool(false)
         } else {
-            serde_json::Value::String(value.clone())
+            CborValue::Text(value.clone())
         };
-        typed.add_condition(eq_condition(field, json_value));
+        typed.add_condition(eq_condition(field, cbor_value));
     }
 
-    AnyTable::from_table_like(api_master::JsonToCborAdapter::new(typed))
+    AnyTable::from_table(typed)
 }
 
 /// Build a cache key that varies with the filter. With no filter,
@@ -277,176 +273,6 @@ fn api_cache_key(resource: &str, filter: Option<&(String, String)>) -> String {
     match filter {
         Some((f, v)) => format!("{resource}?{f}={v}"),
         None => resource.to_string(),
-    }
-}
-
-mod api_master {
-    use async_trait::async_trait;
-    use ciborium::Value as CborValue;
-    use indexmap::IndexMap;
-    use vantage_api_client::RestApi;
-    use vantage_core::{Result, error};
-    use vantage_dataset::traits::{ReadableValueSet, ValueSet, WritableValueSet};
-    use vantage_expressions::AnyExpression;
-    use vantage_table::conditions::ConditionHandle;
-    use vantage_table::pagination::Pagination;
-    use vantage_table::table::Table;
-    use vantage_table::traits::table_like::TableLike;
-    use vantage_types::{EmptyEntity, Record};
-
-    /// Demo-only TableLike adapter. Wraps `Table<RestApi, EmptyEntity>`
-    /// and converts each row's `serde_json::Value` fields to/from
-    /// `ciborium::Value` so the master fits AnyTable's CBOR-shaped slot.
-    #[derive(Clone)]
-    pub struct JsonToCborAdapter {
-        inner: Table<RestApi, EmptyEntity>,
-    }
-
-    impl JsonToCborAdapter {
-        pub fn new(inner: Table<RestApi, EmptyEntity>) -> Self {
-            Self { inner }
-        }
-    }
-
-    fn json_to_cbor(v: serde_json::Value) -> CborValue {
-        // serde round-trip — same lossy bits as elsewhere (NaN, binary
-        // → string), but JSONPlaceholder responses are vanilla JSON so
-        // this is fine.
-        ciborium::Value::serialized(&v).unwrap_or(CborValue::Null)
-    }
-
-    fn cbor_to_json(v: CborValue) -> serde_json::Value {
-        serde_json::to_value(v).unwrap_or(serde_json::Value::Null)
-    }
-
-    fn record_j2c(r: Record<serde_json::Value>) -> Record<CborValue> {
-        r.into_iter().map(|(k, v)| (k, json_to_cbor(v))).collect()
-    }
-
-    fn record_c2j(r: Record<CborValue>) -> Record<serde_json::Value> {
-        r.into_iter().map(|(k, v)| (k, cbor_to_json(v))).collect()
-    }
-
-    impl ValueSet for JsonToCborAdapter {
-        type Id = String;
-        type Value = CborValue;
-    }
-
-    #[async_trait]
-    impl ReadableValueSet for JsonToCborAdapter {
-        async fn list_values(&self) -> Result<IndexMap<String, Record<CborValue>>> {
-            let rows = self.inner.list_values().await?;
-            Ok(rows.into_iter().map(|(k, v)| (k, record_j2c(v))).collect())
-        }
-
-        async fn get_value(&self, id: &String) -> Result<Option<Record<CborValue>>> {
-            Ok(self.inner.get_value(id).await?.map(record_j2c))
-        }
-
-        async fn get_some_value(&self) -> Result<Option<(String, Record<CborValue>)>> {
-            Ok(self
-                .inner
-                .get_some_value()
-                .await?
-                .map(|(k, v)| (k, record_j2c(v))))
-        }
-    }
-
-    #[async_trait]
-    impl WritableValueSet for JsonToCborAdapter {
-        async fn insert_value(
-            &self,
-            id: &String,
-            record: &Record<CborValue>,
-        ) -> Result<Record<CborValue>> {
-            // Round-trip through inner write path so existing semantics
-            // (read-only error) propagate naturally.
-            let json_record = record_c2j(record.clone());
-            let result = self.inner.insert_value(id, &json_record).await?;
-            Ok(record_j2c(result))
-        }
-
-        async fn replace_value(
-            &self,
-            id: &String,
-            record: &Record<CborValue>,
-        ) -> Result<Record<CborValue>> {
-            let json_record = record_c2j(record.clone());
-            let result = self.inner.replace_value(id, &json_record).await?;
-            Ok(record_j2c(result))
-        }
-
-        async fn patch_value(
-            &self,
-            id: &String,
-            partial: &Record<CborValue>,
-        ) -> Result<Record<CborValue>> {
-            let json_partial = record_c2j(partial.clone());
-            let result = self.inner.patch_value(id, &json_partial).await?;
-            Ok(record_j2c(result))
-        }
-
-        async fn delete(&self, id: &String) -> Result<()> {
-            self.inner.delete(id).await
-        }
-
-        async fn delete_all(&self) -> Result<()> {
-            self.inner.delete_all().await
-        }
-    }
-
-    #[async_trait]
-    impl TableLike for JsonToCborAdapter {
-        fn table_name(&self) -> &str {
-            self.inner.table_name()
-        }
-        fn table_alias(&self) -> &str {
-            self.inner.table_alias()
-        }
-        fn column_names(&self) -> Vec<String> {
-            self.inner.column_names()
-        }
-        fn add_condition(
-            &mut self,
-            _condition: Box<dyn std::any::Any + Send + Sync>,
-        ) -> Result<()> {
-            Err(error!(
-                "JsonToCborAdapter (demo): condition pushdown not implemented"
-            ))
-        }
-        fn temp_add_condition(&mut self, _c: AnyExpression) -> Result<ConditionHandle> {
-            Err(error!(
-                "JsonToCborAdapter (demo): temp_add_condition not implemented"
-            ))
-        }
-        fn temp_remove_condition(&mut self, _h: ConditionHandle) -> Result<()> {
-            Err(error!(
-                "JsonToCborAdapter (demo): temp_remove_condition not implemented"
-            ))
-        }
-        fn search_expression(&self, _: &str) -> Result<AnyExpression> {
-            Err(error!(
-                "JsonToCborAdapter (demo): search_expression not implemented"
-            ))
-        }
-        fn clone_box(&self) -> Box<dyn TableLike<Value = CborValue, Id = String>> {
-            Box::new(self.clone())
-        }
-        fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
-            self
-        }
-        fn as_any_ref(&self) -> &dyn std::any::Any {
-            self
-        }
-        fn set_pagination(&mut self, p: Option<Pagination>) {
-            self.inner.set_pagination(p);
-        }
-        fn get_pagination(&self) -> Option<&Pagination> {
-            self.inner.get_pagination()
-        }
-        async fn get_count(&self) -> Result<i64> {
-            self.inner.get_count().await
-        }
     }
 }
 

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.5 — 2026-05-14
+
+- New [`Vista::get_ref`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html#method.get_ref) traverses a named reference and returns the related `Vista`. The driver does the work — it consults its wrapped typed table's `with_one` / `with_many` registry, applies the join condition, and wraps the result back into a `Vista` so callers stay on the universal surface.
+- New [`TableShell::get_ref`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/trait.TableShell.html#method.get_ref) trait method (default returns `Unimplemented`) — drivers wrapping a typed `Table<T, E>` can delegate to `Table::get_ref` and the rest is automatic. The first driver opting in is [`vantage-api-client 0.1.4`](https://docs.rs/vantage-api-client/0.1.4/).
+
 ## 0.4.4 — 2026-05-04
 
 - New [`Vista::driver()`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html#method.driver) returns a short label for the backing driver (`"csv"`, `"sqlite"`, `"postgres"`, `"mysql"`, `"mongodb"`) — handy for diagnostics and CLI output.

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -149,6 +149,25 @@ pub trait TableShell: Send + Sync + 'static {
         .is_unimplemented())
     }
 
+    // ---- References --------------------------------------------------------
+
+    /// Resolve a named relation and return the related table as a new
+    /// `Vista`. The default impl returns `Unimplemented` so existing
+    /// drivers compile until they opt in; drivers that wrap a typed
+    /// `Table<T, E>` can delegate to `Table::get_ref`.
+    fn get_ref(&self, relation: &str) -> Result<Vista> {
+        Err(error!(
+            format!(
+                "get_ref not implemented for '{}'",
+                std::any::type_name::<Self>()
+            ),
+            method = "get_ref",
+            relation = relation,
+            source_type = std::any::type_name::<Self>()
+        )
+        .is_unimplemented())
+    }
+
     // ---- Identity ----------------------------------------------------------
 
     /// Short human label for the underlying driver (e.g. `"csv"`, `"sqlite"`,

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -114,4 +114,18 @@ impl Vista {
     pub async fn get_count(&self) -> Result<i64> {
         self.source.get_vista_count(self).await
     }
+
+    // ---- references --------------------------------------------------------
+
+    /// Traverse a named reference and return the related `Vista`.
+    ///
+    /// The driver does the work: it consults its wrapped typed table's
+    /// reference machinery (set up via `with_one` / `with_many`),
+    /// applies the join condition, and wraps the resulting table in a
+    /// new `Vista` so callers stay on the universal surface. Returns
+    /// `Err` for drivers that don't implement references and for
+    /// unknown relation names.
+    pub fn get_ref(&self, relation: &str) -> Result<Vista> {
+        self.source.get_ref(relation)
+    }
 }


### PR DESCRIPTION
`vantage-api-client` was the only TableSource in the tree still carrying `serde_json::Value` — which meant every master built from it needed a hand-written JSON↔CBOR adapter before it could fit `AnyTable::from_table`. Three things change in 0.1.4: the value type, URI templating, and a direct `Vista` bridge so the adapter is unnecessary in the first place.

### The breaking surface

`RestApi::Value` is now `ciborium::Value`. The only place that leaks into your code is `eq_condition`:

```rust
// before
comments.add_condition(eq_condition("postId", json!(1)));

// after — Into<CborValue> handles the scalars
comments.add_condition(eq_condition("postId", 1i64));
comments.add_condition(eq_condition("name", "Alice"));
```

Master-table call sites get tidier: `AnyTable::from_table(typed)` now accepts `Table<RestApi, _>` directly. The old `live_demo.rs` was the canonical sufferer here — its 130-line `JsonToCborAdapter` is gone in this release.

### URI templates feed references

Tables can declare templated endpoints:

```rust
Table::new("users/{userId}/albums", api)
```

Eq-conditions feed the placeholder, so `with_many("albums", "userId", …)` on the parent table lowers `id=1` into `GET /users/1/albums` instead of `GET /albums?userId=1`. Conditions consumed by the template don't appear in the query string.

This also unblocks `related_in_condition` for `RestApi`. `with_many` re-keys an existing eq-condition onto the FK field synchronously; the `with_one` path resolves the parent on demand through a deferred condition that fires at fetch time. Both `unimplemented!()` panics from earlier versions are gone.

### Vista bridge

`api.vista_factory().from_table(typed)` returns a `Vista`. Columns, id field, title fields, and references all transfer over; reference traversal goes through `Vista::get_ref` (new in [`vantage-vista 0.4.5`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html#method.get_ref)) back to a fresh `Vista` so generic code can keep driving the chain.

The matching CLI runner is `vista_cli` in [`vantage-cli-util 0.4.2`](https://docs.rs/vantage-cli-util/0.4.2/vantage_cli_util/vista_cli/index.html) — same token grammar as `model_cli` but driving `Vista` end-to-end. `examples/jsonplaceholder.rs` is the worked example:

```sh
cargo run --example jsonplaceholder -- users id=1 :albums[0] :photos
```

YAML-spec construction (`VistaFactory::build_from_spec`) is still unimplemented for `RestApiVistaFactory` — first cut focuses on the `from_table` path. Worth picking up alongside the next round of declarative model wiring.

### Versions

- `vantage-api-client` 0.1.3 → 0.1.4 (breaking: value type)
- `vantage-cli-util` 0.4.1 → 0.4.2 (additive: `vista_cli` module)
- `vantage-vista` 0.4.4 → 0.4.5 (additive: `get_ref`)