### PR TITLE
add vantage-aws vista driver

### DIFF
--- a/.github/workflows/aws.yaml
+++ b/.github/workflows/aws.yaml
@@ -27,11 +27,11 @@ jobs:
 
       - name: Build vantage-aws
         working-directory: vantage-aws
-        run: cargo build --all-targets
+        run: cargo build --all-targets --features vista
 
       - name: Run tests (offline only — integration tests are #[ignore]d)
         working-directory: vantage-aws
-        run: cargo test
+        run: cargo test --features vista
 
       - name: Check formatting
         working-directory: vantage-aws
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run clippy
         working-directory: vantage-aws
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets --features vista -- -D warnings
 
       - name: Run aws-cli against live AWS
         working-directory: vantage-aws
@@ -48,10 +48,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: eu-west-2
         run: |
-          cargo run --example aws-cli -- log.groups
-          cargo run --example aws-cli -- log.groups logGroupNamePrefix=/aws/lambda/
-          cargo run --example aws-cli -- iam.users
-          cargo run --example aws-cli -- iam.roles PathPrefix=/aws-service-role/
-          cargo run --example aws-cli -- s3.buckets
-          cargo run --example aws-cli -- lambda.functions
-          cargo run --example aws-cli -- dynamodb.tables
+          cargo run --features vista --example aws-cli -- log.groups
+          cargo run --features vista --example aws-cli -- log.groups logGroupNamePrefix=/aws/lambda/
+          cargo run --features vista --example aws-cli -- iam.users
+          cargo run --features vista --example aws-cli -- iam.roles PathPrefix=/aws-service-role/
+          cargo run --features vista --example aws-cli -- s3.buckets
+          cargo run --features vista --example aws-cli -- lambda.functions
+          cargo run --features vista --example aws-cli -- dynamodb.tables

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4576,7 +4576,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4672,7 +4672,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.4.10 — 2026-05-23
+
+The AWS backend now plugs into the universal Vista layer — wrap a typed `Table<AwsAccount, E>` with [`AwsAccount::vista_factory().from_table(...)`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/vista/struct.AwsVistaFactory.html#method.from_table) and the resulting [`Vista`](https://docs.rs/vantage-vista/0.4/vantage_vista/struct.Vista.html) carries the same column metadata, id field, title columns, and `with_one` / `with_many` relations as the typed table.
+
+- New `vista` cargo feature on `vantage-aws` (off by default) brings in [`vantage_aws::vista`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/vista/index.html). The driver advertises `can_count` only — AWS is read-only at this stage; writes, ordering, search, and explicit paging all return `ErrorKind::Unsupported`.
+- [`Factory::vista_for_name`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/models/struct.Factory.html#method.vista_for_name) and [`Factory::vista_from_arn`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/models/struct.Factory.html#method.vista_from_arn) mirror the existing `for_name` / `from_arn` dispatch but return `Vista`s instead of `AnyTable`s.
+- `aws-cli` rewires onto [`vantage_cli_util::vista_cli`](https://docs.rs/vantage-cli-util/0.4/vantage_cli_util/vista_cli/index.html). Picks up the full grammar — operator suffixes (`field:lt=…`), sort selectors (`[+name]`), column overrides (`=col1,col2`), search (`?term`), aggregates (`@count`, `@sum:field`), and `--format=json|ndjson|cbor-diag` for non-table output. The example now lives behind the `vista` feature.
+- S3 `301 PermanentRedirect` errors are translated into an actionable hint that names the bucket's actual region and tells you how to re-run — no more raw XML in the terminal.
+- `TableSource::eq_value_condition` lets `Reference::resolve_from_row` push typed `CborValue` join values through without round-tripping via `to_string`, which mattered for relations whose key isn't text (timestamps, numeric ids).
+
 ## 0.4.9 — 2026-05-16
 
 - Lambda's `Function` table drops the `with_foreign("log_group", …)` declaration: the typed-Table `with_foreign` mechanism is removed in `vantage-table 0.4.10` (cross-persistence refs move to the Vista layer). The inherent `Function::ref_log_group(aws)` helper still returns a `Table<AwsAccount, LogGroup>` for direct typed use; the universal-Vista form returns once `vantage-aws` gains a Vista factory.

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -1511,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.7"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2134,26 +2134,29 @@ dependencies = [
  "vantage-expressions",
  "vantage-table",
  "vantage-types",
+ "vantage-vista",
 ]
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.4.1"
+version = "0.4.6"
 dependencies = [
  "async-trait",
  "ciborium",
  "comfy-table",
  "indexmap",
  "owo-colors",
+ "serde_json",
  "vantage-core",
  "vantage-dataset",
  "vantage-table",
  "vantage-types",
+ "vantage-vista",
 ]
 
 [[package]]
 name = "vantage-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "atty",
  "indexmap",
@@ -2165,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2184,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-expressions"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "serde",
@@ -2197,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.4.8"
+version = "0.4.12"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2214,11 +2217,12 @@ dependencies = [
  "vantage-dataset",
  "vantage-expressions",
  "vantage-types",
+ "vantage-vista",
 ]
 
 [[package]]
 name = "vantage-types"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ciborium",
  "indexmap",
@@ -2240,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.4.4"
+version = "0.4.10"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -10,12 +10,17 @@ homepage = "https://romaninsh.github.io/vantage"
 repository = "https://github.com/romaninsh/vantage"
 readme = "README.md"
 
+[features]
+default = []
+vista = ["dep:vantage-vista"]
+
 [dependencies]
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.4.10", path = "../vantage-table" }
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-vista = { version = "0.4", path = "../vantage-vista", optional = true }
 
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
@@ -42,6 +47,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 [dev-dependencies]
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
 vantage-cli-util = { version = "0.4.1", path = "../vantage-cli-util" }
+vantage-vista = { version = "0.4", path = "../vantage-vista" }
 
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }
@@ -50,6 +56,7 @@ clap = { version = "4", features = ["derive"] }
 [[example]]
 name = "aws-cli"
 path = "examples/aws-cli.rs"
+required-features = ["vista"]
 
 [[example]]
 name = "aws-dynamo"

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-aws/examples/aws-cli.rs
+++ b/vantage-aws/examples/aws-cli.rs
@@ -1,22 +1,24 @@
-//! `vantage-aws-cli` — generic, model-driven CLI over `vantage-aws`.
+//! `vantage-aws-cli` — Vista-driven CLI over `vantage-aws`.
 //!
-//! Argument shape (everything after `--region`):
+//! Argument grammar matches [`vantage_cli_util::vista_cli`] — see that
+//! crate's docs for the full vocabulary (operators, sort/slice
+//! selectors, search, aggregates, locators, JSON-typed values). Common
+//! shapes:
 //!
 //! ```text
-//! aws-cli <model | arn> [field=value ...] [[N]] [:relation [[N]] ...]
+//! aws-cli [--region <r>] [--format=<f>] <model | arn> [token …]
 //! ```
 //!
-//! - First positional is either a dotted model name (`iam.users`,
-//!   `log.group`, `ecs.task_definitions`, …) or an ARN (`arn:...`).
-//! - Singular forms (`iam.user`) drop into single-record mode and
-//!   render the first matching record. Plural forms (`iam.users`)
-//!   render a list.
-//! - Filters (`field=value` or `field="quoted value"`) AND together.
-//! - `[N]` selects the Nth record from a list and switches into
-//!   single-record mode.
-//! - `:relation` traverses a `with_many` / `with_one` registered on
-//!   the current table and switches into list mode for the child.
-//! - Glued forms work too: `users[0]`, `:members[0]`, `name=foo[0]`.
+//! - First positional is a dotted model name (`iam.users`, `log.group`,
+//!   `ecs.task_definitions`, …) or an ARN. Singular names render the
+//!   first record; plurals render a list.
+//! - `field=value` / `field:lt=value` / `field="quoted text"` filter.
+//! - `[N]` narrows to row N; `[+name]` sorts ascending; `[+name:0]`
+//!   sorts then narrows.
+//! - `:relation` traverses a `with_many` / `with_one`.
+//! - `=col1,col2` overrides the rendered columns.
+//! - `?keyword` searches; `@count` / `@sum:field` aggregate.
+//! - `--format=table|json|ndjson|cbor-diag` switches output.
 //!
 //! Reads creds from the standard env vars (`AWS_ACCESS_KEY_ID`,
 //! `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`,
@@ -25,45 +27,25 @@
 
 use anyhow::{Context, Result};
 use ciborium::Value as CborValue;
-use clap::Parser;
 use indexmap::IndexMap;
 use vantage_aws::AwsAccount;
 use vantage_aws::models::{Factory, FactoryMode};
-use vantage_aws::types::{AnyAwsType, typed_records};
-use vantage_cli_util::model_cli::{self, Mode, ModelFactory, Renderer};
+use vantage_aws::types::AnyAwsType;
+use vantage_cli_util::output::{self, OutputFormat};
+use vantage_cli_util::vista_cli::{self, AggregateOp, Mode, ModelFactory, Renderer};
 use vantage_cli_util::{render_records_columns, render_records_typed};
-use vantage_table::any::AnyTable;
-use vantage_table::traits::table_like::TableLike;
 use vantage_types::{Record, TerminalRender};
+use vantage_vista::{ReferenceKind, Vista};
 
-#[derive(Parser)]
-#[command(
-    name = "vantage-aws-cli",
-    about = "Generic CLI for vantage-aws models",
-    long_about = "Use a dotted model name (e.g. iam.users, log.group) or an ARN as the first arg, \
-                  then chain filters (field=value), index selectors ([0]), and relation \
-                  traversals (:relation). Example: aws-cli iam.user UserName=alice :groups."
-)]
-struct Cli {
-    /// Override the AWS region (sets AWS_REGION before credential load).
-    #[arg(long, global = true)]
-    region: Option<String>,
-
-    /// Positional tokens: model-or-ARN, filters, indices, traversals.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = false)]
-    args: Vec<String>,
-}
-
-/// Adapts the standalone [`Factory`] (which lives in `vantage-aws`
-/// proper) to `vantage-cli-util`'s [`ModelFactory`] trait. Keeps
-/// `vantage-aws` itself free of a runtime dep on `vantage-cli-util`.
+/// Adapts [`Factory`] (which lives in `vantage-aws` proper, free of any
+/// CLI-runner dep) to `vantage-cli-util`'s vista_cli factory trait.
 struct AwsFactoryAdapter(Factory);
 
 impl ModelFactory for AwsFactoryAdapter {
-    fn for_name(&self, name: &str) -> Option<(AnyTable, Mode)> {
-        self.0.for_name(name).map(|(t, m)| {
+    fn for_name(&self, name: &str) -> Option<(Vista, Mode)> {
+        self.0.vista_for_name(name).map(|(v, m)| {
             (
-                t,
+                v,
                 match m {
                     FactoryMode::List => Mode::List,
                     FactoryMode::Single => Mode::Single,
@@ -72,149 +54,283 @@ impl ModelFactory for AwsFactoryAdapter {
         })
     }
 
-    fn for_arn(&self, arn: &str) -> Option<AnyTable> {
-        self.0.from_arn(arn)
+    fn for_locator(&self, locator: &str) -> Option<Vista> {
+        self.0.vista_from_arn(locator)
     }
 }
 
-/// AWS-aware renderer. Lists go through the existing typed table
-/// renderer (with non-title columns hidden); single records print
-/// `id` + title columns, then `----`, then the rest, and finally a
-/// list of traversable relations.
-struct AwsRenderer;
+/// AWS-flavoured renderer. For `--format=table`, lists go through
+/// `render_records_typed` / `render_records_columns` with values typed
+/// up via `AnyAwsType` so ARNs / timestamps render as themselves;
+/// single records print `id` + title columns, `--------`, then the
+/// rest, followed by traversable relations. Other formats forward to
+/// `vantage_cli_util::output`.
+struct AwsRenderer {
+    format: OutputFormat,
+}
 
 impl Renderer for AwsRenderer {
     fn render_list(
         &self,
-        table: &AnyTable,
+        vista: &Vista,
         records: &IndexMap<String, Record<CborValue>>,
         column_override: Option<&[String]>,
     ) {
-        let id_field = table.id_field_name();
-        let column_types = table.column_types();
-        let title_fields = table.title_field_names();
-
-        let typed = typed_records(records.clone(), &column_types);
-
-        if let Some(cols) = column_override {
-            // Explicit override: only the spelled-out columns are
-            // shown. `id` resolves to the table's id field.
-            let resolved: Vec<String> = cols
-                .iter()
-                .map(|raw| {
-                    if raw == "id" {
-                        id_field.clone().unwrap_or_else(|| raw.clone())
-                    } else {
-                        raw.clone()
-                    }
-                })
-                .collect();
-            render_records_columns(&typed, &resolved, &column_types);
-            return;
+        match self.format {
+            OutputFormat::Table => render_list_table(vista, records, column_override),
+            _ => print!("{}", output::render_list(self.format, records)),
         }
-
-        // Default: show id + title columns. Tables with no title
-        // columns (single-column ARN tables in ECS) fall back to
-        // every non-id column so the listing isn't empty.
-        let visible: IndexMap<String, &'static str> = if title_fields.is_empty() {
-            column_types.clone()
-        } else {
-            let mut v = IndexMap::new();
-            for f in &title_fields {
-                if let Some(t) = column_types.get(f) {
-                    v.insert(f.clone(), *t);
-                }
-            }
-            v
-        };
-        render_records_typed(&typed, id_field.as_deref(), &visible);
     }
 
     fn render_record(
         &self,
-        table: &AnyTable,
+        vista: &Vista,
         id: &str,
         record: &Record<CborValue>,
-        relations: &[String],
+        _relations: &[String],
     ) {
-        let id_field = table.id_field_name();
-        let title_fields = table.title_field_names();
-        let column_types = table.column_types();
-
-        let typed_rec: Record<AnyAwsType> = record
-            .iter()
-            .map(|(k, v)| {
-                let declared = column_types.get(k).copied().unwrap_or("");
-                (k.clone(), AnyAwsType::from_cbor_typed(v.clone(), declared))
-            })
-            .collect();
-
-        // id leads, then title columns, then `--------`, then the rest.
-        if let Some(ref name) = id_field {
-            println!(
-                "{}: {}",
-                name,
-                format_field(&typed_rec, name).unwrap_or_else(|| id.to_string())
-            );
-        } else {
-            println!("id: {id}");
-        }
-        for tf in &title_fields {
-            if Some(tf.as_str()) == id_field.as_deref() {
-                continue;
-            }
-            if let Some(s) = format_field(&typed_rec, tf) {
-                println!("{tf}: {s}");
-            }
-        }
-
-        println!("--------");
-
-        for k in column_types.keys() {
-            if Some(k.as_str()) == id_field.as_deref() || title_fields.contains(k) {
-                continue;
-            }
-            if let Some(s) = format_field(&typed_rec, k) {
-                println!("{k}: {s}");
-            }
-        }
-
-        if !relations.is_empty() {
-            println!();
-            println!("Relations:");
-            for r in relations {
-                println!("  :{r}");
-            }
+        match self.format {
+            OutputFormat::Table => render_record_table(vista, id, record),
+            _ => print!("{}", output::render_record(self.format, id, record)),
         }
     }
+
+    fn render_scalar(
+        &self,
+        _vista: &Vista,
+        op: AggregateOp,
+        field: Option<&str>,
+        value: &CborValue,
+    ) {
+        let label = match field {
+            Some(f) => format!("{}({f})", op.name()),
+            None => format!("{}()", op.name()),
+        };
+        match self.format {
+            OutputFormat::Table => println!("{label} = {}", scalar(value)),
+            _ => print!("{}", output::render_scalar(self.format, &label, value)),
+        }
+    }
+}
+
+fn render_list_table(
+    vista: &Vista,
+    records: &IndexMap<String, Record<CborValue>>,
+    column_override: Option<&[String]>,
+) {
+    let id_field = vista.get_id_column().map(str::to_string);
+    let title_fields: Vec<String> = vista
+        .get_title_columns()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    let column_types = column_types_static(vista);
+
+    let typed = typed_records_borrowed(records, vista);
+
+    if let Some(cols) = column_override {
+        // `id` in an override resolves to the table's id field.
+        let resolved: Vec<String> = cols
+            .iter()
+            .map(|raw| {
+                if raw == "id" {
+                    id_field.clone().unwrap_or_else(|| raw.clone())
+                } else {
+                    raw.clone()
+                }
+            })
+            .collect();
+        render_records_columns(&typed, &resolved, &column_types);
+        return;
+    }
+
+    // Default: id + title columns. Tables without title columns
+    // (single-column ARN tables in ECS) fall back to every non-id
+    // column so the listing isn't empty.
+    let visible: IndexMap<String, &'static str> = if title_fields.is_empty() {
+        column_types.clone()
+    } else {
+        let mut v = IndexMap::new();
+        for f in &title_fields {
+            if let Some(t) = column_types.get(f) {
+                v.insert(f.clone(), *t);
+            }
+        }
+        v
+    };
+    render_records_typed(&typed, id_field.as_deref(), &visible);
+}
+
+fn render_record_table(vista: &Vista, id: &str, record: &Record<CborValue>) {
+    let id_field = vista.get_id_column().map(str::to_string);
+    let title_fields: Vec<String> = vista
+        .get_title_columns()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+
+    let typed_rec: Record<AnyAwsType> = record
+        .iter()
+        .map(|(k, v)| {
+            let declared = vista
+                .get_column(k)
+                .map(|c| c.original_type.as_str())
+                .unwrap_or("");
+            (k.clone(), AnyAwsType::from_cbor_typed(v.clone(), declared))
+        })
+        .collect();
+
+    if let Some(ref name) = id_field {
+        println!(
+            "{}: {}",
+            name,
+            format_field(&typed_rec, name).unwrap_or_else(|| id.to_string())
+        );
+    } else {
+        println!("id: {id}");
+    }
+    for tf in &title_fields {
+        if Some(tf.as_str()) == id_field.as_deref() {
+            continue;
+        }
+        if let Some(s) = format_field(&typed_rec, tf) {
+            println!("{tf}: {s}");
+        }
+    }
+
+    println!("--------");
+
+    for name in vista.get_column_names() {
+        if Some(name) == id_field.as_deref() || title_fields.iter().any(|t| t == name) {
+            continue;
+        }
+        if let Some(s) = format_field(&typed_rec, name) {
+            println!("{name}: {s}");
+        }
+    }
+
+    let refs = vista.list_references();
+    if !refs.is_empty() {
+        println!();
+        println!("Relations:");
+        for (name, kind) in refs {
+            let marker = match kind {
+                ReferenceKind::HasOne => "→ one",
+                ReferenceKind::HasMany => "↠ many",
+            };
+            println!("  :{name}  {marker}");
+        }
+    }
+}
+
+/// Materialise vista's column metadata as `IndexMap<name, &'static str>`
+/// for the `render_records_*` helpers. Vista stores type names as
+/// `String`; the helpers expect `&'static str` (from `Column::get_type()`).
+/// We leak each string once — the AWS column-type set is bounded by
+/// the number of distinct Rust types across registered models, and the
+/// CLI exits shortly after rendering.
+fn column_types_static(vista: &Vista) -> IndexMap<String, &'static str> {
+    let mut out = IndexMap::new();
+    for name in vista.get_column_names() {
+        let original = vista
+            .get_column(name)
+            .map(|c| c.original_type.as_str())
+            .unwrap_or("");
+        let leaked: &'static str = Box::leak(original.to_owned().into_boxed_str());
+        out.insert(name.to_string(), leaked);
+    }
+    out
+}
+
+fn typed_records_borrowed(
+    records: &IndexMap<String, Record<CborValue>>,
+    vista: &Vista,
+) -> IndexMap<String, Record<AnyAwsType>> {
+    records
+        .iter()
+        .map(|(id, record)| {
+            let typed: Record<AnyAwsType> = record
+                .iter()
+                .map(|(k, v)| {
+                    let declared = vista
+                        .get_column(k)
+                        .map(|c| c.original_type.as_str())
+                        .unwrap_or("");
+                    (k.clone(), AnyAwsType::from_cbor_typed(v.clone(), declared))
+                })
+                .collect();
+            (id.clone(), typed)
+        })
+        .collect()
 }
 
 fn format_field(record: &Record<AnyAwsType>, key: &str) -> Option<String> {
     record.get(key).map(|v| v.render().to_string())
 }
 
+fn scalar(v: &CborValue) -> String {
+    match v {
+        CborValue::Text(s) => s.clone(),
+        CborValue::Integer(i) => i128::from(*i).to_string(),
+        CborValue::Float(f) => f.to_string(),
+        CborValue::Bool(b) => b.to_string(),
+        CborValue::Null => "—".to_string(),
+        CborValue::Bytes(b) => format!("<{} bytes>", b.len()),
+        other => format!("{other:?}"),
+    }
+}
+
+fn print_usage() {
+    eprintln!(
+        "usage: aws-cli [--region <r>] [--format=<f>] <model | arn> [field=value ...] [[N]] [:relation ...] [@op[:field]]"
+    );
+    eprintln!("\nFormats: table (default), json, ndjson, cbor-diag");
+    eprintln!("\nKnown models:");
+    for name in Factory::known_names() {
+        eprintln!("  {name}");
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = Cli::parse();
-    if let Some(region) = &cli.region {
-        // SAFETY: single-threaded, before any other env reads.
-        unsafe { std::env::set_var("AWS_REGION", region) };
+    // Strip `--region <r>` / `--format=<f>` out of argv before forwarding
+    // positionals to vista_cli. `--region` is AWS-specific (sets the env
+    // var before credential load); `--format=…` mirrors `cli-vista.rs`.
+    let raw: Vec<String> = std::env::args().skip(1).collect();
+    let mut region: Option<String> = None;
+    let mut format = OutputFormat::Table;
+    let mut positional: Vec<String> = Vec::with_capacity(raw.len());
+
+    let mut it = raw.into_iter();
+    while let Some(arg) = it.next() {
+        if let Some(value) = arg.strip_prefix("--format=") {
+            format = OutputFormat::parse(value)
+                .with_context(|| format!("unknown --format `{value}`"))?;
+        } else if arg == "--region" {
+            region = it.next();
+        } else if let Some(value) = arg.strip_prefix("--region=") {
+            region = Some(value.to_string());
+        } else {
+            positional.push(arg);
+        }
     }
+
+    if let Some(r) = &region {
+        // SAFETY: single-threaded, before any other env reads.
+        unsafe { std::env::set_var("AWS_REGION", r) };
+    }
+
+    if positional.is_empty() {
+        print_usage();
+        std::process::exit(2);
+    }
+
     let aws = AwsAccount::from_default().context(
         "Set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_REGION, or configure ~/.aws/credentials [default]",
     )?;
 
-    if cli.args.is_empty() {
-        eprintln!("usage: aws-cli <model | arn> [field=value ...] [[N]] [:relation ...]");
-        eprintln!("\nKnown models:");
-        for name in Factory::known_names() {
-            eprintln!("  {name}");
-        }
-        std::process::exit(2);
-    }
-
     let factory = AwsFactoryAdapter(Factory::new(aws));
-    let renderer = AwsRenderer;
-    model_cli::run(&factory, &renderer, &cli.args).await?;
+    let renderer = AwsRenderer { format };
+    vista_cli::run(&factory, &renderer, &positional).await?;
     Ok(())
 }

--- a/vantage-aws/src/impls/table_source.rs
+++ b/vantage-aws/src/impls/table_source.rs
@@ -46,6 +46,19 @@ impl TableSource for AwsAccount {
         Ok(AwsCondition::eq(field.to_string(), value.to_string()))
     }
 
+    /// Build `field == value` from a typed `Self::Value` (CBOR). Used by
+    /// `Reference::resolve_from_row` when traversing `with_many` /
+    /// `with_one` relations — the join value is pulled out of a
+    /// `Record<CborValue>` and pushed onto the child table verbatim,
+    /// without round-tripping through a string.
+    fn eq_value_condition(
+        &self,
+        field: &str,
+        value: Self::Value,
+    ) -> DatasetResult<Self::Condition> {
+        Ok(AwsCondition::eq(field.to_string(), value))
+    }
+
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         Column::new(name)
     }

--- a/vantage-aws/src/lib.rs
+++ b/vantage-aws/src/lib.rs
@@ -66,6 +66,8 @@ mod sign;
 pub mod dynamodb;
 pub mod models;
 pub mod types;
+#[cfg(feature = "vista")]
+pub mod vista;
 
 pub use account::AwsAccount;
 pub use condition::{AwsCondition, eq, in_};

--- a/vantage-aws/src/models/lambda/function.rs
+++ b/vantage-aws/src/models/lambda/function.rs
@@ -47,10 +47,11 @@ pub struct Function {
 ///   - `versions` → `ListVersionsByFunction` for this function
 ///
 /// Cross-service traversal to CloudWatch Logs is available via the
-/// inherent [`Function::ref_log_group`] helper; the typed `with_foreign`
-/// machinery it previously used was removed in the Vista get_ref rollout,
-/// and `log_group` will reappear as a [`vantage_vista::Vista::with_foreign`]
-/// registration once AWS gains a Vista factory.
+/// inherent [`Function::ref_log_group`] helper. The typed `with_foreign`
+/// machinery it previously used was removed in the Vista `get_ref`
+/// rollout; wiring it as a cross-service Vista reference (via
+/// `add_raw_condition` on the AWS shell) is deferred — for now,
+/// reach the function's log group through the inherent helper.
 ///
 /// ```no_run
 /// # use vantage_aws::AwsAccount;

--- a/vantage-aws/src/models/mod.rs
+++ b/vantage-aws/src/models/mod.rs
@@ -58,6 +58,8 @@ pub mod logs;
 pub mod s3;
 
 use vantage_table::any::AnyTable;
+#[cfg(feature = "vista")]
+use vantage_vista::Vista;
 
 use crate::AwsAccount;
 
@@ -249,6 +251,163 @@ impl Factory {
         }
         if let Some(t) = dynamodb::table::DynamoDbTable::from_arn(arn, aws.clone()) {
             return Some(AnyTable::new(t));
+        }
+        None
+    }
+
+    /// Vista-flavoured mirror of [`Self::for_name`]. Returns a fully
+    /// constructed [`Vista`] (carrying the same per-table metadata as
+    /// `AnyTable`) plus the model's natural mode.
+    ///
+    /// Composite-id endpoints (`iam.access_keys`, `s3.objects`,
+    /// `lambda.aliases`, `lambda.versions`, `ecs.services`, `ecs.tasks`,
+    /// `log.streams`, `log.events`) intentionally aren't surfaced here for
+    /// the same reason they're absent from [`Self::for_name`]: the AWS
+    /// list endpoint requires a parent filter, so the only useful way to
+    /// reach them is via `:relation` traversal from the parent.
+    #[cfg(feature = "vista")]
+    pub fn vista_for_name(&self, name: &str) -> Option<(Vista, FactoryMode)> {
+        let aws = self.aws.clone();
+        let factory = aws.vista_factory();
+        let (vista, mode) = match name {
+            "iam.user" => (
+                factory.from_table(iam::users_table(aws)).ok()?,
+                FactoryMode::Single,
+            ),
+            "iam.users" => (
+                factory.from_table(iam::users_table(aws)).ok()?,
+                FactoryMode::List,
+            ),
+            "iam.group" => (
+                factory.from_table(iam::groups_table(aws)).ok()?,
+                FactoryMode::Single,
+            ),
+            "iam.groups" => (
+                factory.from_table(iam::groups_table(aws)).ok()?,
+                FactoryMode::List,
+            ),
+            "iam.role" => (
+                factory.from_table(iam::roles_table(aws)).ok()?,
+                FactoryMode::Single,
+            ),
+            "iam.roles" => (
+                factory.from_table(iam::roles_table(aws)).ok()?,
+                FactoryMode::List,
+            ),
+            "iam.policy" => (
+                factory.from_table(iam::policies_table(aws)).ok()?,
+                FactoryMode::Single,
+            ),
+            "iam.policies" => (
+                factory.from_table(iam::policies_table(aws)).ok()?,
+                FactoryMode::List,
+            ),
+            "iam.instance_profile" => (
+                factory.from_table(iam::instance_profiles_table(aws)).ok()?,
+                FactoryMode::Single,
+            ),
+            "iam.instance_profiles" => (
+                factory.from_table(iam::instance_profiles_table(aws)).ok()?,
+                FactoryMode::List,
+            ),
+            "log.group" => (
+                factory.from_table(logs::groups_table(aws)).ok()?,
+                FactoryMode::Single,
+            ),
+            "log.groups" => (
+                factory.from_table(logs::groups_table(aws)).ok()?,
+                FactoryMode::List,
+            ),
+            "ecs.cluster" => (
+                factory.from_table(ecs::clusters_table(aws)).ok()?,
+                FactoryMode::Single,
+            ),
+            "ecs.clusters" => (
+                factory.from_table(ecs::clusters_table(aws)).ok()?,
+                FactoryMode::List,
+            ),
+            "ecs.task_definition" => (
+                factory.from_table(ecs::task_definitions_table(aws)).ok()?,
+                FactoryMode::Single,
+            ),
+            "ecs.task_definitions" => (
+                factory.from_table(ecs::task_definitions_table(aws)).ok()?,
+                FactoryMode::List,
+            ),
+            "s3.bucket" => (
+                factory.from_table(s3::buckets_table(aws)).ok()?,
+                FactoryMode::Single,
+            ),
+            "s3.buckets" => (
+                factory.from_table(s3::buckets_table(aws)).ok()?,
+                FactoryMode::List,
+            ),
+            "lambda.function" => (
+                factory.from_table(lambda::functions_table(aws)).ok()?,
+                FactoryMode::Single,
+            ),
+            "lambda.functions" => (
+                factory.from_table(lambda::functions_table(aws)).ok()?,
+                FactoryMode::List,
+            ),
+            "dynamodb.table" => (
+                factory.from_table(dynamodb::tables_table(aws)).ok()?,
+                FactoryMode::Single,
+            ),
+            "dynamodb.tables" => (
+                factory.from_table(dynamodb::tables_table(aws)).ok()?,
+                FactoryMode::List,
+            ),
+            _ => return None,
+        };
+        Some((vista, mode))
+    }
+
+    /// Vista-flavoured mirror of [`Self::from_arn`]. Dispatch order
+    /// matches `from_arn` exactly — S3 objects probed before buckets,
+    /// etc.
+    #[cfg(feature = "vista")]
+    pub fn vista_from_arn(&self, arn: &str) -> Option<Vista> {
+        let aws = self.aws.clone();
+        let factory = aws.vista_factory();
+        if let Some(t) = iam::user::User::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
+        }
+        if let Some(t) = iam::group::Group::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
+        }
+        if let Some(t) = iam::role::Role::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
+        }
+        if let Some(t) = iam::policy::Policy::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
+        }
+        if let Some(t) = iam::instance_profile::InstanceProfile::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
+        }
+        if let Some(t) = iam::access_key::AccessKey::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
+        }
+        if let Some(t) = logs::stream::LogStream::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
+        }
+        if let Some(t) = logs::group::LogGroup::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
+        }
+        if let Some(t) = ecs::cluster::Cluster::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
+        }
+        if let Some(t) = s3::object::Object::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
+        }
+        if let Some(t) = s3::bucket::Bucket::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
+        }
+        if let Some(t) = lambda::function::Function::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
+        }
+        if let Some(t) = dynamodb::table::DynamoDbTable::from_arn(arn, aws.clone()) {
+            return factory.from_table(t).ok();
         }
         None
     }

