### PR TITLE
Bump touched crates to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,7 +4511,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.1.9"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-pool"
-version = "0.1.4"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4617,7 +4617,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.4.13"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4713,7 +4713,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-log-writer"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4736,7 +4736,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.4.11"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bson",
@@ -4760,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-redb"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4782,7 +4782,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.4.9"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bakery_model3",

--- a/learn-1/Cargo.toml
+++ b/learn-1/Cargo.toml
@@ -9,5 +9,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.52.3", features = ["full"] }
 vantage-expressions = { path = "../vantage-expressions" }
-vantage-sql = { version = "0.4.0", path = "../vantage-sql", features = ["sqlite"] }
+vantage-sql = { version = "0.5", path = "../vantage-sql", features = ["sqlite"] }
 vantage-types = { path = "../vantage-types", features = ["serde"] }

--- a/learn-2/Cargo.toml
+++ b/learn-2/Cargo.toml
@@ -11,7 +11,7 @@ tokio = { version = "1.52.3", features = ["full"] }
 vantage-core = { path = "../vantage-core" }
 vantage-expressions = { path = "../vantage-expressions" }
 vantage-dataset = { path = "../vantage-dataset" }
-vantage-sql = { version = "0.4.0", path = "../vantage-sql", features = ["sqlite"] }
+vantage-sql = { version = "0.5", path = "../vantage-sql", features = ["sqlite"] }
 vantage-table = { path = "../vantage-table" }
 vantage-types = { path = "../vantage-types", features = ["serde"] }
 vantage-cli-util = { path = "../vantage-cli-util" }

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle, aligning with the rest of the workspace. No code changes beyond the dependency pin.
+
 ## 0.1.9 — 2026-05-18
 
 - Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. `RestApiTableShell`, `GraphqlApiTableShell`, and `AnyTableShell` now own their [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implement the new `columns` / `references` / `id_column` shell methods. Factory call sites — `RestApi::vista_factory(...).from_yaml(...)`, `AnyTableShell::into_vista_with(...)` — are unchanged.

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.1.9"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"

--- a/vantage-api-pool/CHANGELOG.md
+++ b/vantage-api-pool/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle, aligning with the rest of the workspace. No code changes beyond the dependency pin.
+
 ## 0.1.4 — 2026-05-16
 
 - Internal dependency version refresh; no public API changes.

--- a/vantage-api-pool/Cargo.toml
+++ b/vantage-api-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "vantage-api-pool"
-version = "0.1.4"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 description = "Paginated REST API client pool for Vantage"
 

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+
 ## 0.4.10 — 2026-05-23
 
 The AWS backend now plugs into the universal Vista layer — wrap a typed `Table<AwsAccount, E>` with [`AwsAccount::vista_factory().from_table(...)`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/vista/struct.AwsVistaFactory.html#method.from_table) and the resulting [`Vista`](https://docs.rs/vantage-vista/0.4/vantage_vista/struct.Vista.html) carries the same column metadata, id field, title columns, and `with_one` / `with_many` relations as the typed table.

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.4.10"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -46,7 +46,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 
 [dev-dependencies]
 vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
-vantage-cli-util = { version = "0.4.1", path = "../vantage-cli-util" }
+vantage-cli-util = { version = "0.5", path = "../vantage-cli-util" }
 vantage-vista = { version = "0.4", path = "../vantage-vista" }
 
 anyhow = "1"

--- a/vantage-cli-util/CHANGELOG.md
+++ b/vantage-cli-util/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+
 ## 0.4.6 — 2026-05-18
 
 - Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. Internal test fixtures build their `Vista` via `Box::new(MockShell::new().with_metadata(metadata))` instead of passing metadata to `Vista::new`. No change to the public CLI surface.

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-cli-util"
-version = "0.4.6"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "CLI utilities for Vantage data framework"

--- a/vantage-csv/CHANGELOG.md
+++ b/vantage-csv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+
 ## 0.4.13 — 2026-05-18
 
 - Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. `CsvTableShell` now owns its [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implements the new [`columns`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.columns) / [`references`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.references) / [`id_column`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.id_column) shell methods. `csv.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.4.13"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+
 ## 0.4.5 — 2026-05-22
 
 - `TableScenery::master_capabilities()` exposes the master Vista's capability flags. Lets UI delegates pick `set_viewport` for random-access masters and `request_load_more` for cursor-only ones.

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.4.5"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-log-writer/CHANGELOG.md
+++ b/vantage-log-writer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+
 ## 0.4.2 — 2026-05-18
 
 - Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. `LogWriterTableShell` now owns its [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implements the new `columns` / `references` / `id_column` shell methods. `writer.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.

--- a/vantage-log-writer/Cargo.toml
+++ b/vantage-log-writer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-log-writer"
-version = "0.4.2"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for append-only log files (JSONL)"

--- a/vantage-mongodb/CHANGELOG.md
+++ b/vantage-mongodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+
 ## 0.4.11 — 2026-05-18
 
 - Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. `MongoTableShell` now owns its [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implements the new `columns` / `references` / `id_column` shell methods. `mongodb.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.4.11"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"

--- a/vantage-redb/CHANGELOG.md
+++ b/vantage-redb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+
 ## 0.4.0 — 2026-04-26
 
 Full rewrite for the 0.4 trait surface. **Storage format and public API are not compatible with 0.3** — open in a fresh database file.

--- a/vantage-redb/Cargo.toml
+++ b/vantage-redb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-redb"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+
 ## 0.4.9 — 2026-05-18
 
 - Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. Each SQL `*TableShell` now owns its [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implements the new `columns` / `references` / `id_column` shell methods. Factory entry points (`db.vista_factory().from_table(...)` / `from_yaml(...)`) are unchanged.

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.4.9"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+
 ## 0.4.10 — 2026-05-18
 
 - Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. `SurrealTableShell` now owns its [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implements the new `columns` / `references` / `id_column` shell methods. `surrealdb.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.4.10"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"


### PR DESCRIPTION
Aligns every crate that had its `vantage-table` dep pin updated in #257
onto the 0.5 line. CI gates on per-crate version bumps for any crate
with a diff, so the pin-updated crates needed to move off their
respective 0.4.x / 0.1.x heads.

Bumped:

- `vantage-cli-util` 0.4.6 → 0.5.0
- `vantage-diorama` 0.4.5 → 0.5.0
- `vantage-log-writer` 0.4.2 → 0.5.0
- `vantage-csv` 0.4.13 → 0.5.0
- `vantage-surrealdb` 0.4.10 → 0.5.0
- `vantage-api-pool` 0.1.4 → 0.5.0
- `vantage-aws` 0.4.10 → 0.5.0
- `vantage-sql` 0.4.9 → 0.5.0
- `vantage-api-client` 0.1.9 → 0.5.0
- `vantage-redb` 0.4.0 → 0.5.0
- `vantage-mongodb` 0.4.11 → 0.5.0

`vantage-api-client` and `vantage-api-pool` jump from 0.1.x to 0.5.0 to
align with the rest of the workspace as the 0.5 cycle opens.

Also updates three lingering version pins on the bumped crates:

- `vantage-aws` → `vantage-cli-util = "0.5"`
- `learn-1` / `learn-2` → `vantage-sql = "0.5"`

Each CHANGELOG carries a short 0.5.0 entry stating this is a
dependency-pin alignment release, no code changes.

## Validation

- `cargo check --workspace` — clean
- `cargo clippy --workspace --all-targets --all-features` — zero
  warnings
- `cargo fmt --all -- --check` — clean