### PR TITLE
viewport edge-anchor + write-op bdd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4672,7 +4672,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.4 — 2026-05-20
+
+- Viewport loader now edge-anchors the fetch range. When part of the visible window is already cached, the loader anchors the fetch at the cached/uncached boundary and grows it by `page_size` in the uncached direction — so dragging slowly across a cached region stops re-fetching what's already there. Force-load callers (`request_load_more`) still get the exact range they asked for.
+- Viewport loader gained `tracing` spans on the `vantage_diorama::viewport` target — debounce absorbtion, skip reasons, effective range, fetch latency, and cache-after counts — for diagnosing overfetch and stall behaviour in real UIs.
+- BDD coverage extended to the four facade write ops the original `write_path.feature` left out: `tests/features/v3_replace.feature`, `v3_patch.feature`, `v3_delete.feature`, `v3_delete_all.feature`. Each follows the Insert trio — default-route to master, `WriteFailed` on `on_write` error, and the `mock` / `sqlite` Mirror outline.
+- `OnWriteMode::Mirror`'s `WriteOp::Patch` arm in the BDD harness now reads-modifies-writes the cache so the merged row survives an op that omits columns. `cache.insert_value` is a redb full-replace, so the previous arm silently dropped fields outside the partial.
+
 ## 0.4.3 — 2026-05-20
 
 - `TableScenery` v2: sparse `BTreeMap<usize, Arc<EnrichedRecord>>` storage replaces the dense `Vec`. `row(i)` returns `None` for unloaded indices so virtualised UIs can render a skeleton at that slot.

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -192,7 +192,11 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
 
     {
         let mut guard = state.load_in_flight.lock().unwrap();
-        if guard.as_ref().map(|r| *r == effective_range).unwrap_or(false) {
+        if guard
+            .as_ref()
+            .map(|r| *r == effective_range)
+            .unwrap_or(false)
+        {
             tracing::debug!(
                 target: "vantage_diorama::viewport",
                 effective = ?effective_range,

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -1,3 +1,4 @@
+use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -19,56 +20,208 @@ pub(crate) async fn viewport_loop(
 ) {
     loop {
         if state.dio_weak.upgrade().is_none() {
+            tracing::warn!(target: "vantage_diorama::viewport", "viewport_loop: dio dropped, exiting");
             return;
         }
         let Some(initial) = rx.recv().await else {
+            tracing::warn!(target: "vantage_diorama::viewport", "viewport_loop: channel closed, exiting");
             return;
         };
         let mut latest = initial;
+        let mut absorbed = 0usize;
 
         // Keep absorbing requests until the channel is quiet for `debounce`.
         loop {
             match tokio::time::timeout(debounce, rx.recv()).await {
-                Ok(Some(next)) => latest = next,
-                Ok(None) => return,
+                Ok(Some(next)) => {
+                    absorbed += 1;
+                    latest = next;
+                }
+                Ok(None) => {
+                    tracing::warn!(target: "vantage_diorama::viewport", "viewport_loop: channel closed mid-debounce, exiting");
+                    return;
+                }
                 Err(_) => break,
             }
         }
-
+        tracing::debug!(
+            target: "vantage_diorama::viewport",
+            range = ?latest.range,
+            force_load = latest.force_load,
+            absorbed,
+            "viewport_loop: firing",
+        );
         fire_chunk_load(state.clone(), latest).await;
     }
 }
 
+/// Pick an effective fetch range given the visible viewport.
+///
+/// If part of `visible` is already cached, anchor the fetch at the
+/// cached/uncached boundary and grow it in the *uncached* direction
+/// by `page_size` rows. This eliminates the heavy overlap that happens
+/// when the user drags slowly across a cached region — e.g. visible
+/// `29..49` with cache `30..50` becomes a fetch of `10..30` instead of
+/// re-fetching the cached portion.
+///
+/// Returns `None` when the visible range is fully cached.
+fn compute_fetch_range(
+    state: &TableSceneryState,
+    visible: &Range<usize>,
+    total: Option<usize>,
+) -> Option<Range<usize>> {
+    if visible.start >= visible.end {
+        return None;
+    }
+    let rows = state.rows.read().unwrap();
+    let page_size = state.page_size;
+
+    let mut first_uncached: Option<usize> = None;
+    let mut last_uncached: Option<usize> = None;
+    let mut first_cached: Option<usize> = None;
+    let mut last_cached: Option<usize> = None;
+    for i in visible.clone() {
+        if rows.contains_key(&i) {
+            first_cached.get_or_insert(i);
+            last_cached = Some(i);
+        } else {
+            first_uncached.get_or_insert(i);
+            last_uncached = Some(i);
+        }
+    }
+    drop(rows);
+
+    let first_uncached = first_uncached?;
+    let last_uncached = last_uncached.expect("uncached implies a last");
+
+    let (start, end) = match (first_cached, last_cached) {
+        (None, _) => {
+            // Whole visible is uncached — fetch a page starting at the
+            // top of the visible range so we cover it and prefetch the
+            // tail in scroll direction.
+            (visible.start, visible.start + page_size)
+        }
+        (Some(fc), Some(_)) if first_uncached < fc => {
+            // Gap at the top of visible → user is scrolling up.
+            // Anchor the fetch end at the first cached row and grow
+            // upward by `page_size`.
+            (fc.saturating_sub(page_size), fc)
+        }
+        (Some(_), Some(lc)) if last_uncached > lc => {
+            // Gap at the bottom of visible → user is scrolling down.
+            // Anchor the fetch start one past the last cached row and
+            // grow downward by `page_size`.
+            let s = lc + 1;
+            (s, s + page_size)
+        }
+        _ => {
+            // Hole inside visible with cache on both sides — fetch the
+            // missing run plus a page in the down direction.
+            (first_uncached, first_uncached + page_size)
+        }
+    };
+
+    let end = match total {
+        Some(t) => end.min(t),
+        None => end,
+    };
+    if end <= start {
+        return None;
+    }
+    Some(start..end)
+}
+
 /// Always emits `ViewportChanged`. If the range is fully cached or no
 /// `on_load_chunk` callback is registered, returns without touching
-/// the cache. Otherwise dispatches the callback, then emits
-/// `RangeLoaded` (success) or `LoadFailed` (error).
+/// the cache. Otherwise dispatches the callback against an
+/// edge-anchored "effective" range (see [`compute_fetch_range`]), then
+/// emits `RangeLoaded` (success) or `LoadFailed` (error).
 async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest) {
-    let ViewportRequest { range, force_load } = request;
+    let ViewportRequest {
+        range: visible,
+        force_load,
+    } = request;
     let Some(dio_inner) = state.dio_weak.upgrade() else {
+        tracing::warn!(target: "vantage_diorama::viewport", "fire_chunk_load: dio dropped");
         return;
     };
 
     let _ = dio_inner.event_bus.send(DioEvent::ViewportChanged {
-        range: range.clone(),
+        range: visible.clone(),
     });
 
-    if !force_load && state.range_fully_cached(&range) {
-        return;
-    }
+    let total = *state.total.read().unwrap();
+    let visible_len = visible.end.saturating_sub(visible.start);
+    let visible_cached = {
+        let rows = state.rows.read().unwrap();
+        visible.clone().filter(|i| rows.contains_key(i)).count()
+    };
+
+    // Decide what to actually fetch. `force_load` callers
+    // (`request_load_more`) have already pre-computed a range; respect
+    // it. For viewport-driven loads, shift toward the uncached side.
+    let effective_range = if force_load {
+        visible.clone()
+    } else {
+        match compute_fetch_range(&state, &visible, total) {
+            Some(r) => r,
+            None => {
+                tracing::debug!(
+                    target: "vantage_diorama::viewport",
+                    visible = ?visible,
+                    visible_len,
+                    visible_cached,
+                    "fire_chunk_load: SKIP (visible fully cached)",
+                );
+                return;
+            }
+        }
+    };
 
     let cb = match dio_inner.lens.callbacks.on_load_chunk.as_ref() {
         Some(cb) => cb,
-        None => return,
+        None => {
+            tracing::warn!(
+                target: "vantage_diorama::viewport",
+                visible = ?visible,
+                "fire_chunk_load: SKIP (no on_load_chunk callback)",
+            );
+            return;
+        }
     };
 
     {
         let mut guard = state.load_in_flight.lock().unwrap();
-        if guard.as_ref().map(|r| *r == range).unwrap_or(false) {
+        if guard.as_ref().map(|r| *r == effective_range).unwrap_or(false) {
+            tracing::debug!(
+                target: "vantage_diorama::viewport",
+                effective = ?effective_range,
+                "fire_chunk_load: SKIP (same range already in flight)",
+            );
             return;
         }
-        *guard = Some(range.clone());
+        if let Some(prev) = guard.as_ref() {
+            tracing::warn!(
+                target: "vantage_diorama::viewport",
+                prev = ?prev,
+                effective = ?effective_range,
+                "fire_chunk_load: overwriting in-flight marker (viewport_loop is supposed to be serial)",
+            );
+        }
+        *guard = Some(effective_range.clone());
     }
+
+    // Recompute overlap on the effective range so the log shows the
+    // shift working.
+    let effective_len = effective_range.end - effective_range.start;
+    let effective_cached = {
+        let rows = state.rows.read().unwrap();
+        effective_range
+            .clone()
+            .filter(|i| rows.contains_key(i))
+            .count()
+    };
+    let effective_to_fetch = effective_len - effective_cached;
 
     let sink = ChunkSink {
         target: Arc::downgrade(&state) as std::sync::Weak<dyn crate::lens::SceneryChunkTarget>,
@@ -78,18 +231,54 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
     let dio = Dio {
         inner: dio_inner.clone(),
     };
-    let result = cb(&dio, range.clone(), sink).await;
+    let t = std::time::Instant::now();
+    tracing::debug!(
+        target: "vantage_diorama::viewport",
+        visible = ?visible,
+        visible_len,
+        visible_cached,
+        effective = ?effective_range,
+        effective_len,
+        effective_cached,
+        effective_to_fetch,
+        effective_overfetch_pct = if effective_len > 0 {
+            (effective_cached as f64 / effective_len as f64) * 100.0
+        } else {
+            0.0
+        },
+        force_load,
+        "fire_chunk_load: dispatching on_load_chunk",
+    );
+    let result = cb(&dio, effective_range.clone(), sink).await;
 
     *state.load_in_flight.lock().unwrap() = None;
 
+    let cached_after = state.rows.read().unwrap().len();
     match result {
         Ok(()) => {
             state.bump_generation();
-            let _ = dio_inner.event_bus.send(DioEvent::RangeLoaded { range });
+            tracing::debug!(
+                target: "vantage_diorama::viewport",
+                effective = ?effective_range,
+                effective_len,
+                ms = t.elapsed().as_secs_f64() * 1000.0,
+                cached_after,
+                "fire_chunk_load: OK",
+            );
+            let _ = dio_inner.event_bus.send(DioEvent::RangeLoaded {
+                range: effective_range,
+            });
         }
         Err(e) => {
+            tracing::error!(
+                target: "vantage_diorama::viewport",
+                effective = ?effective_range,
+                ms = t.elapsed().as_secs_f64() * 1000.0,
+                error = %e,
+                "fire_chunk_load: FAILED",
+            );
             let _ = dio_inner.event_bus.send(DioEvent::LoadFailed {
-                range,
+                range: effective_range,
                 error: e.to_string(),
             });
         }

--- a/vantage-diorama/tests/bdd_support/steps/event_path.rs
+++ b/vantage-diorama/tests/bdd_support/steps/event_path.rs
@@ -39,12 +39,7 @@ async fn invalidate_all(w: &mut DioramaWorld) {
 }
 
 #[then(regex = r#"^the cache record "([^"]+)" has (\w+) "([^"]+)"$"#)]
-async fn cache_record_field(
-    w: &mut DioramaWorld,
-    id: String,
-    field: String,
-    expected: String,
-) {
+async fn cache_record_field(w: &mut DioramaWorld, id: String, field: String, expected: String) {
     let dio = w.dio.as_ref().expect("dio not created");
     let row = dio
         .cache()

--- a/vantage-diorama/tests/bdd_support/steps/event_path.rs
+++ b/vantage-diorama/tests/bdd_support/steps/event_path.rs
@@ -38,8 +38,13 @@ async fn invalidate_all(w: &mut DioramaWorld) {
     w.settle().await;
 }
 
-#[then(regex = r#"^the cache record "([^"]+)" has title "([^"]+)"$"#)]
-async fn cache_record_title(w: &mut DioramaWorld, id: String, expected: String) {
+#[then(regex = r#"^the cache record "([^"]+)" has (\w+) "([^"]+)"$"#)]
+async fn cache_record_field(
+    w: &mut DioramaWorld,
+    id: String,
+    field: String,
+    expected: String,
+) {
     let dio = w.dio.as_ref().expect("dio not created");
     let row = dio
         .cache()
@@ -48,7 +53,7 @@ async fn cache_record_title(w: &mut DioramaWorld, id: String, expected: String) 
         .expect("cache get_value")
         .unwrap_or_else(|| panic!("cache has no record {id}"));
     let got = row
-        .get("title")
+        .get(&field)
         .and_then(|v| match v {
             CborValue::Text(s) => Some(s.clone()),
             _ => None,
@@ -56,7 +61,17 @@ async fn cache_record_title(w: &mut DioramaWorld, id: String, expected: String) 
         .unwrap_or_default();
     assert_eq!(
         got, expected,
-        "cache record {id}.title: want {expected}, got {got}"
+        "cache record {id}.{field}: want {expected}, got {got}"
+    );
+}
+
+#[then(regex = r#"^the cache record "([^"]+)" is absent$"#)]
+async fn cache_record_absent(w: &mut DioramaWorld, id: String) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let row = dio.cache().get_value(&id).await.expect("cache get_value");
+    assert!(
+        row.is_none(),
+        "expected cache record {id} to be absent, got {row:?}"
     );
 }
 

--- a/vantage-diorama/tests/bdd_support/steps/write_path.rs
+++ b/vantage-diorama/tests/bdd_support/steps/write_path.rs
@@ -117,7 +117,10 @@ async fn delete_via_facade(w: &mut DioramaWorld, id: String) {
 async fn delete_all_via_facade(w: &mut DioramaWorld) {
     let dio = w.dio.as_ref().expect("dio not created");
     let facade = dio.vista();
-    facade.delete_all().await.expect("facade delete_all enqueue");
+    facade
+        .delete_all()
+        .await
+        .expect("facade delete_all enqueue");
     w.settle().await;
 }
 
@@ -170,12 +173,7 @@ async fn cache_row_count(w: &mut DioramaWorld, n: u64) {
 }
 
 #[then(regex = r#"^the master record "([^"]+)" has (\w+) "([^"]+)"$"#)]
-async fn master_record_field(
-    w: &mut DioramaWorld,
-    id: String,
-    field: String,
-    expected: String,
-) {
+async fn master_record_field(w: &mut DioramaWorld, id: String, field: String, expected: String) {
     let dio = w.dio.as_ref().expect("dio not created");
     let row = dio
         .master()

--- a/vantage-diorama/tests/bdd_support/steps/write_path.rs
+++ b/vantage-diorama/tests/bdd_support/steps/write_path.rs
@@ -9,6 +9,35 @@ use vantage_types::Record;
 
 use crate::bdd_support::{world::DioramaWorld, world::OnWriteMode};
 
+/// Parse a gherkin data table whose first row is the header (with an `id`
+/// column) and remaining rows are records. Returns `(id, record)` pairs
+/// with the id column stripped from the record body — matching the shape
+/// `WritableValueSet::insert_value(&id, &rec)` expects.
+fn parse_record_table(step: &Step, step_phrase: &str) -> Vec<(String, Record<CborValue>)> {
+    let table = step
+        .table
+        .as_ref()
+        .unwrap_or_else(|| panic!("data table required for `{step_phrase}`"));
+    let header = table.rows.first().expect("header row").clone();
+    let id_idx = header
+        .iter()
+        .position(|c| c == "id")
+        .expect("data table missing required `id` header");
+    let mut out = Vec::with_capacity(table.rows.len().saturating_sub(1));
+    for row in table.rows.iter().skip(1) {
+        let id = row[id_idx].clone();
+        let mut rec: Record<CborValue> = Record::new();
+        for (i, val) in row.iter().enumerate() {
+            if i == id_idx {
+                continue;
+            }
+            rec.insert(header[i].clone(), CborValue::Text(val.clone()));
+        }
+        out.push((id, rec));
+    }
+    out
+}
+
 #[given("an on_write callback that records calls")]
 async fn on_write_records(w: &mut DioramaWorld) {
     w.lens_builder.on_write_mode = OnWriteMode::Pass;
@@ -37,28 +66,9 @@ async fn drain_write_queue(_w: &mut DioramaWorld) {
 
 #[when("I insert via the facade")]
 async fn insert_via_facade(w: &mut DioramaWorld, step: &Step) {
-    let table = step
-        .table
-        .as_ref()
-        .expect("data table required for `I insert via the facade`");
-    let header = table.rows.first().expect("header row").clone();
-    let id_idx = header
-        .iter()
-        .position(|c| c == "id")
-        .expect("data table missing required `id` header");
-
     let dio = w.dio.as_ref().expect("dio not created");
     let facade = dio.vista();
-
-    for row in table.rows.iter().skip(1) {
-        let id = row[id_idx].clone();
-        let mut rec: Record<CborValue> = Record::new();
-        for (i, val) in row.iter().enumerate() {
-            if i == id_idx {
-                continue;
-            }
-            rec.insert(header[i].clone(), CborValue::Text(val.clone()));
-        }
+    for (id, rec) in parse_record_table(step, "I insert via the facade") {
         facade
             .insert_value(&id, &rec)
             .await
@@ -66,6 +76,48 @@ async fn insert_via_facade(w: &mut DioramaWorld, step: &Step) {
     }
     // Give the write worker a chance to drain the queue and (on error)
     // publish WriteFailed before the next step asserts on the event log.
+    w.settle().await;
+}
+
+#[when("I replace via the facade")]
+async fn replace_via_facade(w: &mut DioramaWorld, step: &Step) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let facade = dio.vista();
+    for (id, rec) in parse_record_table(step, "I replace via the facade") {
+        facade
+            .replace_value(&id, &rec)
+            .await
+            .expect("facade replace enqueue");
+    }
+    w.settle().await;
+}
+
+#[when("I patch via the facade")]
+async fn patch_via_facade(w: &mut DioramaWorld, step: &Step) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let facade = dio.vista();
+    for (id, partial) in parse_record_table(step, "I patch via the facade") {
+        facade
+            .patch_value(&id, &partial)
+            .await
+            .expect("facade patch enqueue");
+    }
+    w.settle().await;
+}
+
+#[when(regex = r#"^I delete id "([^"]+)" via the facade$"#)]
+async fn delete_via_facade(w: &mut DioramaWorld, id: String) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let facade = dio.vista();
+    facade.delete(&id).await.expect("facade delete enqueue");
+    w.settle().await;
+}
+
+#[when("I delete all via the facade")]
+async fn delete_all_via_facade(w: &mut DioramaWorld) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let facade = dio.vista();
+    facade.delete_all().await.expect("facade delete_all enqueue");
     w.settle().await;
 }
 
@@ -115,4 +167,41 @@ async fn cache_row_count(w: &mut DioramaWorld, n: u64) {
     let dio = w.dio.as_ref().expect("dio not created");
     let got = dio.cache().count().await.expect("cache count") as u64;
     assert_eq!(got, n, "expected {n} cache rows, got {got}");
+}
+
+#[then(regex = r#"^the master record "([^"]+)" has (\w+) "([^"]+)"$"#)]
+async fn master_record_field(
+    w: &mut DioramaWorld,
+    id: String,
+    field: String,
+    expected: String,
+) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let row = dio
+        .master()
+        .get_value(&id)
+        .await
+        .expect("master get_value")
+        .unwrap_or_else(|| panic!("master has no record {id}"));
+    let got = row
+        .get(&field)
+        .and_then(|v| match v {
+            CborValue::Text(s) => Some(s.clone()),
+            _ => None,
+        })
+        .unwrap_or_default();
+    assert_eq!(
+        got, expected,
+        "master record {id}.{field}: want {expected}, got {got}"
+    );
+}
+
+#[then(regex = r#"^the master record "([^"]+)" is absent$"#)]
+async fn master_record_absent(w: &mut DioramaWorld, id: String) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let row = dio.master().get_value(&id).await.expect("master get_value");
+    assert!(
+        row.is_none(),
+        "expected master record {id} to be absent, got {row:?}"
+    );
 }

--- a/vantage-diorama/tests/bdd_support/world.rs
+++ b/vantage-diorama/tests/bdd_support/world.rs
@@ -315,11 +315,8 @@ impl LensBuilderState {
                                 // is a full replace in redb, so an unmerged
                                 // write would drop columns absent from the
                                 // partial.
-                                let mut merged = dio
-                                    .cache()
-                                    .get_value(&id)
-                                    .await?
-                                    .unwrap_or_default();
+                                let mut merged =
+                                    dio.cache().get_value(&id).await?.unwrap_or_default();
                                 for (k, v) in &partial {
                                     merged.insert(k.clone(), v.clone());
                                 }

--- a/vantage-diorama/tests/bdd_support/world.rs
+++ b/vantage-diorama/tests/bdd_support/world.rs
@@ -309,7 +309,21 @@ impl LensBuilderState {
                             }
                             WriteOp::Patch { id, partial } => {
                                 dio.master().patch_value(&id, &partial).await?;
-                                dio.cache().insert_value(&id, &partial).await?;
+                                // Read-merge-write on the cache so consumers
+                                // see the same merged record they'd get from
+                                // a fresh master read. `cache.insert_value`
+                                // is a full replace in redb, so an unmerged
+                                // write would drop columns absent from the
+                                // partial.
+                                let mut merged = dio
+                                    .cache()
+                                    .get_value(&id)
+                                    .await?
+                                    .unwrap_or_default();
+                                for (k, v) in &partial {
+                                    merged.insert(k.clone(), v.clone());
+                                }
+                                dio.cache().insert_value(&id, &merged).await?;
                             }
                             WriteOp::Delete { id } => {
                                 dio.master().delete(&id).await?;

--- a/vantage-diorama/tests/features/v3_delete.feature
+++ b/vantage-diorama/tests/features/v3_delete.feature
@@ -1,0 +1,50 @@
+Feature: Write path — Delete
+
+  v3 — facade `delete` enqueues `WriteOp::Delete`. Default-write routes
+  to master, the Mirror helper applies to both master and cache,
+  and an erroring `on_write` publishes `WriteFailed`.
+
+  Scenario: default_write routes Delete to master when on_write is missing
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+      | b  | two   |
+    And a lens with on_start that copies master to cache
+    When the dio is created
+    And I delete id "a" via the facade
+    Then the master has 1 row
+    And the master record "a" is absent
+    And the cache still has 2 rows
+
+  Scenario: WriteFailed lands on the bus when on_write errors for Delete
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+    And a lens with on_start that copies master to cache
+    And an on_write callback that always errors
+    When the dio is created
+    And I delete id "a" via the facade
+    Then the event log matches snapshot "write_failed_delete"
+
+  Scenario Outline: Delete path works against real backends
+    Given the backend is <backend>
+    And a master with rows
+      | id | title |
+      | a  | one   |
+      | b  | two   |
+    And a lens with on_start that copies master to cache
+    And an on_write callback that mirrors to master and cache
+    When the dio is created
+    And I delete id "a" via the facade
+    And the write queue drains
+    Then on_write has been called 1 time
+    And the event log matches snapshot "mirror_delete_<backend>"
+    And the master has 1 row
+    And the master record "a" is absent
+    And the cache has 1 row
+    And the cache record "a" is absent
+
+    Examples:
+      | backend |
+      | mock    |
+      | sqlite  |

--- a/vantage-diorama/tests/features/v3_delete_all.feature
+++ b/vantage-diorama/tests/features/v3_delete_all.feature
@@ -1,0 +1,47 @@
+Feature: Write path — DeleteAll
+
+  v3 — facade `delete_all` enqueues `WriteOp::DeleteAll`. Default-write
+  routes to master (clearing it), the Mirror helper clears both, and an
+  erroring `on_write` publishes `WriteFailed`.
+
+  Scenario: default_write routes DeleteAll to master when on_write is missing
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+      | b  | two   |
+    And a lens with on_start that copies master to cache
+    When the dio is created
+    And I delete all via the facade
+    Then the master has 0 rows
+    And the cache still has 2 rows
+
+  Scenario: WriteFailed lands on the bus when on_write errors for DeleteAll
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+    And a lens with on_start that copies master to cache
+    And an on_write callback that always errors
+    When the dio is created
+    And I delete all via the facade
+    Then the event log matches snapshot "write_failed_delete_all"
+
+  Scenario Outline: DeleteAll path works against real backends
+    Given the backend is <backend>
+    And a master with rows
+      | id | title |
+      | a  | one   |
+      | b  | two   |
+    And a lens with on_start that copies master to cache
+    And an on_write callback that mirrors to master and cache
+    When the dio is created
+    And I delete all via the facade
+    And the write queue drains
+    Then on_write has been called 1 time
+    And the event log matches snapshot "mirror_delete_all_<backend>"
+    And the master has 0 rows
+    And the cache has 0 rows
+
+    Examples:
+      | backend |
+      | mock    |
+      | sqlite  |

--- a/vantage-diorama/tests/features/v3_patch.feature
+++ b/vantage-diorama/tests/features/v3_patch.feature
@@ -1,0 +1,57 @@
+Feature: Write path — Patch
+
+  v3 — facade `patch_value` enqueues `WriteOp::Patch`, which the
+  default-write path forwards to master and `on_write` can intercept.
+  Patch merges: columns absent from the partial must survive on the
+  authoritative record, both for the default-route master path and for
+  the Mirror helper's cache write.
+
+  Scenario: default_write routes Patch to master when on_write is missing
+    Given a master with rows
+      | id | title | price |
+      | a  | one   | 10    |
+    And a lens with on_start that copies master to cache
+    When the dio is created
+    And I patch via the facade
+      | id | title |
+      | a  | alpha |
+    Then the master record "a" has title "alpha"
+    And the master record "a" has price "10"
+    And the cache record "a" has title "one"
+    And the cache record "a" has price "10"
+
+  Scenario: WriteFailed lands on the bus when on_write errors for Patch
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+    And a lens with on_start that copies master to cache
+    And an on_write callback that always errors
+    When the dio is created
+    And I patch via the facade
+      | id | title |
+      | a  | alpha |
+    Then the event log matches snapshot "write_failed_patch"
+
+  Scenario Outline: Patch path works against real backends
+    Given the backend is <backend>
+    And a master with rows
+      | id | title | price |
+      | a  | one   | 10    |
+    And a lens with on_start that copies master to cache
+    And an on_write callback that mirrors to master and cache
+    When the dio is created
+    And I patch via the facade
+      | id | title |
+      | a  | alpha |
+    And the write queue drains
+    Then on_write has been called 1 time
+    And the event log matches snapshot "mirror_patch_<backend>"
+    And the master record "a" has title "alpha"
+    And the master record "a" has price "10"
+    And the cache record "a" has title "alpha"
+    And the cache record "a" has price "10"
+
+    Examples:
+      | backend |
+      | mock    |
+      | sqlite  |

--- a/vantage-diorama/tests/features/v3_replace.feature
+++ b/vantage-diorama/tests/features/v3_replace.feature
@@ -1,0 +1,53 @@
+Feature: Write path — Replace
+
+  v3 — facade `replace_value` enqueues `WriteOp::Replace`, which the
+  default-write path forwards to master and `on_write` can intercept.
+  Mirrors the Insert trio in `write_path.feature` for the replace op:
+  default-route, WriteFailed, and the mock+sqlite mirror outline.
+
+  Scenario: default_write routes Replace to master when on_write is missing
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+    And a lens with on_start that copies master to cache
+    When the dio is created
+    And I replace via the facade
+      | id | title |
+      | a  | alpha |
+    Then the master has 1 row
+    And the master record "a" has title "alpha"
+    And the cache record "a" has title "one"
+
+  Scenario: WriteFailed lands on the bus when on_write errors for Replace
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+    And a lens with on_start that copies master to cache
+    And an on_write callback that always errors
+    When the dio is created
+    And I replace via the facade
+      | id | title |
+      | a  | alpha |
+    Then the event log matches snapshot "write_failed_replace"
+
+  Scenario Outline: Replace path works against real backends
+    Given the backend is <backend>
+    And a master with rows
+      | id | title |
+      | a  | one   |
+    And a lens with on_start that copies master to cache
+    And an on_write callback that mirrors to master and cache
+    When the dio is created
+    And I replace via the facade
+      | id | title |
+      | a  | alpha |
+    And the write queue drains
+    Then on_write has been called 1 time
+    And the event log matches snapshot "mirror_replace_<backend>"
+    And the master record "a" has title "alpha"
+    And the cache record "a" has title "alpha"
+
+    Examples:
+      | backend |
+      | mock    |
+      | sqlite  |

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_delete_all_mock.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_delete_all_mock.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 62
+expression: events
+---
+[]

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_delete_all_sqlite.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_delete_all_sqlite.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 62
+expression: events
+---
+[]

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_delete_mock.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_delete_mock.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 62
+expression: events
+---
+[]

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_delete_sqlite.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_delete_sqlite.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 62
+expression: events
+---
+[]

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_patch_mock.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_patch_mock.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 62
+expression: events
+---
+[]

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_patch_sqlite.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_patch_sqlite.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 62
+expression: events
+---
+[]

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_replace_mock.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_replace_mock.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 62
+expression: events
+---
+[]

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_replace_sqlite.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@mirror_replace_sqlite.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 62
+expression: events
+---
+[]

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@write_failed_delete.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@write_failed_delete.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 62
+expression: events
+---
+- "WriteFailed { id: Some(\"a\"), error: \"on_write rejected\" }"

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@write_failed_delete_all.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@write_failed_delete_all.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 62
+expression: events
+---
+- "WriteFailed { id: None, error: \"on_write rejected\" }"

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@write_failed_patch.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@write_failed_patch.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 62
+expression: events
+---
+- "WriteFailed { id: Some(\"a\"), error: \"on_write rejected\" }"

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@write_failed_replace.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@write_failed_replace.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 62
+expression: events
+---
+- "WriteFailed { id: Some(\"a\"), error: \"on_write rejected\" }"


### PR DESCRIPTION
The viewport loader stopped re-fetching cached regions on slow scroll. The previous in-flight dedupe only caught *identical* ranges, so dragging the viewport one row at a time across a cached region produced a stream of 95%-overlap refetches — visible `29..49` against cache `30..50` would refetch `29..49` instead of just grabbing the missing row 29.

`compute_fetch_range` now edge-anchors: when part of the visible window is cached, it anchors the fetch at the cached/uncached boundary and grows `page_size` rows in the *uncached* direction. That same `29..49` / `30..50` case becomes a single fetch of `10..30`. Force-load callers (`request_load_more`) still get the exact range they asked for — the shift is opt-out for callers that know what they want.

While in there, the loader picked up `tracing` instrumentation on the `vantage_diorama::viewport` target: debounce-absorbed count, skip reason, effective vs visible range, fetch latency, cache-after rows. `RUST_LOG=vantage_diorama::viewport=debug` when you want to know why a UI is stalling or overfetching.

### BDD for the v3 write ops

`v3_replace.feature`, `v3_patch.feature`, `v3_delete.feature`, `v3_delete_all.feature` close the gap `write_path.feature` left when the v3 facade landed in #251. Each follows the Insert trio shape: default-route to master, `WriteFailed` on `on_write` error, mock+sqlite Mirror outline.

Wiring the Patch scenario surfaced a footgun in the harness's `OnWriteMode::Mirror` — it was calling `cache.insert_value(&id, &partial)`, but redb `insert_value` is a full replace, so every column the partial didn't touch got silently dropped. The harness now reads-modifies-writes. No production `Mirror` helper ships yet, so this is harness-only, but it's the same trap any production helper would walk into.

### Versions

- `vantage-diorama` 0.4.3 → 0.4.4

No public API changes.