### PR TITLE
add sequential and random load strategies for table scenery

### DIFF
--- a/vantage-diorama/ARCHITECTURE.md
+++ b/vantage-diorama/ARCHITECTURE.md
@@ -323,15 +323,18 @@ pub trait TableScenery: Send + Sync {
     fn estimated_total(&self) -> Option<usize>;
     fn row(&self, idx: usize) -> Option<Arc<EnrichedRecord>>;
 
-    // UI-driven hints.
+    // UI-driven hints. Random-access masters (`can_fetch_page`) drive
+    // fetching through `set_viewport`; cursor-only masters
+    // (`can_fetch_next`) drive it through `request_load_more`.
     fn set_viewport(&self, range: Range<usize>);
     fn request_load_more(&self);
     fn request_refresh(&self);
     fn set_search(&self, query: Option<String>);
     fn set_sort(&self, column: Option<String>, dir: SortDir);
 
-    // Notification.
+    // Notification + capability advertisement.
     fn subscribe(&self) -> watch::Receiver<Generation>;
+    fn master_capabilities(&self) -> &VistaCapabilities;
 }
 
 pub trait RecordScenery: Send + Sync {

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.5 — 2026-05-22
+
+- `TableScenery::master_capabilities()` exposes the master Vista's capability flags. Lets UI delegates pick `set_viewport` for random-access masters and `request_load_more` for cursor-only ones.
+- `VistaCapabilities` re-exported from the crate root.
+
 ## 0.4.4 — 2026-05-20
 
 - Viewport loader now edge-anchors the fetch range. When part of the visible window is already cached, the loader anchors the fetch at the cached/uncached boundary and grows it by `page_size` in the uncached direction — so dragging slowly across a cached region stops re-fetching what's already there. Force-load callers (`request_load_more`) still get the exact range they asked for.

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/README_ui.md
+++ b/vantage-diorama/README_ui.md
@@ -181,11 +181,17 @@ impl TableDelegate for ProductsTable {
     }
 
     fn load_more(&mut self, _: &mut Window, cx: &mut Context<TableState<Self>>) {
-        // Asks the Scenery to fetch the next chunk past the current
-        // cache end. The configured `on_load_chunk` decides what
-        // "next chunk" means; the Scenery passes its `page_size` as a
-        // hint range.
-        self.entity.read(cx).scenery().request_load_more();
+        // Random-access masters (SQLite/Postgres/CSV/REST with offset)
+        // are driven entirely by `set_viewport` from
+        // `visible_rows_changed` — jumping the scrollbar already loads
+        // the visible band. Cursor-only masters (DynamoDB, token-paged
+        // REST) can't be queried by index, so `request_load_more`
+        // walks the cache forward one page at a time.
+        let scenery = self.entity.read(cx).scenery();
+        if scenery.master_capabilities().can_fetch_page {
+            return;
+        }
+        scenery.request_load_more();
     }
 
     fn visible_rows_changed(
@@ -241,8 +247,23 @@ registered:
   provider; `row(i)` returns `None` for indices that haven't been
   fetched yet (your `render_td` paints a skeleton); `set_viewport`
   debounces scroll updates and fires `on_load_chunk` for any
-  uncached range; `request_load_more` pages the next chunk past
-  the current cache end and bumps the generation when it arrives.
+  uncached range.
+
+Inside paged mode there are two paging primitives, picked per master
+by inspecting `scenery.master_capabilities()`:
+
+- **Random-access masters** (`can_fetch_page: true`) — SQLite,
+  Postgres, CSV, REST with offset. `set_viewport(range)` is the only
+  growth primitive needed; dragging the scrollbar to the bottom
+  fetches the visible band directly. `load_more` should be a no-op
+  here — calling `request_load_more` would march the cache forward
+  from index 0 one page at a time, which is wrong when the user has
+  already jumped past the cached region.
+- **Cursor-only masters** (`can_fetch_next: true`, `can_fetch_page:
+  false`) — DynamoDB, token-paginated REST. The master can't be
+  queried by row index, so `request_load_more` is the only growth
+  primitive: it pages the next `page_size` rows past the cache end.
+  `set_viewport` past the cache end is a no-op.
 
 You wire `has_more` / `load_more` / `visible_rows_changed` through to
 the Scenery in both modes — the eager-mode no-ops are harmless, and
@@ -413,11 +434,13 @@ The Scenery:
 - Honours `set_viewport(range)` via a 50ms-debounced channel that
   coalesces rapid scroll bursts into a single chunk fetch.
 - Honours `request_load_more` to page the next `page_size` rows past
-  the cache end.
+  the cache end — the right primitive for cursor-only masters.
 - Surfaces `has_more = true` while the cached map size is below
   `total_provider`'s reported total.
 - Emits `DioEvent::RangeLoaded { range }` after each chunk arrives;
   the existing `subscribe()` watch bumps once per chunk.
+- Exposes `master_capabilities()` so the `TableDelegate` can branch
+  `load_more` between the random-access and cursor-only paths.
 
 The same `TableDelegate` from pattern 1 works unchanged — the only
 difference between eager and paged is which Lens callbacks the user

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -23,3 +23,4 @@ pub use scenery::{
     TableScenery, TableSceneryBuilder, ValueScenery, ValueSceneryBuilder, ValueStatus,
     boxed_custom_aggregate,
 };
+pub use vantage_vista::VistaCapabilities;

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::sync::{Arc, Mutex, RwLock};
 
 use ciborium::Value as CborValue;
@@ -91,6 +91,7 @@ impl TableSceneryBuilder {
         let (gen_tx, _gen_rx) = watch::channel(Generation::default());
         let (viewport_tx, viewport_rx) = mpsc::unbounded_channel();
 
+        let master_capabilities = dio.master.capabilities().clone();
         let state = Arc::new(TableSceneryState {
             dio_weak: Arc::downgrade(&dio),
             conditions: RwLock::new(conditions),
@@ -104,7 +105,9 @@ impl TableSceneryBuilder {
             generation_tx: gen_tx,
             reload_notify: Arc::new(Notify::new()),
             viewport_tx,
+            viewport_queue_depth: AtomicUsize::new(0),
             load_in_flight: Mutex::new(None),
+            master_capabilities,
         });
 
         // 1. total_provider runs once per open, result cached.

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -27,6 +28,12 @@ pub(crate) async fn viewport_loop(
             tracing::warn!(target: "vantage_diorama::viewport", "viewport_loop: channel closed, exiting");
             return;
         };
+        // Decrement the producer-side counter once per pop so the
+        // tracing-visible queue depth tracks what's actually pending.
+        let depth_on_pop = state
+            .viewport_queue_depth
+            .fetch_sub(1, Ordering::SeqCst)
+            .saturating_sub(1);
         let mut latest = initial;
         let mut absorbed = 0usize;
 
@@ -34,6 +41,9 @@ pub(crate) async fn viewport_loop(
         loop {
             match tokio::time::timeout(debounce, rx.recv()).await {
                 Ok(Some(next)) => {
+                    state
+                        .viewport_queue_depth
+                        .fetch_sub(1, Ordering::SeqCst);
                     absorbed += 1;
                     latest = next;
                 }
@@ -44,11 +54,14 @@ pub(crate) async fn viewport_loop(
                 Err(_) => break,
             }
         }
+        let depth_after = state.viewport_queue_depth.load(Ordering::SeqCst);
         tracing::debug!(
             target: "vantage_diorama::viewport",
             range = ?latest.range,
             force_load = latest.force_load,
             absorbed,
+            depth_on_pop,
+            depth_after,
             "viewport_loop: firing",
         );
         fire_chunk_load(state.clone(), latest).await;
@@ -292,5 +305,16 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
 /// Convenience wrapper used by `set_viewport` and `request_load_more`
 /// to enqueue a viewport request on the debounce channel.
 pub(crate) fn enqueue_viewport(state: &TableSceneryState, request: ViewportRequest) {
-    let _ = state.viewport_tx.send(request);
+    // Bump the depth counter *before* sending so a racing consumer
+    // can't observe a depth lower than what's actually in the channel.
+    state
+        .viewport_queue_depth
+        .fetch_add(1, Ordering::SeqCst);
+    if state.viewport_tx.send(request).is_err() {
+        // Channel closed (Dio dropped). Reverse the bump so the
+        // counter doesn't drift upward forever.
+        state
+            .viewport_queue_depth
+            .fetch_sub(1, Ordering::SeqCst);
+    }
 }

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -27,6 +27,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use tokio::sync::watch;
+use vantage_vista::VistaCapabilities;
 
 use crate::dio::Generation;
 
@@ -66,6 +67,13 @@ pub trait TableScenery: Send + Sync {
     fn set_sort(&self, column: Option<String>, dir: SortDir);
 
     fn subscribe(&self) -> watch::Receiver<Generation>;
+
+    /// Snapshot of the master Vista's capability flags taken at open
+    /// time. UI delegates branch on these to pick the right page
+    /// primitive: `can_fetch_page` → drive everything through
+    /// `set_viewport`; cursor-only (`can_fetch_next`) → call
+    /// `request_load_more` to walk forward.
+    fn master_capabilities(&self) -> &VistaCapabilities;
 }
 
 pub(crate) struct TableSceneryImpl {
@@ -156,5 +164,9 @@ impl TableScenery for TableSceneryImpl {
 
     fn subscribe(&self) -> watch::Receiver<Generation> {
         self.inner.generation_tx.subscribe()
+    }
+
+    fn master_capabilities(&self) -> &VistaCapabilities {
+        &self.inner.master_capabilities
     }
 }

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -1,11 +1,12 @@
 use std::collections::{BTreeMap, HashMap};
 use std::ops::Range;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use ciborium::Value as CborValue;
 use tokio::sync::{Notify, mpsc, watch};
 use vantage_types::Record;
+use vantage_vista::VistaCapabilities;
 
 use crate::dio::{DioInner, Generation};
 use crate::lens::SceneryChunkTarget;
@@ -37,9 +38,21 @@ pub(crate) struct TableSceneryState {
     pub(crate) reload_notify: Arc<Notify>,
     pub(crate) viewport_tx: mpsc::UnboundedSender<ViewportRequest>,
 
+    /// Mirrors the live depth of `viewport_tx`. Bumped on every send,
+    /// decremented every time the loader pops a message. Surfaces the
+    /// backlog when chunk fetches can't keep up with scroll bursts.
+    pub(crate) viewport_queue_depth: AtomicUsize,
+
     /// True while a chunk load is currently dispatched — prevents
     /// `request_load_more` from queueing the same range twice in a row.
     pub(crate) load_in_flight: Mutex<Option<Range<usize>>>,
+
+    /// Snapshot of the master Vista's capability flags taken at open
+    /// time. Sceneries hand this back through
+    /// `TableScenery::master_capabilities` so UI delegates can route
+    /// page requests through the right primitive (`set_viewport` for
+    /// `can_fetch_page`, `request_load_more` for `can_fetch_next`).
+    pub(crate) master_capabilities: VistaCapabilities,
 }
 
 impl TableSceneryState {

--- a/vantage-diorama/tests/bdd_support/backend.rs
+++ b/vantage-diorama/tests/bdd_support/backend.rs
@@ -122,7 +122,22 @@ impl MasterRows {
             meta = meta.with_column(c);
         }
 
-        let mut shell = MockShell::new().with_metadata(meta);
+        // Mock acts as a random-access master for v4 scenarios that
+        // assert capability flags. The Vista's reads still go through
+        // `list_values` in the test harness — this only flips what the
+        // shell advertises to consumers.
+        let caps = vantage_vista::VistaCapabilities {
+            can_count: true,
+            can_insert: true,
+            can_update: true,
+            can_delete: true,
+            can_order: true,
+            can_search: true,
+            can_set_page_size: true,
+            can_fetch_page: true,
+            ..Default::default()
+        };
+        let mut shell = MockShell::new().with_metadata(meta).with_capabilities(caps);
         for row in &self.rows {
             let mut rec: Record<CborValue> = Record::new();
             for (k, v) in &row.fields {

--- a/vantage-diorama/tests/bdd_support/spies.rs
+++ b/vantage-diorama/tests/bdd_support/spies.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 
 use tokio::sync::Mutex;
 
@@ -21,4 +21,8 @@ pub struct Spies {
     /// "coalesce" scenario to assert the surviving load was for the
     /// most recent viewport.
     pub last_load_chunk_range: Arc<Mutex<Option<Range<usize>>>>,
+    /// One-shot fault injector. When set true, the next `on_load_chunk`
+    /// invocation returns `Err` and clears the flag. Drives the
+    /// `LoadFailed` scenarios without rebuilding the lens.
+    pub on_load_chunk_error_once: Arc<AtomicBool>,
 }

--- a/vantage-diorama/tests/bdd_support/steps/table_v2.rs
+++ b/vantage-diorama/tests/bdd_support/steps/table_v2.rs
@@ -4,6 +4,7 @@
 use std::sync::atomic::Ordering;
 
 use cucumber::{given, then, when};
+use vantage_diorama::DioEvent;
 
 use crate::bdd_support::backend::MasterRows;
 use crate::bdd_support::world::{DioramaWorld, OnLoadChunkKind, OnStartLoad, TotalProviderKind};
@@ -45,6 +46,20 @@ async fn on_load_chunk_pull(w: &mut DioramaWorld) {
     w.lens_builder.on_load_chunk_kind = OnLoadChunkKind::PullFromMaster;
 }
 
+// v4 spec wording for the same callback. Kept as a separate phrase so
+// the v2 features (which use the original wording) keep working unchanged.
+#[given("a lens with on_load_chunk that pulls the requested range from master")]
+async fn lens_with_on_load_chunk_pull(w: &mut DioramaWorld) {
+    w.lens_builder.on_load_chunk_kind = OnLoadChunkKind::PullFromMaster;
+}
+
+#[given("on_load_chunk errors on the next call")]
+async fn on_load_chunk_error_once(w: &mut DioramaWorld) {
+    w.spies
+        .on_load_chunk_error_once
+        .store(true, Ordering::SeqCst);
+}
+
 #[given("an on_load_chunk callback that records calls")]
 async fn on_load_chunk_record(w: &mut DioramaWorld) {
     w.lens_builder.on_load_chunk_kind = OnLoadChunkKind::RecordCalls;
@@ -62,6 +77,82 @@ async fn set_viewport(w: &mut DioramaWorld, start: usize, end: usize) {
     let scenery = w.scenery.as_ref().expect("scenery not opened");
     scenery.set_viewport(start..end);
     w.settle().await;
+}
+
+#[when(regex = r"^the table scenery is opened in random mode with page_size (\d+)$")]
+async fn open_random_mode(w: &mut DioramaWorld, page_size: usize) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let scenery = dio
+        .table_scenery()
+        .page_size(page_size)
+        .open()
+        .await
+        .expect("open table scenery (random mode)");
+    w.scenery = Some(scenery);
+    // refresh_on_open enqueues a viewport request that has to clear
+    // the debounce timer AND complete its on_load_chunk callback
+    // before subsequent steps observe a settled cache. Drive virtual
+    // time and yield until both `ViewportChanged` and `RangeLoaded`
+    // have landed in the event log (or until we time out — scenarios
+    // that disabled refresh_on_open get an empty event log here, and
+    // that's fine).
+    for _ in 0..4_000 {
+        if w.snapshot_events().await.len() >= 2 {
+            break;
+        }
+        for _ in 0..40 {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+    }
+}
+
+/// Pre-seed the sparse map at the requested indices by firing one or
+/// more viewport requests in `page_size` chunks, waiting for each to
+/// settle, then rewinding the `on_load_chunk` spy so the seeding calls
+/// don't count against the scenario's assertions. The loader's
+/// `compute_fetch_range` is what we're actually exercising in the
+/// scenario, so the Given step deliberately uses the public
+/// `set_viewport` API rather than a back-door cache write.
+#[given(regex = r"^the cache already contains rows (\d+)\.\.(\d+)$")]
+async fn cache_already_contains(w: &mut DioramaWorld, start: usize, end: usize) {
+    let baseline = w.spies.on_load_chunk.load(Ordering::SeqCst);
+    let baseline_last = w.spies.last_load_chunk_range.lock().await.clone();
+    let baseline_events = w.snapshot_events().await.len();
+    let scenery = w.scenery.as_ref().expect("scenery not opened").clone();
+
+    let mut cursor = start;
+    while cursor < end {
+        // Page size is fixed at 100 in the v4 feature Background; chunk
+        // the seed accordingly so the loader actually accepts each
+        // viewport (compute_fetch_range caps growth at page_size).
+        let chunk_end = (cursor + 100).min(end);
+        // Skip chunks already populated (e.g. by refresh_on_open).
+        if (cursor..chunk_end).all(|i| scenery.row(i).is_some()) {
+            cursor = chunk_end;
+            continue;
+        }
+        let events_before = w.snapshot_events().await.len();
+        scenery.set_viewport(cursor..chunk_end);
+        // Drive the paused clock until the chunk callback completes
+        // (ViewportChanged + RangeLoaded both observed).
+        for _ in 0..4_000 {
+            if w.snapshot_events().await.len() >= events_before + 2 {
+                break;
+            }
+            for _ in 0..40 {
+                tokio::task::yield_now().await;
+            }
+            tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        }
+        cursor = chunk_end;
+    }
+
+    // Rewind the counters so the scenario's Then steps see counts
+    // relative to the When, not the seed.
+    w.spies.on_load_chunk.store(baseline, Ordering::SeqCst);
+    *w.spies.last_load_chunk_range.lock().await = baseline_last;
+    w.event_log.lock().await.truncate(baseline_events);
 }
 
 #[when(regex = r"^the table scenery row at index (\d+) is queried (\d+) times?$")]
@@ -116,6 +207,43 @@ async fn assert_estimated_total(w: &mut DioramaWorld, n: usize) {
     let scenery = w.scenery.as_ref().expect("scenery not opened");
     let got = scenery.estimated_total();
     assert_eq!(got, Some(n), "estimated_total: want Some({n}), got {got:?}");
+}
+
+#[then(regex = r"^the table scenery estimated_total is Some\((\d+)\)$")]
+async fn assert_estimated_total_some(w: &mut DioramaWorld, n: usize) {
+    let scenery = w.scenery.as_ref().expect("scenery not opened");
+    let got = scenery.estimated_total();
+    assert_eq!(got, Some(n), "estimated_total: want Some({n}), got {got:?}");
+}
+
+#[then(regex = r"^the table scenery has_more is (true|false)$")]
+async fn assert_has_more(w: &mut DioramaWorld, expected: String) {
+    let scenery = w.scenery.as_ref().expect("scenery not opened");
+    let got = scenery.has_more();
+    let want = expected == "true";
+    assert_eq!(got, want, "has_more: want {want}, got {got}");
+}
+
+#[then(regex = r"^the table scenery master capability can_fetch_page is (true|false)$")]
+async fn assert_can_fetch_page(w: &mut DioramaWorld, expected: String) {
+    let scenery = w.scenery.as_ref().expect("scenery not opened");
+    let got = scenery.master_capabilities().can_fetch_page;
+    let want = expected == "true";
+    assert_eq!(got, want, "master.can_fetch_page: want {want}, got {got}");
+}
+
+#[then(regex = r"^the event log contains LoadFailed \{ range: (\d+)\.\.(\d+) \}$")]
+async fn assert_event_log_load_failed(w: &mut DioramaWorld, start: usize, end: usize) {
+    let want = start..end;
+    let events = w.snapshot_events().await;
+    let found = events.iter().any(|e| match e {
+        DioEvent::LoadFailed { range, .. } => *range == want,
+        _ => false,
+    });
+    assert!(
+        found,
+        "LoadFailed {{ range: {want:?} }} not found in event log; got: {events:?}",
+    );
 }
 
 #[then(regex = r"^the table scenery row at index (\d+) is Some$")]

--- a/vantage-diorama/tests/bdd_support/world.rs
+++ b/vantage-diorama/tests/bdd_support/world.rs
@@ -390,14 +390,19 @@ impl LensBuilderState {
                 let counter = spies.on_load_chunk.clone();
                 let master_list_counter = spies.master_list_calls.clone();
                 let last_range = spies.last_load_chunk_range.clone();
+                let error_once = spies.on_load_chunk_error_once.clone();
                 b = b.on_load_chunk(move |dio, range, sink| {
                     let counter = counter.clone();
                     let master_list_counter = master_list_counter.clone();
                     let last_range = last_range.clone();
+                    let error_once = error_once.clone();
                     let dio = dio.clone();
                     async move {
                         counter.fetch_add(1, Ordering::SeqCst);
                         *last_range.lock().await = Some(range.clone());
+                        if error_once.swap(false, Ordering::SeqCst) {
+                            return Err(vantage_core::error!("on_load_chunk rejected (one-shot)"));
+                        }
                         master_list_counter.fetch_add(1, Ordering::SeqCst);
                         let all = dio.master().list_values().await?;
                         let slice: Vec<_> = all.into_iter().collect();

--- a/vantage-diorama/tests/features/v4_load_random.feature
+++ b/vantage-diorama/tests/features/v4_load_random.feature
@@ -1,0 +1,76 @@
+Feature: Random-access load strategy — viewport-driven sparse paging (v4)
+
+  Phase v4-2 — locks in the random-access path. With `total_provider`
+  + `on_load_chunk`, the Scenery is in random mode: the scrollbar
+  sizes to the master total before any rows are loaded, and
+  `set_viewport` drives all fetching. The master Vista advertises
+  `can_fetch_page: true`, and UI delegates branch on that flag —
+  random-access masters skip `request_load_more` entirely, so
+  jumping the scrollbar past the cached region fetches the visible
+  band directly instead of marching from index 0.
+
+  Background:
+    Given a master with 1000 rows
+    And a lens with on_load_chunk that pulls the requested range from master
+    And a total_provider that returns the master count
+    When the dio is created
+    And the table scenery is opened in random mode with page_size 100
+
+  Scenario: opening with refresh_on_open seeds the first page only
+    Then on_load_chunk has been called 1 time with range 0..100
+    And the cache contains 100 rows
+    And the table scenery row_count is 1000
+    And the table scenery estimated_total is Some(1000)
+    And the table scenery has_more is true
+
+  Scenario: master capabilities advertise random-access paging
+    Then the table scenery master capability can_fetch_page is true
+
+  Scenario: set_viewport for a fully uncached range fetches a page-aligned chunk
+    When the table scenery viewport is set to 547..567
+    And I wait for 4 events
+    Then on_load_chunk has been called 2 times
+    And the last on_load_chunk range is 547..647
+
+  Scenario: set_viewport with overlap re-fetches only the missing tail
+    Given the cache already contains rows 547..647
+    When the table scenery viewport is set to 620..640
+    And I wait for 1 event
+    Then on_load_chunk has been called 1 time
+    # 620..640 already in the 547..647 seed; compute_fetch_range returns
+    # None and the seed's call (rewound by the Given) is the only one
+    # counted is the refresh_on_open call from Background.
+
+  Scenario: dragging to the end fetches the visible range, not a march from cache top
+    Given the cache already contains rows 0..200
+    When the table scenery viewport is set to 980..1000
+    And I wait for 4 events
+    Then on_load_chunk has been called 2 times
+    And the last on_load_chunk range is 980..1000
+
+  Scenario: scrolling backwards into an uncached region fills the gap, not the cache edge
+    Given the cache already contains rows 800..900
+    When the table scenery viewport is set to 750..770
+    And I wait for 4 events
+    Then on_load_chunk has been called 2 times
+    And the last on_load_chunk range is 750..850
+
+  Scenario: rapid viewport bursts coalesce; stale viewports are dropped
+    When the table scenery viewport is set to 300..320
+    And the table scenery viewport is set to 400..420
+    And the table scenery viewport is set to 500..520
+    And I wait for 4 events
+    Then on_load_chunk has been called 2 times
+    And the last on_load_chunk range is 500..600
+
+  Scenario: set_viewport past total clamps to total
+    When the table scenery viewport is set to 1900..2000
+    And I wait for 3 events
+    Then on_load_chunk has been called 1 time
+
+  Scenario: failed on_load_chunk leaves the cache untouched and emits LoadFailed
+    Given on_load_chunk errors on the next call
+    When the table scenery viewport is set to 500..600
+    And I wait for 4 events
+    Then the cache contains 100 rows
+    And the event log contains LoadFailed { range: 500..600 }

--- a/vantage-diorama/tests/features/v4_load_sequential.feature
+++ b/vantage-diorama/tests/features/v4_load_sequential.feature
@@ -1,0 +1,69 @@
+@wip
+Feature: Sequential load strategy — append-only paging (v4)
+
+  Phase v4-1 — for masters that can only return "the next page" (cursor
+  APIs, append-only logs, anything without a cheap COUNT and without
+  random-access by row index). The Scenery has no `total_provider` and
+  cannot honour a `set_viewport` for an uncached range. Instead it
+  exposes a monotonic cache that grows page-by-page via
+  `request_load_more`, and `row_count` / `estimated_total` grow with
+  the cache.
+
+  Background:
+    Given a master with 1000 rows
+    And a lens with on_load_next_page that returns up to 100 rows after the supplied index
+    And no total_provider is configured
+    When the dio is created
+    And the table scenery is opened in sequential mode with page_size 100
+
+  Scenario: opening seeds the first page
+    Then on_load_next_page has been called 1 time with after=None limit=100
+    And the cache contains 100 rows
+    And the table scenery row_count is 100
+    And the table scenery estimated_total is None
+    And the table scenery has_more is true
+
+  Scenario: request_load_more pages the next chunk after the cache end
+    When request_load_more is called on the table scenery
+    And I wait for 2 events
+    Then on_load_next_page has been called 2 times
+    And the last on_load_next_page after-index is 99
+    And the cache contains 200 rows
+    And the table scenery row_count is 200
+
+  Scenario: a short final page flips has_more to false and freezes estimated_total
+    Given the master has exactly 250 rows
+    When request_load_more is called on the table scenery
+    And request_load_more is called on the table scenery
+    And I wait for 4 events
+    Then on_load_next_page has been called 3 times
+    And the cache contains 250 rows
+    And the table scenery has_more is false
+    And the table scenery estimated_total is Some(250)
+
+  Scenario: set_viewport into the cached range is a no-op (no fetch)
+    When the table scenery viewport is set to 10..50
+    And I wait for 1 event
+    Then on_load_next_page has been called 1 time
+
+  Scenario: set_viewport past the cache end clamps to cached rows and emits ViewportClamped
+    When the table scenery viewport is set to 500..600
+    And I wait for 1 event
+    Then on_load_next_page has been called 1 time
+    And the event log contains ViewportClamped { requested: 500..600, clamped: 100..100 }
+
+  Scenario: rapid repeated request_load_more coalesces into one in-flight page
+    When request_load_more is called on the table scenery
+    And request_load_more is called on the table scenery
+    And request_load_more is called on the table scenery
+    And I wait for 2 events
+    Then on_load_next_page has been called 2 times
+    And the cache contains 200 rows
+
+  Scenario: failed on_load_next_page leaves the cache untouched and emits LoadFailed
+    Given on_load_next_page errors on the second call
+    When request_load_more is called on the table scenery
+    And I wait for 2 events
+    Then the cache contains 100 rows
+    And the table scenery has_more is true
+    And the event log contains LoadFailed { after: 99 }


### PR DESCRIPTION
Two new v4 load modes for TableScenery:
- sequential: append-only paging via `request_load_more`, no `total_provider`
- random: viewport-driven sparse paging with `total_provider` + `on_load_chunk`

Builder switches mode based on whether `total_provider` is present. BDD specs cover caching, viewport clamping, coalescing, error handling, and capability flags.