### PR TITLE
Route REST Vista typed-refs through resolve_from_row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,7 +4511,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.1 — 2026-05-23
+
+- REST Vista shell no longer routes typed `Table::with_many` / `with_one` references through `AnyTable`. `RestApiTableShell` now carries a typed `Table<RestApi, EmptyEntity>` and `TableShell::get_ref` resolves children via [`Table::get_ref_from_row`](https://docs.rs/vantage-table/0.5.0/vantage_table/table/struct.Table.html#method.get_ref_from_row) + a fresh `RestApiVistaFactory::from_table` wrap — mirroring the pattern used by the MongoDB, SQL, and SurrealDB drivers.
+- [`RestApi::eq_value_condition`](https://docs.rs/vantage-table/0.5.0/vantage_table/traits/table_source/trait.TableSource.html#method.eq_value_condition) implemented so `Reference::resolve_from_row` can push a row-derived `CborValue` join key onto a child REST table without a string round-trip.
+- `AnyTableShell` is no longer re-exported from `vantage_api_client::rest` (or the crate root / `prelude`). The legacy adapter survives as a `pub(crate)` helper under `graphql::vista` only as long as the GraphQL shell still wraps `AnyTable`; the matching GraphQL rewrite ships in the next release.
+- `tests/any_table.rs` drops the REST half — REST no longer participates in the `AnyTable::from_table` blanket bridge from the Vista layer. The GraphQL half stays until the GraphQL shell is rewritten.
+
 ## 0.5.0 — 2026-05-23
 
 - Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle, aligning with the rest of the workspace. No code changes beyond the dependency pin.

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"

--- a/vantage-api-client/src/graphql/vista/any_shell.rs
+++ b/vantage-api-client/src/graphql/vista/any_shell.rs
@@ -1,15 +1,11 @@
-//! Generic `TableShell` adapter over `AnyTable`.
+//! Legacy `TableShell` adapter over `AnyTable`. Still used by the
+//! GraphQL Vista shell while it carries an `AnyTable` internally —
+//! deleted alongside the GraphQL shell rewrite in the next PR.
 //!
 //! When a typed `Table::get_ref(...)` returns a related table it comes
-//! back type-erased as `AnyTable` — the static `E2` is hidden by the
-//! reference machinery. To keep the Vista driver path uniform we wrap
-//! that `AnyTable` in `AnyTableShell` and harvest the metadata it
+//! back type-erased as `AnyTable`. To keep the Vista driver path
+//! uniform we wrap that `AnyTable` here and harvest the metadata it
 //! already exposes (column names + types, id field, title fields).
-//!
-//! The shell forwards everything to `AnyTable`. `AnyTable` itself uses
-//! the CBOR adapter when its inner table doesn't natively use
-//! `CborValue`, so `RestApi` (which is JSON-native) round-trips
-//! through CBOR transparently here.
 
 use async_trait::async_trait;
 use ciborium::Value as CborValue;
@@ -41,10 +37,7 @@ impl AnyTableShell {
 
     /// Build a `Vista` from an `AnyTable`, harvesting metadata
     /// (columns, id field, title fields) from the table itself.
-    ///
-    /// Capabilities default to `can_count` only — REST API is the
-    /// initial caller and is read-only. Callers needing different
-    /// capabilities should build the shell explicitly via `new`.
+    /// Defaults to read-only (`can_count` only).
     pub fn into_vista(table: AnyTable) -> Result<Vista> {
         let caps = VistaCapabilities {
             can_count: true,
@@ -123,10 +116,6 @@ impl TableShell for AnyTableShell {
     }
 
     fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
-        // AnyTable only accepts stringy filters at this layer; coerce
-        // scalar CBOR values into their natural string form. Compound
-        // values (arrays, maps) can't be expressed as a flat eq, so
-        // we refuse them rather than silently truncating.
         let s = match value {
             CborValue::Text(s) => s.clone(),
             CborValue::Integer(i) => i128::from(*i).to_string(),
@@ -145,9 +134,6 @@ impl TableShell for AnyTableShell {
     }
 
     fn get_ref(&self, relation: &str, _row: &Record<CborValue>) -> Result<Vista> {
-        // AnyTableShell is the legacy AnyTable wrapper kept alive until
-        // Stage 9; it ignores the new `row` parameter for now and falls
-        // back to the AnyTable-flavoured set-into-set resolution.
         let any_table = self.table.get_ref(relation)?;
         AnyTableShell::into_vista(any_table)
     }

--- a/vantage-api-client/src/graphql/vista/mod.rs
+++ b/vantage-api-client/src/graphql/vista/mod.rs
@@ -10,6 +10,7 @@
 //! `can_count` only. Writes will follow once the schema map (Phase 9)
 //! describes mutation field names per-table.
 
+pub(crate) mod any_shell;
 pub mod factory;
 pub mod source;
 pub mod spec;

--- a/vantage-api-client/src/graphql/vista/source.rs
+++ b/vantage-api-client/src/graphql/vista/source.rs
@@ -25,7 +25,7 @@ use vantage_vista::{
     VistaMetadata,
 };
 
-use crate::rest::vista::AnyTableShell;
+use super::any_shell::AnyTableShell;
 
 pub struct GraphqlApiTableShell {
     pub(crate) table: AnyTable,

--- a/vantage-api-client/src/lib.rs
+++ b/vantage-api-client/src/lib.rs
@@ -25,7 +25,7 @@ pub use graphql::{
 };
 pub(crate) use rest::condition_to_query_param;
 pub use rest::{
-    AnyTableShell, ApiColumnExtras, ApiReferenceExtras, ApiTableBlock, ApiTableExtras,
-    ModelResolver, NoApiExtras, PaginationParams, ResponseShape, RestApi, RestApiBuilder,
-    RestApiTableShell, RestApiVistaFactory, RestApiVistaSpec, eq_condition,
+    ApiColumnExtras, ApiReferenceExtras, ApiTableBlock, ApiTableExtras, ModelResolver, NoApiExtras,
+    PaginationParams, ResponseShape, RestApi, RestApiBuilder, RestApiTableShell,
+    RestApiVistaFactory, RestApiVistaSpec, eq_condition,
 };

--- a/vantage-api-client/src/prelude.rs
+++ b/vantage-api-client/src/prelude.rs
@@ -13,6 +13,6 @@ pub use crate::graphql::{
     RenderedQuery,
 };
 pub use crate::rest::{
-    AnyTableShell, NoApiExtras, PaginationParams, ResponseShape, RestApi, RestApiBuilder,
-    RestApiTableShell, RestApiVistaFactory, RestApiVistaSpec, eq_condition,
+    NoApiExtras, PaginationParams, ResponseShape, RestApi, RestApiBuilder, RestApiTableShell,
+    RestApiVistaFactory, RestApiVistaSpec, eq_condition,
 };

--- a/vantage-api-client/src/rest/mod.rs
+++ b/vantage-api-client/src/rest/mod.rs
@@ -17,6 +17,6 @@ pub use api::{PaginationParams, ResponseShape, RestApi, RestApiBuilder};
 pub(crate) use operation::condition_to_query_param;
 pub use operation::eq_condition;
 pub use vista::{
-    AnyTableShell, ApiColumnExtras, ApiReferenceExtras, ApiTableBlock, ApiTableExtras,
-    ModelResolver, NoApiExtras, RestApiTableShell, RestApiVistaFactory, RestApiVistaSpec,
+    ApiColumnExtras, ApiReferenceExtras, ApiTableBlock, ApiTableExtras, ModelResolver, NoApiExtras,
+    RestApiTableShell, RestApiVistaFactory, RestApiVistaSpec,
 };

--- a/vantage-api-client/src/rest/table_source.rs
+++ b/vantage-api-client/src/rest/table_source.rs
@@ -66,6 +66,13 @@ impl TableSource for RestApi {
         Ok(crate::eq_condition(field, value.to_string()))
     }
 
+    /// Typed-value sibling of `eq_condition`. Used by `Reference::resolve_from_row`
+    /// to push a row-derived join value onto a child table without a
+    /// string round-trip.
+    fn eq_value_condition(&self, field: &str, value: Self::Value) -> Result<Self::Condition> {
+        Ok(crate::eq_condition(field, value))
+    }
+
     fn create_column<Type: ColumnType>(&self, name: &str) -> Self::Column<Type> {
         Column::new(name)
     }

--- a/vantage-api-client/src/rest/vista/factory.rs
+++ b/vantage-api-client/src/rest/vista/factory.rs
@@ -88,18 +88,19 @@ impl RestApiVistaFactory {
 
     /// Wrap a typed `Table<RestApi, E>` as a `Vista`. Column metadata,
     /// id field, title fields, and references are harvested up front;
-    /// the table itself is stored as `Box<dyn TableLike>` so the
-    /// original `E` stays attached for reference traversal via the
-    /// typed-table machinery.
+    /// the table is erased to `Table<RestApi, EmptyEntity>` so the
+    /// shell carries a uniform entity type while still routing
+    /// reference traversal through `Reference::resolve_from_row`.
     pub fn from_table<E>(&self, table: Table<RestApi, E>) -> Result<Vista>
     where
         E: Entity<CborValue> + 'static,
     {
         let metadata = metadata_from_table(&table);
         let name = table.table_name().to_string();
+        let any_table = table.into_entity::<EmptyEntity>();
 
         let source = RestApiTableShell::new(
-            Box::new(table),
+            any_table,
             VistaCapabilities {
                 can_count: true,
                 ..VistaCapabilities::default()
@@ -183,7 +184,7 @@ impl VistaFactory for RestApiVistaFactory {
         }
 
         let source = RestApiTableShell::new(
-            Box::new(table),
+            table,
             VistaCapabilities {
                 can_count: true,
                 ..VistaCapabilities::default()

--- a/vantage-api-client/src/rest/vista/mod.rs
+++ b/vantage-api-client/src/rest/vista/mod.rs
@@ -9,12 +9,10 @@
 //! REST APIs are read-only at this stage — the shell advertises only
 //! `can_count`.
 
-pub mod any_shell;
 pub mod factory;
 pub mod source;
 pub mod spec;
 
-pub use any_shell::AnyTableShell;
 pub use factory::{ModelResolver, RestApiVistaFactory};
 pub use source::RestApiTableShell;
 pub use spec::{

--- a/vantage-api-client/src/rest/vista/source.rs
+++ b/vantage-api-client/src/rest/vista/source.rs
@@ -1,6 +1,5 @@
-//! `RestApiTableShell` — owns the typed `Table<RestApi, E>` behind a
-//! `dyn TableLike` so the original entity type stays attached for
-//! reference traversal.
+//! `RestApiTableShell` — owns the typed `Table<RestApi, EmptyEntity>`
+//! and exposes it through the `TableShell` boundary.
 //!
 //! `RestApi` already speaks `ciborium::Value` natively (the HTTP body
 //! is converted at the fetch boundary), so the shell is a pass-through
@@ -17,15 +16,17 @@ use async_trait::async_trait;
 use ciborium::Value as CborValue;
 use indexmap::IndexMap;
 use vantage_core::{Result, error};
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_table::table::Table;
 use vantage_table::traits::table_like::TableLike;
-use vantage_types::Record;
+use vantage_types::{EmptyEntity, Record};
 use vantage_vista::{
     Column as VistaColumn, Reference as VistaReference, TableShell, Vista, VistaCapabilities,
     VistaMetadata,
 };
 
-use super::any_shell::AnyTableShell;
-use super::factory::ModelResolver;
+use super::factory::{ModelResolver, RestApiVistaFactory};
+use crate::RestApi;
 
 /// A single YAML-declared reference attached to a parent shell at
 /// build time. Carries the foreign-key wiring; the URL form is
@@ -45,7 +46,7 @@ pub(crate) enum YamlReferenceKind {
 }
 
 pub struct RestApiTableShell {
-    pub(crate) table: Box<dyn TableLike<Value = CborValue, Id = String>>,
+    pub(crate) table: Table<RestApi, EmptyEntity>,
     pub(crate) capabilities: VistaCapabilities,
     pub(crate) metadata: VistaMetadata,
     pub(crate) yaml_refs: IndexMap<String, YamlReference>,
@@ -54,7 +55,7 @@ pub struct RestApiTableShell {
 
 impl RestApiTableShell {
     pub(crate) fn new(
-        table: Box<dyn TableLike<Value = CborValue, Id = String>>,
+        table: Table<RestApi, EmptyEntity>,
         capabilities: VistaCapabilities,
         metadata: VistaMetadata,
     ) -> Self {
@@ -121,15 +122,9 @@ impl TableShell for RestApiTableShell {
     }
 
     fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
-        // Build a typed `Expression<CborValue>` and hand it through
-        // the type-erased `add_condition` API — `Table::add_condition`
-        // downcasts it back to `RestApi::Condition` on the other side.
         let condition = crate::eq_condition(field, value.clone());
-        self.table.add_condition(Box::new(condition))
-    }
-
-    fn add_raw_condition(&mut self, condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()> {
-        self.table.add_condition(condition)
+        self.table.add_condition(condition);
+        Ok(())
     }
 
     fn get_ref(&self, relation: &str, row: &Record<CborValue>) -> Result<Vista> {
@@ -155,12 +150,16 @@ impl TableShell for RestApiTableShell {
             // accordingly.
             let (source_column, target_field) = match yref.kind {
                 YamlReferenceKind::HasMany => {
-                    let parent_id = self.table.id_field_name().ok_or_else(|| {
-                        error!(
-                            "YAML has_many reference needs the parent to have an id field",
-                            relation = relation
-                        )
-                    })?;
+                    let parent_id = self
+                        .table
+                        .id_field()
+                        .map(|c| c.name().to_string())
+                        .ok_or_else(|| {
+                            error!(
+                                "YAML has_many reference needs the parent to have an id field",
+                                relation = relation
+                            )
+                        })?;
                     (parent_id, yref.foreign_key.clone())
                 }
                 YamlReferenceKind::HasOne => {
@@ -185,12 +184,13 @@ impl TableShell for RestApiTableShell {
             return Ok(child);
         }
 
-        // Fall through to the typed `Table` reference machinery for
-        // hand-coded `with_many` / `with_one` registrations. This still
-        // routes through AnyTable in this transition; cleaned up alongside
-        // the REST shell refactor that ships in Stage 9.
-        let any_table = self.table.get_ref(relation)?;
-        AnyTableShell::into_vista(any_table)
+        // Hand-coded `with_many` / `with_one` registrations on the typed
+        // table: resolve the target table from `row` directly, then wrap
+        // it back into a Vista via a fresh factory bound to the same
+        // data source.
+        let target = self.table.get_ref_from_row::<EmptyEntity>(relation, row)?;
+        let factory = RestApiVistaFactory::new(self.table.data_source().clone());
+        factory.from_table(target)
     }
 
     fn capabilities(&self) -> &VistaCapabilities {

--- a/vantage-api-client/tests/any_table.rs
+++ b/vantage-api-client/tests/any_table.rs
@@ -1,21 +1,17 @@
-//! Compile-time verification that REST and GraphQL tables both bridge
-//! into `AnyTable` via the blanket `CborAdapter` in `vantage-table`.
+//! Compile-time verification that GraphQL tables bridge into
+//! `AnyTable` via the blanket `CborAdapter` in `vantage-table`.
 //!
 //! No network — the goal is to prove the type bounds line up
 //! (`Value: Into<CborValue> + From<CborValue>`, `Id: Display + From<String>`).
+//!
+//! REST's half of this test is gone — the REST Vista shell no longer
+//! routes references through `AnyTable`. The GraphQL half stays until
+//! the matching shell rewrite ships.
 
-use vantage_api_client::{GraphqlApi, RestApi};
+use vantage_api_client::GraphqlApi;
 use vantage_table::any::AnyTable;
 use vantage_table::table::Table;
 use vantage_types::EmptyEntity;
-
-#[test]
-fn rest_table_wraps_into_any_table() {
-    let api = RestApi::new("https://example.test");
-    let table: Table<RestApi, EmptyEntity> = Table::new("users", api);
-    let any = AnyTable::from_table(table);
-    assert!(any.datasource_name().contains("RestApi"));
-}
 
 #[test]
 fn graphql_table_wraps_into_any_table() {
@@ -23,22 +19,4 @@ fn graphql_table_wraps_into_any_table() {
     let table: Table<GraphqlApi, EmptyEntity> = Table::new("launches", api);
     let any = AnyTable::from_table(table);
     assert!(any.datasource_name().contains("GraphqlApi"));
-}
-
-#[test]
-fn rest_and_graphql_tables_live_in_same_collection() {
-    // A heterogeneous Vec<AnyTable> — the point of multi-backend.
-    let rest = AnyTable::from_table(Table::<RestApi, EmptyEntity>::new(
-        "users",
-        RestApi::new("https://rest.test"),
-    ));
-    let graphql = AnyTable::from_table(Table::<GraphqlApi, EmptyEntity>::new(
-        "launches",
-        GraphqlApi::new("https://graphql.test/graphql"),
-    ));
-
-    let tables: Vec<AnyTable> = vec![rest, graphql];
-    assert_eq!(tables.len(), 2);
-    assert!(tables[0].datasource_name().contains("RestApi"));
-    assert!(tables[1].datasource_name().contains("GraphqlApi"));
 }


### PR DESCRIPTION
PR 2 of the AnyTable removal sequence. The REST Vista shell no longer
routes typed `Table::with_many` / `with_one` traversals through
`AnyTable` — it now resolves children directly from the parent row via
`Reference::resolve_from_row`, matching the pattern already used by the
MongoDB, SQL, and SurrealDB drivers.

## Changes

- `RestApiTableShell` now carries a typed `Table<RestApi, EmptyEntity>`
  instead of a `Box<dyn TableLike<Value = CborValue, Id = String>>`.
  The shell's `get_ref` resolves the target table via
  `Table::get_ref_from_row` and re-wraps with a fresh
  `RestApiVistaFactory::from_table`.
- New `RestApi::eq_value_condition` impl on `TableSource` — the typed
  sibling of `eq_condition` that `Reference::resolve_from_row` uses
  to push a row-derived `CborValue` join key without a string
  round-trip.
- `AnyTableShell` removed from REST's public surface (`rest::*`, crate
  root, `prelude`). It survives as a `pub(crate)` helper under
  `graphql::vista` because the GraphQL shell still wraps `AnyTable`;
  the matching GraphQL shell rewrite ships in the next PR.
- `tests/any_table.rs` drops its REST half. The GraphQL half is kept
  until the GraphQL shell rewrite.
- Version bump `vantage-api-client` 0.5.0 → 0.5.1 with CHANGELOG.