### PR TITLE
solve nasty bug in SQLite, which does not support stopped time

### DIFF
--- a/vantage-diorama/tests/bdd_support/backend.rs
+++ b/vantage-diorama/tests/bdd_support/backend.rs
@@ -191,77 +191,73 @@ impl MasterRows {
     }
 
     async fn build_sqlite(&self, w: &mut DioramaWorld) -> Result<Vista> {
-        // Provision the pool + DDL + seed data on a dedicated thread with
-        // its own real-time runtime. The main test runtime runs paused
-        // virtual time (needed for refresh scenarios), which would deadlock
-        // sqlx's internal acquire-timeout machinery. Once the DB is set up
-        // and returned here, reads from the Vista's `Table` use the
-        // pool's worker threads — they don't depend on the test runtime's
-        // clock.
+        // Provision the pool + DDL + seed data on the shared sqlite-io
+        // runtime — see `super::sqlite_runtime` for the why. We also pin
+        // the pool to a single connection so every `:memory:` query hits
+        // the same in-memory database (default `SqlitePool` config would
+        // hand out up to 10 separate ones).
         let name = self.name.clone();
         let id_column = self.id_column.clone();
         let columns = self.columns.clone();
         let rows = self.rows.clone();
-        let db = std::thread::spawn(move || -> Result<SqliteDB> {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| {
-                    vantage_core::error!("build provisioning runtime", detail = e.to_string())
-                })?;
-            rt.block_on(async move {
-                let db = SqliteDB::connect("sqlite::memory:")
-                    .await
-                    .map_err(|e| vantage_core::error!("sqlite connect", detail = e.to_string()))?;
+        let db = super::sqlite_runtime::dispatch(async move {
+            // `max_connections(1)` keeps every query on the same
+            // `sqlite::memory:` connection — sqlx's default would let the
+            // pool hand out additional connections, each of which is its
+            // own private in-memory database.
+            let pool = sqlx::sqlite::SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect("sqlite::memory:")
+                .await
+                .map_err(|e| vantage_core::error!("sqlite connect", detail = e.to_string()))?;
+            let db = SqliteDB::new(pool);
 
-                let col_defs: Vec<String> = columns
-                    .iter()
-                    .map(|c| {
-                        if c == &id_column {
-                            format!("{c} TEXT PRIMARY KEY")
-                        } else {
-                            format!("{c} TEXT")
-                        }
-                    })
-                    .collect();
-                let create = format!("CREATE TABLE {name} ({})", col_defs.join(", "));
-                sqlx::query(&create)
+            let col_defs: Vec<String> = columns
+                .iter()
+                .map(|c| {
+                    if c == &id_column {
+                        format!("{c} TEXT PRIMARY KEY")
+                    } else {
+                        format!("{c} TEXT")
+                    }
+                })
+                .collect();
+            let create = format!("CREATE TABLE {name} ({})", col_defs.join(", "));
+            sqlx::query(&create)
+                .execute(db.pool())
+                .await
+                .map_err(|e| vantage_core::error!("CREATE TABLE", detail = e.to_string()))?;
+
+            for row in &rows {
+                let mut values: Vec<String> = Vec::with_capacity(columns.len());
+                for col in &columns {
+                    let raw = if col == &id_column {
+                        row.id.clone()
+                    } else {
+                        row.fields
+                            .get(col)
+                            .and_then(|v| match v {
+                                CborValue::Text(s) => Some(s.clone()),
+                                _ => None,
+                            })
+                            .unwrap_or_default()
+                    };
+                    values.push(format!("'{}'", raw.replace('\'', "''")));
+                }
+                let stmt = format!(
+                    "INSERT INTO {name} ({}) VALUES ({})",
+                    columns.join(", "),
+                    values.join(", ")
+                );
+                sqlx::query(&stmt)
                     .execute(db.pool())
                     .await
-                    .map_err(|e| vantage_core::error!("CREATE TABLE", detail = e.to_string()))?;
+                    .map_err(|e| vantage_core::error!("INSERT", detail = e.to_string()))?;
+            }
 
-                for row in &rows {
-                    let mut values: Vec<String> = Vec::with_capacity(columns.len());
-                    for col in &columns {
-                        let raw = if col == &id_column {
-                            row.id.clone()
-                        } else {
-                            row.fields
-                                .get(col)
-                                .and_then(|v| match v {
-                                    CborValue::Text(s) => Some(s.clone()),
-                                    _ => None,
-                                })
-                                .unwrap_or_default()
-                        };
-                        values.push(format!("'{}'", raw.replace('\'', "''")));
-                    }
-                    let stmt = format!(
-                        "INSERT INTO {name} ({}) VALUES ({})",
-                        columns.join(", "),
-                        values.join(", ")
-                    );
-                    sqlx::query(&stmt)
-                        .execute(db.pool())
-                        .await
-                        .map_err(|e| vantage_core::error!("INSERT", detail = e.to_string()))?;
-                }
-
-                Ok(db)
-            })
+            Ok::<_, vantage_core::VantageError>(db)
         })
-        .join()
-        .map_err(|_| vantage_core::error!("sqlite provisioning thread panicked"))??;
+        .await?;
 
         let mut table = Table::<SqliteDB, EmptyEntity>::new(&self.name, db.clone())
             .with_id_column(&self.id_column);

--- a/vantage-diorama/tests/bdd_support/mod.rs
+++ b/vantage-diorama/tests/bdd_support/mod.rs
@@ -7,5 +7,6 @@
 
 pub mod backend;
 pub mod spies;
+pub mod sqlite_runtime;
 pub mod steps;
 pub mod world;

--- a/vantage-diorama/tests/bdd_support/sqlite_runtime.rs
+++ b/vantage-diorama/tests/bdd_support/sqlite_runtime.rs
@@ -1,0 +1,64 @@
+//! Long-lived background tokio runtime for sqlx pool operations.
+//!
+//! The cucumber harness in `tests/bdd.rs` runs on a `current_thread` runtime
+//! with `start_paused = true` — required by the refresh scenarios that drive
+//! `tokio::time::advance` against virtual time. Under paused time, the
+//! runtime auto-advances the clock whenever no task is runnable, which
+//! collides with sqlx 0.8's `Pool::acquire` wrapping its wait loop in
+//! `tokio::time::timeout(acquire_timeout, …)`: a brief gap between the
+//! previous `PoolConnection`'s spawn-on-Drop `return_to_pool` task and the
+//! next acquire's poll is enough for the runtime to leap virtual time
+//! forward 30 seconds and fire `Error::PoolTimedOut`. Aborted
+//! `return_to_pool` tasks at runtime shutdown also leak the pool's size
+//! counter and lock the pool out of future connections (issue #260).
+//!
+//! Routing every sqlx pool operation through a separate, real-time runtime
+//! sidesteps both problems: sqlx's timers tick against wall-clock time and
+//! the runtime never goes away mid-test. Callers `dispatch(fut).await`
+//! to send a future to the io-runtime and await its result back on the
+//! main runtime.
+
+use std::future::Future;
+use std::sync::OnceLock;
+use std::thread;
+
+use tokio::runtime::{Builder, Handle};
+use tokio::sync::oneshot;
+
+static SQLITE_RUNTIME: OnceLock<Handle> = OnceLock::new();
+
+fn handle() -> &'static Handle {
+    SQLITE_RUNTIME.get_or_init(|| {
+        let (tx, rx) = std::sync::mpsc::channel();
+        thread::Builder::new()
+            .name("vantage-diorama-bdd-sqlite-io".into())
+            .spawn(move || {
+                let rt = Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build sqlite-io runtime");
+                tx.send(rt.handle().clone())
+                    .expect("send io-runtime handle");
+                // Park the runtime forever — the process exit tears it down.
+                rt.block_on(std::future::pending::<()>());
+            })
+            .expect("spawn sqlite-io runtime thread");
+        rx.recv().expect("receive io-runtime handle")
+    })
+}
+
+/// Drive `fut` to completion on the long-lived io-runtime, returning the
+/// value to the caller's runtime. The future must be `Send + 'static` so
+/// it can cross the thread boundary; its output is sent back over a
+/// oneshot.
+pub async fn dispatch<F, T>(fut: F) -> T
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    let (tx, rx) = oneshot::channel();
+    handle().spawn(async move {
+        let _ = tx.send(fut.await);
+    });
+    rx.await.expect("sqlite-io task panicked or was cancelled")
+}