--- a/vantage-aws/src/restxml/transport.rs
+++ b/vantage-aws/src/restxml/transport.rs
@@ -457,8 +457,7 @@ mod tests {
 
     #[test]
     fn s3_permanent_redirect_hint_ignores_unrelated_errors() {
-        let body =
-            r#"<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>"#;
+        let body = r#"<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>"#;
         assert!(s3_permanent_redirect_hint(403, body).is_none());
         assert!(s3_permanent_redirect_hint(301, body).is_none());
     }

--- a/vantage-aws/src/restxml/transport.rs
+++ b/vantage-aws/src/restxml/transport.rs
@@ -220,6 +220,9 @@ pub(crate) async fn restxml_call(
         .map_err(|e| error!("Failed to read AWS REST-XML response body", detail = e))?;
 
     if !status.is_success() {
+        if let Some(hint) = s3_permanent_redirect_hint(status.as_u16(), &response_text) {
+            return Err(error!(hint));
+        }
         return Err(error!(
             "AWS REST-XML request returned error status",
             url = url.as_str(),
@@ -229,6 +232,64 @@ pub(crate) async fn restxml_call(
     }
 
     Ok(response_text)
+}
+
+/// S3 returns `301 PermanentRedirect` when a bucket-scoped request goes
+/// to the wrong region. SigV4 binds the signature to the original host,
+/// so transparent redirect-following isn't viable — but the response
+/// body names the correct endpoint, which we surface as an actionable
+/// message ("re-run with --region eu-west-2") instead of dumping raw
+/// XML at the user.
+fn s3_permanent_redirect_hint(status: u16, body: &str) -> Option<String> {
+    if status != 301 || !body.contains("<Code>PermanentRedirect</Code>") {
+        return None;
+    }
+    let bucket = xml_inner(body, "Bucket");
+    let endpoint = xml_inner(body, "Endpoint")?;
+    let region = parse_s3_endpoint_region(endpoint)?;
+    let bucket_label = bucket.unwrap_or("(unknown)");
+    Some(format!(
+        "S3 bucket `{bucket_label}` lives in region `{region}`, \
+         not the one currently configured. Re-run with `--region {region}` \
+         (or set AWS_REGION={region}). Original endpoint: {endpoint}."
+    ))
+}
+
+/// Pull the region out of an S3 redirect `<Endpoint>` value. S3 emits
+/// the endpoint in one of four shapes (depending on bucket age and
+/// region):
+///   - `<bucket>.s3.<region>.amazonaws.com` — modern virtual-hosted
+///   - `<bucket>.s3-<region>.amazonaws.com` — legacy dash form (still
+///     used for some pre-2019 buckets in older regions)
+///   - `s3.<region>.amazonaws.com` — path-style, modern
+///   - `s3-<region>.amazonaws.com` — path-style, legacy
+fn parse_s3_endpoint_region(endpoint: &str) -> Option<&str> {
+    let stripped = endpoint.strip_suffix(".amazonaws.com")?;
+    // Try the `.s3.` / `.s3-` (virtual-hosted) markers first — they
+    // carry an explicit boundary before `s3`. Fall back to a
+    // start-of-string `s3.` / `s3-` for path-style endpoints.
+    for marker in [".s3.", ".s3-"] {
+        if let Some(idx) = stripped.rfind(marker) {
+            return Some(&stripped[idx + marker.len()..]);
+        }
+    }
+    for marker in ["s3.", "s3-"] {
+        if let Some(rest) = stripped.strip_prefix(marker) {
+            return Some(rest);
+        }
+    }
+    None
+}
+
+/// Extract the *first* `<tag>…</tag>` inner text from a flat XML
+/// string. Good enough for AWS error bodies, which are single-level and
+/// don't have nested elements named the same as the wrapper.
+fn xml_inner<'a>(xml: &'a str, tag: &str) -> Option<&'a str> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = xml.find(&open)? + open.len();
+    let end = xml[start..].find(&close)? + start;
+    Some(&xml[start..end])
 }
 
 fn build_url(host: &str, path: &str, query: &[(String, String)]) -> String {
@@ -356,5 +417,49 @@ mod tests {
         assert_eq!(m, "GET");
         assert_eq!(p, "/");
         assert!(q.is_empty());
+    }
+
+    #[test]
+    fn s3_permanent_redirect_hint_names_bucket_and_region() {
+        let body = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>PermanentRedirect</Code><Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message><Endpoint>ba-coruscant-dev-bucket1.s3.eu-west-2.amazonaws.com</Endpoint><Bucket>ba-coruscant-dev-bucket1</Bucket><RequestId>X</RequestId><HostId>Y</HostId></Error>"#;
+        let hint = s3_permanent_redirect_hint(301, body).expect("hint should fire");
+        assert!(hint.contains("ba-coruscant-dev-bucket1"));
+        assert!(hint.contains("eu-west-2"));
+        assert!(hint.contains("--region eu-west-2"));
+    }
+
+    #[test]
+    fn parse_s3_endpoint_region_handles_all_four_shapes() {
+        // virtual-hosted, modern
+        assert_eq!(
+            parse_s3_endpoint_region("my-bucket.s3.eu-west-2.amazonaws.com"),
+            Some("eu-west-2"),
+        );
+        // virtual-hosted, legacy dash form
+        assert_eq!(
+            parse_s3_endpoint_region("my-bucket.s3-eu-west-1.amazonaws.com"),
+            Some("eu-west-1"),
+        );
+        // path-style, modern
+        assert_eq!(
+            parse_s3_endpoint_region("s3.us-east-1.amazonaws.com"),
+            Some("us-east-1"),
+        );
+        // path-style, legacy
+        assert_eq!(
+            parse_s3_endpoint_region("s3-ap-southeast-2.amazonaws.com"),
+            Some("ap-southeast-2"),
+        );
+        // unrelated host → None
+        assert_eq!(parse_s3_endpoint_region("example.com"), None);
+    }
+
+    #[test]
+    fn s3_permanent_redirect_hint_ignores_unrelated_errors() {
+        let body =
+            r#"<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>"#;
+        assert!(s3_permanent_redirect_hint(403, body).is_none());
+        assert!(s3_permanent_redirect_hint(301, body).is_none());
     }
 }

--- a/vantage-aws/src/vista/factory.rs
+++ b/vantage-aws/src/vista/factory.rs
@@ -1,0 +1,103 @@
+//! `AwsVistaFactory` — typed-table entry point plus the `VistaFactory`
+//! trait impl. AWS is read-only, so the factory advertises only
+//! `can_count`. YAML construction (`build_from_spec`) is stubbed —
+//! AWS table names encode wire-protocol details that don't lower
+//! cleanly to a generic YAML schema, and no consumer needs it yet.
+
+use ciborium::Value as CborValue;
+use vantage_core::{Result, error};
+use vantage_table::column::flags::ColumnFlag;
+use vantage_table::table::Table;
+use vantage_table::traits::column_like::ColumnLike;
+use vantage_types::{EmptyEntity, Entity};
+use vantage_vista::{
+    Column as VistaColumn, NoExtras, Vista, VistaCapabilities, VistaFactory, VistaMetadata,
+    flags as vista_flags,
+};
+
+use crate::AwsAccount;
+use crate::vista::source::AwsTableShell;
+use crate::vista::spec::{AwsColumnExtras, AwsTableExtras, AwsVistaSpec};
+
+pub struct AwsVistaFactory {
+    aws: AwsAccount,
+}
+
+impl AwsVistaFactory {
+    pub fn new(aws: AwsAccount) -> Self {
+        Self { aws }
+    }
+
+    /// Wrap a typed `Table<AwsAccount, E>` as a `Vista`. Column
+    /// metadata, id field, and title fields are harvested from the
+    /// typed table; the original `E` is erased to `EmptyEntity` for
+    /// storage in the shell.
+    pub fn from_table<E>(&self, table: Table<AwsAccount, E>) -> Result<Vista>
+    where
+        E: Entity<CborValue> + 'static,
+    {
+        let name = table.table_name().to_string();
+        let any_table = table.into_entity::<EmptyEntity>();
+        Ok(self.wrap(any_table, name))
+    }
+
+    fn wrap(&self, table: Table<AwsAccount, EmptyEntity>, name: String) -> Vista {
+        let metadata = metadata_from_table(&table);
+        let source = AwsTableShell::new(
+            table,
+            VistaCapabilities {
+                can_count: true,
+                ..VistaCapabilities::default()
+            },
+            metadata,
+        );
+        Vista::new(name, Box::new(source))
+    }
+
+    /// Borrow the underlying account — useful when callers need to
+    /// build sibling tables off the same credentials.
+    pub fn aws(&self) -> &AwsAccount {
+        &self.aws
+    }
+}
+
+impl VistaFactory for AwsVistaFactory {
+    type TableExtras = AwsTableExtras;
+    type ColumnExtras = AwsColumnExtras;
+    type ReferenceExtras = NoExtras;
+
+    fn build_from_spec(&self, _spec: AwsVistaSpec) -> Result<Vista> {
+        Err(error!(
+            "AWS Vista YAML spec construction is not implemented — \
+             build a typed table via the constructors in `vantage_aws::models` \
+             and wrap it with `AwsVistaFactory::from_table`"
+        ))
+    }
+}
+
+pub(crate) fn metadata_from_table<E>(table: &Table<AwsAccount, E>) -> VistaMetadata
+where
+    E: Entity<CborValue> + 'static,
+{
+    let mut metadata = VistaMetadata::new();
+    for (name, col) in table.columns() {
+        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+        if col.flags().contains(&ColumnFlag::Hidden) {
+            vc = vc.with_flag(vista_flags::HIDDEN);
+        }
+        metadata = metadata.with_column(vc);
+    }
+    if let Some(id_field) = table.id_field() {
+        let id_name = id_field.name().to_string();
+        metadata = metadata.with_id_column(id_name.clone());
+        if let Some(col) = metadata.columns.get_mut(&id_name) {
+            col.flags.push(vista_flags::ID.to_string());
+        }
+    }
+    for title in table.title_fields() {
+        if let Some(col) = metadata.columns.get_mut(title) {
+            col.flags.push(vista_flags::TITLE.to_string());
+        }
+    }
+    metadata
+}

--- a/vantage-aws/src/vista/mod.rs
+++ b/vantage-aws/src/vista/mod.rs
@@ -1,0 +1,23 @@
+//! Vista bridge for the AWS backend.
+//!
+//! Construct a `Vista` from a typed `Table<AwsAccount, E>` via
+//! `AwsAccount::vista_factory().from_table(...)`. AWS is read-only at
+//! this stage — the shell advertises only `can_count`. YAML-driven
+//! construction is stubbed; see [`factory::AwsVistaFactory`].
+
+pub mod factory;
+pub mod source;
+pub mod spec;
+
+pub use factory::AwsVistaFactory;
+pub use source::AwsTableShell;
+pub use spec::{AwsColumnExtras, AwsTableExtras, AwsVistaSpec};
+
+use crate::AwsAccount;
+
+impl AwsAccount {
+    /// Return a Vista factory bound to this AWS account.
+    pub fn vista_factory(&self) -> AwsVistaFactory {
+        AwsVistaFactory::new(self.clone())
+    }
+}

--- a/vantage-aws/src/vista/source.rs
+++ b/vantage-aws/src/vista/source.rs
@@ -1,0 +1,164 @@
+//! `AwsTableShell` — owns a `Table<AwsAccount, EmptyEntity>` and
+//! exposes it through the `TableShell` boundary.
+//!
+//! AWS already speaks `ciborium::Value` natively (the wire protocols
+//! parse into CBOR), so this is a passthrough on reads. Conditions
+//! translate `(field, CborValue)` into an `AwsCondition::Eq` and push
+//! it onto the wrapped table; the dispatch layer folds AwsConditions
+//! into the request body at fetch time. AWS is read-only in v0 — only
+//! `can_count` is advertised.
+//!
+//! AWS list APIs expose no HEAD / COUNT / point-get operation, so
+//! `get_vista_count` and `get_vista_value` both materialise the listing
+//! and then count or filter in memory. [`crate::AwsAccount::with_max_pages`]
+//! caps the walk; without it, both methods will keep paginating until the
+//! response stream is exhausted. Callers that need an unbounded count on
+//! an unbounded list should not call these.
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::Result;
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+use vantage_vista::{
+    Column as VistaColumn, Reference as VistaReference, ReferenceKind, TableShell, Vista,
+    VistaCapabilities, VistaMetadata,
+};
+
+use crate::AwsAccount;
+use crate::condition::AwsCondition;
+
+pub struct AwsTableShell {
+    pub(crate) table: Table<AwsAccount, EmptyEntity>,
+    pub(crate) capabilities: VistaCapabilities,
+    pub(crate) metadata: VistaMetadata,
+}
+
+impl AwsTableShell {
+    pub(crate) fn new(
+        table: Table<AwsAccount, EmptyEntity>,
+        capabilities: VistaCapabilities,
+        metadata: VistaMetadata,
+    ) -> Self {
+        Self {
+            table,
+            capabilities,
+            metadata,
+        }
+    }
+}
+
+#[async_trait]
+impl TableShell for AwsTableShell {
+    fn columns(&self) -> &IndexMap<String, VistaColumn> {
+        &self.metadata.columns
+    }
+
+    fn references(&self) -> &IndexMap<String, VistaReference> {
+        &self.metadata.references
+    }
+
+    fn id_column(&self) -> Option<&str> {
+        self.metadata.id_column.as_deref()
+    }
+
+    async fn list_vista_values(
+        &self,
+        _vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        self.table.list_values().await
+    }
+
+    async fn get_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        // AWS list endpoints don't expose a point-get; fall back to
+        // narrowing the listed map by id — same shape as the REST shell.
+        let mut data = self.table.list_values().await?;
+        Ok(data.shift_remove(id))
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        _vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        let data = self.table.list_values().await?;
+        Ok(data.into_iter().next())
+    }
+
+    async fn get_vista_count(&self, _vista: &Vista) -> Result<i64> {
+        Ok(self.table.list_values().await?.len() as i64)
+    }
+
+    fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
+        // `AwsCondition::Eq` carries the value as `CborValue` directly;
+        // the wire-format builders (`build_json1_body`, `build_query_form`)
+        // do the JSON / string conversion at execute time.
+        self.table
+            .add_condition(AwsCondition::eq(field.to_string(), value.clone()));
+        Ok(())
+    }
+
+    fn get_ref(&self, relation: &str, row: &Record<CborValue>) -> Result<Vista> {
+        let target = self.table.get_ref_from_row::<EmptyEntity>(relation, row)?;
+        let factory = crate::vista::factory::AwsVistaFactory::new(self.table.data_source().clone());
+        factory.from_table(target)
+    }
+
+    fn get_ref_kinds(&self) -> Vec<(String, ReferenceKind)> {
+        self.table.ref_kinds()
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.capabilities
+    }
+
+    fn driver_name(&self) -> &'static str {
+        "aws"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AwsAccount;
+    use crate::models::iam;
+    use crate::vista::factory::metadata_from_table;
+    use vantage_types::EmptyEntity;
+
+    fn shell_for_iam_users() -> AwsTableShell {
+        let aws = AwsAccount::new("AKIATEST", "secret", "eu-west-2");
+        let table = iam::users_table(aws).into_entity::<EmptyEntity>();
+        let metadata = metadata_from_table(&table);
+        let capabilities = VistaCapabilities {
+            can_count: true,
+            ..VistaCapabilities::default()
+        };
+        AwsTableShell::new(table, capabilities, metadata)
+    }
+
+    #[test]
+    fn add_eq_condition_pushes_aws_condition_eq_onto_wrapped_table() {
+        // `dispatch` reads `table.conditions()` when assembling the
+        // request body; a missing or mistranslated condition is invisible
+        // without this introspection.
+        let mut shell = shell_for_iam_users();
+        shell
+            .add_eq_condition("PathPrefix", &CborValue::Text("/admin/".into()))
+            .expect("add_eq_condition");
+
+        let conditions: Vec<&AwsCondition> = shell.table.conditions().collect();
+        assert_eq!(conditions.len(), 1);
+        match conditions[0] {
+            AwsCondition::Eq { field, value } => {
+                assert_eq!(field, "PathPrefix");
+                assert_eq!(value, &CborValue::Text("/admin/".into()));
+            }
+            other => panic!("expected AwsCondition::Eq, got {other:?}"),
+        }
+    }
+}

