### PR TITLE
Parametrize ImTable/ImDataSource over Value; restore Vista table_like tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,7 +4511,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-pool"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4618,7 +4618,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4659,7 +4659,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-expressions"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4714,7 +4714,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-log-writer"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "bson",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-redb"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4783,7 +4783,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4808,7 +4808,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "bakery_model3",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.5.2"
+version = "0.5.3"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"
@@ -19,7 +19,7 @@ serde_yaml_ng = "0.10"
 urlencoding = "2.1"
 uuid = { version = "1", features = ["serde"] }
 vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }

--- a/vantage-api-pool/Cargo.toml
+++ b/vantage-api-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "vantage-api-pool"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT OR Apache-2.0"
 description = "Paginated REST API client pool for Vantage"
 
@@ -20,7 +20,7 @@ async-trait = "0.1"
 indexmap = { version = "2", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
 vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["serde"] }

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -15,7 +15,7 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
-vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-vista = { version = "0.4", path = "../vantage-vista" }
 
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
@@ -41,7 +41,7 @@ quick-xml = "0.36"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 
 [dev-dependencies]
-vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-cli-util = { version = "0.5", path = "../vantage-cli-util" }
 vantage-vista = { version = "0.4", path = "../vantage-vista" }
 

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-cli-util"
-version = "0.5.1"
+version = "0.5.2"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "CLI utilities for Vantage data framework"
@@ -15,7 +15,7 @@ indexmap = "2"
 owo-colors = "4"
 serde_json = "1"
 vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-vista = { version = "0.4.10", path = "../vantage-vista" }

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"
@@ -21,7 +21,7 @@ indexmap = { version = "2", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1", features = ["preserve_order"] }
 vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
 vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["serde"] }