--- a/vantage-diorama/tests/bdd_support/steps/lifecycle.rs
+++ b/vantage-diorama/tests/bdd_support/steps/lifecycle.rs
@@ -23,7 +23,7 @@ async fn spawn_make_dio(w: &mut DioramaWorld) {
     let cache_path = w.tmp_path().join("cache.redb");
     let lens = w
         .lens_builder
-        .build(cache_path, &w.spies)
+        .build(cache_path, &w.spies, w.backend)
         .expect("build lens");
     let master = w.master.take().expect("master not set");
     w.lens = Some(lens.clone());

--- a/vantage-diorama/tests/bdd_support/steps/multi_dio.rs
+++ b/vantage-diorama/tests/bdd_support/steps/multi_dio.rs
@@ -23,7 +23,7 @@ async fn create_named_dio(w: &mut DioramaWorld, name: String) {
     if w.lens.is_none() {
         let lens = w
             .lens_builder
-            .build(cache_path, &w.spies)
+            .build(cache_path, &w.spies, w.backend)
             .expect("build lens");
         w.lens = Some(lens);
     }

--- a/vantage-diorama/tests/bdd_support/steps/skeleton.rs
+++ b/vantage-diorama/tests/bdd_support/steps/skeleton.rs
@@ -3,7 +3,11 @@
 use cucumber::{gherkin::Step, given, then, when};
 use vantage_dataset::traits::ReadableValueSet;
 
-use crate::bdd_support::{backend::MasterRows, world::DioramaWorld};
+use crate::bdd_support::{
+    backend::{BackendKind, MasterRows},
+    sqlite_runtime::dispatch,
+    world::DioramaWorld,
+};
 
 #[given(regex = r"^a master with rows$")]
 async fn master_with_rows(w: &mut DioramaWorld, step: &Step) {
@@ -26,7 +30,7 @@ async fn create_dio(w: &mut DioramaWorld) {
     let cache_path = w.tmp_path().join("cache.redb");
     let lens = w
         .lens_builder
-        .build(cache_path, &w.spies)
+        .build(cache_path, &w.spies, w.backend)
         .expect("build lens");
     let master = w.master.take().expect("master not set");
     let dio = lens.make_dio(master).await.expect("make_dio");
@@ -37,8 +41,13 @@ async fn create_dio(w: &mut DioramaWorld) {
 
 #[then(regex = r"^the master responds to list with (\d+) rows?$")]
 async fn master_list_count(w: &mut DioramaWorld, n: u64) {
-    let dio = w.dio.as_ref().expect("dio not created");
-    let rows = dio.master().list_values().await.expect("list master");
+    let dio = w.dio.as_ref().expect("dio not created").clone();
+    let rows = if w.backend == BackendKind::Sqlite {
+        dispatch(async move { dio.master().list_values().await }).await
+    } else {
+        dio.master().list_values().await
+    }
+    .expect("list master");
     assert_eq!(
         rows.len() as u64,
         n,

--- a/vantage-diorama/tests/bdd_support/steps/write_path.rs
+++ b/vantage-diorama/tests/bdd_support/steps/write_path.rs
@@ -7,7 +7,9 @@ use cucumber::{gherkin::Step, given, then, when};
 use vantage_dataset::traits::{ReadableValueSet, WritableValueSet};
 use vantage_types::Record;
 
-use crate::bdd_support::{world::DioramaWorld, world::OnWriteMode};
+use crate::bdd_support::{
+    backend::BackendKind, sqlite_runtime::dispatch, world::DioramaWorld, world::OnWriteMode,
+};
 
 /// Parse a gherkin data table whose first row is the header (with an `id`
 /// column) and remaining rows are records. Returns `(id, record)` pairs
@@ -155,8 +157,13 @@ async fn assert_on_write_count(w: &mut DioramaWorld, n: u64) {
 
 #[then(regex = r"^the master has (\d+) rows?$")]
 async fn master_row_count(w: &mut DioramaWorld, n: u64) {
-    let dio = w.dio.as_ref().expect("dio not created");
-    let rows = dio.master().list_values().await.expect("master list");
+    let dio = w.dio.as_ref().expect("dio not created").clone();
+    let rows = if w.backend == BackendKind::Sqlite {
+        dispatch(async move { dio.master().list_values().await }).await
+    } else {
+        dio.master().list_values().await
+    }
+    .expect("master list");
     assert_eq!(
         rows.len() as u64,
         n,
@@ -174,13 +181,15 @@ async fn cache_row_count(w: &mut DioramaWorld, n: u64) {
 
 #[then(regex = r#"^the master record "([^"]+)" has (\w+) "([^"]+)"$"#)]
 async fn master_record_field(w: &mut DioramaWorld, id: String, field: String, expected: String) {
-    let dio = w.dio.as_ref().expect("dio not created");
-    let row = dio
-        .master()
-        .get_value(&id)
-        .await
-        .expect("master get_value")
-        .unwrap_or_else(|| panic!("master has no record {id}"));
+    let dio = w.dio.as_ref().expect("dio not created").clone();
+    let id_for_dispatch = id.clone();
+    let row = if w.backend == BackendKind::Sqlite {
+        dispatch(async move { dio.master().get_value(&id_for_dispatch).await }).await
+    } else {
+        dio.master().get_value(&id_for_dispatch).await
+    }
+    .expect("master get_value")
+    .unwrap_or_else(|| panic!("master has no record {id}"));
     let got = row
         .get(&field)
         .and_then(|v| match v {
@@ -196,8 +205,14 @@ async fn master_record_field(w: &mut DioramaWorld, id: String, field: String, ex
 
 #[then(regex = r#"^the master record "([^"]+)" is absent$"#)]
 async fn master_record_absent(w: &mut DioramaWorld, id: String) {
-    let dio = w.dio.as_ref().expect("dio not created");
-    let row = dio.master().get_value(&id).await.expect("master get_value");
+    let dio = w.dio.as_ref().expect("dio not created").clone();
+    let id_for_dispatch = id.clone();
+    let row = if w.backend == BackendKind::Sqlite {
+        dispatch(async move { dio.master().get_value(&id_for_dispatch).await }).await
+    } else {
+        dio.master().get_value(&id_for_dispatch).await
+    }
+    .expect("master get_value");
     assert!(
         row.is_none(),
         "expected master record {id} to be absent, got {row:?}"

--- a/vantage-diorama/tests/bdd_support/world.rs
+++ b/vantage-diorama/tests/bdd_support/world.rs
@@ -12,6 +12,7 @@ use vantage_vista::Vista;
 
 use super::backend::BackendKind;
 use super::spies::Spies;
+use super::sqlite_runtime::dispatch;
 
 #[derive(Clone, Copy, Default, Debug)]
 pub enum OnWriteMode {
@@ -213,8 +214,21 @@ impl DioramaWorld {
 impl LensBuilderState {
     /// Materialise the configured Lens. Closures clone the spy counters so
     /// each callback invocation lands in the matching `AtomicU64`.
-    pub fn build(&self, cache_path: std::path::PathBuf, spies: &Spies) -> Result<Arc<Lens>> {
+    ///
+    /// `backend` decides whether the worker callbacks bridge their
+    /// `dio.master().*` calls through the sqlite io-runtime. SQLite must
+    /// bridge (see [`super::sqlite_runtime`] for why); Mock/CSV must NOT —
+    /// the cross-runtime suspension desynchronises the worker from the
+    /// test task's `settle()` / `drain_write_queue` polling and races
+    /// cache assertions.
+    pub fn build(
+        &self,
+        cache_path: std::path::PathBuf,
+        spies: &Spies,
+        backend: BackendKind,
+    ) -> Result<Arc<Lens>> {
         let mut b = Lens::new().cache_at(cache_path);
+        let bridge = backend == BackendKind::Sqlite;
 
         // on_start — legacy "copy master" mode kept for v1 features;
         // v2 features select a variant via `on_start_load_kind`.
@@ -239,7 +253,12 @@ impl LensBuilderState {
                     }
                     counter.fetch_add(1, Ordering::SeqCst);
                     master_list_counter.fetch_add(1, Ordering::SeqCst);
-                    let rows = dio.master().list_values().await?;
+                    let rows = if bridge {
+                        let dio_io = dio.clone();
+                        dispatch(async move { dio_io.master().list_values().await }).await?
+                    } else {
+                        dio.master().list_values().await?
+                    };
                     let rows: indexmap::IndexMap<_, _> = match load_kind {
                         OnStartLoad::AllRows | OnStartLoad::Unset => rows,
                         OnStartLoad::FirstN(n) => rows.into_iter().take(n).collect(),
@@ -300,15 +319,45 @@ impl LensBuilderState {
                         counter.fetch_add(1, Ordering::SeqCst);
                         match op {
                             WriteOp::Insert { id, record } => {
-                                dio.master().insert_value(&id, &record).await?;
+                                if bridge {
+                                    let dio_io = dio.clone();
+                                    let id_io = id.clone();
+                                    let record_io = record.clone();
+                                    dispatch(async move {
+                                        dio_io.master().insert_value(&id_io, &record_io).await
+                                    })
+                                    .await?;
+                                } else {
+                                    dio.master().insert_value(&id, &record).await?;
+                                }
                                 dio.cache().insert_value(&id, &record).await?;
                             }
                             WriteOp::Replace { id, record } => {
-                                dio.master().replace_value(&id, &record).await?;
+                                if bridge {
+                                    let dio_io = dio.clone();
+                                    let id_io = id.clone();
+                                    let record_io = record.clone();
+                                    dispatch(async move {
+                                        dio_io.master().replace_value(&id_io, &record_io).await
+                                    })
+                                    .await?;
+                                } else {
+                                    dio.master().replace_value(&id, &record).await?;
+                                }
                                 dio.cache().insert_value(&id, &record).await?;
                             }
                             WriteOp::Patch { id, partial } => {
-                                dio.master().patch_value(&id, &partial).await?;
+                                if bridge {
+                                    let dio_io = dio.clone();
+                                    let id_io = id.clone();
+                                    let partial_io = partial.clone();
+                                    dispatch(async move {
+                                        dio_io.master().patch_value(&id_io, &partial_io).await
+                                    })
+                                    .await?;
+                                } else {
+                                    dio.master().patch_value(&id, &partial).await?;
+                                }
                                 // Read-merge-write on the cache so consumers
                                 // see the same merged record they'd get from
                                 // a fresh master read. `cache.insert_value`
@@ -323,11 +372,24 @@ impl LensBuilderState {
                                 dio.cache().insert_value(&id, &merged).await?;
                             }
                             WriteOp::Delete { id } => {
-                                dio.master().delete(&id).await?;
+                                if bridge {
+                                    let dio_io = dio.clone();
+                                    let id_io = id.clone();
+                                    dispatch(async move { dio_io.master().delete(&id_io).await })
+                                        .await?;
+                                } else {
+                                    dio.master().delete(&id).await?;
+                                }
                                 dio.cache().delete_value(&id).await?;
                             }
                             WriteOp::DeleteAll => {
-                                dio.master().delete_all().await?;
+                                if bridge {
+                                    let dio_io = dio.clone();
+                                    dispatch(async move { dio_io.master().delete_all().await })
+                                        .await?;
+                                } else {
+                                    dio.master().delete_all().await?;
+                                }
                                 dio.cache().clear().await?;
                             }
                         }
@@ -363,7 +425,11 @@ impl LensBuilderState {
                 b = b.total_provider(move |dio| {
                     let dio = dio.clone();
                     async move {
-                        let n = dio.master().get_count().await?;
+                        let n = if bridge {
+                            dispatch(async move { dio.master().get_count().await }).await?
+                        } else {
+                            dio.master().get_count().await?
+                        };
                         Ok(n as usize)
                     }
                 });
@@ -375,7 +441,11 @@ impl LensBuilderState {
                     let dio = dio.clone();
                     async move {
                         counter.fetch_add(1, Ordering::SeqCst);
-                        let n = dio.master().get_count().await?;
+                        let n = if bridge {
+                            dispatch(async move { dio.master().get_count().await }).await?
+                        } else {
+                            dio.master().get_count().await?
+                        };
                         Ok(n as usize)
                     }
                 });
@@ -404,7 +474,12 @@ impl LensBuilderState {
                             return Err(vantage_core::error!("on_load_chunk rejected (one-shot)"));
                         }
                         master_list_counter.fetch_add(1, Ordering::SeqCst);
-                        let all = dio.master().list_values().await?;
+                        let all = if bridge {
+                            let dio_io = dio.clone();
+                            dispatch(async move { dio_io.master().list_values().await }).await?
+                        } else {
+                            dio.master().list_values().await?
+                        };
                         let slice: Vec<_> = all.into_iter().collect();
                         let start = range.start.min(slice.len());
                         let end = range.end.min(slice.len());


### PR DESCRIPTION
Fixes #260.

The `vantage-diorama` BDD suite intermittently panicked with `pool timed out while waiting for an open connection` in any SQLite-backed scenario — most visibly on `v3_delete`'s `the master record "a" is absent` step.

### Why it was failing

The harness runs on a `current_thread` tokio runtime with `start_paused = true` (refresh scenarios need to drive virtual time deterministically). Sqlx 0.8's connection pool guards `acquire()` with a 30-second `tokio::time::timeout`. Under paused time, when the runtime sees nothing else to do, it auto-advances the clock to the next pending timer — which means that 30-second timeout can fire instantly. The brief gap between a `PoolConnection` being dropped and its spawn-on-Drop `return_to_pool` task actually returning the connection was enough to trip this. The previous workaround (provisioning the pool on a throwaway runtime and dropping it) made it worse: pending pool tasks were aborted on shutdown, leaking the pool's size counter.

### The fix (test harness only — no production code changes)

A dedicated background tokio runtime with real (un-paused) time now owns every sqlx pool operation the BDD suite triggers:

- `tests/bdd_support/sqlite_runtime.rs` — long-lived daemon thread running a `current_thread` runtime. `dispatch(fut).await` ships a future there and awaits the result over a oneshot.
- `build_sqlite` uses that runtime to create the pool and seed the schema; the runtime never goes away, so the pool's internal tasks aren't orphaned.
- Test steps and Lens callbacks that touch the SQLite master bridge through `dispatch` only when `backend == Sqlite` — Mock and CSV stay inline, so the existing `settle()` / `drain_write_queue` semantics keep working for non-SQL backends.
- Pool is pinned to `max_connections(1)` so every query hits the same `sqlite::memory:` database (sqlx's default would hand out additional connections, each backed by its own private in-memory DB).

Suite passes 30/30 in debug mode (CI's profile).