### PR TITLE
yaml factory for rest api driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4055,6 +4055,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "tokio",
  "urlencoding",
  "vantage-cli-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4046,7 +4046,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4367,7 +4367,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.5 — 2026-05-15
+
+YAML-driven model definitions: describe a REST resource in YAML, accumulate a registry, and traverse references — including across models defined in separate YAML files — without writing Rust factory closures.
+
+- [`RestApiVistaFactory::register_yaml(&str)`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.RestApiVistaFactory.html#method.register_yaml) parses a `RestApiVistaSpec` and stashes it under `spec.name`. [`build(name)`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.RestApiVistaFactory.html#method.build) materialises a `Vista` on demand; references resolve through the same registry so a parent's `:relation` traversal finds the child's spec without further wiring.
+- New table-level `api` block carries `endpoint: parent/{parentId}/child` for APIs that require path-based filtering. Defaults to `spec.name` when absent — declaring `name: users` is enough for a plain `/users` resource.
+- [`RestApiVistaFactory::with_model_resolver(Arc<dyn Fn(&str) -> Result<Vista>>)`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.RestApiVistaFactory.html#method.with_model_resolver) installs a callback that overrides the internal registry — for cross-driver setups (e.g. a UI shell whose inventory layer routes some models through SQL and others through REST) the resolver decides which factory builds each name.
+- Cross-cutting public types: [`ApiTableExtras`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.ApiTableExtras.html), [`ApiTableBlock`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.ApiTableBlock.html), `ApiColumnExtras`, `ApiReferenceExtras`, and [`ModelResolver`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/type.ModelResolver.html). `NoApiExtras` stays as a legacy alias.
+- New `examples/jsonplaceholder_yaml.rs` — same demo as `jsonplaceholder` with all three models in `data/jsonplaceholder/*.yaml`. Run `cargo run --example jsonplaceholder_yaml -- users id=1 :albums :photos`.
+
 ## 0.1.4 — 2026-05-14
 
 REST API now speaks [`ciborium::Value`](https://docs.rs/ciborium/) end-to-end and bridges into the universal [`Vista`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html) surface.

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.1.4"
+version = "0.1.5"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST API backends"
@@ -20,7 +20,7 @@ vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.4.2", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.4.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.4.6", path = "../vantage-vista" }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -13,6 +13,7 @@ indexmap = { version = "2", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+serde_yaml_ng = "0.10"
 urlencoding = "2.1"
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }

--- a/vantage-api-client/TODO.md
+++ b/vantage-api-client/TODO.md
@@ -1,0 +1,201 @@
+# Vista YAML — deferred features
+
+Features that vantage-ui's `inventory::TableConfig`
+(`/Users/rw/Work/worktrees/vantage-ui/witty-burrow/vantage-ui/inventory/src/table.rs`)
+carries but `RestApiVistaSpec` does not. Each one needs a design call
+before adoption.
+
+# Architectural follow-ups
+
+Items below are not YAML features — they're cleanups that came out of
+implementing the YAML factory and are worth a dedicated PR each.
+
+## Obsolete `AnyTable` in the Vista path
+
+`RestApiTableShell::get_ref` has two branches: the YAML path (resolver
+returns `Vista` directly — clean) and the typed-Rust fallback
+(`self.table.get_ref(relation)` returns `AnyTable`, which we then wrap
+via `AnyTableShell::into_vista`). The fallback exists because
+`TableLike::get_ref` is contractually `Result<AnyTable>` — and
+`vantage-table` can't return `Vista` directly without inverting the
+crate dependency (`vantage-vista` already depends on `vantage-table`).
+
+Path to remove it:
+
+1. Add Rust-native relation declarations at the Vista layer:
+   `Vista::with_many(rel, fk, Fn(...) -> Vista)`, paralleling the
+   YAML registry the shell already maintains.
+2. Demote `Table::with_many` / `with_one` / `with_foreign` to legacy.
+   They stay around for compat but stop being the entry point for
+   declaring relations.
+3. Move all the user-facing examples (jsonplaceholder, bakery models,
+   dynamo example) to the Vista-layer API.
+4. Drop the `TableLike::get_ref` fallback in `RestApiTableShell` —
+   YAML refs and Rust refs both route through the same Vista-layer
+   registry.
+5. Delete `AnyTableShell` (only exists to bridge the legacy path).
+
+Bigger refactor than today's; `AnyTable` survives across drivers
+(CSV, SQL, Mongo, etc.) until those examples migrate too.
+
+## Replace `Expression<CborValue>` with a custom `ApiCondition`
+
+`RestApi::Condition = vantage_expressions::Expression<CborValue>` —
+inherited from when the crate mirrored SQL-shaped expressions. For
+REST we only ever build eq-conditions plus the deferred-FK variant,
+and the URL builder peels them by template-string matching
+(`"{} = {}"`) and nested `ExpressiveEnum` indexing. That's overkill.
+
+Mirror what `vantage-csv` does — ship a focused condition type:
+
+```rust
+pub enum ApiCondition {
+    Eq { field: String, value: ApiValue },
+}
+
+pub enum ApiValue {
+    Scalar(CborValue),
+    /// Resolves at fetch time — used by YAML / `with_one`-style
+    /// FK conditions that need the parent's value.
+    Deferred(DeferredFkFn),
+}
+```
+
+What changes:
+
+- `operation.rs` simplifies — `eq_condition` builds the enum directly;
+  `condition_to_query_param` matches on `ApiCondition::Eq` instead of
+  template strings.
+- `endpoint_url` / `build_query_string` / `related_in_condition` /
+  `resolve_deferreds` in `api.rs` switch to the typed enum.
+- `vantage-expressions` dependency may drop from `vantage-api-client/Cargo.toml`
+  (verify — check for stragglers via `ExprDataSource` impl).
+- `RestApiTableShell::add_eq_condition` keeps its public signature
+  (`field, &CborValue`); only the typed thing flowing into
+  `self.table.add_condition` changes shape.
+- Tests in `operation.rs` re-stated against the enum.
+
+~150–200 lines of crate-local rewrite. Strictly a clarification — no
+external behaviour change. Worth doing before more REST-specific
+features (e.g. `narrow_via`) accrete on the Expression shape.
+
+## Ship a default `Renderer` in `vantage-cli-util`
+
+`vantage_cli_util::vista_cli` defines a `Renderer` trait
+(`render_list` + `render_record`) but no default impl, so every
+consumer rolls its own. Today both
+`vantage-aws/examples/dynamo-single-table.rs` and the two
+`jsonplaceholder*.rs` examples carry ~80 lines of near-identical
+tab-printing + title-field + relations-footer logic. Pure
+duplication.
+
+What to build:
+
+```rust
+// vantage-cli-util/src/vista_cli.rs
+pub struct DefaultRenderer;
+
+impl Renderer for DefaultRenderer {
+    fn render_list(&self, vista: &Vista, records: &..., column_override: Option<&[String]>) {
+        // delegate to `render_records_typed` (already in cli-util)
+        // honour title fields / column_override / id column.
+    }
+    fn render_record(&self, vista: &Vista, id: &str, record: &..., relations: &[String]) {
+        // title fields → divider → remaining fields → relations footer
+    }
+}
+```
+
+Consumers shrink to:
+
+```rust
+use vantage_cli_util::vista_cli::{self, DefaultRenderer};
+vista_cli::run(&factory, &DefaultRenderer, &args).await?;
+```
+
+Net negative LoC across the workspace. The bakery `cli-vista.rs`
+example already uses `render_records` for list mode, so the styled
+output is known good for `Record<CborValue>`. The only visible
+behaviour change is that the dynamo example (currently bare
+`\t`-separated) switches to comfy-table styling — almost certainly
+an improvement. Examples that want different shapes keep rolling
+their own.
+
+vantage-ui ships per-column `rules: { email: true, unique: true }` for
+client/server validation.
+
+```yaml
+- name: email
+  type: string
+  rules: { email: true, unique: true }
+```
+
+Open question: do validation rules belong in `VistaSpec` (every driver
+honours them) or in a UI-layer extension? Schema validation is a
+cross-cutting concern; centralising it in Vista keeps drivers
+consistent but expands the spec surface.
+
+## Static params (`params`) — out of scope
+
+vantage-ui uses `params: { eq: { archived: false } }` for AWS
+operations that need a mandatory request body, plus to bake default
+filter conditions into a Vista.
+
+```yaml
+params:
+  eq:
+    archived: false
+```
+
+Maps roughly to "default eq-conditions baked into the Vista at build
+time". Worth adopting once we wire AWS-style APIs through this
+factory.
+
+## `narrow_via` on references — out of scope
+
+For AWS-style APIs filtered by a string-prefix on the parent's id —
+not a foreign key — vantage-ui's `ReferenceDef` has `narrow_via`:
+
+```yaml
+references:
+  events:
+    table: aws_log_events
+    kind: has_many
+    foreign_key: logGroupName
+    narrow_via: logGroupNamePrefix
+```
+
+The parent's `logGroupName` value submits as `?logGroupNamePrefix=…`
+on the child request rather than `?logGroupName=…`. jsonplaceholder
+doesn't need it; revisit when wiring CloudWatch / S3 / IAM through
+this factory.
+
+## Rhai expression columns — yes for consideration
+
+vantage-ui supports `expressions: { full_name: "name + ' ' + last_name" }`
+for server-side computed columns:
+
+```yaml
+expressions:
+  full_name: "name + ' ' + last_name"
+```
+
+Plausibly a Vista-layer feature — any driver could honor it via
+post-processing the row stream. Needs design before adoption:
+embedded scripting language has security (sandboxing), perf (eval per
+row), and `vantage-vista` dependency-graph implications.
+
+## Datasource fields in table YAML — declined
+
+`auth`, `response_shape`, `pagination`, `base_url` describe the
+datasource, not individual tables. vantage-ui already keeps them in a
+separate `datasource: <name>.yaml`. They stay out of table YAML; the
+`RestApi` constructor consumes them in Rust before the factory runs.
+
+## UI rendering hints — relocate to UI layer
+
+Per-value `color` / `labels`, column `link` / `width` / `pin` /
+`label` / `tooltip` are pure rendering hints. They belong in a UI-side
+extension (a sibling spec or overlay), not at the Vista layer. Their
+new home is part of the vantage-ui migration that motivates this
+factory.

--- a/vantage-api-client/data/jsonplaceholder/albums.yaml
+++ b/vantage-api-client/data/jsonplaceholder/albums.yaml
@@ -1,0 +1,19 @@
+name: albums
+columns:
+  id:
+    type: int
+    flags: [id]
+  title:
+    type: string
+    flags: [title]
+  userId:
+    type: int
+references:
+  user:
+    table: users
+    kind: has_one
+    foreign_key: userId
+  photos:
+    table: photos
+    kind: has_many
+    foreign_key: albumId

--- a/vantage-api-client/data/jsonplaceholder/photos.yaml
+++ b/vantage-api-client/data/jsonplaceholder/photos.yaml
@@ -1,0 +1,19 @@
+name: photos
+columns:
+  id:
+    type: int
+    flags: [id]
+  title:
+    type: string
+    flags: [title]
+  albumId:
+    type: int
+  url:
+    type: string
+  thumbnailUrl:
+    type: string
+references:
+  album:
+    table: albums
+    kind: has_one
+    foreign_key: albumId

--- a/vantage-api-client/data/jsonplaceholder/users.yaml
+++ b/vantage-api-client/data/jsonplaceholder/users.yaml
@@ -1,0 +1,21 @@
+name: users
+columns:
+  id:
+    type: int
+    flags: [id]
+  name:
+    type: string
+    flags: [title]
+  username:
+    type: string
+  email:
+    type: string
+  phone:
+    type: string
+  website:
+    type: string
+references:
+  albums:
+    table: albums
+    kind: has_many
+    foreign_key: userId

--- a/vantage-api-client/examples/jsonplaceholder.rs
+++ b/vantage-api-client/examples/jsonplaceholder.rs
@@ -72,17 +72,12 @@ pub struct Photo {
 
 // ── Table factories ──────────────────────────────────────────────────────
 //
-// Each model exposes two factories:
-//   * the top-level table — `users`, `albums`, `photos` — used when the
-//     entity is queried in its own right;
-//   * a URI-template variant — `users/{userId}/albums`,
-//     `albums/{albumId}/photos` — used as a `with_many` build target
-//     so traversing from a parent narrows directly to the nested
-//     endpoint.
-//
-// The condition produced by RestApi's `related_in_condition`
-// (`userId = <parent_id>`) is consumed by the template's `{userId}`
-// substitution at request time; nothing leaks into the query string.
+// One factory per entity. References are declared with `with_many` /
+// `with_one`; jsonplaceholder accepts query-string filtering on every
+// resource (`/albums?userId=1`, `/users?id=2`), which is what
+// `related_in_condition` produces by default — no URI templates
+// needed at this level. APIs that *require* path-based filtering can
+// opt into per-reference URI templates through the YAML factory.
 
 impl User {
     pub fn api_table(api: RestApi) -> Table<RestApi, User> {
@@ -93,42 +88,25 @@ impl User {
             .with_column_of::<Option<String>>("email")
             .with_column_of::<Option<String>>("phone")
             .with_column_of::<Option<String>>("website")
-            .with_many("albums", "userId", Album::api_table_for_user)
+            .with_many("albums", "userId", Album::api_table)
     }
 }
 
 impl Album {
     pub fn api_table(api: RestApi) -> Table<RestApi, Album> {
-        Self::columns(Table::new("albums", api))
-    }
-
-    /// Nested form used when traversing from a User. The `{userId}`
-    /// placeholder is resolved by `RestApi`'s template substitution at
-    /// request time from the eq-condition wired up by `with_many`.
-    pub fn api_table_for_user(api: RestApi) -> Table<RestApi, Album> {
-        Self::columns(Table::new("users/{userId}/albums", api))
-    }
-
-    fn columns(t: Table<RestApi, Album>) -> Table<RestApi, Album> {
-        t.with_id_column("id")
+        Table::new("albums", api)
+            .with_id_column("id")
             .with_title_column_of::<Option<String>>("title")
             .with_column_of::<Option<i64>>("userId")
             .with_one("user", "userId", User::api_table)
-            .with_many("photos", "albumId", Photo::api_table_for_album)
+            .with_many("photos", "albumId", Photo::api_table)
     }
 }
 
 impl Photo {
     pub fn api_table(api: RestApi) -> Table<RestApi, Photo> {
-        Self::columns(Table::new("photos", api))
-    }
-
-    pub fn api_table_for_album(api: RestApi) -> Table<RestApi, Photo> {
-        Self::columns(Table::new("albums/{albumId}/photos", api))
-    }
-
-    fn columns(t: Table<RestApi, Photo>) -> Table<RestApi, Photo> {
-        t.with_id_column("id")
+        Table::new("photos", api)
+            .with_id_column("id")
             .with_title_column_of::<Option<String>>("title")
             .with_column_of::<Option<i64>>("albumId")
             .with_column_of::<Option<String>>("url")

--- a/vantage-api-client/examples/jsonplaceholder_yaml.rs
+++ b/vantage-api-client/examples/jsonplaceholder_yaml.rs
@@ -1,0 +1,195 @@
+//! `jsonplaceholder_yaml` — same demo as `jsonplaceholder`, but every
+//! model is defined in a YAML spec rather than in Rust. Three files
+//! under `data/jsonplaceholder/` describe Users, Albums, and Photos;
+//! the factory accumulates them via `register_yaml` and the internal
+//! registry serves as the model resolver for `:relation` traversal.
+//!
+//! Usage:
+//!
+//! ```sh
+//! cargo run --example jsonplaceholder_yaml -- users
+//! cargo run --example jsonplaceholder_yaml -- users id=1 :albums
+//! cargo run --example jsonplaceholder_yaml -- users id=1 ':albums[0]' :photos
+//! cargo run --example jsonplaceholder_yaml -- albums id=11 :user
+//! cargo run --example jsonplaceholder_yaml -- photos id=42 ':album[0]' :user
+//! ```
+//!
+//! Output matches `jsonplaceholder` line-for-line; only the URLs in
+//! transit differ (the YAML declares `endpoint_template` on the
+//! `:albums` and `:photos` references, so they take the path-based
+//! `/users/{userId}/albums` and `/albums/{albumId}/photos` forms).
+
+use std::sync::Arc;
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_api_client::{RestApi, RestApiVistaFactory, ResponseShape};
+use vantage_cli_util::vista_cli::{self, Mode, ModelFactory, Renderer};
+use vantage_types::Record;
+use vantage_vista::Vista;
+
+const BASE_URL: &str = "https://jsonplaceholder.typicode.com";
+
+const USERS_YAML: &str = include_str!("../data/jsonplaceholder/users.yaml");
+const ALBUMS_YAML: &str = include_str!("../data/jsonplaceholder/albums.yaml");
+const PHOTOS_YAML: &str = include_str!("../data/jsonplaceholder/photos.yaml");
+
+// ── Factory + renderer for the vista_cli runner ─────────────────────────
+
+struct JsonPlaceholderFactory {
+    inner: Arc<RestApiVistaFactory>,
+}
+
+impl JsonPlaceholderFactory {
+    fn build(api: RestApi) -> anyhow::Result<Self> {
+        let mut factory = RestApiVistaFactory::new(api);
+        factory.register_yaml(USERS_YAML)?;
+        factory.register_yaml(ALBUMS_YAML)?;
+        factory.register_yaml(PHOTOS_YAML)?;
+        Ok(Self {
+            inner: Arc::new(factory),
+        })
+    }
+}
+
+impl ModelFactory for JsonPlaceholderFactory {
+    fn for_name(&self, name: &str) -> Option<(Vista, Mode)> {
+        let (canonical, mode) = match name {
+            "user" => ("users", Mode::Single),
+            "users" => ("users", Mode::List),
+            "album" => ("albums", Mode::Single),
+            "albums" => ("albums", Mode::List),
+            "photo" => ("photos", Mode::Single),
+            "photos" => ("photos", Mode::List),
+            _ => return None,
+        };
+        self.inner.build(canonical).ok().map(|v| (v, mode))
+    }
+}
+
+const KNOWN_MODELS: &[&str] = &[
+    "user", "users", "album", "albums", "photo", "photos",
+];
+
+struct CborRenderer;
+
+impl Renderer for CborRenderer {
+    fn render_list(
+        &self,
+        vista: &Vista,
+        records: &IndexMap<String, Record<CborValue>>,
+        column_override: Option<&[String]>,
+    ) {
+        let id_field = vista.get_id_column().unwrap_or("id").to_string();
+        let title_fields: Vec<String> = vista
+            .get_title_columns()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let columns: Vec<String> = if let Some(cols) = column_override {
+            cols.iter()
+                .map(|c| if c == "id" { id_field.clone() } else { c.clone() })
+                .collect()
+        } else if !title_fields.is_empty() {
+            title_fields
+        } else {
+            vista
+                .get_column_names()
+                .into_iter()
+                .filter(|c| *c != id_field)
+                .take(3)
+                .map(|s| s.to_string())
+                .collect()
+        };
+
+        let mut header = vec![id_field.clone()];
+        header.extend(columns.iter().cloned());
+        println!("{}", header.join("\t"));
+
+        for (id, rec) in records {
+            let mut row = vec![id.clone()];
+            for c in &columns {
+                row.push(rec.get(c).map(cbor_short).unwrap_or_default());
+            }
+            println!("{}", row.join("\t"));
+        }
+        println!(
+            "\n({} record{})",
+            records.len(),
+            if records.len() == 1 { "" } else { "s" }
+        );
+    }
+
+    fn render_record(
+        &self,
+        vista: &Vista,
+        id: &str,
+        record: &Record<CborValue>,
+        relations: &[String],
+    ) {
+        let id_field = vista.get_id_column().unwrap_or("id");
+        println!("{}: {}", id_field, id);
+        let title_fields: Vec<&str> = vista.get_title_columns();
+        for tf in &title_fields {
+            if *tf == id_field {
+                continue;
+            }
+            if let Some(v) = record.get(*tf) {
+                println!("{}: {}", tf, cbor_short(v));
+            }
+        }
+        println!("--------");
+        for (k, v) in record.iter() {
+            if k == id_field || title_fields.iter().any(|t| t == k) {
+                continue;
+            }
+            println!("{}: {}", k, cbor_short(v));
+        }
+        if !relations.is_empty() {
+            println!();
+            println!("Relations:");
+            for r in relations {
+                println!("  :{r}");
+            }
+        }
+    }
+}
+
+fn cbor_short(v: &CborValue) -> String {
+    use ciborium::Value as C;
+    match v {
+        C::Text(s) => s.clone(),
+        C::Integer(i) => i128::from(*i).to_string(),
+        C::Float(f) => f.to_string(),
+        C::Bool(b) => b.to_string(),
+        C::Null => "null".to_string(),
+        C::Bytes(b) => format!("<{} bytes>", b.len()),
+        other => format!("{other:?}"),
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!(
+            "usage: jsonplaceholder_yaml <model> [field=value ...] [[N]] [:relation ...]"
+        );
+        eprintln!("\nKnown models:");
+        for n in KNOWN_MODELS {
+            eprintln!("  {n}");
+        }
+        std::process::exit(2);
+    }
+
+    let api = RestApi::builder(BASE_URL)
+        .response_shape(ResponseShape::BareArray)
+        .build();
+    let factory = JsonPlaceholderFactory::build(api)?;
+    let renderer = CborRenderer;
+    vista_cli::run(&factory, &renderer, &args)
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(())
+}

--- a/vantage-api-client/examples/jsonplaceholder_yaml.rs
+++ b/vantage-api-client/examples/jsonplaceholder_yaml.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use ciborium::Value as CborValue;
 use indexmap::IndexMap;
-use vantage_api_client::{RestApi, RestApiVistaFactory, ResponseShape};
+use vantage_api_client::{ResponseShape, RestApi, RestApiVistaFactory};
 use vantage_cli_util::vista_cli::{self, Mode, ModelFactory, Renderer};
 use vantage_types::Record;
 use vantage_vista::Vista;
@@ -67,9 +67,7 @@ impl ModelFactory for JsonPlaceholderFactory {
     }
 }
 
-const KNOWN_MODELS: &[&str] = &[
-    "user", "users", "album", "albums", "photo", "photos",
-];
+const KNOWN_MODELS: &[&str] = &["user", "users", "album", "albums", "photo", "photos"];
 
 struct CborRenderer;
 
@@ -89,7 +87,13 @@ impl Renderer for CborRenderer {
 
         let columns: Vec<String> = if let Some(cols) = column_override {
             cols.iter()
-                .map(|c| if c == "id" { id_field.clone() } else { c.clone() })
+                .map(|c| {
+                    if c == "id" {
+                        id_field.clone()
+                    } else {
+                        c.clone()
+                    }
+                })
                 .collect()
         } else if !title_fields.is_empty() {
             title_fields
@@ -173,9 +177,7 @@ fn cbor_short(v: &CborValue) -> String {
 async fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     if args.is_empty() {
-        eprintln!(
-            "usage: jsonplaceholder_yaml <model> [field=value ...] [[N]] [:relation ...]"
-        );
+        eprintln!("usage: jsonplaceholder_yaml <model> [field=value ...] [[N]] [:relation ...]");
         eprintln!("\nKnown models:");
         for n in KNOWN_MODELS {
             eprintln!("  {n}");

--- a/vantage-api-client/src/lib.rs
+++ b/vantage-api-client/src/lib.rs
@@ -7,5 +7,6 @@ pub use api::{PaginationParams, ResponseShape, RestApi, RestApiBuilder};
 pub(crate) use operation::condition_to_query_param;
 pub use operation::eq_condition;
 pub use vista::{
-    AnyTableShell, NoApiExtras, RestApiTableShell, RestApiVistaFactory, RestApiVistaSpec,
+    AnyTableShell, ApiColumnExtras, ApiReferenceExtras, ApiTableBlock, ApiTableExtras,
+    ModelResolver, NoApiExtras, RestApiTableShell, RestApiVistaFactory, RestApiVistaSpec,
 };

--- a/vantage-api-client/src/vista/factory.rs
+++ b/vantage-api-client/src/vista/factory.rs
@@ -68,10 +68,7 @@ impl RestApiVistaFactory {
                 detail = e.to_string()
             )
         })?;
-        self.specs
-            .write()
-            .unwrap()
-            .insert(spec.name.clone(), spec);
+        self.specs.write().unwrap().insert(spec.name.clone(), spec);
         Ok(())
     }
 
@@ -85,12 +82,7 @@ impl RestApiVistaFactory {
             .unwrap()
             .get(name)
             .cloned()
-            .ok_or_else(|| {
-                error!(
-                    "No registered spec for model name",
-                    name = name.to_string()
-                )
-            })?;
+            .ok_or_else(|| error!("No registered spec for model name", name = name.to_string()))?;
         self.build_from_spec(spec)
     }
 
@@ -210,10 +202,7 @@ impl RestApiVistaFactory {
     /// Lower a `RestApiVistaSpec` into a typed `Table<RestApi,
     /// EmptyEntity>`. Endpoint defaults to `spec.name` when the
     /// `api.endpoint` block is absent.
-    fn table_from_spec(
-        &self,
-        spec: &RestApiVistaSpec,
-    ) -> Result<Table<RestApi, EmptyEntity>> {
+    fn table_from_spec(&self, spec: &RestApiVistaSpec) -> Result<Table<RestApi, EmptyEntity>> {
         let endpoint = spec
             .driver
             .api
@@ -284,9 +273,7 @@ fn column_for_type(name: &str, ty: &str) -> Result<TableColumn<CborValue>> {
             TableColumn::from_column(TableColumn::<f64>::new(name))
         }
         "bool" | "boolean" => TableColumn::from_column(TableColumn::<bool>::new(name)),
-        "string" | "text" | "str" => {
-            TableColumn::from_column(TableColumn::<String>::new(name))
-        }
+        "string" | "text" | "str" => TableColumn::from_column(TableColumn::<String>::new(name)),
         "json" | "any" => TableColumn::from_column(TableColumn::<CborValue>::new(name)),
         other => {
             return Err(error!(

--- a/vantage-api-client/src/vista/factory.rs
+++ b/vantage-api-client/src/vista/factory.rs
@@ -1,39 +1,104 @@
-//! `RestApiVistaFactory` — typed-table entry point and `VistaFactory`
-//! trait impl. REST API is read-only at this stage, so the factory
-//! advertises only `can_count`.
+//! `RestApiVistaFactory` — typed-table entry point, `VistaFactory`
+//! trait impl, plus the YAML factory pipeline (`build_from_spec`,
+//! `register_yaml`, `with_model_resolver`).
+//!
+//! REST API is read-only at this stage, so the factory advertises
+//! only `can_count`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use ciborium::Value as CborValue;
-use vantage_core::Result;
+use vantage_core::{Result, error};
+use vantage_table::column::core::Column as TableColumn;
 use vantage_table::column::flags::ColumnFlag;
 use vantage_table::table::Table;
 use vantage_table::traits::column_like::ColumnLike;
-use vantage_types::Entity;
+use vantage_types::{EmptyEntity, Entity};
 use vantage_vista::{
     Column as VistaColumn, Reference as VistaReference, ReferenceKind, Vista, VistaCapabilities,
     VistaFactory, VistaMetadata, flags as vista_flags,
 };
 
 use crate::RestApi;
-use crate::vista::source::RestApiTableShell;
-use crate::vista::spec::{NoApiExtras, RestApiVistaSpec};
+use crate::vista::source::{RestApiTableShell, YamlReference, YamlReferenceKind};
+use crate::vista::spec::{ApiColumnExtras, ApiReferenceExtras, ApiTableExtras, RestApiVistaSpec};
+
+/// Callback that maps a model name to its `Vista`. The factory uses
+/// it at relation-traversal time so cross-driver lookups (vantage-ui's
+/// inventory layer) and same-driver lookups (the internal
+/// `register_yaml` registry) flow through one channel.
+pub type ModelResolver = Arc<dyn Fn(&str) -> Result<Vista> + Send + Sync>;
 
 pub struct RestApiVistaFactory {
     api: RestApi,
+    specs: Arc<RwLock<HashMap<String, RestApiVistaSpec>>>,
+    resolver: Option<ModelResolver>,
 }
 
 impl RestApiVistaFactory {
     pub fn new(api: RestApi) -> Self {
-        Self { api }
+        Self {
+            api,
+            specs: Arc::new(RwLock::new(HashMap::new())),
+            resolver: None,
+        }
     }
 
     pub fn api(&self) -> &RestApi {
         &self.api
     }
 
+    /// Install a model-resolver callback. Use this when models live
+    /// across multiple drivers (e.g. vantage-ui's inventory crosses
+    /// drivers and decides which factory to build each model from).
+    pub fn with_model_resolver(mut self, resolver: ModelResolver) -> Self {
+        self.resolver = Some(resolver);
+        self
+    }
+
+    /// Accumulate a YAML spec in the factory's internal registry.
+    /// When no explicit resolver is installed, references resolve
+    /// against this registry — i.e. all models live in the same
+    /// `RestApi` and are built lazily on first traversal.
+    pub fn register_yaml(&mut self, yaml: &str) -> Result<()> {
+        let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).map_err(|e| {
+            error!(
+                "Failed to parse RestApiVistaSpec YAML",
+                detail = e.to_string()
+            )
+        })?;
+        self.specs
+            .write()
+            .unwrap()
+            .insert(spec.name.clone(), spec);
+        Ok(())
+    }
+
+    /// Build the Vista for a previously-registered model name. Uses
+    /// the internal registry; the installed resolver (if any) takes
+    /// over at relation traversal time.
+    pub fn build(&self, name: &str) -> Result<Vista> {
+        let spec = self
+            .specs
+            .read()
+            .unwrap()
+            .get(name)
+            .cloned()
+            .ok_or_else(|| {
+                error!(
+                    "No registered spec for model name",
+                    name = name.to_string()
+                )
+            })?;
+        self.build_from_spec(spec)
+    }
+
     /// Wrap a typed `Table<RestApi, E>` as a `Vista`. Column metadata,
     /// id field, title fields, and references are harvested up front;
     /// the table itself is stored as `Box<dyn TableLike>` so the
-    /// original `E` stays attached for reference traversal.
+    /// original `E` stays attached for reference traversal via the
+    /// typed-table machinery.
     pub fn from_table<E>(&self, table: Table<RestApi, E>) -> Result<Vista>
     where
         E: Entity<CborValue> + 'static,
@@ -50,18 +115,188 @@ impl RestApiVistaFactory {
         );
         Ok(Vista::new(name, Box::new(source), metadata))
     }
+
+    /// Resolve a model name to a Vista — either via the installed
+    /// resolver or through the internal registry.
+    fn resolver_for_specs(&self) -> ModelResolver {
+        if let Some(r) = &self.resolver {
+            return r.clone();
+        }
+        // Default resolver: recursively build_from_spec against the
+        // shared registry. Cloning the Arc keeps the closure cheap.
+        let specs = self.specs.clone();
+        let api = self.api.clone();
+        Arc::new(move |name: &str| -> Result<Vista> {
+            let spec = specs.read().unwrap().get(name).cloned().ok_or_else(|| {
+                error!(
+                    "Model resolver: no spec registered for name",
+                    name = name.to_string()
+                )
+            })?;
+            // Reuse the same factory pipeline as the top-level build.
+            let mut factory = RestApiVistaFactory::new(api.clone());
+            factory.specs = specs.clone();
+            factory.build_from_spec(spec)
+        })
+    }
 }
 
 impl VistaFactory for RestApiVistaFactory {
-    type TableExtras = NoApiExtras;
-    type ColumnExtras = NoApiExtras;
-    type ReferenceExtras = NoApiExtras;
+    type TableExtras = ApiTableExtras;
+    type ColumnExtras = ApiColumnExtras;
+    type ReferenceExtras = ApiReferenceExtras;
 
-    fn build_from_spec(&self, _spec: RestApiVistaSpec) -> Result<Vista> {
-        Err(vantage_core::error!(
-            "YAML spec construction not yet implemented for RestApiVistaFactory"
-        ))
+    fn build_from_spec(&self, spec: RestApiVistaSpec) -> Result<Vista> {
+        let table = self.table_from_spec(&spec)?;
+        let vista_name = spec.name.clone();
+
+        // Harvest column / id / title metadata from the typed table.
+        let mut metadata = metadata_from_table(&table);
+
+        // Surface YAML-declared references as Vista metadata so
+        // generic UI layers see them via `vista.get_references()`.
+        for (rel_name, ref_spec) in &spec.references {
+            metadata = metadata.with_reference(VistaReference::new(
+                rel_name.clone(),
+                ref_spec.table.clone(),
+                ref_spec.kind,
+                ref_spec
+                    .foreign_key
+                    .clone()
+                    .unwrap_or_else(|| rel_name.clone()),
+            ));
+        }
+
+        // Build the YAML reference table for the shell. The shell
+        // consults this at `get_ref` time and threads a `DeferredFn`
+        // through the child. The child's URL form is the child's
+        // own concern (its `api.endpoint`), not the parent's.
+        let mut yaml_refs = indexmap::IndexMap::new();
+        for (rel_name, ref_spec) in &spec.references {
+            yaml_refs.insert(
+                rel_name.clone(),
+                YamlReference {
+                    target: ref_spec.table.clone(),
+                    kind: match ref_spec.kind {
+                        ReferenceKind::HasOne => YamlReferenceKind::HasOne,
+                        ReferenceKind::HasMany => YamlReferenceKind::HasMany,
+                        ReferenceKind::HasForeign => YamlReferenceKind::HasMany,
+                    },
+                    foreign_key: ref_spec
+                        .foreign_key
+                        .clone()
+                        .unwrap_or_else(|| rel_name.clone()),
+                },
+            );
+        }
+
+        let source = RestApiTableShell::new(
+            Box::new(table),
+            VistaCapabilities {
+                can_count: true,
+                ..VistaCapabilities::default()
+            },
+        )
+        .with_yaml_refs(yaml_refs)
+        .with_resolver(self.resolver_for_specs());
+
+        let mut vista = Vista::new(vista_name.clone(), Box::new(source), metadata);
+        vista.set_name(vista_name);
+        Ok(vista)
     }
+}
+
+impl RestApiVistaFactory {
+    /// Lower a `RestApiVistaSpec` into a typed `Table<RestApi,
+    /// EmptyEntity>`. Endpoint defaults to `spec.name` when the
+    /// `api.endpoint` block is absent.
+    fn table_from_spec(
+        &self,
+        spec: &RestApiVistaSpec,
+    ) -> Result<Table<RestApi, EmptyEntity>> {
+        let endpoint = spec
+            .driver
+            .api
+            .as_ref()
+            .and_then(|b| b.endpoint.clone())
+            .unwrap_or_else(|| spec.name.clone());
+
+        let id_column = resolve_id_column(spec);
+
+        let mut table = Table::<RestApi, EmptyEntity>::new(endpoint, self.api.clone());
+        for (name, col_spec) in &spec.columns {
+            table.add_column(build_column(name, col_spec)?);
+            if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
+                table.add_title_field(name);
+            }
+        }
+
+        if !table.columns().contains_key(&id_column) {
+            return Err(error!(
+                "id column not present in spec.columns",
+                id = id_column
+            ));
+        }
+        table.set_id_field(&id_column);
+
+        Ok(table)
+    }
+}
+
+/// Pick the id column from an `id_column:` field or the first column
+/// flagged `id`; falls back to `"id"`.
+fn resolve_id_column(spec: &RestApiVistaSpec) -> String {
+    if let Some(id) = &spec.id_column {
+        return id.clone();
+    }
+    for (name, col_spec) in &spec.columns {
+        if col_spec.flags.iter().any(|f| f == vista_flags::ID) {
+            return name.clone();
+        }
+    }
+    "id".to_string()
+}
+
+fn build_column(
+    name: &str,
+    col_spec: &vantage_vista::ColumnSpec<ApiColumnExtras>,
+) -> Result<TableColumn<CborValue>> {
+    let ty = col_spec.col_type.as_deref().unwrap_or("string");
+    let hidden = col_spec.flags.iter().any(|f| f == vista_flags::HIDDEN);
+
+    let mut col = column_for_type(name, ty)?;
+    if hidden {
+        col = col.with_flag(ColumnFlag::Hidden);
+    }
+    Ok(col)
+}
+
+/// YAML type alias → typed `Column<T>` → erased to `Column<CborValue>`
+/// for storage. The original type label survives via
+/// `Column::from_column`, so generic UIs see "i64" / "f64" / "bool"
+/// / "string" in `column_types()` regardless of the wire format.
+fn column_for_type(name: &str, ty: &str) -> Result<TableColumn<CborValue>> {
+    let col: TableColumn<CborValue> = match ty {
+        "int" | "integer" | "i64" | "i32" => {
+            TableColumn::from_column(TableColumn::<i64>::new(name))
+        }
+        "float" | "double" | "f64" | "f32" => {
+            TableColumn::from_column(TableColumn::<f64>::new(name))
+        }
+        "bool" | "boolean" => TableColumn::from_column(TableColumn::<bool>::new(name)),
+        "string" | "text" | "str" => {
+            TableColumn::from_column(TableColumn::<String>::new(name))
+        }
+        "json" | "any" => TableColumn::from_column(TableColumn::<CborValue>::new(name)),
+        other => {
+            return Err(error!(
+                "Unknown YAML column type",
+                column = name,
+                ty = other.to_string()
+            ));
+        }
+    };
+    Ok(col)
 }
 
 fn metadata_from_table<E>(table: &Table<RestApi, E>) -> VistaMetadata
@@ -91,10 +326,6 @@ where
     for relation in table.references() {
         metadata = metadata.with_reference(VistaReference::new(
             relation.clone(),
-            // Target / foreign-key metadata are driver-internal for
-            // REST API (the typed table's reference closure owns the
-            // child build); surface a placeholder so the universal
-            // shape stays populated.
             "",
             ReferenceKind::HasMany,
             "",

--- a/vantage-api-client/src/vista/mod.rs
+++ b/vantage-api-client/src/vista/mod.rs
@@ -15,9 +15,12 @@ pub mod source;
 pub mod spec;
 
 pub use any_shell::AnyTableShell;
-pub use factory::RestApiVistaFactory;
+pub use factory::{ModelResolver, RestApiVistaFactory};
 pub use source::RestApiTableShell;
-pub use spec::{NoApiExtras, RestApiVistaSpec};
+pub use spec::{
+    ApiColumnExtras, ApiReferenceExtras, ApiTableBlock, ApiTableExtras, NoApiExtras,
+    RestApiVistaSpec,
+};
 
 use crate::RestApi;
 

--- a/vantage-api-client/src/vista/source.rs
+++ b/vantage-api-client/src/vista/source.rs
@@ -6,26 +6,52 @@
 //! is converted at the fetch boundary), so the shell is a pass-through
 //! with no per-record translation.
 //!
-//! Why `Box<dyn TableLike>` and not `Table<RestApi, EmptyEntity>`?
-//! `with_many` / `with_one` register references whose `SourceE` is the
-//! original entity (`User`, `Album`, …). At traversal time
-//! `HasMany::resolve_as_any` downcasts `Table<T, SourceE>` against the
-//! stored value; erasing the entity to `EmptyEntity` would break that
-//! downcast.
+//! YAML-declared references are carried separately (`yaml_refs`)
+//! because `Table::with_many` / `with_one` require compile-time-known
+//! build-target closures that YAML can't synthesise. At traversal
+//! time the shell consults the resolver (a factory-wide callback that
+//! maps model names to child Vistas) and threads a `DeferredFn`
+//! through the child so the parent's id resolves only when the child
+//! actually fetches.
+
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use ciborium::Value as CborValue;
 use indexmap::IndexMap;
-use vantage_core::Result;
+use vantage_core::{Result, error};
+use vantage_expressions::Expression;
+use vantage_expressions::traits::expressive::{DeferredFn, ExpressiveEnum};
 use vantage_table::traits::table_like::TableLike;
 use vantage_types::Record;
 use vantage_vista::{TableShell, Vista, VistaCapabilities};
 
+use crate::vista::factory::ModelResolver;
+
 use super::any_shell::AnyTableShell;
+
+/// A single YAML-declared reference attached to a parent shell at
+/// build time. Carries the foreign-key wiring; the URL form is
+/// the child's own concern (its `api.endpoint`) — the parent only
+/// declares the relationship.
+#[derive(Clone)]
+pub(crate) struct YamlReference {
+    pub target: String,
+    pub kind: YamlReferenceKind,
+    pub foreign_key: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum YamlReferenceKind {
+    HasMany,
+    HasOne,
+}
 
 pub struct RestApiTableShell {
     pub(crate) table: Box<dyn TableLike<Value = CborValue, Id = String>>,
     pub(crate) capabilities: VistaCapabilities,
+    pub(crate) yaml_refs: IndexMap<String, YamlReference>,
+    pub(crate) resolver: Option<ModelResolver>,
 }
 
 impl RestApiTableShell {
@@ -36,7 +62,67 @@ impl RestApiTableShell {
         Self {
             table,
             capabilities,
+            yaml_refs: IndexMap::new(),
+            resolver: None,
         }
+    }
+
+    pub(crate) fn with_yaml_refs(mut self, refs: IndexMap<String, YamlReference>) -> Self {
+        self.yaml_refs = refs;
+        self
+    }
+
+    pub(crate) fn with_resolver(mut self, resolver: ModelResolver) -> Self {
+        self.resolver = Some(resolver);
+        self
+    }
+
+    /// Construct the deferred FK condition for a YAML reference. The
+    /// returned `Expression` carries a `DeferredFn` that, when
+    /// resolved at child-fetch time, reads `source_column` out of the
+    /// parent's first record and emits it as a scalar — same shape
+    /// `condition_to_query_param` already peels for synchronous eq
+    /// conditions.
+    fn build_deferred_fk_condition(
+        parent_table: Box<dyn TableLike<Value = CborValue, Id = String>>,
+        source_column: String,
+        target_field: String,
+    ) -> Expression<CborValue> {
+        let parent_arc = Arc::new(parent_table);
+        let column = source_column;
+        let target_field_for_error = target_field.clone();
+        let deferred = DeferredFn::new(move || {
+            let parent = parent_arc.clone_box();
+            let column = column.clone();
+            let target = target_field_for_error.clone();
+            Box::pin(async move {
+                let records = parent.list_values().await?;
+                let value = records
+                    .values()
+                    .next()
+                    .and_then(|r| r.get(&column))
+                    .cloned()
+                    .ok_or_else(|| {
+                        error!(
+                            "YAML reference: parent yielded no row or column missing",
+                            source_column = column,
+                            target_field = target
+                        )
+                    })?;
+                Ok(ExpressiveEnum::Scalar(value))
+            })
+        });
+
+        Expression::new(
+            "{} = {}",
+            vec![
+                ExpressiveEnum::Nested(Expression::new(target_field, vec![])),
+                ExpressiveEnum::Nested(Expression::new(
+                    "{}",
+                    vec![ExpressiveEnum::Deferred(deferred)],
+                )),
+            ],
+        )
     }
 }
 
@@ -78,14 +164,64 @@ impl TableShell for RestApiTableShell {
         self.table.add_condition(Box::new(condition))
     }
 
+    fn add_raw_condition(
+        &mut self,
+        condition: Box<dyn std::any::Any + Send + Sync>,
+    ) -> Result<()> {
+        self.table.add_condition(condition)
+    }
+
     fn get_ref(&self, relation: &str) -> Result<Vista> {
-        // `TableLike::get_ref` delegates to `Table<T, E>::get_ref`,
-        // which uses the typed-table reference machinery. The result
-        // already carries the right conditions (parent-narrowing eq
-        // translated by `related_in_condition`) and the right table
-        // name (possibly a URI template, since the child factory
-        // chose one). Wrap it in a Vista so generic code can keep
-        // driving it.
+        // YAML-declared references first: the factory wired them via
+        // `yaml_refs` at build time. Resolve them through the
+        // model-resolver callback so cross-driver lookups (vantage-ui's
+        // inventory) work alongside same-driver ones.
+        if let Some(yref) = self.yaml_refs.get(relation) {
+            let resolver = self.resolver.as_ref().ok_or_else(|| {
+                error!(
+                    "YAML reference requires a model resolver — call \
+                     `with_model_resolver` on the factory or register \
+                     the target spec via `register_yaml`",
+                    relation = relation
+                )
+            })?;
+
+            let mut child = resolver(&yref.target)?;
+
+            // For `has_many` the parent's id flows onto the child's FK
+            // column; for `has_one` the parent's FK column value
+            // becomes the child's id. The source column we read from
+            // the parent at fetch time differs accordingly.
+            let (source_column, target_field) = match yref.kind {
+                YamlReferenceKind::HasMany => {
+                    let parent_id = self.table.id_field_name().ok_or_else(|| {
+                        error!(
+                            "YAML has_many reference needs the parent to have an id field",
+                            relation = relation
+                        )
+                    })?;
+                    (parent_id, yref.foreign_key.clone())
+                }
+                YamlReferenceKind::HasOne => {
+                    let child_id = child
+                        .get_id_column()
+                        .map(str::to_string)
+                        .unwrap_or_else(|| "id".to_string());
+                    (yref.foreign_key.clone(), child_id)
+                }
+            };
+
+            let parent_clone = self.table.clone_box();
+            let condition =
+                Self::build_deferred_fk_condition(parent_clone, source_column, target_field);
+            child.add_raw_condition(condition)?;
+
+            return Ok(child);
+        }
+
+        // Fall through to the typed `Table` reference machinery —
+        // hand-coded `with_many` / `with_one` / `with_foreign`
+        // registrations in Rust callers go through this path.
         let any_table = self.table.get_ref(relation)?;
         AnyTableShell::into_vista(any_table)
     }

--- a/vantage-api-client/src/vista/source.rs
+++ b/vantage-api-client/src/vista/source.rs
@@ -164,10 +164,7 @@ impl TableShell for RestApiTableShell {
         self.table.add_condition(Box::new(condition))
     }
 
-    fn add_raw_condition(
-        &mut self,
-        condition: Box<dyn std::any::Any + Send + Sync>,
-    ) -> Result<()> {
+    fn add_raw_condition(&mut self, condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()> {
         self.table.add_condition(condition)
     }
 

--- a/vantage-api-client/src/vista/spec.rs
+++ b/vantage-api-client/src/vista/spec.rs
@@ -1,11 +1,39 @@
 //! YAML-facing types for the REST-API Vista driver.
 //!
-//! REST APIs carry no driver-specific blocks for now, so all three
-//! extension types use `NoExtras`. Kept as separate typedefs so we can
-//! grow a per-table/per-column block later (e.g. response-shape
-//! overrides) without breaking callers.
+//! Only the table-level `api` block carries driver-specific fields.
+//! Column and reference extras stay at `NoExtras` — the universal
+//! `VistaSpec` already covers what's needed (column type/flags,
+//! reference target/kind/foreign_key). URL templating lives on each
+//! table's own `api.endpoint` and is shared across all traversals;
+//! the URL builder peels matching eq-conditions into `{placeholder}`
+//! segments and lets the rest fall through to the query string.
 
+use serde::{Deserialize, Serialize};
 use vantage_vista::{NoExtras, VistaSpec};
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApiTableExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api: Option<ApiTableBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ApiTableBlock {
+    /// URL path under the data source's base URL. May contain
+    /// `{placeholder}` segments that `RestApi` substitutes from
+    /// eq-conditions at request time; non-matching eq-conditions
+    /// become query params. Defaults to `spec.name` when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+}
+
+pub type ApiColumnExtras = NoExtras;
+pub type ApiReferenceExtras = NoExtras;
+
+/// Legacy alias for callers that already imported `NoApiExtras` from
+/// the placeholder version of this module.
 pub type NoApiExtras = NoExtras;
-pub type RestApiVistaSpec = VistaSpec<NoApiExtras, NoApiExtras, NoApiExtras>;
+
+pub type RestApiVistaSpec = VistaSpec<ApiTableExtras, ApiColumnExtras, ApiReferenceExtras>;

--- a/vantage-api-client/tests/yaml_factory.rs
+++ b/vantage-api-client/tests/yaml_factory.rs
@@ -1,0 +1,196 @@
+//! Offline tests for the YAML factory. They cover parsing, the
+//! registry path, capability advertisement, and reference metadata.
+//! Network-driven behaviour (URI template substitution, deferred FK
+//! resolution) is exercised by `examples/jsonplaceholder_yaml.rs`.
+
+use vantage_api_client::{RestApi, ResponseShape, RestApiVistaFactory, RestApiVistaSpec};
+use vantage_vista::{ReferenceKind, VistaFactory};
+
+fn factory() -> RestApiVistaFactory {
+    let api = RestApi::builder("https://example.com")
+        .response_shape(ResponseShape::BareArray)
+        .build();
+    RestApiVistaFactory::new(api)
+}
+
+#[test]
+fn parses_minimal_spec() {
+    let yaml = r#"
+name: users
+columns:
+  id: { type: int, flags: [id] }
+  name: { type: string, flags: [title] }
+"#;
+    let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(spec.name, "users");
+    assert_eq!(spec.columns.len(), 2);
+    assert_eq!(spec.columns["id"].col_type.as_deref(), Some("int"));
+    assert!(spec.references.is_empty());
+}
+
+#[test]
+fn parses_table_endpoint_block() {
+    let yaml = r#"
+name: nested
+api:
+  endpoint: parent/{parentId}/nested
+columns:
+  id: { type: int, flags: [id] }
+"#;
+    let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(
+        spec.driver.api.unwrap().endpoint.as_deref(),
+        Some("parent/{parentId}/nested")
+    );
+}
+
+#[test]
+fn parses_reference_metadata() {
+    let yaml = r#"
+name: users
+columns:
+  id: { type: int, flags: [id] }
+references:
+  albums:
+    table: albums
+    kind: has_many
+    foreign_key: userId
+"#;
+    let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+    let albums = &spec.references["albums"];
+    assert_eq!(albums.table, "albums");
+    assert_eq!(albums.kind, ReferenceKind::HasMany);
+    assert_eq!(albums.foreign_key.as_deref(), Some("userId"));
+}
+
+#[test]
+fn rejects_unknown_field_in_api_block() {
+    let yaml = r#"
+name: users
+columns:
+  id: { type: int, flags: [id] }
+api:
+  endpoint: users
+  bogus: 1
+"#;
+    let err = serde_yaml_ng::from_str::<RestApiVistaSpec>(yaml).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("bogus") || msg.contains("unknown"),
+        "expected typo-detecting error, got: {msg}"
+    );
+}
+
+#[test]
+fn build_from_spec_harvests_metadata() {
+    let factory = factory();
+    let yaml = r#"
+name: users
+columns:
+  id: { type: int, flags: [id] }
+  name: { type: string, flags: [title] }
+  email: { type: string }
+references:
+  albums:
+    table: albums
+    kind: has_many
+    foreign_key: userId
+"#;
+    let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+    let vista = factory.build_from_spec(spec).expect("build");
+
+    assert_eq!(vista.name(), "users");
+    assert_eq!(vista.get_id_column(), Some("id"));
+    assert_eq!(vista.get_title_columns(), vec!["name"]);
+    assert_eq!(
+        vista.get_column_names(),
+        vec!["id", "name", "email"]
+    );
+    assert_eq!(vista.get_references(), vec!["albums"]);
+    let albums = vista.get_reference("albums").unwrap();
+    assert_eq!(albums.target, "albums");
+    assert_eq!(albums.foreign_key, "userId");
+}
+
+#[test]
+fn endpoint_defaults_to_name_when_block_absent() {
+    let factory = factory();
+    let yaml = r#"
+name: users
+columns:
+  id: { type: int, flags: [id] }
+"#;
+    let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+    let _vista = factory.build_from_spec(spec).expect("build");
+    // No public accessor for the inner table's endpoint; absence of
+    // an error is the assertion. URL building is exercised by the
+    // YAML example end-to-end.
+}
+
+#[test]
+fn unknown_column_type_errors() {
+    let factory = factory();
+    let yaml = r#"
+name: users
+columns:
+  id: { type: int, flags: [id] }
+  weird: { type: quaternion }
+"#;
+    let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+    let err = match factory.build_from_spec(spec) {
+        Ok(_) => panic!("expected unknown-type error"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Unknown YAML column type"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn missing_id_column_errors() {
+    let factory = factory();
+    let yaml = r#"
+name: users
+id_column: missing_id
+columns:
+  name: { type: string }
+"#;
+    let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+    let err = match factory.build_from_spec(spec) {
+        Ok(_) => panic!("expected missing-id error"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("id column not present"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn register_yaml_then_build_by_name() {
+    let mut factory = factory();
+    factory
+        .register_yaml(
+            r#"
+name: users
+columns:
+  id: { type: int, flags: [id] }
+  name: { type: string, flags: [title] }
+"#,
+        )
+        .unwrap();
+    let vista = factory.build("users").expect("build");
+    assert_eq!(vista.name(), "users");
+}
+
+#[test]
+fn build_unknown_name_errors() {
+    let factory = factory();
+    let err = match factory.build("ghost") {
+        Ok(_) => panic!("expected unknown-name error"),
+        Err(e) => e,
+    };
+    assert!(err.to_string().contains("No registered spec"), "got: {err}");
+}

--- a/vantage-api-client/tests/yaml_factory.rs
+++ b/vantage-api-client/tests/yaml_factory.rs
@@ -3,7 +3,7 @@
 //! Network-driven behaviour (URI template substitution, deferred FK
 //! resolution) is exercised by `examples/jsonplaceholder_yaml.rs`.
 
-use vantage_api_client::{RestApi, ResponseShape, RestApiVistaFactory, RestApiVistaSpec};
+use vantage_api_client::{ResponseShape, RestApi, RestApiVistaFactory, RestApiVistaSpec};
 use vantage_vista::{ReferenceKind, VistaFactory};
 
 fn factory() -> RestApiVistaFactory {
@@ -102,10 +102,7 @@ references:
     assert_eq!(vista.name(), "users");
     assert_eq!(vista.get_id_column(), Some("id"));
     assert_eq!(vista.get_title_columns(), vec!["name"]);
-    assert_eq!(
-        vista.get_column_names(),
-        vec!["id", "name", "email"]
-    );
+    assert_eq!(vista.get_column_names(), vec!["id", "name", "email"]);
     assert_eq!(vista.get_references(), vec!["albums"]);
     let albums = vista.get_reference("albums").unwrap();
     assert_eq!(albums.target, "albums");
@@ -142,10 +139,7 @@ columns:
         Err(e) => e,
     };
     let msg = err.to_string();
-    assert!(
-        msg.contains("Unknown YAML column type"),
-        "got: {msg}"
-    );
+    assert!(msg.contains("Unknown YAML column type"), "got: {msg}");
 }
 
 #[test]

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.9 — 2026-05-15
+
+- New [`TableLike::set_table_name(String)`](https://docs.rs/vantage-table/0.4.9/vantage_table/traits/table_like/trait.TableLike.html#method.set_table_name) trait method (default no-op) and matching inherent [`Table::set_table_name`](https://docs.rs/vantage-table/0.4.9/vantage_table/struct.Table.html#method.set_table_name). `AnyTable` forwards. Lets drivers that use the `table_name` field as a request-shape (REST API endpoints, URI templates) swap it at reference-traversal time without rebuilding the table.
+
 ## 0.4.8 — 2026-04-30
 
 - `TableLike` gains five reflection / mutation methods so type-erased callers (the new model-driven CLI in `vantage-cli-util`, anything else holding an `AnyTable`) can reach metadata that previously only existed on the typed side. All have default impls so existing implementors compile unchanged.

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/any.rs
+++ b/vantage-table/src/any.rs
@@ -249,6 +249,10 @@ impl TableLike for AnyTable {
         self.inner.table_name()
     }
 
+    fn set_table_name(&mut self, name: String) {
+        self.inner.set_table_name(name);
+    }
+
     fn table_alias(&self) -> &str {
         self.inner.table_alias()
     }
@@ -510,6 +514,10 @@ where
 {
     fn table_name(&self) -> &str {
         self.inner.table_name()
+    }
+
+    fn set_table_name(&mut self, name: String) {
+        self.inner.set_table_name(name);
     }
 
     fn table_alias(&self) -> &str {

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -91,6 +91,13 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
         &self.table_name
     }
 
+    /// Override the table name. Used by REST API drivers to swap a
+    /// canonical resource path for a per-reference URI template at
+    /// traversal time.
+    pub fn set_table_name(&mut self, name: impl Into<String>) {
+        self.table_name = name.into();
+    }
+
     /// Get the underlying data source
     pub fn data_source(&self) -> &T {
         &self.data_source

--- a/vantage-table/src/table/impls/table_like.rs
+++ b/vantage-table/src/table/impls/table_like.rs
@@ -27,6 +27,10 @@ where
         self.table_name()
     }
 
+    fn set_table_name(&mut self, name: String) {
+        Table::<T, E>::set_table_name(self, name);
+    }
+
     fn column_names(&self) -> Vec<String> {
         self.columns.keys().cloned().collect()
     }

--- a/vantage-table/src/traits/table_like.rs
+++ b/vantage-table/src/traits/table_like.rs
@@ -13,6 +13,12 @@ pub trait TableLike: ReadableValueSet + WritableValueSet + Send + Sync {
     fn table_alias(&self) -> &str;
     fn column_names(&self) -> Vec<String>;
 
+    /// Override the table name. Default is a no-op for backends that
+    /// don't honor it; the REST API driver overrides it to swap a
+    /// canonical endpoint for a per-reference URI template at
+    /// traversal time.
+    fn set_table_name(&mut self, _name: String) {}
+
     /// Name of the column flagged as the id field, if any.
     fn id_field_name(&self) -> Option<String> {
         None

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.6 — 2026-05-15
+
+- New [`Vista::add_raw_condition<C>(condition: C)`](https://docs.rs/vantage-vista/0.4.6/vantage_vista/struct.Vista.html#method.add_raw_condition) and matching [`TableShell::add_raw_condition`](https://docs.rs/vantage-vista/0.4.6/vantage_vista/trait.TableShell.html#method.add_raw_condition) trait method (default returns `Unimplemented`). Drivers can downcast the boxed value to their own `T::Condition` and push it directly into the wrapped table. Used by YAML factories that need to inject deferred-FK eq conditions (where the value is read out of a parent record at fetch time), which the scalar `add_condition_eq` channel can't express.
+
 ## 0.4.5 — 2026-05-14
 
 - New [`Vista::get_ref`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html#method.get_ref) traverses a named reference and returns the related `Vista`. The driver does the work — it consults its wrapped typed table's `with_one` / `with_many` registry, applies the join condition, and wraps the result back into a `Vista` so callers stay on the universal surface.

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -149,6 +149,28 @@ pub trait TableShell: Send + Sync + 'static {
         .is_unimplemented())
     }
 
+    /// Push a driver-native condition into the wrapped table. The
+    /// caller boxes the condition as `dyn Any` and the driver
+    /// downcasts to its own `T::Condition`. Used by YAML-driven
+    /// relation traversal, where the factory constructs a
+    /// `DeferredFn`-bearing condition outside the value-set surface
+    /// (which only accepts scalar eq) and pushes it through this
+    /// channel. Default is `Unimplemented`.
+    fn add_raw_condition(
+        &mut self,
+        _condition: Box<dyn std::any::Any + Send + Sync>,
+    ) -> Result<()> {
+        Err(error!(
+            format!(
+                "add_raw_condition not implemented for '{}'",
+                std::any::type_name::<Self>()
+            ),
+            method = "add_raw_condition",
+            source_type = std::any::type_name::<Self>()
+        )
+        .is_unimplemented())
+    }
+
     // ---- References --------------------------------------------------------
 
     /// Resolve a named relation and return the related table as a new

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -120,10 +120,7 @@ impl Vista {
     /// YAML-driven relation factories that need to inject deferred
     /// FK eq-conditions (i.e. conditions whose value is resolved at
     /// fetch time by reading a parent record).
-    pub fn add_raw_condition<C: Send + Sync + 'static>(
-        &mut self,
-        condition: C,
-    ) -> Result<()> {
+    pub fn add_raw_condition<C: Send + Sync + 'static>(&mut self, condition: C) -> Result<()> {
         self.source.add_raw_condition(Box::new(condition))
     }
 

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -115,6 +115,18 @@ impl Vista {
         self.source.get_vista_count(self).await
     }
 
+    /// Push a driver-native condition into the wrapped table. The
+    /// boxed value must match the driver's `T::Condition`. Used by
+    /// YAML-driven relation factories that need to inject deferred
+    /// FK eq-conditions (i.e. conditions whose value is resolved at
+    /// fetch time by reading a parent record).
+    pub fn add_raw_condition<C: Send + Sync + 'static>(
+        &mut self,
+        condition: C,
+    ) -> Result<()> {
+        self.source.add_raw_condition(Box::new(condition))
+    }
+
     // ---- references --------------------------------------------------------
 
     /// Traverse a named reference and return the related `Vista`.


### PR DESCRIPTION
Vista factory converts Yaml files into Tables, wrapping them into Vista for portability. Previous pr #240 didn't add that. Also - cleaned up some Json related issues.

`RestApiVistaFactory` now does exactly that. Register specs, build by name, traverse relations:

```rust
let mut factory = RestApiVistaFactory::new(api);
factory.register_yaml(include_str!("../data/jsonplaceholder/users.yaml"))?;
factory.register_yaml(include_str!("../data/jsonplaceholder/albums.yaml"))?;

let users = factory.build("users")?;             // Vista
let albums = users.get_ref("albums")?;           // resolves through the registry
```

```yaml
name: users
columns:
  id:   { type: int, flags: [id] }
  name: { type: string, flags: [title] }
references:
  albums: { table: albums, kind: has_many, foreign_key: userId }
```

Existing Rust callers (`User::api_table(api).with_many(...)`) keep working unchanged — this is additive.

### Cross-driver resolvers

When the inventory routes some names through SQL and others through REST, `with_model_resolver` swaps the internal registry for a caller-supplied callback. The REST factory still owns the REST specs; the resolver decides which factory builds each name. Same-driver setups don't need it and the registry is the default.

### Table-level URI templates

YAML can carry `api: { endpoint: parent/{parentId}/child }` when the API requires path-based filtering. The URL builder peels matching eq-conditions into the placeholders and lets the rest fall through to the query string. Defaults to `spec.name`, so the common case stays one line.

### Why not stick with `with_many` closures?

YAML specs survive editing, diffing, hot-reload, and inventory aggregation. Closures don't. The two coexist: YAML for inventory-driven setups, hand-rolled tables when you want compile-time entity bindings (the existing `jsonplaceholder.rs` example still demonstrates the latter).

### Plumbing in adjacent crates

`vantage-vista` 0.4.6 adds `add_raw_condition` on `TableShell` and `Vista` so a driver can accept a `dyn Any` condition. The YAML factory uses it to push a `DeferredFn`-bearing eq condition that resolves the parent's FK value at child-fetch time — the existing scalar `add_condition_eq` channel can't express that. `vantage-table` 0.4.9 adds `set_table_name` (no callers yet — preparatory, for the eventual move to per-reference URI templates).

### Versions and follow-ups

- `vantage-api-client` 0.1.4 → 0.1.5
- `vantage-vista` 0.4.5 → 0.4.6
- `vantage-table` 0.4.8 → 0.4.9

`vantage-api-client/TODO.md` lists the deferred features (Rhai expression columns, `narrow_via` for prefix-filtered references, default static params, a shared `Renderer` in `vantage-cli-util`) — each gets a dedicated PR.