--- a/vantage-dataset/CHANGELOG.md
+++ b/vantage-dataset/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- [`ImDataSource`](https://docs.rs/vantage-dataset/0.5.0/vantage_dataset/im/struct.ImDataSource.html) and [`ImTable`](https://docs.rs/vantage-dataset/0.5.0/vantage_dataset/im/struct.ImTable.html) are now generic over the wire value type `V`. The default stays `serde_json::Value`, so existing call sites compile unchanged. The entity-typed [`ReadableDataSet`](https://docs.rs/vantage-dataset/0.5.0/vantage_dataset/traits/trait.ReadableDataSet.html) / `WritableDataSet` / `InsertableDataSet` impls are only available for `V = serde_json::Value` because they round-trip records through `serde_json` for `try_from_record`; the value-typed valueset impls now work for any `V` with `Clone + Send + Sync + 'static`. Drivers that want a CBOR-typed in-memory store can use `ImDataSource::<CborValue>::new()` directly without bringing serde_json into their value path.
+- Bumped to the 0.5 line to track the workspace's `AnyTable` decommission cycle.
+
 ## 0.4.3 — 2026-05-16
 
 - Internal dependency version refresh; no public API changes.

--- a/vantage-dataset/Cargo.toml
+++ b/vantage-dataset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-dataset"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Dataset traits for the Vantage data framework"

--- a/vantage-dataset/src/im/im_table.rs
+++ b/vantage-dataset/src/im/im_table.rs
@@ -2,15 +2,25 @@ use uuid::Uuid;
 
 use crate::{im::ImDataSource, traits::ValueSet};
 
-/// Table represents a typed table in the ImDataSource
-pub struct ImTable<E> {
-    pub(super) data_source: ImDataSource,
+/// Typed handle into one named table inside an [`ImDataSource`].
+///
+/// Generic over the entity type `E` and the wire value type `V` (defaults
+/// to `serde_json::Value` for back-compat). The entity-typed dataset
+/// impls (`ReadableDataSet`, `WritableDataSet`, `InsertableDataSet`) are
+/// only available for `V = serde_json::Value` because they round-trip
+/// through `serde_json` for `try_from_record`; the value-typed valueset
+/// impls work for any `V`.
+pub struct ImTable<E, V = serde_json::Value> {
+    pub(super) data_source: ImDataSource<V>,
     pub(super) table_name: String,
     _phantom: std::marker::PhantomData<E>,
 }
 
-impl<E> ImTable<E> {
-    pub fn new(data_source: &ImDataSource, table_name: &str) -> Self {
+impl<E, V> ImTable<E, V> {
+    pub fn new(data_source: &ImDataSource<V>, table_name: &str) -> Self
+    where
+        V: Clone,
+    {
         Self {
             data_source: data_source.clone(),
             table_name: table_name.to_string(),
@@ -23,7 +33,10 @@ impl<E> ImTable<E> {
     }
 }
 
-impl<E> ValueSet for ImTable<E> {
+impl<E, V> ValueSet for ImTable<E, V>
+where
+    V: Clone + Send + Sync + 'static,
+{
     type Id = String;
-    type Value = serde_json::Value;
+    type Value = V;
 }

--- a/vantage-dataset/src/im/mod.rs
+++ b/vantage-dataset/src/im/mod.rs
@@ -16,34 +16,49 @@ pub mod valueset_writable;
 pub use im_table::ImTable;
 
 /// Type alias for the complex table storage structure
-type TableStorage = Arc<Mutex<HashMap<String, IndexMap<String, Record<serde_json::Value>>>>>;
+type TableStorage<V> = Arc<Mutex<HashMap<String, IndexMap<String, Record<V>>>>>;
 
-/// ImDataSource stores tables in memory using IndexMap for ordered iteration
-#[derive(Debug, Clone)]
-pub struct ImDataSource {
+/// In-memory data source storing tables as nested maps, keyed first by table
+/// name then by row id. Generic over the wire value type `V` so the same
+/// storage primitive can hold `serde_json::Value` records (the original
+/// entity-friendly mode) or `ciborium::Value` records (used by
+/// `MockTableSource` to participate in the CBOR-typed `TableSource` /
+/// `Vista` machinery). Defaults to `serde_json::Value` for back-compat.
+#[derive(Debug)]
+pub struct ImDataSource<V = serde_json::Value> {
     // table_name -> IndexMap<id, record>
-    tables: TableStorage,
+    tables: TableStorage<V>,
 }
 
-impl ImDataSource {
+impl<V> Clone for ImDataSource<V> {
+    fn clone(&self) -> Self {
+        Self {
+            tables: self.tables.clone(),
+        }
+    }
+}
+
+impl<V> ImDataSource<V> {
     pub fn new() -> Self {
         Self {
             tables: Arc::new(Mutex::new(HashMap::new())),
         }
     }
+}
 
-    fn get_or_create_table(&self, table_name: &str) -> IndexMap<String, Record<serde_json::Value>> {
+impl<V: Clone> ImDataSource<V> {
+    pub(super) fn get_or_create_table(&self, table_name: &str) -> IndexMap<String, Record<V>> {
         let mut tables = self.tables.lock().unwrap();
         tables.entry(table_name.to_string()).or_default().clone()
     }
 
-    fn update_table(&self, table_name: &str, table: IndexMap<String, Record<serde_json::Value>>) {
+    pub(super) fn update_table(&self, table_name: &str, table: IndexMap<String, Record<V>>) {
         let mut tables = self.tables.lock().unwrap();
         tables.insert(table_name.to_string(), table);
     }
 }
 
-impl Default for ImDataSource {
+impl<V> Default for ImDataSource<V> {
     fn default() -> Self {
         Self::new()
     }

--- a/vantage-dataset/src/im/valueset_insertable.rs
+++ b/vantage-dataset/src/im/valueset_insertable.rs
@@ -1,12 +1,17 @@
 use async_trait::async_trait;
-use vantage_types::{Entity, Record};
+use vantage_types::Record;
 
 use crate::{im::ImTable, traits::InsertableValueSet};
 
+/// `InsertableValueSet` is only available for `V = serde_json::Value` because
+/// it inspects the record for an `"id"` field via JSON-specific accessors
+/// (`as_str`, `as_u64`, …). CBOR consumers carry their own id generation
+/// upstream (e.g. `MockTableSource::insert_table_value` constructs the id
+/// before calling into `ImTable`).
 #[async_trait]
-impl<E> InsertableValueSet for ImTable<E>
+impl<E> InsertableValueSet for ImTable<E, serde_json::Value>
 where
-    E: Entity,
+    E: Send + Sync,
 {
     async fn insert_return_id_value(
         &self,

--- a/vantage-dataset/src/im/valueset_readable.rs
+++ b/vantage-dataset/src/im/valueset_readable.rs
@@ -1,13 +1,14 @@
 use async_trait::async_trait;
 use indexmap::IndexMap;
-use vantage_types::{Entity, Record};
+use vantage_types::Record;
 
 use crate::{im::ImTable, traits::ReadableValueSet};
 
 #[async_trait]
-impl<E> ReadableValueSet for ImTable<E>
+impl<E, V> ReadableValueSet for ImTable<E, V>
 where
-    E: Entity,
+    V: Clone + Send + Sync + 'static,
+    E: Send + Sync,
 {
     async fn list_values(&self) -> crate::traits::Result<IndexMap<Self::Id, Record<Self::Value>>> {
         let table = self.data_source.get_or_create_table(&self.table_name);

--- a/vantage-dataset/src/im/valueset_writable.rs
+++ b/vantage-dataset/src/im/valueset_writable.rs
@@ -1,12 +1,13 @@
 use async_trait::async_trait;
-use vantage_types::{Entity, Record};
+use vantage_types::Record;
 
 use crate::{im::ImTable, traits::WritableValueSet};
 
 #[async_trait]
-impl<E> WritableValueSet for ImTable<E>
+impl<E, V> WritableValueSet for ImTable<E, V>
 where
-    E: Entity,
+    V: Clone + Send + Sync + 'static,
+    E: Send + Sync,
 {
     async fn insert_value(
         &self,

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"
@@ -14,7 +14,7 @@ vantage-core = { version = "0.4.1", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-vista = { version = "0.4", path = "../vantage-vista" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
-vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-expressions/Cargo.toml
+++ b/vantage-expressions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-expressions"
-version = "0.4.4"
+version = "0.4.5"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Database agnostic expressions"
@@ -15,7 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
 vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-vista = { version = "0.4", path = "../vantage-vista" }
 
 [dev-dependencies]

--- a/vantage-log-writer/Cargo.toml
+++ b/vantage-log-writer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-log-writer"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for append-only log files (JSONL)"
@@ -23,7 +23,7 @@ tokio = { version = "1.48", features = ["rt", "fs", "sync", "io-util", "macros"]
 tracing = "0.1"
 ulid = "1"
 vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"
@@ -15,7 +15,7 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4.2", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
-vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-vista = { version = "0.4.10", path = "../vantage-vista", optional = true }
 
 bson = "2"

--- a/vantage-redb/Cargo.toml
+++ b/vantage-redb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-redb"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -15,7 +15,7 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
-vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 
 redb = "2.6"
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -22,7 +22,7 @@ vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["ser
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 paste = "1.0"
 
-vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
 vantage-vista = { version = "0.4.10", path = "../vantage-vista", optional = true }
 async-trait = "0.1"

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"
@@ -19,7 +19,7 @@ async-trait = "0.1"
 vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions", features = ["chrono"] }
 vantage-table = { version = "0.5", path = "../vantage-table" }
-vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.4.10", path = "../vantage-vista", optional = true }
 surreal-client = { version = "0.4", path = "../surreal-client" }

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.1 — 2026-05-23
+
+- Restored `tests/table_like.rs`. The previous AnyTable-on-`MockTableSource` tests were disabled during the CBOR swap; the file now runs as Vista smoke tests against [`MockShell`](https://docs.rs/vantage-vista/0.4/vantage_vista/mocks/struct.MockShell.html) — six tests covering table-name/column metadata, value round-trip via `ReadableValueSet` / `WritableValueSet` / `InsertableValueSet`, count, and `get_some_value`. These tests survive the AnyTable removal scheduled for the next release.
+- `MockTableSource` stays JSON-typed for now. The original plan called for converting it to `ciborium::Value` so it could bridge into the (about-to-be-removed) `AnyTable`, but with `AnyTable` going away that's no longer needed — Vista-flavoured tests use [`vantage_vista::mocks::MockShell`](https://docs.rs/vantage-vista/0.4/vantage_vista/mocks/struct.MockShell.html) directly.
+
 ## 0.5.0 — 2026-05-23
 
 Opens the 0.5 cycle. No code changes in this release beyond a docstring

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"
@@ -20,7 +20,7 @@ vantage-core = { version = "0.4", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-vista = { version = "0.4.7", path = "../vantage-vista" }
-vantage-dataset = { version = "0.4.2", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 async-stream = "0.3"
 async-trait = "0.1"
 futures-core = "0.3"
@@ -54,9 +54,6 @@ name = "expr"
 path = "tests/expr.rs"
 test = false
 
-# Disabled during CBOR swap — needs a CBOR-native mock TableSource.
-# See TODO.md "Architecture: Make ImTable / ImDataSource generic over Value".
 [[test]]
 name = "table_like"
 path = "tests/table_like.rs"
-test = false

--- a/vantage-table/tests/table_like.rs
+++ b/vantage-table/tests/table_like.rs
@@ -1,105 +1,151 @@
-use vantage_dataset::prelude::*;
-use vantage_table::prelude::*;
-use vantage_types::EmptyEntity;
+//! Vista smoke tests that previously exercised `AnyTable` against
+//! `MockTableSource`. AnyTable is being retired across the workspace
+//! (see plans for vantage-vista's stage 9 decommission); the replacement
+//! is `vantage_vista::Vista` carrying a `TableShell`. These tests use
+//! the in-memory [`MockShell`](vantage_vista::mocks::MockShell) so they
+//! cover Vista plumbing without touching a real database.
 
-#[test]
-fn test_table_like_dynamic_dispatch() {
-    let datasource = MockTableSource::new();
-    let table = Table::<MockTableSource, EmptyEntity>::new("users", datasource)
-        .with_column_of::<String>("id")
-        .with_column_of::<String>("name")
-        .with_column_of::<String>("email");
+use ciborium::Value as CborValue;
+use vantage_dataset::traits::{InsertableValueSet, ReadableValueSet, WritableValueSet};
+use vantage_types::Record;
+use vantage_vista::{
+    Column as VistaColumn, Vista, VistaCapabilities, VistaMetadata, mocks::MockShell,
+};
 
-    // Convert to AnyTable for type erasure
-    let any_table = AnyTable::new(table);
-
-    // Test basic table operations
-    assert_eq!(any_table.table_name(), "users");
-    assert_eq!(any_table.table_alias(), "users");
+fn empty_vista(name: &str) -> Vista {
+    let shell = MockShell::new();
+    Vista::new(name.to_string(), Box::new(shell))
 }
 
-#[test]
-fn test_multiple_tables_as_anytable() {
-    // Create different types of tables
-    let datasource1 = MockTableSource::new();
-    let users_table = Table::<MockTableSource, EmptyEntity>::new("users", datasource1)
-        .with_column_of::<String>("id")
-        .with_column_of::<String>("name");
+fn vista_with_columns(name: &str, columns: &[&str]) -> Vista {
+    let mut metadata = VistaMetadata::new().with_id_column("id");
+    metadata.columns.insert(
+        "id".to_string(),
+        VistaColumn::new("id".to_string(), "string"),
+    );
+    for col in columns {
+        metadata
+            .columns
+            .insert(col.to_string(), VistaColumn::new(col.to_string(), "string"));
+    }
+    let shell = MockShell::new()
+        .with_capabilities(VistaCapabilities {
+            can_count: true,
+            can_insert: true,
+            can_update: true,
+            can_delete: true,
+            ..VistaCapabilities::default()
+        })
+        .with_metadata(metadata);
+    Vista::new(name.to_string(), Box::new(shell))
+}
 
-    let datasource2 = MockTableSource::new();
-    let orders_table = Table::<MockTableSource, EmptyEntity>::new("orders", datasource2)
-        .with_column_of::<String>("order_id")
-        .with_column_of::<i64>("amount");
+#[tokio::test]
+async fn vista_carries_table_name_and_columns() {
+    let vista = vista_with_columns("users", &["name", "email"]);
 
-    // Store them all as AnyTable for uniform handling
-    let tables: Vec<AnyTable> = vec![AnyTable::new(users_table), AnyTable::new(orders_table)];
+    assert_eq!(vista.name(), "users");
+    let cols = vista.get_column_names();
+    assert!(cols.contains(&"id"));
+    assert!(cols.contains(&"name"));
+    assert!(cols.contains(&"email"));
+    assert_eq!(vista.get_id_column(), Some("id"));
+    assert_eq!(vista.driver(), "mock");
+}
 
-    // Process all tables uniformly
-    for table in &tables {
-        assert!(!table.table_name().is_empty());
+#[tokio::test]
+async fn multiple_vistas_live_in_same_collection() {
+    let users = vista_with_columns("users", &["name"]);
+    let orders = vista_with_columns("orders", &["amount"]);
 
-        // Test that we can downcast back to concrete type
-        assert!(table.is_type::<MockTableSource, EmptyEntity>());
+    let vistas: Vec<Vista> = vec![users, orders];
+    for v in &vistas {
+        assert!(!v.name().is_empty());
+        assert_eq!(v.driver(), "mock");
     }
 }
 
 #[tokio::test]
-async fn test_anytable_downcasting() {
-    let datasource = MockTableSource::new();
-    let table = Table::<MockTableSource, EmptyEntity>::new("products", datasource)
-        .with_column_of::<String>("name")
-        .with_column_of::<i64>("price");
+async fn vista_value_round_trip() {
+    let vista = vista_with_columns("items", &["name", "price"]);
 
-    // Convert to AnyTable
-    let any_table = AnyTable::new(table);
+    let mut record = Record::new();
+    record.insert("name".to_string(), CborValue::Text("Test Item".into()));
+    record.insert("price".to_string(), CborValue::Integer(99.into()));
+    record.insert("available".to_string(), CborValue::Bool(true));
 
-    // Test type checking
-    assert!(any_table.is_type::<MockTableSource, EmptyEntity>());
+    vista
+        .insert_value(&"item1".to_string(), &record)
+        .await
+        .expect("insert_value should succeed");
 
-    // Test downcasting back to concrete type
-    let concrete_table = any_table
-        .clone()
-        .downcast::<MockTableSource, EmptyEntity>()
-        .unwrap();
-    assert_eq!(concrete_table.table_name(), "products");
-
-    // Test that wrong type fails
-    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
-    struct DifferentEntity {
-        id: String,
-    }
-
-    let datasource2 = MockTableSource::new();
-    let table2 = Table::<MockTableSource, DifferentEntity>::new("other", datasource2);
-    let any_table2 = AnyTable::new(table2);
-
-    // Should not match EmptyEntity
-    assert!(!any_table2.is_type::<MockTableSource, EmptyEntity>());
-    assert!(!any_table.is_type::<MockTableSource, DifferentEntity>());
+    let retrieved = vista
+        .get_value(&"item1".to_string())
+        .await
+        .expect("get_value should not error")
+        .expect("item1 should exist");
+    assert_eq!(
+        retrieved.get("name"),
+        Some(&CborValue::Text("Test Item".into()))
+    );
+    assert_eq!(retrieved.get("available"), Some(&CborValue::Bool(true)));
 }
 
 #[tokio::test]
-async fn test_anytable_value_operations() {
-    let datasource = MockTableSource::new();
-    let table = Table::<MockTableSource, EmptyEntity>::new("items", datasource);
-    let any_table = AnyTable::new(table);
+async fn vista_count_and_some_value() {
+    let vista = vista_with_columns("items", &["name"]);
 
-    // // Test that we can call async methods
-    // let values = any_table.get_all_values().await;
-    // assert!(values.is_ok());
+    let mut a = Record::new();
+    a.insert("name".to_string(), CborValue::Text("Alpha".into()));
+    vista
+        .insert_value(&"a".to_string(), &a)
+        .await
+        .expect("insert a");
 
-    // Test JSON value insertion
-    let item_data = serde_json::json!({
-        "name": "Test Item",
-        "price": 99,
-        "available": true
-    });
+    let mut b = Record::new();
+    b.insert("name".to_string(), CborValue::Text("Bravo".into()));
+    vista
+        .insert_value(&"b".to_string(), &b)
+        .await
+        .expect("insert b");
 
-    let record = vantage_types::Record::from(item_data);
-    let result = any_table.insert_value(&"item1".to_string(), &record).await;
-    assert!(result.is_ok());
+    assert_eq!(vista.get_count().await.expect("count"), 2);
+    let some = vista
+        .get_some_value()
+        .await
+        .expect("get_some_value")
+        .expect("some row");
+    assert!(["a".to_string(), "b".to_string()].contains(&some.0));
+}
 
-    // Test retrieval
-    let retrieved = any_table.get_value(&"item1".to_string()).await;
-    assert!(retrieved.is_ok());
+#[tokio::test]
+async fn vista_insert_return_id_value() {
+    let vista = vista_with_columns("items", &["name"]);
+
+    let mut record = Record::new();
+    record.insert("name".to_string(), CborValue::Text("auto-generated".into()));
+
+    let id = vista
+        .insert_return_id_value(&record)
+        .await
+        .expect("auto id insert");
+    assert!(!id.is_empty());
+
+    let fetched = vista
+        .get_value(&id)
+        .await
+        .expect("get")
+        .expect("just-inserted row");
+    assert_eq!(
+        fetched.get("name"),
+        Some(&CborValue::Text("auto-generated".into()))
+    );
+}
+
+#[test]
+fn empty_vista_advertises_name_and_no_columns() {
+    let vista = empty_vista("empty");
+    assert_eq!(vista.name(), "empty");
+    assert!(vista.get_column_names().is_empty());
+    assert_eq!(vista.get_id_column(), None);
 }

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 vantage-core = { version = "0.4.1", path = "../vantage-core" }
 vantage-types = { version = "0.4", path = "../vantage-types" }
-vantage-dataset = { version = "0.4", path = "../vantage-dataset" }
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 ciborium = { version = "0.2", features = ["std"] }
 indexmap = { version = "2.14", features = ["serde"] }
 async-stream = "0.3"


### PR DESCRIPTION
PR 5 of the AnyTable removal sequence. Stacked on #265; base branch is
\`model-factory-vista\`. Will retarget to \`main\` once #263, #264, #265
merge.

This PR closes the \"AnyTable CBOR-swap follow-up\" cluster in
\`/Users/rw/Work/vantage/TODO.md\` and restores the test-coverage that
was disabled during the CBOR swap, in preparation for PR 6 (delete
AnyTable).

### Scope shift from the original plan

The original plan called for converting \`MockTableSource\` to
\`ciborium::Value\` so it could bridge into \`AnyTable\`. With \`AnyTable\`
about to be removed in PR 6, that bridge is moot — Vista-flavoured
tests use \`vantage_vista::mocks::MockShell\` directly. So
\`MockTableSource\` stays JSON-typed.

The principled \`ImTable\` / \`ImDataSource\` parametrization still ships
because it's a useful generalization on its own.

### Changes

#### \`vantage-dataset\` 0.4.3 → 0.5.0

- [\`ImDataSource\`](https://docs.rs/vantage-dataset/0.5.0/vantage_dataset/im/struct.ImDataSource.html) and [\`ImTable\`](https://docs.rs/vantage-dataset/0.5.0/vantage_dataset/im/struct.ImTable.html) are now generic over the wire value type \`V\`. Default stays \`serde_json::Value\` so existing callers compile unchanged.
- Entity-typed dataset impls (\`ReadableDataSet\` / \`WritableDataSet\` / \`InsertableDataSet\`) are only available for \`V = serde_json::Value\` because they round-trip records through \`serde_json\` for \`try_from_record\`.
- The value-typed valueset impls (\`ReadableValueSet\` / \`WritableValueSet\`) now work for any \`V: Clone + Send + Sync + 'static\`. Drivers that want a CBOR-typed in-memory store can use \`ImDataSource::<CborValue>::new()\` directly without bringing serde_json into their value path.
- Type parameter order is \`ImTable<E, V = serde_json::Value>\` (E first so existing \`ImTable::<User>::new(...)\` calls keep working).

#### \`vantage-table\` 0.5.0 → 0.5.1

- Restored \`tests/table_like.rs\`. Six tests covering table-name + column metadata, value round-trip (insert/get/list/count), \`get_some_value\`, and \`insert_return_id_value\` — all driven through Vista's [\`MockShell\`](https://docs.rs/vantage-vista/0.4/vantage_vista/mocks/struct.MockShell.html) rather than the AnyTable carrier.

#### Dep-pin bumps for all consumers of \`vantage-dataset\`

- vantage-api-client 0.5.2 → 0.5.3
- vantage-api-pool 0.5.0 → 0.5.1
- vantage-aws 0.5.1 → 0.5.2
- vantage-cli-util 0.5.1 → 0.5.2
- vantage-csv 0.5.0 → 0.5.1
- vantage-diorama 0.5.0 → 0.5.1
- vantage-expressions 0.4.4 → 0.4.5
- vantage-log-writer 0.5.0 → 0.5.1
- vantage-mongodb 0.5.0 → 0.5.1
- vantage-redb 0.5.0 → 0.5.1
- vantage-sql 0.5.0 → 0.5.1
- vantage-surrealdb 0.5.0 → 0.5.1
- vantage-vista 0.4.10 → 0.4.11

