### PR TITLE
diorama bdd harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4671,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +425,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -522,6 +538,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -530,7 +547,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -555,7 +572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "ansi-str",
- "console",
+ "console 0.16.3",
  "crossterm",
  "unicode-segmentation",
  "unicode-width",
@@ -568,6 +585,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -683,6 +713,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +804,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cucumber"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd12917efc3a8b069a4975ef3cb2f2d835d42d04b3814d90838488f9dd9bf69"
+dependencies = [
+ "anyhow",
+ "clap",
+ "console 0.15.11",
+ "cucumber-codegen",
+ "cucumber-expressions",
+ "derive_more 0.99.20",
+ "drain_filter_polyfill",
+ "either",
+ "futures",
+ "gherkin",
+ "globwalk",
+ "humantime",
+ "inventory",
+ "itertools",
+ "lazy-regex",
+ "linked-hash-map",
+ "once_cell",
+ "pin-project",
+ "regex",
+ "sealed",
+ "smart-default",
+]
+
+[[package]]
+name = "cucumber-codegen"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e19cd9e8e7cfd79fbf844eb6a7334117973c01f6bad35571262b00891e60f1c"
+dependencies = [
+ "cucumber-expressions",
+ "inflections",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
+ "synthez",
+]
+
+[[package]]
+name = "cucumber-expressions"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d794fed319eea24246fb5f57632f7ae38d61195817b7eb659455aa5bdd7c1810"
+dependencies = [
+ "derive_more 0.99.20",
+ "either",
+ "nom",
+ "nom_locate",
+ "regex",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -850,6 +949,17 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
@@ -922,6 +1032,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "drain_filter_polyfill"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,7 +1067,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1222,6 +1338,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "gherkin"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b79820c0df536d1f3a089a2fa958f61cb96ce9e0f3f8f507f5a31179567755"
+dependencies = [
+ "heck 0.4.1",
+ "peg",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+ "textwrap",
+ "thiserror 1.0.69",
+ "typed-builder 0.15.2",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax 0.8.10",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,6 +1448,12 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1424,6 +1593,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -1644,6 +1819,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1844,34 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console 0.16.3",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1681,6 +1900,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1924,29 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1791,6 +2042,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2040,7 +2297,7 @@ dependencies = [
  "bitflags",
  "bson",
  "derive-where",
- "derive_more",
+ "derive_more 2.1.1",
  "futures-core",
  "futures-io",
  "futures-util",
@@ -2071,7 +2328,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "typed-builder",
+ "typed-builder 0.22.0",
  "uuid",
  "webpki-roots",
 ]
@@ -2113,6 +2370,17 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
 ]
 
 [[package]]
@@ -2286,6 +2554,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "peg"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,6 +2594,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2631,6 +2946,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax 0.8.10",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,14 +2965,26 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rend"
@@ -2770,6 +3109,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,6 +3253,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2903,6 +3281,18 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sealed"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a8caec23b7800fb97971a1c6ae365b6239aaeddfb934d6265f8505e795699d"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "security-framework"
@@ -3109,6 +3499,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,6 +3518,23 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
@@ -3223,7 +3636,7 @@ checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -3452,6 +3865,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "synthez"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d2c2202510a1e186e63e596d9318c91a8cbe85cd1a56a7be0c333e5f59ec8d"
+dependencies = [
+ "syn 2.0.117",
+ "synthez-codegen",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-codegen"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f724aa6d44b7162f3158a57bccd871a77b39a4aef737e01bcdff41f4772c7746"
+dependencies = [
+ "syn 2.0.117",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bfa6ec52465e2425fd43ce5bbbe0f0b623964f7c63feb6b10980e816c654ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sealed",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3504,10 +3950,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -3883,11 +4350,31 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe83c85a85875e8c4cb9ce4a890f05b23d38cd0d47647db7895d3d2a79566d2"
+dependencies = [
+ "typed-builder-macro 0.15.2",
+]
+
+[[package]]
+name = "typed-builder"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "398a3a3c918c96de527dc11e6e846cd549d4508030b8a33e1da12789c856b81a"
 dependencies = [
- "typed-builder-macro",
+ "typed-builder-macro 0.22.0",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3928,6 +4415,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
@@ -4182,8 +4675,12 @@ version = "0.4.0"
 dependencies = [
  "async-trait",
  "ciborium",
+ "cucumber",
+ "futures",
  "indexmap",
+ "insta",
  "redb",
+ "rstest",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4191,6 +4688,7 @@ dependencies = [
  "vantage-core",
  "vantage-csv",
  "vantage-dataset",
+ "vantage-sql",
  "vantage-table",
  "vantage-types",
  "vantage-vista",
@@ -4466,6 +4964,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4656,6 +5164,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4745,6 +5262,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -4910,7 +5436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -4921,7 +5447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.1 — 2026-05-18
+
+- New BDD test harness under `vantage-diorama/tests/` using [cucumber](https://crates.io/crates/cucumber). Scenarios run on a single-threaded paused-clock tokio runtime so refresh/timeout behaviour is deterministic — `tokio::time::advance` is the only thing that moves the clock.
+- Initial features cover the Phase-1 mock-backend wiring (`skeleton.feature`) and the three Lens lifecycle contracts (`lifecycle.feature`): `on_start_blocking=true` parks `make_dio`, `on_start_blocking=false` lets it return, and dropping the last `Dio` handle shuts the write worker down cleanly.
+- Added `#[doc(hidden)]` `Dio::take_write_worker_handle` so the harness can await clean worker exit. Not part of the supported surface — `#[doc(hidden)]` is the contract.
+
 ## 0.4.0 — 2026-05-18
 
 - Initial release. `vantage-diorama` adds a cached, composable, reactive surface in front of a `vantage-vista` `Vista`: `Dio::vista()` hands callers a fresh facade Vista that reads through the cache, while writes go to the master and re-emit through the event bus.

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -26,5 +26,14 @@ tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "test-util", "sync", "time"] }
 vantage-csv = { path = "../vantage-csv", features = ["vista"] }
+vantage-sql = { path = "../vantage-sql", features = ["sqlite", "vista"] }
+cucumber = { version = "0.21", default-features = false, features = ["macros"] }
+insta = { version = "1.41", features = ["yaml"] }
+rstest = "0.23"
+futures = "0.3"
+
+[[test]]
+name = "bdd"
+harness = false

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -85,6 +85,22 @@ impl Dio {
         self.inner.event_bus.subscribe()
     }
 
+    /// Take the per-Dio write worker's `JoinHandle` out of the inner
+    /// state. Returns `Some` on the first call, `None` afterwards.
+    ///
+    /// Once taken, the worker is no longer owned by the Dio — it keeps
+    /// running until the last `Sender` (held by `DioInner`) drops, at
+    /// which point the loop's `recv()` returns `None` and the task
+    /// completes. Callers can `await` the returned handle to observe
+    /// that clean shutdown.
+    ///
+    /// Intended for test harnesses asserting worker lifecycle; not part
+    /// of the standard surface.
+    #[doc(hidden)]
+    pub async fn take_write_worker_handle(&self) -> Option<JoinHandle<()>> {
+        self.inner.write_worker.lock().await.take()
+    }
+
     /// Start a [`TableScenery`](crate::scenery::TableScenery) builder
     /// for this Dio. Chainable; call `.open().await` to spawn the
     /// reactive view.

--- a/vantage-diorama/tests/bdd.rs
+++ b/vantage-diorama/tests/bdd.rs
@@ -1,0 +1,18 @@
+//! Cucumber entry point. Each scenario gets a fresh [`DioramaWorld`] on a
+//! single-threaded paused-clock tokio runtime — `tokio::time::advance` is
+//! the only way time moves, which keeps refresh/timeout scenarios
+//! deterministic.
+
+use cucumber::World;
+
+mod bdd_support;
+
+use bdd_support::world::DioramaWorld;
+
+#[tokio::main(flavor = "current_thread", start_paused = true)]
+async fn main() {
+    DioramaWorld::cucumber()
+        .fail_on_skipped()
+        .run_and_exit("tests/features")
+        .await;
+}

--- a/vantage-diorama/tests/bdd_support/backend.rs
+++ b/vantage-diorama/tests/bdd_support/backend.rs
@@ -1,0 +1,104 @@
+//! Backend dispatch — turn a parsed Gherkin data table into a master `Vista`
+//! against whichever backend the scenario selects.
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::Result;
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum BackendKind {
+    #[default]
+    Mock,
+    Csv,
+    Sqlite,
+}
+
+impl BackendKind {
+    pub fn parse(s: &str) -> Self {
+        match s.to_ascii_lowercase().as_str() {
+            "csv" => Self::Csv,
+            "sqlite" => Self::Sqlite,
+            _ => Self::Mock,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RowSpec {
+    pub id: String,
+    pub fields: IndexMap<String, CborValue>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MasterRows {
+    pub name: String,
+    pub id_column: String,
+    pub columns: Vec<String>,
+    pub rows: Vec<RowSpec>,
+}
+
+impl MasterRows {
+    /// Parse a Gherkin data table. The first row is the header; the
+    /// `id_column` defaults to `"id"` and must appear in the header.
+    pub fn from_table(name: &str, table: &cucumber::gherkin::Table) -> Self {
+        let mut iter = table.rows.iter();
+        let header = iter.next().cloned().unwrap_or_default();
+        let id_column = "id".to_string();
+        let id_idx = header
+            .iter()
+            .position(|c| c == &id_column)
+            .expect("data table missing required `id` header");
+
+        let rows = iter
+            .map(|row| {
+                let id = row[id_idx].clone();
+                let mut fields = IndexMap::new();
+                for (i, val) in row.iter().enumerate() {
+                    if i == id_idx {
+                        continue;
+                    }
+                    fields.insert(header[i].clone(), CborValue::Text(val.clone()));
+                }
+                RowSpec { id, fields }
+            })
+            .collect();
+
+        Self {
+            name: name.to_string(),
+            id_column,
+            columns: header,
+            rows,
+        }
+    }
+
+    pub async fn build_master(&self, backend: BackendKind) -> Result<Vista> {
+        match backend {
+            BackendKind::Mock => Ok(self.build_mock()),
+            BackendKind::Csv => unimplemented!("CSV backend lands in Phase 5"),
+            BackendKind::Sqlite => unimplemented!("SQLite backend lands in Phase 5"),
+        }
+    }
+
+    fn build_mock(&self) -> Vista {
+        let mut meta = VistaMetadata::new().with_id_column(&self.id_column);
+        for col in &self.columns {
+            let mut c = Column::new(col, "String");
+            if col == &self.id_column {
+                c = c.with_flag("id");
+            }
+            meta = meta.with_column(c);
+        }
+
+        let mut shell = MockShell::new().with_metadata(meta);
+        for row in &self.rows {
+            let mut rec: Record<CborValue> = Record::new();
+            for (k, v) in &row.fields {
+                rec.insert(k.clone(), v.clone());
+            }
+            shell = shell.with_record(&row.id, rec);
+        }
+        Vista::new(self.name.clone(), Box::new(shell))
+    }
+}

--- a/vantage-diorama/tests/bdd_support/mod.rs
+++ b/vantage-diorama/tests/bdd_support/mod.rs
@@ -1,0 +1,16 @@
+//! Shared harness used by the cucumber binary in `tests/bdd.rs`.
+//!
+//! Submodules are picked up because `tests/bdd.rs` declares `mod bdd_support`.
+//! Step modules under [`steps`] self-register with cucumber's macro runtime
+//! at compile time — declaring them here is enough.
+
+#![allow(unused_imports)] // Phase-1 placeholders consumed in later phases
+
+pub mod backend;
+pub mod spies;
+pub mod steps;
+pub mod world;
+
+pub use backend::{BackendKind, MasterRows, RowSpec};
+pub use spies::Spies;
+pub use world::{DioramaWorld, LensBuilderState, OnWriteMode};

--- a/vantage-diorama/tests/bdd_support/spies.rs
+++ b/vantage-diorama/tests/bdd_support/spies.rs
@@ -1,0 +1,10 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+
+#[derive(Clone, Default)]
+pub struct Spies {
+    pub on_start: Arc<AtomicU64>,
+    pub on_refresh: Arc<AtomicU64>,
+    pub on_event: Arc<AtomicU64>,
+    pub on_write: Arc<AtomicU64>,
+}

--- a/vantage-diorama/tests/bdd_support/steps/lifecycle.rs
+++ b/vantage-diorama/tests/bdd_support/steps/lifecycle.rs
@@ -1,0 +1,97 @@
+//! Phase-2 steps: Lens lifecycle — `on_start_blocking` true/false and
+//! the last-Dio-drop → worker-exit contract.
+
+use std::sync::atomic::Ordering;
+
+use cucumber::{given, then, when};
+
+use crate::bdd_support::world::DioramaWorld;
+
+#[given("a gated on_start that copies master to cache")]
+async fn gated_on_start(w: &mut DioramaWorld) {
+    w.lens_builder.on_start_load_master = true;
+    let _ = w.install_on_start_gate();
+}
+
+#[given(regex = r"^on_start_blocking is (true|false)$")]
+async fn set_on_start_blocking(w: &mut DioramaWorld, val: String) {
+    w.lens_builder.on_start_blocking = Some(val == "true");
+}
+
+#[when("I spawn make_dio")]
+async fn spawn_make_dio(w: &mut DioramaWorld) {
+    let cache_path = w.tmp_path().join("cache.redb");
+    let lens = w
+        .lens_builder
+        .build(cache_path, &w.spies)
+        .expect("build lens");
+    let master = w.master.take().expect("master not set");
+    w.lens = Some(lens.clone());
+    let handle = tokio::spawn(async move { lens.make_dio(master).await });
+    w.pending_dio = Some(handle);
+    w.settle().await;
+}
+
+#[then("make_dio is still pending")]
+async fn make_dio_pending(w: &mut DioramaWorld) {
+    let handle = w.pending_dio.as_ref().expect("no pending make_dio");
+    assert!(
+        !handle.is_finished(),
+        "expected make_dio to be parked on on_start gate, but it finished early"
+    );
+}
+
+#[then("make_dio completes")]
+async fn make_dio_completes(w: &mut DioramaWorld) {
+    let handle = w.pending_dio.take().expect("no pending make_dio");
+    let dio = handle
+        .await
+        .expect("make_dio task panicked")
+        .expect("make_dio returned err");
+    w.start_recorder(dio.subscribe_events());
+    w.dio = Some(dio);
+}
+
+#[when("I release on_start")]
+async fn release_on_start(w: &mut DioramaWorld) {
+    w.release_on_start_gate();
+    w.settle().await;
+}
+
+#[then(regex = r"^on_start has been called (\d+) times?$")]
+async fn assert_on_start_count(w: &mut DioramaWorld, n: u64) {
+    let got = w.spies.on_start.load(Ordering::SeqCst);
+    assert_eq!(got, n, "expected on_start={n}, got {got}");
+}
+
+#[when("I capture the write worker handle")]
+async fn capture_worker_handle(w: &mut DioramaWorld) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let handle = dio
+        .take_write_worker_handle()
+        .await
+        .expect("write worker handle already taken");
+    w.worker_handle = Some(handle);
+}
+
+#[when("I drop the dio")]
+async fn drop_dio(w: &mut DioramaWorld) {
+    // Drop the event recorder before the dio so the broadcast channel
+    // doesn't keep the inner state alive via the recorder task.
+    if let Some(rec) = w.recorder.take() {
+        rec.abort();
+        let _ = rec.await;
+    }
+    let _ = w.dio.take();
+    w.extra_dios.clear();
+    // Drop the Arc<Lens> too — make_dio held a clone inside DioInner,
+    // but the outer Arc the test holds also keeps the cache backend alive.
+    let _ = w.lens.take();
+    w.settle().await;
+}
+
+#[then("the write worker exits cleanly")]
+async fn worker_exits(w: &mut DioramaWorld) {
+    let handle = w.worker_handle.take().expect("no captured worker handle");
+    handle.await.expect("write worker task panicked");
+}

--- a/vantage-diorama/tests/bdd_support/steps/mod.rs
+++ b/vantage-diorama/tests/bdd_support/steps/mod.rs
@@ -1,0 +1,5 @@
+//! Step modules. Each `#[given]/#[when]/#[then]` here registers itself with
+//! cucumber's macro runtime at compile time.
+
+pub mod lifecycle;
+pub mod skeleton;

--- a/vantage-diorama/tests/bdd_support/steps/skeleton.rs
+++ b/vantage-diorama/tests/bdd_support/steps/skeleton.rs
@@ -1,0 +1,62 @@
+//! Phase-1 steps: prove the Mock backend + Lens + Dio path end-to-end.
+
+use cucumber::{gherkin::Step, given, then, when};
+use vantage_dataset::traits::ReadableValueSet;
+
+use crate::bdd_support::{
+    backend::{BackendKind, MasterRows},
+    world::DioramaWorld,
+};
+
+#[given(regex = r"^a master with rows$")]
+async fn master_with_rows(w: &mut DioramaWorld, step: &Step) {
+    let table = step
+        .table
+        .as_ref()
+        .expect("data table required for `a master with rows`");
+    let rows = MasterRows::from_table("items", table);
+    let backend = w.backend;
+    let master = rows
+        .build_master(backend)
+        .await
+        .expect("build master vista");
+    w.master = Some(master);
+}
+
+#[given("a lens with on_start that copies master to cache")]
+async fn lens_with_on_start_load(w: &mut DioramaWorld) {
+    w.lens_builder.on_start_load_master = true;
+}
+
+#[given(regex = r"^the backend is (mock|csv|sqlite)$")]
+async fn select_backend(w: &mut DioramaWorld, kind: String) {
+    w.backend = BackendKind::parse(&kind);
+}
+
+#[when("the dio is created")]
+async fn create_dio(w: &mut DioramaWorld) {
+    let cache_path = w.tmp_path().join("cache.redb");
+    let lens = w
+        .lens_builder
+        .build(cache_path, &w.spies)
+        .expect("build lens");
+    let master = w.master.take().expect("master not set");
+    let dio = lens.make_dio(master).await.expect("make_dio");
+    w.start_recorder(dio.subscribe_events());
+    w.lens = Some(lens);
+    w.dio = Some(dio);
+}
+
+#[then(regex = r"^the cache contains (\d+) rows?$")]
+async fn cache_contains_n(w: &mut DioramaWorld, n: u64) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let count = dio.cache().count().await.expect("cache count") as u64;
+    assert_eq!(count, n, "expected {n} cached rows, got {count}");
+}
+
+#[then(regex = r"^the master responds to list with (\d+) rows?$")]
+async fn master_list_count(w: &mut DioramaWorld, n: u64) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let rows = dio.master().list_values().await.expect("list master");
+    assert_eq!(rows.len() as u64, n, "expected {n} master rows, got {}", rows.len());
+}

--- a/vantage-diorama/tests/bdd_support/steps/skeleton.rs
+++ b/vantage-diorama/tests/bdd_support/steps/skeleton.rs
@@ -58,5 +58,10 @@ async fn cache_contains_n(w: &mut DioramaWorld, n: u64) {
 async fn master_list_count(w: &mut DioramaWorld, n: u64) {
     let dio = w.dio.as_ref().expect("dio not created");
     let rows = dio.master().list_values().await.expect("list master");
-    assert_eq!(rows.len() as u64, n, "expected {n} master rows, got {}", rows.len());
+    assert_eq!(
+        rows.len() as u64,
+        n,
+        "expected {n} master rows, got {}",
+        rows.len()
+    );
 }

--- a/vantage-diorama/tests/bdd_support/world.rs
+++ b/vantage-diorama/tests/bdd_support/world.rs
@@ -1,0 +1,231 @@
+#![allow(dead_code)] // Phase-1 placeholders consumed in later phases
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use cucumber::World;
+use tempfile::TempDir;
+use tokio::sync::{Mutex, Notify, broadcast};
+use vantage_core::Result;
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_diorama::{Dio, DioEvent, Lens};
+use vantage_vista::Vista;
+
+use super::backend::BackendKind;
+use super::spies::Spies;
+
+#[derive(Clone, Copy, Default, Debug)]
+pub enum OnWriteMode {
+    #[default]
+    Unset,
+    Pass,
+    Error,
+}
+
+#[derive(Default, Debug)]
+pub struct LensBuilderState {
+    pub refresh_every: Option<Duration>,
+    pub on_start_load_master: bool,
+    pub on_start_blocking: Option<bool>,
+    pub on_write_mode: OnWriteMode,
+    pub register_on_event: bool,
+    pub register_on_refresh: bool,
+    /// When present, the `on_start` closure awaits this Notify before
+    /// running its body. Lets a test pin "make_dio is/isn't waiting on
+    /// the callback" deterministically — see scenario 1/2.
+    pub on_start_gate: Option<Arc<Notify>>,
+}
+
+#[derive(World)]
+#[world(init = Self::new)]
+pub struct DioramaWorld {
+    pub tmp: Option<TempDir>,
+    pub backend: BackendKind,
+    pub master: Option<Vista>,
+    pub lens_builder: LensBuilderState,
+    pub lens: Option<Arc<Lens>>,
+    pub dio: Option<Dio>,
+    pub extra_dios: Vec<Dio>,
+    pub event_log: Arc<Mutex<Vec<DioEvent>>>,
+    pub recorder: Option<tokio::task::JoinHandle<()>>,
+    pub spies: Spies,
+    pub last_error: Option<String>,
+    pub sqlite_db: Option<vantage_sql::sqlite::SqliteDB>,
+    /// Mirrors `lens_builder.on_start_gate` so the test can release the
+    /// callback after `make_dio` has returned.
+    pub on_start_gate: Option<Arc<Notify>>,
+    /// Captured before dropping the Dio so the test can `await` clean
+    /// worker exit — see scenario 9.
+    pub worker_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Spawned `make_dio` future when a scenario needs to assert
+    /// "pending" vs "complete" — see scenario 1.
+    pub pending_dio: Option<tokio::task::JoinHandle<Result<Dio>>>,
+}
+
+impl std::fmt::Debug for DioramaWorld {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DioramaWorld")
+            .field("backend", &self.backend)
+            .field("has_master", &self.master.is_some())
+            .field("has_dio", &self.dio.is_some())
+            .field("extra_dios", &self.extra_dios.len())
+            .field("last_error", &self.last_error)
+            .finish()
+    }
+}
+
+impl DioramaWorld {
+    async fn new() -> Self {
+        Self {
+            tmp: None,
+            backend: BackendKind::default(),
+            master: None,
+            lens_builder: LensBuilderState::default(),
+            lens: None,
+            dio: None,
+            extra_dios: Vec::new(),
+            event_log: Arc::new(Mutex::new(Vec::new())),
+            recorder: None,
+            spies: Spies::default(),
+            last_error: None,
+            sqlite_db: None,
+            on_start_gate: None,
+            worker_handle: None,
+            pending_dio: None,
+        }
+    }
+
+    /// Yield repeatedly so spawned tasks have a chance to progress on
+    /// the single-threaded paused-clock runtime. Five turns is enough
+    /// for `make_dio` to spawn the worker + refresh task and park the
+    /// `on_start` future on its gate.
+    pub async fn settle(&self) {
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// Install a one-shot Notify into both `LensBuilderState` and the World
+    /// itself so steps can release the gate later.
+    pub fn install_on_start_gate(&mut self) -> Arc<Notify> {
+        let notify = Arc::new(Notify::new());
+        self.lens_builder.on_start_gate = Some(notify.clone());
+        self.on_start_gate = Some(notify.clone());
+        notify
+    }
+
+    pub fn release_on_start_gate(&self) {
+        if let Some(n) = self.on_start_gate.as_ref() {
+            n.notify_one();
+        }
+    }
+
+    /// Drain `rx` into `self.event_log` until the receiver closes. Called by
+    /// the `when the dio is created` step right after `subscribe_events`.
+    pub fn start_recorder(&mut self, mut rx: broadcast::Receiver<DioEvent>) {
+        let log = self.event_log.clone();
+        let handle = tokio::spawn(async move {
+            while let Ok(evt) = rx.recv().await {
+                log.lock().await.push(evt);
+            }
+        });
+        self.recorder = Some(handle);
+    }
+
+    pub async fn snapshot_events(&self) -> Vec<DioEvent> {
+        self.event_log.lock().await.clone()
+    }
+
+    pub fn tmp_path(&mut self) -> std::path::PathBuf {
+        if self.tmp.is_none() {
+            self.tmp = Some(TempDir::new().expect("create tempdir"));
+        }
+        self.tmp.as_ref().unwrap().path().to_path_buf()
+    }
+}
+
+impl LensBuilderState {
+    /// Materialise the configured Lens. Closures clone the spy counters so
+    /// each callback invocation lands in the matching `AtomicU64`.
+    pub fn build(&self, cache_path: std::path::PathBuf, spies: &Spies) -> Result<Arc<Lens>> {
+        let mut b = Lens::new().cache_at(cache_path);
+
+        if self.on_start_load_master {
+            let counter = spies.on_start.clone();
+            let gate = self.on_start_gate.clone();
+            b = b.on_start(move |dio| {
+                let dio = dio.clone();
+                let counter = counter.clone();
+                let gate = gate.clone();
+                async move {
+                    if let Some(n) = gate.as_ref() {
+                        n.notified().await;
+                    }
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await
+                }
+            });
+        }
+
+        if let Some(blocking) = self.on_start_blocking {
+            b = b.on_start_blocking(blocking);
+        }
+
+        if let Some(interval) = self.refresh_every {
+            b = b.refresh_every(interval);
+        }
+
+        if self.register_on_refresh {
+            let counter = spies.on_refresh.clone();
+            b = b.on_refresh(move |dio| {
+                let dio = dio.clone();
+                let counter = counter.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await
+                }
+            });
+        }
+
+        match self.on_write_mode {
+            OnWriteMode::Unset => {}
+            OnWriteMode::Pass => {
+                let counter = spies.on_write.clone();
+                b = b.on_write(move |_dio, _op| {
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        Ok(())
+                    }
+                });
+            }
+            OnWriteMode::Error => {
+                let counter = spies.on_write.clone();
+                b = b.on_write(move |_dio, _op| {
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        Err(vantage_core::error!("on_write rejected"))
+                    }
+                });
+            }
+        }
+
+        if self.register_on_event {
+            let counter = spies.on_event.clone();
+            b = b.on_event(move |_dio, _evt| {
+                let counter = counter.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            });
+        }
+
+        let lens = b.build().map_err(|e| vantage_core::error!(e.to_string()))?;
+        Ok(Arc::new(lens))
+    }
+}

--- a/vantage-diorama/tests/features/lifecycle.feature
+++ b/vantage-diorama/tests/features/lifecycle.feature
@@ -1,0 +1,40 @@
+Feature: Lens lifecycle
+
+  The three contracts that make a Lens behave predictably: on_start
+  blocks make_dio iff `on_start_blocking` is true, and the per-Dio
+  write worker shuts down cleanly when the last external Dio handle
+  drops.
+
+  Scenario: on_start_blocking=true makes make_dio wait for the callback
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+    And a gated on_start that copies master to cache
+    And on_start_blocking is true
+    When I spawn make_dio
+    Then make_dio is still pending
+    And on_start has been called 0 times
+    When I release on_start
+    Then make_dio completes
+    And on_start has been called 1 time
+
+  Scenario: on_start_blocking=false lets make_dio return immediately
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+    And a gated on_start that copies master to cache
+    And on_start_blocking is false
+    When the dio is created
+    Then on_start has been called 0 times
+    When I release on_start
+    Then on_start has been called 1 time
+
+  Scenario: dropping the last Dio handle stops the write worker cleanly
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+    And a lens with on_start that copies master to cache
+    When the dio is created
+    And I capture the write worker handle
+    And I drop the dio
+    Then the write worker exits cleanly

--- a/vantage-diorama/tests/features/skeleton.feature
+++ b/vantage-diorama/tests/features/skeleton.feature
@@ -1,0 +1,15 @@
+Feature: Harness skeleton
+
+  Phase-1 proof of life: the cucumber harness wires a master Vista
+  through a Lens into a Dio, the on_start callback runs, and the cache
+  ends up populated with the rows we declared.
+
+  Scenario: mock backend builds, dio hydrates cache from master
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+      | b  | two   |
+    And a lens with on_start that copies master to cache
+    When the dio is created
+    Then the master responds to list with 2 rows
+    And the cache contains 2 rows


### PR DESCRIPTION
Concurrency in `vantage-diorama` was untested where it matters most — `make_dio` parks (or doesn't) on the `on_start` callback depending on `on_start_blocking`, refresh fires on a `tokio::time` interval, and the per-Dio write worker is supposed to exit cleanly when the last `Dio` handle drops. Three contracts that are easy to break and easy to test flakily.

This PR adds a [cucumber](https://crates.io/crates/cucumber) harness under `vantage-diorama/tests/` that pins them down. Scenarios run on a single-threaded paused-clock tokio runtime (`#[tokio::main(flavor = "current_thread", start_paused = true)]`), so `tokio::time::advance` is the only thing that moves the clock — refresh/timeout assertions stop being timing-dependent.

`features/lifecycle.feature` covers the three contracts directly: `on_start_blocking=true` keeps `make_dio` pending until the callback's gate releases, `on_start_blocking=false` lets it return immediately while `on_start` runs in the background, and dropping the last `Dio` lets the worker's `recv()` see `None` and the task finish. `features/skeleton.feature` is the proof-of-life that the Mock backend wiring works at all.

One small `Dio` change to make the worker-drop scenario assertable: `take_write_worker_handle` is `#[doc(hidden)]` so a test can `await` the `JoinHandle` after dropping the Dio. Not part of the supported surface — the attribute is the contract.

Backend dispatch already accepts `Mock` / `Csv` / `Sqlite`, but only `Mock` is wired today. The other two `unimplemented!()` until later phases of the harness work — the dev-dependencies (`vantage-sql` with `sqlite` + `vista`) are pulled in already so adding them is just a `build_master` arm.

`vantage-diorama` 0.4.0 → 0.4.1. No public API changes for callers.