### PR TITLE
publish in dependency order

### DIFF
--- a/.github/workflows/publish-on-merge.yaml
+++ b/.github/workflows/publish-on-merge.yaml
@@ -70,7 +70,61 @@ jobs:
           CRATES: ${{ steps.detect.outputs.crates }}
         run: |
           set -euo pipefail
-          for crate in $CRATES; do
+          # Canonical topological publish order. `cargo publish` checks
+          # each crate's [dependencies] against crates.io at packaging
+          # time, so a downstream crate's bumped version must already be
+          # on the registry before its dependent publishes. Alphabetical
+          # iteration fails when api-client (depends on vista) runs
+          # before vista. New publishable crates must be appended here
+          # at the right layer; the unknown-crate tail is a safety net,
+          # not a substitute.
+          PUBLISH_ORDER=(
+            vantage-core
+            vantage-types
+            vantage-dataset
+            vantage-vista
+            vantage-expressions
+            vantage-table
+            vantage-cli-util
+            vantage-redb
+            vantage-api-pool
+            vantage-aws
+            vantage-api-client
+            vantage-csv
+            vantage-mongodb
+            vantage-sql
+            vantage-surrealdb
+            vantage-log-writer
+            vantage-live
+            vantage-config
+          )
+
+          # Project the bumped crates onto the canonical order. Anything
+          # not in the canonical list is appended at the end and logged
+          # — that's a signal to update PUBLISH_ORDER, not silently
+          # depend on alphabetical luck.
+          mapfile -t bumped < <(printf '%s\n' $CRATES | sort -u)
+          ordered=()
+          for canonical in "${PUBLISH_ORDER[@]}"; do
+            for c in "${bumped[@]}"; do
+              if [ "$c" = "$canonical" ]; then
+                ordered+=("$c")
+              fi
+            done
+          done
+          for c in "${bumped[@]}"; do
+            in_order=0
+            for o in "${ordered[@]}"; do
+              [ "$c" = "$o" ] && { in_order=1; break; }
+            done
+            if [ $in_order -eq 0 ]; then
+              echo "::warning::Crate '$c' is not in PUBLISH_ORDER — appending at end. Update the workflow."
+              ordered+=("$c")
+            fi
+          done
+
+          printf 'Publish order: %s\n' "${ordered[*]}"
+          for crate in "${ordered[@]}"; do
             echo "::group::Publishing $crate"
             (cd "$crate" && cargo publish --no-verify --allow-dirty)
             echo "::endgroup::"


### PR DESCRIPTION
PR #240 merged fine but the post-merge publish job died on the first crate: `vantage-api-client 0.1.4` requires `vantage-vista = "0.4.5"`, and at that point `vantage-vista` hadn't been published yet — the job iterates crates alphabetically. Even `--no-verify` doesn't skip the dep-requirement check that `cargo package` does against the registry.

Fix: hardcode a topological `PUBLISH_ORDER` and project the bumped-crate list onto it before iterating. Crates not in the list get appended at the end with a warning, so adding a new publishable crate is loud rather than silently risking re-ordering.

`cargo publish --dry-run` as a PR-time check doesn't help here: at PR time the new versions aren't on crates.io either, so dry-run hits the same registry-resolution error. Staging tarballs into a local registry would replicate the actual sequencing — that's what `cargo workspaces` / `release-plz` do, but neither was worth the lift for this size of workspace.

Run #240's failure: <https://github.com/romaninsh/vantage/actions/runs/25888126558>. The four crates from that run were published manually.