--- a/vantage-aws/src/vista/spec.rs
+++ b/vantage-aws/src/vista/spec.rs
@@ -1,0 +1,31 @@
+//! YAML-facing types for the AWS Vista driver.
+//!
+//! Placeholders for now — AWS Vista doesn't yet support YAML-driven
+//! construction. AWS table names are wire-protocol identifiers of the
+//! form `{protocol}/{array_key}:{service}/{target}` (see `lib.rs`); a
+//! YAML schema would have to either re-encode that vocabulary or hide
+//! it behind another layer of indirection, and neither lowering is
+//! useful without a concrete consumer to shape it. The typed
+//! constructors under [`crate::models`] are the only sensible source
+//! today.
+//!
+//! The types here are kept to satisfy [`VistaFactory`]'s associated-type
+//! contract; `AwsVistaFactory::build_from_spec` returns an error until
+//! a real consumer needs it. When that day comes, the natural extras
+//! to surface are per-table `region` / `max_pages` overrides and
+//! per-column `original_type` hints — sketch them then, not now.
+//!
+//! [`VistaFactory`]: vantage_vista::VistaFactory
+
+use serde::{Deserialize, Serialize};
+use vantage_vista::{NoExtras, VistaSpec};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AwsTableExtras {}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AwsColumnExtras {}
+
+pub type AwsVistaSpec = VistaSpec<AwsTableExtras, AwsColumnExtras, NoExtras>;

