### PR TITLE
wire YAML references through surreal vista factory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "async-trait",
  "bakery_model3",

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.11 — 2026-05-23
+
+- YAML `references:` blocks now build live traversals. `SurrealVistaFactory::build_from_spec` registers each `has_one` / `has_many` entry as a `with_one` / `with_many` on the underlying [`Table`](https://docs.rs/vantage-table/0.5.0/vantage_table/table/struct.Table.html), so `vista.get_ref("clients", &row)` returns a fully-typed child Vista — no Rust glue per relation.
+- New [`SurrealSpecResolver`](https://docs.rs/vantage-surrealdb/0.4.11/vantage_surrealdb/vista/type.SurrealSpecResolver.html) (`Arc<dyn Fn(&str) -> Option<SurrealVistaSpec>>`) plus [`SurrealVistaFactory::with_resolver`](https://docs.rs/vantage-surrealdb/0.4.11/vantage_surrealdb/vista/struct.SurrealVistaFactory.html#method.with_resolver): pass in a name-to-spec lookup and child tables get their columns from the resolved spec at traversal time, not from a single pre-built registry.
+- Many-to-many drops out of chained `has_many` / `has_one` traversal — no new YAML keyword needed. See `tests/7_vista_refs.rs` for `client → bakery → clients`.
+- Without a resolver the references still parse and surface in [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html), but traversed children come back column-less; the next query then fails loudly.
+
 ## 0.4.10 — 2026-05-18
 
 - Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. `SurrealTableShell` now owns its [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implements the new `columns` / `references` / `id_column` shell methods. `surrealdb.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.4.10"
+version = "0.4.11"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/vista/factory.rs
+++ b/vantage-surrealdb/src/vista/factory.rs
@@ -1,6 +1,8 @@
 //! `SurrealVistaFactory` — typed-table and YAML entry points, plus the
 //! `VistaFactory` trait impl. SurrealDB advertises full read/write/count.
 
+use std::sync::Arc;
+
 use vantage_core::{Result, error};
 use vantage_table::column::core::Column as TableColumn;
 use vantage_table::column::flags::ColumnFlag;
@@ -8,8 +10,8 @@ use vantage_table::table::Table;
 use vantage_table::traits::column_like::ColumnLike;
 use vantage_types::{EmptyEntity, Entity};
 use vantage_vista::{
-    Column as VistaColumn, NoExtras, Vista, VistaCapabilities, VistaFactory, VistaMetadata,
-    flags as vista_flags,
+    Column as VistaColumn, NoExtras, ReferenceKind, Vista, VistaCapabilities, VistaFactory,
+    VistaMetadata, flags as vista_flags, reference::Reference as VistaReferenceMeta,
 };
 
 use crate::surrealdb::SurrealDB;
@@ -18,13 +20,27 @@ use crate::types::AnySurrealType;
 use crate::vista::source::SurrealTableShell;
 use crate::vista::spec::{SurrealColumnExtras, SurrealTableExtras, SurrealVistaSpec};
 
+/// Resolves a YAML spec by table name. The factory hands clones of this
+/// into each `with_one` / `with_many` closure so child tables can be
+/// rebuilt from the live spec at traversal time.
+pub type SurrealSpecResolver = Arc<dyn Fn(&str) -> Option<SurrealVistaSpec> + Send + Sync>;
+
 pub struct SurrealVistaFactory {
     db: SurrealDB,
+    resolver: Option<SurrealSpecResolver>,
 }
 
 impl SurrealVistaFactory {
     pub fn new(db: SurrealDB) -> Self {
-        Self { db }
+        Self { db, resolver: None }
+    }
+
+    /// Attach a spec resolver. Required for YAML-declared references to
+    /// resolve their target tables — without it, traversals yield a
+    /// column-less target Table and the next query fails loudly.
+    pub fn with_resolver(mut self, resolver: SurrealSpecResolver) -> Self {
+        self.resolver = Some(resolver);
+        self
     }
 
     /// Wrap a typed table as a Vista. Column metadata is harvested from the
@@ -35,16 +51,16 @@ impl SurrealVistaFactory {
         E: Entity<AnySurrealType> + 'static,
     {
         let name = table.table_name().to_string();
-        Ok(self.wrap(table, name))
+        let metadata = metadata_from_table(&table);
+        Ok(self.wrap(table, name, metadata))
     }
 
     /// Single source-construction site shared by `from_table` and
     /// `build_from_spec`.
-    fn wrap<E>(&self, table: Table<SurrealDB, E>, name: String) -> Vista
+    fn wrap<E>(&self, table: Table<SurrealDB, E>, name: String, metadata: VistaMetadata) -> Vista
     where
         E: Entity<AnySurrealType> + 'static,
     {
-        let metadata = metadata_from_table(&table);
         let source = SurrealTableShell::new(
             table,
             VistaCapabilities {
@@ -60,6 +76,7 @@ impl SurrealVistaFactory {
                 ..VistaCapabilities::default()
             },
             metadata,
+            self.resolver.clone(),
         );
         Vista::new(name, Box::new(source))
     }
@@ -69,32 +86,7 @@ impl SurrealVistaFactory {
         &self,
         spec: &SurrealVistaSpec,
     ) -> Result<Table<SurrealDB, EmptyEntity>> {
-        let table_name = spec
-            .driver
-            .surreal
-            .as_ref()
-            .and_then(|m| m.table.clone())
-            .unwrap_or_else(|| spec.name.clone());
-
-        let mut table = Table::<SurrealDB, EmptyEntity>::new(table_name, self.db.clone());
-
-        for (name, col_spec) in &spec.columns {
-            table.add_column(build_column(name, col_spec)?);
-            if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
-                table.add_title_field(name);
-            }
-        }
-
-        let id_column = resolve_id_column(spec);
-        if !table.columns().contains_key(&id_column) {
-            return Err(error!(
-                "id column not present in spec.columns",
-                id = id_column
-            ));
-        }
-        table.set_id_field(&id_column);
-
-        Ok(table)
+        build_surreal_table(spec, self.db.clone(), self.resolver.clone())
     }
 }
 
@@ -106,10 +98,88 @@ impl VistaFactory for SurrealVistaFactory {
     fn build_from_spec(&self, spec: SurrealVistaSpec) -> Result<Vista> {
         let vista_name = spec.name.clone();
         let table = self.table_from_spec(&spec)?;
-        let mut vista = self.wrap(table, vista_name.clone());
+        let mut metadata = metadata_from_table(&table);
+        for (rel_name, ref_spec) in &spec.references {
+            let fk = ref_spec
+                .foreign_key
+                .clone()
+                .unwrap_or_else(|| rel_name.clone());
+            metadata = metadata.with_reference(VistaReferenceMeta::new(
+                rel_name.clone(),
+                ref_spec.table.clone(),
+                ref_spec.kind,
+                fk,
+            ));
+        }
+        let mut vista = self.wrap(table, vista_name.clone(), metadata);
         vista.set_name(vista_name);
         Ok(vista)
     }
+}
+
+/// Build a `Table<SurrealDB, EmptyEntity>` from a spec, registering each
+/// `references:` entry as a typed `with_one` / `with_many` on the parent.
+///
+/// Each reference closure captures a clone of the resolver `Arc` and the
+/// target table name; at traversal time it asks the resolver for the
+/// target's current spec and rebuilds the child table. On a resolver miss,
+/// the closure falls back to an empty `Table::new(target_name, db)` — the
+/// next query then fails loudly when it discovers no columns are defined.
+pub(crate) fn build_surreal_table(
+    spec: &SurrealVistaSpec,
+    db: SurrealDB,
+    resolver: Option<SurrealSpecResolver>,
+) -> Result<Table<SurrealDB, EmptyEntity>> {
+    let table_name = spec
+        .driver
+        .surreal
+        .as_ref()
+        .and_then(|m| m.table.clone())
+        .unwrap_or_else(|| spec.name.clone());
+
+    let mut table = Table::<SurrealDB, EmptyEntity>::new(table_name, db);
+
+    for (name, col_spec) in &spec.columns {
+        table.add_column(build_column(name, col_spec)?);
+        if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
+            table.add_title_field(name);
+        }
+    }
+
+    let id_column = resolve_id_column(spec);
+    if !table.columns().contains_key(&id_column) {
+        return Err(error!(
+            "id column not present in spec.columns",
+            id = id_column
+        ));
+    }
+    table.set_id_field(&id_column);
+
+    for (rel_name, ref_spec) in &spec.references {
+        let target_name = ref_spec.table.clone();
+        let fk = ref_spec
+            .foreign_key
+            .clone()
+            .unwrap_or_else(|| rel_name.clone());
+        let resolver_clone = resolver.clone();
+
+        let build_child = move |db: SurrealDB| -> Table<SurrealDB, EmptyEntity> {
+            if let Some(r) = &resolver_clone
+                && let Some(child_spec) = r(&target_name)
+                && let Ok(child) = build_surreal_table(&child_spec, db.clone(), Some(r.clone()))
+            {
+                return child;
+            }
+            Table::<SurrealDB, EmptyEntity>::new(target_name.clone(), db)
+        };
+
+        table = match ref_spec.kind {
+            ReferenceKind::HasOne => table.with_one::<EmptyEntity>(rel_name, &fk, build_child),
+            ReferenceKind::HasMany => table.with_many::<EmptyEntity>(rel_name, &fk, build_child),
+        };
+    }
+
+    Ok(table)
 }
 
 pub(crate) fn resolve_id_column(spec: &SurrealVistaSpec) -> String {
@@ -204,4 +274,137 @@ where
         }
     }
     metadata
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indexmap::IndexMap;
+    use surreal_client::{MockSurrealEngine, SurrealClient};
+    use vantage_vista::VistaFactory;
+
+    fn test_db() -> SurrealDB {
+        let client = SurrealClient::new(
+            Box::new(MockSurrealEngine::new()),
+            Some("test".into()),
+            Some("test".into()),
+        );
+        SurrealDB::new(client)
+    }
+
+    fn parse(yaml: &str) -> SurrealVistaSpec {
+        serde_yaml_ng::from_str(yaml).expect("yaml parse")
+    }
+
+    fn registry_resolver(specs: Vec<(String, SurrealVistaSpec)>) -> SurrealSpecResolver {
+        let map: IndexMap<String, SurrealVistaSpec> = specs.into_iter().collect();
+        let map = Arc::new(map);
+        Arc::new(move |name: &str| map.get(name).cloned())
+    }
+
+    #[test]
+    fn build_from_spec_surfaces_references_in_metadata() {
+        let yaml = r#"
+name: bakery
+columns:
+  id: { type: thing, flags: [id] }
+  name: { type: string, flags: [title] }
+references:
+  products:
+    table: product
+    kind: has_many
+    foreign_key: bakery
+  primary_product:
+    table: product
+    kind: has_one
+    foreign_key: primary_product
+"#;
+        let spec = parse(yaml);
+        let factory = SurrealVistaFactory::new(test_db());
+        let vista = factory.build_from_spec(spec).expect("build");
+
+        let mut listed = vista.get_references();
+        listed.sort();
+        assert_eq!(listed, vec!["primary_product", "products"]);
+
+        let products = vista.get_reference("products").expect("products ref");
+        assert_eq!(products.target, "product");
+        assert_eq!(products.kind, ReferenceKind::HasMany);
+        assert_eq!(products.foreign_key, "bakery");
+
+        let primary = vista.get_reference("primary_product").expect("primary ref");
+        assert_eq!(primary.kind, ReferenceKind::HasOne);
+    }
+
+    #[test]
+    fn resolver_supplies_child_columns_on_traversal() {
+        let bakery_yaml = r#"
+name: bakery
+columns:
+  id: { type: thing, flags: [id] }
+references:
+  products:
+    table: product
+    kind: has_many
+    foreign_key: bakery
+"#;
+        let product_yaml = r#"
+name: product
+columns:
+  id: { type: thing, flags: [id] }
+  name: { type: string, flags: [title] }
+  price: { type: int }
+  bakery: { type: thing }
+"#;
+        let bakery_spec = parse(bakery_yaml);
+        let product_spec = parse(product_yaml);
+
+        let resolver = registry_resolver(vec![
+            ("bakery".into(), bakery_spec.clone()),
+            ("product".into(), product_spec.clone()),
+        ]);
+
+        let factory = SurrealVistaFactory::new(test_db()).with_resolver(resolver);
+        let bakery = factory.build_from_spec(bakery_spec).expect("build bakery");
+
+        let mut row: vantage_types::Record<ciborium::Value> = vantage_types::Record::new();
+        row.insert(
+            "id".into(),
+            ciborium::Value::Text("bakery:hill_valley".into()),
+        );
+
+        let child = bakery.get_ref("products", &row).expect("traverse products");
+
+        let mut cols = child.get_column_names();
+        cols.sort();
+        assert_eq!(cols, vec!["bakery", "id", "name", "price"]);
+        assert_eq!(child.get_id_column(), Some("id"));
+    }
+
+    #[test]
+    fn resolver_miss_falls_back_to_empty_child_table() {
+        let bakery_yaml = r#"
+name: bakery
+columns:
+  id: { type: thing, flags: [id] }
+references:
+  ghosts:
+    table: missing_table
+    kind: has_many
+    foreign_key: bakery
+"#;
+        let bakery_spec = parse(bakery_yaml);
+        let resolver = registry_resolver(vec![]);
+        let factory = SurrealVistaFactory::new(test_db()).with_resolver(resolver);
+        let bakery = factory.build_from_spec(bakery_spec).expect("build");
+
+        let mut row: vantage_types::Record<ciborium::Value> = vantage_types::Record::new();
+        row.insert(
+            "id".into(),
+            ciborium::Value::Text("bakery:hill_valley".into()),
+        );
+
+        let child = bakery.get_ref("ghosts", &row).expect("fallback child");
+        assert!(child.get_column_names().is_empty());
+    }
 }

--- a/vantage-surrealdb/src/vista/mod.rs
+++ b/vantage-surrealdb/src/vista/mod.rs
@@ -13,7 +13,7 @@ pub mod factory;
 pub mod source;
 pub mod spec;
 
-pub use factory::SurrealVistaFactory;
+pub use factory::{SurrealSpecResolver, SurrealVistaFactory};
 pub use source::SurrealTableShell;
 pub use spec::{
     SurrealColumnBlock, SurrealColumnExtras, SurrealTableBlock, SurrealTableExtras,

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -35,6 +35,7 @@ use crate::surreal_expr;
 use crate::surrealdb::SurrealDB;
 use crate::thing::Thing;
 use crate::types::AnySurrealType;
+use crate::vista::factory::SurrealSpecResolver;
 
 pub struct SurrealTableShell<E = EmptyEntity>
 where
@@ -45,6 +46,7 @@ where
     pub(crate) metadata: VistaMetadata,
     pub(crate) current_search_handle: Option<ConditionHandle>,
     pub(crate) page_size: Option<usize>,
+    pub(crate) resolver: Option<SurrealSpecResolver>,
 }
 
 impl<E> SurrealTableShell<E>
@@ -55,6 +57,7 @@ where
         table: Table<SurrealDB, E>,
         capabilities: VistaCapabilities,
         metadata: VistaMetadata,
+        resolver: Option<SurrealSpecResolver>,
     ) -> Self {
         Self {
             table,
@@ -62,6 +65,7 @@ where
             metadata,
             current_search_handle: None,
             page_size: None,
+            resolver,
         }
     }
 
@@ -227,8 +231,11 @@ where
         let target = self
             .table
             .get_ref_from_row::<EmptyEntity>(relation, &native_row)?;
-        let factory =
+        let mut factory =
             crate::vista::factory::SurrealVistaFactory::new(self.table.data_source().clone());
+        if let Some(resolver) = &self.resolver {
+            factory = factory.with_resolver(resolver.clone());
+        }
         factory.from_table(target)
     }
 

--- a/vantage-surrealdb/src/vista/spec.rs
+++ b/vantage-surrealdb/src/vista/spec.rs
@@ -95,4 +95,33 @@ columns:
         let spec: SurrealVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
         assert!(spec.driver.surreal.is_none());
     }
+
+    #[test]
+    fn yaml_parses_references_block() {
+        let yaml = r#"
+name: bakery
+columns:
+  id: { type: thing, flags: [id] }
+references:
+  clients:
+    table: client
+    kind: has_many
+    foreign_key: bakery
+  primary_product:
+    table: product
+    kind: has_one
+    foreign_key: primary_product
+"#;
+        let spec: SurrealVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(spec.references.len(), 2);
+
+        let clients = &spec.references["clients"];
+        assert_eq!(clients.table, "client");
+        assert_eq!(clients.kind, vantage_vista::ReferenceKind::HasMany);
+        assert_eq!(clients.foreign_key.as_deref(), Some("bakery"));
+
+        let primary = &spec.references["primary_product"];
+        assert_eq!(primary.table, "product");
+        assert_eq!(primary.kind, vantage_vista::ReferenceKind::HasOne);
+    }
 }

--- a/vantage-surrealdb/tests/7_vista_refs.rs
+++ b/vantage-surrealdb/tests/7_vista_refs.rs
@@ -1,0 +1,215 @@
+//! YAML-vista reference traversal — has_many / has_one chains end-to-end
+//! against a live SurrealDB. Demonstrates that many-to-many emerges from
+//! chained traversal (bakery → clients → bakery) without any new YAML kind.
+//!
+//! Each test runs in a fresh randomised database so parallel runs don't
+//! collide. Reads `SURREALDB_URL` (defaults to localhost:8000) for the host.
+
+#![cfg(feature = "vista")]
+
+use std::error::Error;
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+use surreal_client::SurrealConnection;
+use uuid::Uuid;
+use vantage_dataset::prelude::*;
+use vantage_expressions::ExprDataSource;
+use vantage_surrealdb::surreal_expr;
+use vantage_surrealdb::surrealdb::SurrealDB;
+use vantage_surrealdb::vista::{SurrealSpecResolver, SurrealVistaFactory, SurrealVistaSpec};
+use vantage_vista::VistaFactory;
+
+type TestResult = std::result::Result<(), Box<dyn Error>>;
+
+fn surreal_dsn(database: &str) -> String {
+    let base = std::env::var("SURREALDB_URL")
+        .unwrap_or_else(|_| "cbor://root:root@localhost:8000/bakery/v2".to_string());
+    let (prefix, _) = base.rsplit_once('/').unwrap_or((&base, ""));
+    format!("{}/{}", prefix, database)
+}
+
+async fn setup() -> (SurrealDB, String, String) {
+    let database = format!("vista_refs_{}", Uuid::new_v4().simple());
+    let client = SurrealConnection::dsn(surreal_dsn(&database))
+        .expect("Invalid SURREALDB_URL DSN")
+        .connect()
+        .await
+        .expect("Failed to connect to SurrealDB");
+    let db = SurrealDB::new(client);
+    let bakery_table = format!("bakery_{}", Uuid::new_v4().simple());
+    let client_table = format!("client_{}", Uuid::new_v4().simple());
+    (db, bakery_table, client_table)
+}
+
+async fn seed_v2_like(
+    db: &SurrealDB,
+    bakery_table: &str,
+    client_table: &str,
+) -> std::result::Result<(), Box<dyn Error>> {
+    db.execute(&surreal_expr!(&format!(
+        "CREATE {}:hill_valley SET name = 'Hill Valley Bakery'",
+        bakery_table
+    )))
+    .await?;
+    db.execute(&surreal_expr!(&format!(
+        "CREATE {}:marty SET name = 'Marty McFly', bakery = {}:hill_valley",
+        client_table, bakery_table
+    )))
+    .await?;
+    db.execute(&surreal_expr!(&format!(
+        "CREATE {}:doc SET name = 'Doc Brown', bakery = {}:hill_valley",
+        client_table, bakery_table
+    )))
+    .await?;
+    db.execute(&surreal_expr!(&format!(
+        "CREATE {}:biff SET name = 'Biff Tannen', bakery = {}:hill_valley",
+        client_table, bakery_table
+    )))
+    .await?;
+    Ok(())
+}
+
+fn registry_resolver(specs: Vec<(String, SurrealVistaSpec)>) -> SurrealSpecResolver {
+    let map: IndexMap<String, SurrealVistaSpec> = specs.into_iter().collect();
+    let map = Arc::new(map);
+    Arc::new(move |name: &str| map.get(name).cloned())
+}
+
+fn build_specs(bakery_table: &str, client_table: &str) -> (SurrealVistaSpec, SurrealVistaSpec) {
+    let bakery_yaml = format!(
+        r#"
+name: bakery
+columns:
+  id: {{ type: thing, flags: [id] }}
+  name: {{ type: string, flags: [title] }}
+surreal:
+  table: {}
+references:
+  clients:
+    table: client
+    kind: has_many
+    foreign_key: bakery
+"#,
+        bakery_table
+    );
+    let client_yaml = format!(
+        r#"
+name: client
+columns:
+  id: {{ type: thing, flags: [id] }}
+  name: {{ type: string, flags: [title] }}
+  bakery: {{ type: thing }}
+surreal:
+  table: {}
+references:
+  bakery:
+    table: bakery
+    kind: has_one
+    foreign_key: bakery
+"#,
+        client_table
+    );
+    (
+        serde_yaml_ng::from_str(&bakery_yaml).expect("bakery yaml"),
+        serde_yaml_ng::from_str(&client_yaml).expect("client yaml"),
+    )
+}
+
+#[tokio::test]
+async fn has_many_traversal_lists_related_rows() -> TestResult {
+    let (db, bakery_table, client_table) = setup().await;
+    seed_v2_like(&db, &bakery_table, &client_table).await?;
+
+    let (bakery_spec, client_spec) = build_specs(&bakery_table, &client_table);
+    let resolver = registry_resolver(vec![
+        ("bakery".into(), bakery_spec.clone()),
+        ("client".into(), client_spec),
+    ]);
+    let factory = SurrealVistaFactory::new(db.clone()).with_resolver(resolver);
+
+    let bakery = factory.build_from_spec(bakery_spec)?;
+    let bakery_row = bakery
+        .get_value(&"hill_valley".to_string())
+        .await?
+        .expect("bakery row");
+
+    let clients = bakery.get_ref("clients", &bakery_row)?;
+    let rows = clients.list_values().await?;
+    assert_eq!(rows.len(), 3, "hill_valley has 3 clients");
+
+    let mut names: Vec<String> = rows
+        .values()
+        .filter_map(|r| match r.get("name") {
+            Some(ciborium::Value::Text(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["Biff Tannen", "Doc Brown", "Marty McFly"]);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn has_one_traversal_returns_parent_row() -> TestResult {
+    let (db, bakery_table, client_table) = setup().await;
+    seed_v2_like(&db, &bakery_table, &client_table).await?;
+
+    let (bakery_spec, client_spec) = build_specs(&bakery_table, &client_table);
+    let resolver = registry_resolver(vec![
+        ("bakery".into(), bakery_spec),
+        ("client".into(), client_spec.clone()),
+    ]);
+    let factory = SurrealVistaFactory::new(db.clone()).with_resolver(resolver);
+
+    let client = factory.build_from_spec(client_spec)?;
+    let client_row = client
+        .get_value(&"marty".to_string())
+        .await?
+        .expect("client row");
+
+    let bakery = client.get_ref("bakery", &client_row)?;
+    let rows = bakery.list_values().await?;
+    assert_eq!(rows.len(), 1, "marty belongs to one bakery");
+    let row = rows.values().next().expect("bakery row");
+    assert_eq!(
+        row.get("name"),
+        Some(&ciborium::Value::Text("Hill Valley Bakery".to_string()))
+    );
+
+    Ok(())
+}
+
+/// Many-to-many via chained traversal: client → bakery → clients.
+/// "Other clients of the same bakery as Marty" — relational m2m without
+/// any new YAML keyword.
+#[tokio::test]
+async fn many_to_many_via_chained_has_many_through_has_one() -> TestResult {
+    let (db, bakery_table, client_table) = setup().await;
+    seed_v2_like(&db, &bakery_table, &client_table).await?;
+
+    let (bakery_spec, client_spec) = build_specs(&bakery_table, &client_table);
+    let resolver = registry_resolver(vec![
+        ("bakery".into(), bakery_spec),
+        ("client".into(), client_spec.clone()),
+    ]);
+    let factory = SurrealVistaFactory::new(db.clone()).with_resolver(resolver);
+
+    let client = factory.build_from_spec(client_spec)?;
+    let marty = client
+        .get_value(&"marty".to_string())
+        .await?
+        .expect("marty");
+
+    let bakery_for_marty = client.get_ref("bakery", &marty)?;
+    let bakery_rows = bakery_for_marty.list_values().await?;
+    assert_eq!(bakery_rows.len(), 1);
+    let (_, bakery_row) = bakery_rows.into_iter().next().unwrap();
+
+    let sibling_clients = bakery_for_marty.get_ref("clients", &bakery_row)?;
+    let sibling_rows = sibling_clients.list_values().await?;
+    assert_eq!(sibling_rows.len(), 3, "all 3 clients of marty's bakery");
+
+    Ok(())
+}


### PR DESCRIPTION
YAML `references:` blocks on a `SurrealVistaSpec` now build live traversals. Until now they parsed into `VistaMetadata` but `vista.get_ref("clients", &row)` came back column-less — fine for introspection, useless for querying. `SurrealVistaFactory::build_from_spec` now registers each `has_one` / `has_many` as a `with_one` / `with_many` on the underlying `Table`, so the child Vista is fully typed and queryable.

Existing callers using `from_table` (typed-table path) are unaffected; YAML callers without references are unaffected.

### Resolver

Child tables need their own columns to be queryable, and the parent's spec doesn't know them. The factory takes an optional `SurrealSpecResolver` (`Arc<dyn Fn(&str) -> Option<SurrealVistaSpec>>`) that maps target-table names to specs at traversal time:

```rust
let factory = SurrealVistaFactory::new(db.clone())
    .with_resolver(my_registry_lookup);
let bakery = factory.build_from_spec(bakery_spec)?;
let clients = bakery.get_ref("clients", &row)?;   // typed child, ready to query
let rows = clients.list_values().await?;
```

Without a resolver, references still parse and surface in metadata, but traversed children come back column-less — the next query fails loudly. That's the deliberate failure mode for spec authors who forget to register the registry.

### Many-to-many

Falls out of chaining `has_one` then `has_many`. `client → bakery → clients` is "other clients of the same bakery" — no new YAML keyword, no `through:` block. `tests/7_vista_refs.rs` covers the three shapes (has_many, has_one, chained m2m) end-to-end against a live SurrealDB.

### Versions

- `vantage-surrealdb` 0.4.10 → 0.4.11