--- a/vantage-aws/tests/vista.rs
+++ b/vantage-aws/tests/vista.rs
@@ -1,0 +1,258 @@
+//! Offline contract tests for the AWS Vista driver.
+//!
+//! These tests don't talk to AWS — they only assert metadata, capability
+//! advertisement, and error-kind boundaries that hold whether or not
+//! credentials are configured. Live-fetch tests would belong alongside
+//! `dynamodb_live.rs`; this file is the part that can run on any
+//! developer machine and in CI without secrets.
+
+#![cfg(feature = "vista")]
+
+use ciborium::Value as CborValue;
+use vantage_aws::AwsAccount;
+use vantage_aws::models::{Factory, FactoryMode, ecs, iam, lambda, logs, s3};
+use vantage_core::{ErrorKind, Result};
+use vantage_dataset::prelude::WritableValueSet;
+use vantage_types::Record;
+use vantage_vista::{ReferenceKind, SortDirection};
+
+fn aws() -> AwsAccount {
+    AwsAccount::new("AKIATEST", "secret", "eu-west-2")
+}
+
+#[test]
+fn capabilities_advertise_read_only() -> Result<()> {
+    let factory = aws().vista_factory();
+    let vista = factory.from_table(iam::users_table(aws()))?;
+
+    let caps = vista.capabilities();
+    assert!(
+        caps.can_count,
+        "AWS list endpoints can be counted (by exhausting them)"
+    );
+    assert!(!caps.can_insert);
+    assert!(!caps.can_update);
+    assert!(!caps.can_delete);
+    assert!(!caps.can_subscribe);
+    assert!(!caps.can_order);
+    assert!(!caps.can_search);
+    assert!(!caps.can_set_page_size);
+    assert!(!caps.can_fetch_page);
+    assert!(!caps.can_fetch_next);
+
+    assert_eq!(vista.driver(), "aws");
+    Ok(())
+}
+
+#[test]
+fn metadata_round_trip_from_iam_users() -> Result<()> {
+    let factory = aws().vista_factory();
+    let vista = factory.from_table(iam::users_table(aws()))?;
+
+    assert_eq!(vista.name(), "query/Users:iam/2010-05-08.ListUsers");
+    assert_eq!(vista.get_id_column(), Some("UserName"));
+
+    let names = vista.get_column_names();
+    assert!(names.contains(&"UserName"));
+    assert!(names.contains(&"Arn"));
+    assert!(names.contains(&"CreateDate"));
+    assert!(names.contains(&"PasswordLastUsed"));
+
+    // Title columns come from the typed table's `with_title_column_of`.
+    let titles = vista.get_title_columns();
+    assert!(titles.contains(&"Path"));
+    assert!(titles.contains(&"CreateDate"));
+    Ok(())
+}
+
+#[test]
+fn ref_kinds_match_typed_relations() -> Result<()> {
+    let factory = aws().vista_factory();
+
+    let users = factory.from_table(iam::users_table(aws()))?;
+    let user_refs = users.list_references();
+    assert_eq!(
+        user_refs,
+        vec![
+            ("groups".into(), ReferenceKind::HasMany),
+            ("access_keys".into(), ReferenceKind::HasMany),
+            ("attached_policies".into(), ReferenceKind::HasMany),
+        ],
+    );
+
+    let functions = factory.from_table(lambda::functions_table(aws()))?;
+    let function_refs = functions.list_references();
+    assert_eq!(
+        function_refs,
+        vec![
+            ("aliases".into(), ReferenceKind::HasMany),
+            ("versions".into(), ReferenceKind::HasMany),
+        ],
+    );
+
+    let groups = factory.from_table(logs::groups_table(aws()))?;
+    let group_refs = groups.list_references();
+    assert_eq!(
+        group_refs,
+        vec![
+            ("events".into(), ReferenceKind::HasMany),
+            ("streams".into(), ReferenceKind::HasMany),
+        ],
+    );
+
+    let clusters = factory.from_table(ecs::clusters_table(aws()))?;
+    let cluster_refs = clusters.list_references();
+    assert_eq!(
+        cluster_refs,
+        vec![
+            ("services".into(), ReferenceKind::HasMany),
+            ("tasks".into(), ReferenceKind::HasMany),
+        ],
+    );
+
+    let buckets = factory.from_table(s3::buckets_table(aws()))?;
+    let bucket_refs = buckets.list_references();
+    assert_eq!(
+        bucket_refs,
+        vec![("objects".into(), ReferenceKind::HasMany)],
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn writes_return_unsupported() -> Result<()> {
+    let factory = aws().vista_factory();
+    let vista = factory.from_table(iam::users_table(aws()))?;
+
+    let empty = Record::new();
+    let id = "anyone".to_string();
+
+    let insert_err = vista
+        .insert_value(&id, &empty)
+        .await
+        .expect_err("insert should be unsupported on a read-only driver");
+    assert_eq!(insert_err.kind(), ErrorKind::Unsupported);
+    assert!(
+        insert_err.to_string().contains("can_insert"),
+        "expected capability name in message, got: {insert_err}",
+    );
+
+    let replace_err = vista
+        .replace_value(&id, &empty)
+        .await
+        .expect_err("replace should be unsupported");
+    assert_eq!(replace_err.kind(), ErrorKind::Unsupported);
+    assert!(replace_err.to_string().contains("can_update"));
+
+    let delete_err = vista
+        .delete(&id)
+        .await
+        .expect_err("delete should be unsupported");
+    assert_eq!(delete_err.kind(), ErrorKind::Unsupported);
+    assert!(delete_err.to_string().contains("can_delete"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_primitives_return_unsupported() -> Result<()> {
+    let factory = aws().vista_factory();
+    let mut vista = factory.from_table(iam::users_table(aws()))?;
+
+    let order_err = vista
+        .add_order("UserName", SortDirection::Ascending)
+        .expect_err("AWS doesn't advertise can_order");
+    assert_eq!(order_err.kind(), ErrorKind::Unsupported);
+
+    let search_err = vista
+        .add_search("anything")
+        .expect_err("AWS doesn't advertise can_search");
+    assert_eq!(search_err.kind(), ErrorKind::Unsupported);
+
+    let size_err = vista
+        .set_page_size(10)
+        .expect_err("AWS doesn't advertise can_set_page_size");
+    assert_eq!(size_err.kind(), ErrorKind::Unsupported);
+
+    let page_err = vista
+        .fetch_page(1)
+        .await
+        .expect_err("AWS doesn't advertise can_fetch_page");
+    assert_eq!(page_err.kind(), ErrorKind::Unsupported);
+
+    let next_err = vista
+        .fetch_next(None)
+        .await
+        .expect_err("AWS doesn't advertise can_fetch_next");
+    assert_eq!(next_err.kind(), ErrorKind::Unsupported);
+    Ok(())
+}
+
+/// The CLI renderer keys off `Column::original_type` via
+/// `AnyAwsType::from_cbor_typed`, which does suffix matching against
+/// `"::Arn"` / `"::AwsDateTime"`. A type rename or relocation that
+/// breaks that suffix would silently degrade column rendering to plain
+/// `Text`. This test pins the suffixes so a rename trips CI instead.
+#[test]
+fn column_original_type_carries_renderer_keys() -> Result<()> {
+    let factory = aws().vista_factory();
+    let vista = factory.from_table(iam::users_table(aws()))?;
+
+    let arn = vista.get_column("Arn").expect("Arn column exists");
+    assert!(
+        arn.original_type.ends_with("::Arn"),
+        "expected Arn column to carry an ::Arn-suffixed type name, got `{}`",
+        arn.original_type,
+    );
+
+    let created = vista
+        .get_column("CreateDate")
+        .expect("CreateDate column exists");
+    assert!(
+        created.original_type.ends_with("::AwsDateTime"),
+        "expected CreateDate column to carry an ::AwsDateTime-suffixed type name, got `{}`",
+        created.original_type,
+    );
+
+    let user_name = vista
+        .get_column("UserName")
+        .expect("UserName column exists");
+    assert_eq!(user_name.original_type, "alloc::string::String");
+    Ok(())
+}
+
+#[test]
+fn factory_vista_for_name_covers_every_known_name() {
+    let factory = Factory::new(aws());
+
+    for name in Factory::known_names() {
+        let (_vista, mode) = factory
+            .vista_for_name(name)
+            .unwrap_or_else(|| panic!("vista_for_name missing arm for `{name}`"));
+
+        // Every known name is either singular (no trailing 's') or
+        // plural; the dispatcher in `Factory::vista_for_name` mirrors
+        // that convention, so we can derive the expected mode from the
+        // string alone.
+        let expected = if name.ends_with('s') {
+            FactoryMode::List
+        } else {
+            FactoryMode::Single
+        };
+        assert_eq!(
+            mode, expected,
+            "wrong FactoryMode for `{name}`: got {mode:?}, expected {expected:?}",
+        );
+    }
+}
+
+#[test]
+fn add_condition_eq_does_not_error() -> Result<()> {
+    // The behavioural side of pushdown (the condition actually shaping
+    // the AWS request body) is verified by the unit test inside
+    // `src/vista/source.rs` where we can introspect the wrapped table.
+    // This integration test just confirms the Vista-facing call shape.
+    let factory = aws().vista_factory();
+    let mut vista = factory.from_table(iam::users_table(aws()))?;
+    vista.add_condition_eq("PathPrefix", CborValue::Text("/admin/".into()))?;
+    Ok(())
+}

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -41,9 +41,7 @@ pub(crate) async fn viewport_loop(
         loop {
             match tokio::time::timeout(debounce, rx.recv()).await {
                 Ok(Some(next)) => {
-                    state
-                        .viewport_queue_depth
-                        .fetch_sub(1, Ordering::SeqCst);
+                    state.viewport_queue_depth.fetch_sub(1, Ordering::SeqCst);
                     absorbed += 1;
                     latest = next;
                 }
@@ -307,14 +305,10 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
 pub(crate) fn enqueue_viewport(state: &TableSceneryState, request: ViewportRequest) {
     // Bump the depth counter *before* sending so a racing consumer
     // can't observe a depth lower than what's actually in the channel.
-    state
-        .viewport_queue_depth
-        .fetch_add(1, Ordering::SeqCst);
+    state.viewport_queue_depth.fetch_add(1, Ordering::SeqCst);
     if state.viewport_tx.send(request).is_err() {
         // Channel closed (Dio dropped). Reverse the bump so the
         // counter doesn't drift upward forever.
-        state
-            .viewport_queue_depth
-            .fetch_sub(1, Ordering::SeqCst);
+        state.viewport_queue_depth.fetch_sub(1, Ordering::SeqCst);
     }
 }


### PR DESCRIPTION
The AWS backend joins SurrealDB and MongoDB in the universal Vista layer. Behind a new `vista` cargo feature on `vantage-aws`, wrap a typed `Table<AwsAccount, E>` with `AwsAccount::vista_factory().from_table(...)` and the resulting [`Vista`](https://docs.rs/vantage-vista/0.4/vantage_vista/struct.Vista.html) carries the same id, title columns, and `with_one` / `with_many` relations as the typed table. The feature defaults off — without it, your `vantage-aws` build is identical to 0.4.9 plus the two small fixes mentioned at the bottom.

### Capabilities

AWS list endpoints are read-only and don't expose order, search, or explicit paging, so the driver advertises only `can_count`. Writes, `add_order`, `add_search`, `set_page_size`, `fetch_page`, and `fetch_next` all return `ErrorKind::Unsupported` — `tests/vista.rs` pins the contract. Counting and id-narrowed reads work by exhausting the listing in memory, so `AwsAccount::with_max_pages(n)` matters when pointing at a busy account.

YAML-driven construction (`build_from_spec`) is intentionally stubbed. AWS table names encode wire-protocol details of the form `query/Users:iam/2010-05-08.ListUsers` — a generic YAML schema would either have to re-encode that vocabulary or hide it behind another indirection, and neither lowering is useful without a concrete consumer to shape it. The typed constructors under [`vantage_aws::models`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/models/index.html) are the only entry point today.

### `aws-cli` rewired

The example moves off `vantage_cli_util::model_cli` and onto [`vista_cli`](https://docs.rs/vantage-cli-util/0.4/vantage_cli_util/vista_cli/index.html), same as the SurrealDB / MongoDB examples. You get the full grammar — operator suffixes (`field:lt=…`), sort selectors (`[+name]`), column overrides (`=col1,col2`), search (`?term`), aggregates (`@count`, `@sum:field`), and `--format=json|ndjson|cbor-diag` for non-table output. The example now sits behind the `vista` feature:

```sh
cargo run --example aws-cli --features vista -- iam.users
cargo run --example aws-cli --features vista -- lambda.functions [+FunctionName] @count
```

### Two small fixes that landed alongside

S3 returns `301 PermanentRedirect` when a bucket-scoped request lands in the wrong region. SigV4 binds the signature to the original host, so transparent redirect-following isn't viable — but the response body names the correct endpoint, which is now surfaced as `"S3 bucket `foo` lives in region `eu-west-2`, not the one currently configured. Re-run with `--region eu-west-2`"` instead of raw XML.

`TableSource::eq_value_condition` (new, with a default impl that goes through `to_string`) lets `Reference::resolve_from_row` push typed `CborValue` join values through without round-tripping via string. AWS overrides it because `AwsCondition::Eq` already carries values as `CborValue`; non-AWS impls don't have to change.

### Versions

- `vantage-aws` 0.4.9 → 0.4.10