### PR TITLE
fix CI bugs

### DIFF
--- a/.github/workflows/aws.yaml
+++ b/.github/workflows/aws.yaml
@@ -27,11 +27,11 @@ jobs:
 
       - name: Build vantage-aws
         working-directory: vantage-aws
-        run: cargo build --all-targets --features vista
+        run: cargo build --all-targets
 
       - name: Run tests (offline only — integration tests are #[ignore]d)
         working-directory: vantage-aws
-        run: cargo test --features vista
+        run: cargo test
 
       - name: Check formatting
         working-directory: vantage-aws
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run clippy
         working-directory: vantage-aws
-        run: cargo clippy --all-targets --features vista -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Run aws-cli against live AWS
         working-directory: vantage-aws
@@ -48,10 +48,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: eu-west-2
         run: |
-          cargo run --features vista --example aws-cli -- log.groups
-          cargo run --features vista --example aws-cli -- log.groups logGroupNamePrefix=/aws/lambda/
-          cargo run --features vista --example aws-cli -- iam.users
-          cargo run --features vista --example aws-cli -- iam.roles PathPrefix=/aws-service-role/
-          cargo run --features vista --example aws-cli -- s3.buckets
-          cargo run --features vista --example aws-cli -- lambda.functions
-          cargo run --features vista --example aws-cli -- dynamodb.tables
+          cargo run --example aws-cli -- log.groups
+          cargo run --example aws-cli -- log.groups logGroupNamePrefix=/aws/lambda/
+          cargo run --example aws-cli -- iam.users
+          cargo run --example aws-cli -- iam.roles PathPrefix=/aws-service-role/
+          cargo run --example aws-cli -- s3.buckets
+          cargo run --example aws-cli -- lambda.functions
+          cargo run --example aws-cli -- dynamodb.tables

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3787,7 +3787,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surreal-client"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4511,7 +4511,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-pool"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4605,7 +4605,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -4618,7 +4618,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4659,7 +4659,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-expressions"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4714,7 +4714,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-log-writer"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4737,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "bson",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-redb"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4783,7 +4783,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4808,7 +4808,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "bakery_model3",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4862,7 +4862,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "ciborium",
  "csv",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types-entity"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.4.12"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/surreal-client/CHANGELOG.md
+++ b/surreal-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.4.3 — 2026-05-16
 
 - Internal dependency version refresh; no public API changes.
@@ -8,18 +12,27 @@
 
 - `ws://` and `wss://` now route through the CBOR engine. `cbor://` remains as an alias.
 - The JSON `WsEngine` is gone. CBOR is the only wire format.
-- `Engine` trait: `send_message_cbor` is the real method; `send_message` is a default that transcodes JSON↔CBOR around it. `supports_cbor()` removed (always true).
+- `Engine` trait: `send_message_cbor` is the real method; `send_message` is a default that
+  transcodes JSON↔CBOR around it. `supports_cbor()` removed (always true).
 - `SurrealClient::supports_cbor()` removed.
 - `SurrealError::Rpc` variant removed.
 - `RpcMessage`/`RpcResponse` types removed.
-- New private `cbor_convert` module implements the JSON↔CBOR fallback used by the JSON convenience methods. SurrealDB recordids (Tag 8) are flattened to `"table:id"` strings; bytes are base64; other CBOR-only types are best-effort. Use `query_cbor` for full fidelity.
+- New private `cbor_convert` module implements the JSON↔CBOR fallback used by the JSON convenience
+  methods. SurrealDB recordids (Tag 8) are flattened to `"table:id"` strings; bytes are base64;
+  other CBOR-only types are best-effort. Use `query_cbor` for full fidelity.
 
 ## 0.4.1 — 2026-05-03
 
-- WebSocket message handlers (`ws`, `ws_cbor`, `ws_pool`) wrap their spawned futures with `tracing::Instrument::in_current_span()` so connection events stay attached to the trace that opened the connection.
-- Replaced `println!` / `eprintln!` in the WS handlers with `tracing::debug!` / `warn!` so consumers' subscribers see them. `tracing` becomes a direct dependency.
-- The JSON `WsEngine` no longer panics on malformed inbound payloads — bad JSON, missing `id`, and unexpected frames now log at `warn` / `debug` and the message is dropped instead of taking the entire message-handler task down.
+- WebSocket message handlers (`ws`, `ws_cbor`, `ws_pool`) wrap their spawned futures with
+  `tracing::Instrument::in_current_span()` so connection events stay attached to the trace that
+  opened the connection.
+- Replaced `println!` / `eprintln!` in the WS handlers with `tracing::debug!` / `warn!` so
+  consumers' subscribers see them. `tracing` becomes a direct dependency.
+- The JSON `WsEngine` no longer panics on malformed inbound payloads — bad JSON, missing `id`, and
+  unexpected frames now log at `warn` / `debug` and the message is dropped instead of taking the
+  entire message-handler task down.
 
 ## 0.4.0 — 2026-04-16
 
-- Initial 0.4 release. Standalone SurrealDB client over WebSocket with CBOR transport — used by `vantage-surrealdb` and usable on its own.
+- Initial 0.4 release. Standalone SurrealDB client over WebSocket with CBOR transport — used by
+  `vantage-surrealdb` and usable on its own.

--- a/surreal-client/Cargo.toml
+++ b/surreal-client/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "surreal-client"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "CBOR-based SurrealDB client for the Vantage data framework"
@@ -31,7 +31,7 @@ tracing = "0.1"
 futures = "0.3.32"
 url = "2.5.8"
 uuid = { version = "1.23", features = ["v4"] }
-vantage-types = { version = "0.4", path = "../vantage-types" }
-vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-types = { version = "0.5", path = "../vantage-types" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
 paste = "1.0"
 indexmap = "2.14"

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,36 +1,77 @@
 # Changelog
 
+## 0.5.5 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.4 — 2026-05-23
 
-- Doc comment touch-ups tracking [vantage-table 0.5.2](https://docs.rs/vantage-table/0.5.2/vantage_table/)'s `AnyTable` removal. No code change.
+- Doc comment touch-ups tracking
+  [vantage-table 0.5.2](https://docs.rs/vantage-table/0.5.2/vantage_table/)'s `AnyTable` removal. No
+  code change.
 
 ## 0.5.3 — 2026-05-23
 
-- Dep-pin bump on `vantage-dataset` to 0.5; tracks the `ImTable` / `ImDataSource` parametrization. No public API change.
+- Dep-pin bump on `vantage-dataset` to 0.5; tracks the `ImTable` / `ImDataSource` parametrization.
+  No public API change.
 
 ## 0.5.2 — 2026-05-23
 
-- GraphQL Vista shell rewritten on a typed `Table<GraphqlApi, EmptyEntity>` — `AnyTable` is gone from the GraphQL path. `GraphqlApiTableShell` converts `AnyGraphqlType` ↔ [`CborValue`](https://docs.rs/ciborium/latest/ciborium/value/enum.Value.html) at the Vista boundary via the symmetric `From` impls; the typed table keeps the native value flow for filters and reference traversal.
-- `GraphqlApiTableShell::get_ref` now resolves children through [`Table::get_ref_from_row`](https://docs.rs/vantage-table/0.5.0/vantage_table/table/struct.Table.html#method.get_ref_from_row) + a fresh `GraphqlApiVistaFactory::from_table` wrap — same row-based traversal pattern as REST / MongoDB / SQL.
-- [`GraphqlApi::eq_value_condition`](https://docs.rs/vantage-table/0.5.0/vantage_table/traits/table_source/trait.TableSource.html#method.eq_value_condition) implemented so `Reference::resolve_from_row` can push a row-derived `AnyGraphqlType` join key without a string round-trip.
-- `GraphqlApiTableShell` implements `get_ref_kinds` via the typed table's reference registry. Vista metadata's `references` map now carries real cardinality flags (`HasOne` / `HasMany`) instead of the placeholder `HasMany`; target name and FK column remain blank because the typed `Reference` doesn't expose them.
+- GraphQL Vista shell rewritten on a typed `Table<GraphqlApi, EmptyEntity>` — `AnyTable` is gone
+  from the GraphQL path. `GraphqlApiTableShell` converts `AnyGraphqlType` ↔
+  [`CborValue`](https://docs.rs/ciborium/latest/ciborium/value/enum.Value.html) at the Vista
+  boundary via the symmetric `From` impls; the typed table keeps the native value flow for filters
+  and reference traversal.
+- `GraphqlApiTableShell::get_ref` now resolves children through
+  [`Table::get_ref_from_row`](https://docs.rs/vantage-table/0.5.0/vantage_table/table/struct.Table.html#method.get_ref_from_row) +
+  a fresh `GraphqlApiVistaFactory::from_table` wrap — same row-based traversal pattern as REST /
+  MongoDB / SQL.
+- [`GraphqlApi::eq_value_condition`](https://docs.rs/vantage-table/0.5.0/vantage_table/traits/table_source/trait.TableSource.html#method.eq_value_condition)
+  implemented so `Reference::resolve_from_row` can push a row-derived `AnyGraphqlType` join key
+  without a string round-trip.
+- `GraphqlApiTableShell` implements `get_ref_kinds` via the typed table's reference registry. Vista
+  metadata's `references` map now carries real cardinality flags (`HasOne` / `HasMany`) instead of
+  the placeholder `HasMany`; target name and FK column remain blank because the typed `Reference`
+  doesn't expose them.
 - Removed `graphql/vista/any_shell.rs` — no remaining consumers.
-- Removed `tests/any_table.rs` — both halves are gone now that neither shell routes through `AnyTable`.
+- Removed `tests/any_table.rs` — both halves are gone now that neither shell routes through
+  `AnyTable`.
 
 ## 0.5.1 — 2026-05-23
 
-- REST Vista shell no longer routes typed `Table::with_many` / `with_one` references through `AnyTable`. `RestApiTableShell` now carries a typed `Table<RestApi, EmptyEntity>` and `TableShell::get_ref` resolves children via [`Table::get_ref_from_row`](https://docs.rs/vantage-table/0.5.0/vantage_table/table/struct.Table.html#method.get_ref_from_row) + a fresh `RestApiVistaFactory::from_table` wrap — mirroring the pattern used by the MongoDB, SQL, and SurrealDB drivers.
-- [`RestApi::eq_value_condition`](https://docs.rs/vantage-table/0.5.0/vantage_table/traits/table_source/trait.TableSource.html#method.eq_value_condition) implemented so `Reference::resolve_from_row` can push a row-derived `CborValue` join key onto a child REST table without a string round-trip.
-- `AnyTableShell` is no longer re-exported from `vantage_api_client::rest` (or the crate root / `prelude`). The legacy adapter survives as a `pub(crate)` helper under `graphql::vista` only as long as the GraphQL shell still wraps `AnyTable`; the matching GraphQL rewrite ships in the next release.
-- `tests/any_table.rs` drops the REST half — REST no longer participates in the `AnyTable::from_table` blanket bridge from the Vista layer. The GraphQL half stays until the GraphQL shell is rewritten.
+- REST Vista shell no longer routes typed `Table::with_many` / `with_one` references through
+  `AnyTable`. `RestApiTableShell` now carries a typed `Table<RestApi, EmptyEntity>` and
+  `TableShell::get_ref` resolves children via
+  [`Table::get_ref_from_row`](https://docs.rs/vantage-table/0.5.0/vantage_table/table/struct.Table.html#method.get_ref_from_row) +
+  a fresh `RestApiVistaFactory::from_table` wrap — mirroring the pattern used by the MongoDB, SQL,
+  and SurrealDB drivers.
+- [`RestApi::eq_value_condition`](https://docs.rs/vantage-table/0.5.0/vantage_table/traits/table_source/trait.TableSource.html#method.eq_value_condition)
+  implemented so `Reference::resolve_from_row` can push a row-derived `CborValue` join key onto a
+  child REST table without a string round-trip.
+- `AnyTableShell` is no longer re-exported from `vantage_api_client::rest` (or the crate root /
+  `prelude`). The legacy adapter survives as a `pub(crate)` helper under `graphql::vista` only as
+  long as the GraphQL shell still wraps `AnyTable`; the matching GraphQL rewrite ships in the next
+  release.
+- `tests/any_table.rs` drops the REST half — REST no longer participates in the
+  `AnyTable::from_table` blanket bridge from the Vista layer. The GraphQL half stays until the
+  GraphQL shell is rewritten.
 
 ## 0.5.0 — 2026-05-23
 
-- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle, aligning with the rest of the workspace. No code changes beyond the dependency pin.
+- Bumped to the 0.5 line to track
+  [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the
+  `AnyTable` decommission cycle, aligning with the rest of the workspace. No code changes beyond the
+  dependency pin.
 
 ## 0.1.9 — 2026-05-18
 
-- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. `RestApiTableShell`, `GraphqlApiTableShell`, and `AnyTableShell` now own their [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implement the new `columns` / `references` / `id_column` shell methods. Factory call sites — `RestApi::vista_factory(...).from_yaml(...)`, `AnyTableShell::into_vista_with(...)` — are unchanged.
+- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s
+  schema-on-source refactor. `RestApiTableShell`, `GraphqlApiTableShell`, and `AnyTableShell` now
+  own their
+  [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html)
+  and implement the new `columns` / `references` / `id_column` shell methods. Factory call sites —
+  `RestApi::vista_factory(...).from_yaml(...)`, `AnyTableShell::into_vista_with(...)` — are
+  unchanged.
 - Pins `vantage-vista = "0.4.10"`.
 
 ## 0.1.8 — 2026-05-16
@@ -39,58 +80,140 @@
 
 ## 0.1.7 — 2026-05-16
 
-- REST and GraphQL `TableShell::get_ref` impls updated for [`Vista::get_ref(relation, &row)`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.get_ref)'s row-based signature.
-- REST's YAML-driven traversal drops the `DeferredFn`-based parent-fetch dance: with the parent row passed in, the shell reads the join field directly and pushes a plain eq-condition on the resolver-built child Vista. The `with_model_resolver` callback survives for cross-driver inventory routing.
-- The YAML factory's `ReferenceKind::HasForeign → HasMany` workaround is gone now that `ReferenceKind` is two-variant; declared cardinality flows straight through to the child Vista.
+- REST and GraphQL `TableShell::get_ref` impls updated for
+  [`Vista::get_ref(relation, &row)`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.get_ref)'s
+  row-based signature.
+- REST's YAML-driven traversal drops the `DeferredFn`-based parent-fetch dance: with the parent row
+  passed in, the shell reads the join field directly and pushes a plain eq-condition on the
+  resolver-built child Vista. The `with_model_resolver` callback survives for cross-driver inventory
+  routing.
+- The YAML factory's `ReferenceKind::HasForeign → HasMany` workaround is gone now that
+  `ReferenceKind` is two-variant; declared cardinality flows straight through to the child Vista.
 - Pins `vantage-vista = "0.4.7"`, `vantage-table = "0.4.10"`.
 
 ## 0.1.6 — 2026-05-16
 
-GraphQL joins REST inside `vantage-api-client`. The crate is now home to two protocol adapters, with a YAML-driven Vista bridge for each. The example wires the SpaceX public GraphQL API end-to-end.
+GraphQL joins REST inside `vantage-api-client`. The crate is now home to two protocol adapters, with
+a YAML-driven Vista bridge for each. The example wires the SpaceX public GraphQL API end-to-end.
 
-- **Breaking**: REST internals moved under `vantage_api_client::rest::*`. Crate-root re-exports (`RestApi`, `RestApiBuilder`, `ResponseShape`, `PaginationParams`, `eq_condition`, `AnyTableShell`, `RestApiTableShell`, `RestApiVistaFactory`, `RestApiVistaSpec`, `NoApiExtras`) are unchanged, so most consumers compile without edits. Code that imported through `vantage_api_client::vista::*` directly now lives at `vantage_api_client::rest::vista::*`.
-- **New**: [`GraphqlApi`](https://docs.rs/vantage-api-client/0.1.6/vantage_api_client/struct.GraphqlApi.html) — POST-based GraphQL data source. Renders typed query documents with inline filters and `$limit`/`$offset` variables. Two filter dialects ship out of the box: `Hasura` (`where: { field: { _eq: v } }`) and `Generic` (`(find: { field: v })`, for hand-rolled schemas like SpaceX).
-- **New**: [`GraphqlApiVistaFactory`](https://docs.rs/vantage-api-client/0.1.6/vantage_api_client/struct.GraphqlApiVistaFactory.html) — builds a Vista from either a typed `Table<GraphqlApi, E>` or a hand-maintained YAML schema (`build_from_spec`). The YAML carries per-table `graphql:` blocks for `root_field`, `dialect`, and `filter_arg` overrides; column types map to typed Vantage columns (`int`, `bigint`, `bool`, `float`, `string`, `datetime`, `date`, `time`, `uuid`, `json`).
-- **New**: typed condition operators via [`GraphqlOperation`](https://docs.rs/vantage-api-client/0.1.6/vantage_api_client/trait.GraphqlOperation.html) — `.eq()`, `.ne()`, `.gt()`/`.gte()`/`.lt()`/`.lte()`, `.in_()`, `.like()`/`.ilike()`, `.is_null()`/`.is_not_null()`. Blanket-implemented over `Expressive<T>` so typed columns get them for free.
-- **New**: relationship traversal via `with_many`/`with_one`. The adapter peels existing parent eq-conditions in-sync and falls back to async `DeferredField` resolution otherwise; both paths render dialect-correct (`_eq` for Hasura, flat for Generic).
-- **New**: [`AnyGraphqlType`](https://docs.rs/vantage-api-client/0.1.6/vantage_api_client/struct.AnyGraphqlType.html) — type-erased value wrapping `serde_json::Value` with a 15-variant scalar enum (`Null`, `Bool`, `Int`, `BigInt`, `Float`, `String`, `Id`, `DateTime`, `Date`, `Time`, `Uuid`, `Decimal`, `Json`, `Object`, `Array`). Built-in Rust impls cover `bool`, `i32`/`i64`/`f64`, `String`/`&str`, `chrono::DateTime<Utc>`/`NaiveDate`/`NaiveTime`, `uuid::Uuid`, `serde_json::Value`, `Vec<AnyGraphqlType>`, `IndexMap<String, AnyGraphqlType>`. Downstream crates can plug their own types onto existing variants, or call `vantage_type_system!` a second time for a fresh variant set (e.g. a `vantage-graphql-geo` extension).
-- **New**: `prelude` module for one-shot imports of both protocols. CBOR bridges round-trip cleanly through `AnyTable`, so a `Vec<AnyTable>` can mix REST and GraphQL tables.
-- **New example**: `examples/graphql_spacex.rs` — YAML-driven CLI over the public SpaceX GraphQL API. Ten entities (`launches`, `rockets`, `capsules`, `cores`, `ships`, `payloads`, `missions`, `dragons`, `landpads`, `launchpads`) in `examples/schema/*.yaml`. Run `cargo run --example graphql_spacex -- launches`. Endpoint overridable via `$SPACEX_ENDPOINT`.
+- **Breaking**: REST internals moved under `vantage_api_client::rest::*`. Crate-root re-exports
+  (`RestApi`, `RestApiBuilder`, `ResponseShape`, `PaginationParams`, `eq_condition`,
+  `AnyTableShell`, `RestApiTableShell`, `RestApiVistaFactory`, `RestApiVistaSpec`, `NoApiExtras`)
+  are unchanged, so most consumers compile without edits. Code that imported through
+  `vantage_api_client::vista::*` directly now lives at `vantage_api_client::rest::vista::*`.
+- **New**:
+  [`GraphqlApi`](https://docs.rs/vantage-api-client/0.1.6/vantage_api_client/struct.GraphqlApi.html)
+  — POST-based GraphQL data source. Renders typed query documents with inline filters and
+  `$limit`/`$offset` variables. Two filter dialects ship out of the box: `Hasura`
+  (`where: { field: { _eq: v } }`) and `Generic` (`(find: { field: v })`, for hand-rolled schemas
+  like SpaceX).
+- **New**:
+  [`GraphqlApiVistaFactory`](https://docs.rs/vantage-api-client/0.1.6/vantage_api_client/struct.GraphqlApiVistaFactory.html)
+  — builds a Vista from either a typed `Table<GraphqlApi, E>` or a hand-maintained YAML schema
+  (`build_from_spec`). The YAML carries per-table `graphql:` blocks for `root_field`, `dialect`, and
+  `filter_arg` overrides; column types map to typed Vantage columns (`int`, `bigint`, `bool`,
+  `float`, `string`, `datetime`, `date`, `time`, `uuid`, `json`).
+- **New**: typed condition operators via
+  [`GraphqlOperation`](https://docs.rs/vantage-api-client/0.1.6/vantage_api_client/trait.GraphqlOperation.html)
+  — `.eq()`, `.ne()`, `.gt()`/`.gte()`/`.lt()`/`.lte()`, `.in_()`, `.like()`/`.ilike()`,
+  `.is_null()`/`.is_not_null()`. Blanket-implemented over `Expressive<T>` so typed columns get them
+  for free.
+- **New**: relationship traversal via `with_many`/`with_one`. The adapter peels existing parent
+  eq-conditions in-sync and falls back to async `DeferredField` resolution otherwise; both paths
+  render dialect-correct (`_eq` for Hasura, flat for Generic).
+- **New**:
+  [`AnyGraphqlType`](https://docs.rs/vantage-api-client/0.1.6/vantage_api_client/struct.AnyGraphqlType.html)
+  — type-erased value wrapping `serde_json::Value` with a 15-variant scalar enum (`Null`, `Bool`,
+  `Int`, `BigInt`, `Float`, `String`, `Id`, `DateTime`, `Date`, `Time`, `Uuid`, `Decimal`, `Json`,
+  `Object`, `Array`). Built-in Rust impls cover `bool`, `i32`/`i64`/`f64`, `String`/`&str`,
+  `chrono::DateTime<Utc>`/`NaiveDate`/`NaiveTime`, `uuid::Uuid`, `serde_json::Value`,
+  `Vec<AnyGraphqlType>`, `IndexMap<String, AnyGraphqlType>`. Downstream crates can plug their own
+  types onto existing variants, or call `vantage_type_system!` a second time for a fresh variant set
+  (e.g. a `vantage-graphql-geo` extension).
+- **New**: `prelude` module for one-shot imports of both protocols. CBOR bridges round-trip cleanly
+  through `AnyTable`, so a `Vec<AnyTable>` can mix REST and GraphQL tables.
+- **New example**: `examples/graphql_spacex.rs` — YAML-driven CLI over the public SpaceX GraphQL
+  API. Ten entities (`launches`, `rockets`, `capsules`, `cores`, `ships`, `payloads`, `missions`,
+  `dragons`, `landpads`, `launchpads`) in `examples/schema/*.yaml`. Run
+  `cargo run --example graphql_spacex -- launches`. Endpoint overridable via `$SPACEX_ENDPOINT`.
 - Dependencies added: `chrono`, `uuid`, `paste` (runtime).
 
 ## 0.1.5 — 2026-05-15
 
-YAML-driven model definitions: describe a REST resource in YAML, accumulate a registry, and traverse references — including across models defined in separate YAML files — without writing Rust factory closures.
+YAML-driven model definitions: describe a REST resource in YAML, accumulate a registry, and traverse
+references — including across models defined in separate YAML files — without writing Rust factory
+closures.
 
-- [`RestApiVistaFactory::register_yaml(&str)`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.RestApiVistaFactory.html#method.register_yaml) parses a `RestApiVistaSpec` and stashes it under `spec.name`. [`build(name)`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.RestApiVistaFactory.html#method.build) materialises a `Vista` on demand; references resolve through the same registry so a parent's `:relation` traversal finds the child's spec without further wiring.
-- New table-level `api` block carries `endpoint: parent/{parentId}/child` for APIs that require path-based filtering. Defaults to `spec.name` when absent — declaring `name: users` is enough for a plain `/users` resource.
-- [`RestApiVistaFactory::with_model_resolver(Arc<dyn Fn(&str) -> Result<Vista>>)`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.RestApiVistaFactory.html#method.with_model_resolver) installs a callback that overrides the internal registry — for cross-driver setups (e.g. a UI shell whose inventory layer routes some models through SQL and others through REST) the resolver decides which factory builds each name.
-- Cross-cutting public types: [`ApiTableExtras`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.ApiTableExtras.html), [`ApiTableBlock`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.ApiTableBlock.html), `ApiColumnExtras`, `ApiReferenceExtras`, and [`ModelResolver`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/type.ModelResolver.html). `NoApiExtras` stays as a legacy alias.
-- New `examples/jsonplaceholder_yaml.rs` — same demo as `jsonplaceholder` with all three models in `data/jsonplaceholder/*.yaml`. Run `cargo run --example jsonplaceholder_yaml -- users id=1 :albums :photos`.
+- [`RestApiVistaFactory::register_yaml(&str)`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.RestApiVistaFactory.html#method.register_yaml)
+  parses a `RestApiVistaSpec` and stashes it under `spec.name`.
+  [`build(name)`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.RestApiVistaFactory.html#method.build)
+  materialises a `Vista` on demand; references resolve through the same registry so a parent's
+  `:relation` traversal finds the child's spec without further wiring.
+- New table-level `api` block carries `endpoint: parent/{parentId}/child` for APIs that require
+  path-based filtering. Defaults to `spec.name` when absent — declaring `name: users` is enough for
+  a plain `/users` resource.
+- [`RestApiVistaFactory::with_model_resolver(Arc<dyn Fn(&str) -> Result<Vista>>)`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.RestApiVistaFactory.html#method.with_model_resolver)
+  installs a callback that overrides the internal registry — for cross-driver setups (e.g. a UI
+  shell whose inventory layer routes some models through SQL and others through REST) the resolver
+  decides which factory builds each name.
+- Cross-cutting public types:
+  [`ApiTableExtras`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.ApiTableExtras.html),
+  [`ApiTableBlock`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/struct.ApiTableBlock.html),
+  `ApiColumnExtras`, `ApiReferenceExtras`, and
+  [`ModelResolver`](https://docs.rs/vantage-api-client/0.1.5/vantage_api_client/type.ModelResolver.html).
+  `NoApiExtras` stays as a legacy alias.
+- New `examples/jsonplaceholder_yaml.rs` — same demo as `jsonplaceholder` with all three models in
+  `data/jsonplaceholder/*.yaml`. Run
+  `cargo run --example jsonplaceholder_yaml -- users id=1 :albums :photos`.
 
 ## 0.1.4 — 2026-05-14
 
-REST API now speaks [`ciborium::Value`](https://docs.rs/ciborium/) end-to-end and bridges into the universal [`Vista`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html) surface.
+REST API now speaks [`ciborium::Value`](https://docs.rs/ciborium/) end-to-end and bridges into the
+universal [`Vista`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html) surface.
 
-- **Breaking**: `RestApi::Value` is now `ciborium::Value` instead of `serde_json::Value`. `eq_condition(field, value)` accepts anything that implements `Into<CborValue>` — so `eq_condition("userId", 1i64)` and `eq_condition("name", "Alice")` work without a wrapper macro. Existing callers passing `json!(...)` need to switch to the matching CBOR variant. Records returned from `list_values` carry `Record<CborValue>` now, which means master tables wrap into `AnyTable::from_table` directly — no JSON↔CBOR adapter boilerplate at the call site.
-- URI templates in table names get substituted from eq-conditions at request time. Declare a child table as `Table::new("users/{userId}/albums", api)` and a parent's `id=1` condition lowers to `GET /users/1/albums`, with `userId` peeled out of the query string. Lets `with_many` / `with_one` traversal hit nested REST endpoints natively.
-- [`related_in_condition`](https://docs.rs/vantage-api-client/0.1.4/vantage_api_client/struct.RestApi.html) is implemented: `with_many` re-keys an existing eq-condition onto the child's FK field, and `with_one` resolves the parent record on demand through a deferred condition that's executed at fetch time. No more `unimplemented!()` panic for REST API references.
-- New [`vista_factory`](https://docs.rs/vantage-api-client/0.1.4/vantage_api_client/struct.RestApi.html#method.vista_factory) method returns a `RestApiVistaFactory` that wraps a typed `Table<RestApi, E>` as a `Vista`. Columns, id field, title fields, and references are harvested up front; the original entity stays attached for reference traversal.
-- New `examples/jsonplaceholder.rs` demo — model-driven CLI over <https://jsonplaceholder.typicode.com> using the new Vista bridge and the `vista_cli` runner from [`vantage-cli-util 0.4.2`](https://docs.rs/vantage-cli-util/0.4.2/vantage_cli_util/). Run `cargo run --example jsonplaceholder -- users id=1 :albums`.
+- **Breaking**: `RestApi::Value` is now `ciborium::Value` instead of `serde_json::Value`.
+  `eq_condition(field, value)` accepts anything that implements `Into<CborValue>` — so
+  `eq_condition("userId", 1i64)` and `eq_condition("name", "Alice")` work without a wrapper macro.
+  Existing callers passing `json!(...)` need to switch to the matching CBOR variant. Records
+  returned from `list_values` carry `Record<CborValue>` now, which means master tables wrap into
+  `AnyTable::from_table` directly — no JSON↔CBOR adapter boilerplate at the call site.
+- URI templates in table names get substituted from eq-conditions at request time. Declare a child
+  table as `Table::new("users/{userId}/albums", api)` and a parent's `id=1` condition lowers to
+  `GET /users/1/albums`, with `userId` peeled out of the query string. Lets `with_many` / `with_one`
+  traversal hit nested REST endpoints natively.
+- [`related_in_condition`](https://docs.rs/vantage-api-client/0.1.4/vantage_api_client/struct.RestApi.html)
+  is implemented: `with_many` re-keys an existing eq-condition onto the child's FK field, and
+  `with_one` resolves the parent record on demand through a deferred condition that's executed at
+  fetch time. No more `unimplemented!()` panic for REST API references.
+- New
+  [`vista_factory`](https://docs.rs/vantage-api-client/0.1.4/vantage_api_client/struct.RestApi.html#method.vista_factory)
+  method returns a `RestApiVistaFactory` that wraps a typed `Table<RestApi, E>` as a `Vista`.
+  Columns, id field, title fields, and references are harvested up front; the original entity stays
+  attached for reference traversal.
+- New `examples/jsonplaceholder.rs` demo — model-driven CLI over
+  <https://jsonplaceholder.typicode.com> using the new Vista bridge and the `vista_cli` runner from
+  [`vantage-cli-util 0.4.2`](https://docs.rs/vantage-cli-util/0.4.2/vantage_cli_util/). Run
+  `cargo run --example jsonplaceholder -- users id=1 :albums`.
 
 ## 0.1.3 — 2026-05-09
 
-Opt-in [`RestApiBuilder::no_pagination()`](https://docs.rs/vantage-api-client/0.1.3/vantage_api_client/struct.RestApiBuilder.html#method.no_pagination) for APIs that don't paginate. ([#230](https://github.com/romaninsh/vantage/pull/230))
+Opt-in
+[`RestApiBuilder::no_pagination()`](https://docs.rs/vantage-api-client/0.1.3/vantage_api_client/struct.RestApiBuilder.html#method.no_pagination)
+for APIs that don't paginate. ([#230](https://github.com/romaninsh/vantage/pull/230))
 
 ```rust
 let api = RestApi::builder(base_url).no_pagination().build();
 ```
 
-FastAPI / Pydantic services often treat unknown query params as strict filters and silently return empty rows, so adding `_page=1&_limit=50` makes the response empty. Setting this stops vantage from sending those params, and a perpetual grid asking for page > 1 short-circuits to an empty result so it actually marks itself exhausted instead of looping. Default behaviour is unchanged.
+FastAPI / Pydantic services often treat unknown query params as strict filters and silently return
+empty rows, so adding `_page=1&_limit=50` makes the response empty. Setting this stops vantage from
+sending those params, and a perpetual grid asking for page > 1 short-circuits to an empty result so
+it actually marks itself exhausted instead of looping. Default behaviour is unchanged.
 
 ## 0.1.2 — 2026-04-26
 
-`RestApi::builder` now configures response shape and pagination convention, so the same client works against APIs with different conventions:
+`RestApi::builder` now configures response shape and pagination convention, so the same client works
+against APIs with different conventions:
 
 ```rust
 use vantage_api_client::{RestApi, ResponseShape, PaginationParams, eq_condition};
@@ -124,10 +247,20 @@ comments.add_condition(eq_condition("postId", json!(1)));
 
 What's new:
 
-- `RestApi::builder(base_url)` builder. Methods: `.auth(value)`, `.response_shape(shape)`, `.pagination_params(params)`, `.build()`. The legacy `RestApi::new(url)` still works and matches the 0.1.x default.
-- `ResponseShape::{BareArray, Wrapped { array_key }, WrappedByTableName}` — covers most public-API shapes (bare arrays like JSONPlaceholder/GitHub, wrapped-under-fixed-key like the legacy default, wrapped-under-table-name like DummyJSON).
-- `PaginationParams::page_limit(page, limit)` — 1-based page index (JSON Server convention). `PaginationParams::skip_limit(skip, limit)` — 0-based item offset (DummyJSON convention). `RestApi` now appends pagination to the URL when a `Pagination` is set on the wrapping `Table`.
-- `eq_condition(field, value)` helper for building conditions on `Table<RestApi, _>`. Required because Rust's orphan rule blocks `Expressive<serde_json::Value>` impls for primitive types in this crate. Conditions added via `add_condition` are translated to URL query params on `list_values` (`?field=value`); multiple conditions AND together. Non-eq operators are silently skipped for now.
+- `RestApi::builder(base_url)` builder. Methods: `.auth(value)`, `.response_shape(shape)`,
+  `.pagination_params(params)`, `.build()`. The legacy `RestApi::new(url)` still works and matches
+  the 0.1.x default.
+- `ResponseShape::{BareArray, Wrapped { array_key }, WrappedByTableName}` — covers most public-API
+  shapes (bare arrays like JSONPlaceholder/GitHub, wrapped-under-fixed-key like the legacy default,
+  wrapped-under-table-name like DummyJSON).
+- `PaginationParams::page_limit(page, limit)` — 1-based page index (JSON Server convention).
+  `PaginationParams::skip_limit(skip, limit)` — 0-based item offset (DummyJSON convention).
+  `RestApi` now appends pagination to the URL when a `Pagination` is set on the wrapping `Table`.
+- `eq_condition(field, value)` helper for building conditions on `Table<RestApi, _>`. Required
+  because Rust's orphan rule blocks `Expressive<serde_json::Value>` impls for primitive types in
+  this crate. Conditions added via `add_condition` are translated to URL query params on
+  `list_values` (`?field=value`); multiple conditions AND together. Non-eq operators are silently
+  skipped for now.
 - `urlencoding` joins the runtime deps so query params get encoded properly.
 
 ## 0.1.1 — 2026-04-19

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.5.4"
+version = "0.5.5"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"
@@ -18,12 +18,12 @@ serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml_ng = "0.10"
 urlencoding = "2.1"
 uuid = { version = "1", features = ["serde"] }
-vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
-vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
-vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.4.10", path = "../vantage-vista" }
+vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/vantage-api-pool/CHANGELOG.md
+++ b/vantage-api-pool/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## 0.5.2 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.0 — 2026-05-23
 
-- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle, aligning with the rest of the workspace. No code changes beyond the dependency pin.
+- Bumped to the 0.5 line to track
+  [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the
+  `AnyTable` decommission cycle, aligning with the rest of the workspace. No code changes beyond the
+  dependency pin.
 
 ## 0.1.4 — 2026-05-16
 
@@ -14,8 +21,12 @@
 
 ## 0.1.2 — 2026-05-03
 
-- HTTP worker pool, request/response matcher, and all paginator variants now wrap their spawned futures with `tracing::Instrument::in_current_span()` so the caller's span follows the future across the `tokio::spawn` boundary. Any tracing layer the consumer installs sees background-task events as descendants of the originating request.
-- `eprintln!` calls in the worker, matcher, and retry paths replaced with `tracing::warn!` / `error!` so subscribers actually see them. `tracing` becomes a direct dependency.
+- HTTP worker pool, request/response matcher, and all paginator variants now wrap their spawned
+  futures with `tracing::Instrument::in_current_span()` so the caller's span follows the future
+  across the `tokio::spawn` boundary. Any tracing layer the consumer installs sees background-task
+  events as descendants of the originating request.
+- `eprintln!` calls in the worker, matcher, and retry paths replaced with `tracing::warn!` /
+  `error!` so subscribers actually see them. `tracing` becomes a direct dependency.
 
 ## 0.1.1 — 2026-04-19
 

--- a/vantage-api-pool/Cargo.toml
+++ b/vantage-api-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "vantage-api-pool"
-version = "0.5.1"
+version = "0.5.2"
 license = "MIT OR Apache-2.0"
 description = "Paginated REST API client pool for Vantage"
 
@@ -19,11 +19,11 @@ tracing = "0.1"
 async-trait = "0.1"
 indexmap = { version = "2", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
-vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
-vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
-vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["serde"] }
+vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,136 +1,343 @@
 # Changelog
 
+## 0.5.3 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.1 — 2026-05-23
 
-- `Factory::for_name` / `Factory::from_arn` now return [`Vista`](https://docs.rs/vantage-vista/0.4/vantage_vista/struct.Vista.html) directly — the dual AnyTable / Vista API from 0.4.10 collapses into a single Vista path. The `vista_for_name` / `vista_from_arn` shims are gone (rename callers to `for_name` / `from_arn`).
-- The optional `vista` cargo feature is removed; the `vantage-vista` dependency is now unconditional. `vantage_aws::vista::*` is always available.
+- `Factory::for_name` / `Factory::from_arn` now return
+  [`Vista`](https://docs.rs/vantage-vista/0.4/vantage_vista/struct.Vista.html) directly — the dual
+  AnyTable / Vista API from 0.4.10 collapses into a single Vista path. The `vista_for_name` /
+  `vista_from_arn` shims are gone (rename callers to `for_name` / `from_arn`).
+- The optional `vista` cargo feature is removed; the `vantage-vista` dependency is now
+  unconditional. `vantage_aws::vista::*` is always available.
 - `aws-cli` example drops its `required-features = ["vista"]` gate now that there's only one path.
-- `dynamo-single-table` example removed — it was the last in-tree user of the legacy `model_cli` runner (the `AnyTable`-based one), and migrating it to `vista_cli` is left as a follow-up. The multi-service `aws-cli` example still demonstrates the same Vista patterns against real AWS endpoints.
+- `dynamo-single-table` example removed — it was the last in-tree user of the legacy `model_cli`
+  runner (the `AnyTable`-based one), and migrating it to `vista_cli` is left as a follow-up. The
+  multi-service `aws-cli` example still demonstrates the same Vista patterns against real AWS
+  endpoints.
 
 ## 0.5.0 — 2026-05-23
 
-- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+- Bumped to the 0.5 line to track
+  [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the
+  `AnyTable` decommission cycle. No code changes beyond the dependency pin.
 
 ## 0.4.10 — 2026-05-23
 
-The AWS backend now plugs into the universal Vista layer — wrap a typed `Table<AwsAccount, E>` with [`AwsAccount::vista_factory().from_table(...)`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/vista/struct.AwsVistaFactory.html#method.from_table) and the resulting [`Vista`](https://docs.rs/vantage-vista/0.4/vantage_vista/struct.Vista.html) carries the same column metadata, id field, title columns, and `with_one` / `with_many` relations as the typed table.
+The AWS backend now plugs into the universal Vista layer — wrap a typed `Table<AwsAccount, E>` with
+[`AwsAccount::vista_factory().from_table(...)`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/vista/struct.AwsVistaFactory.html#method.from_table)
+and the resulting [`Vista`](https://docs.rs/vantage-vista/0.4/vantage_vista/struct.Vista.html)
+carries the same column metadata, id field, title columns, and `with_one` / `with_many` relations as
+the typed table.
 
-- New `vista` cargo feature on `vantage-aws` (off by default) brings in [`vantage_aws::vista`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/vista/index.html). The driver advertises `can_count` only — AWS is read-only at this stage; writes, ordering, search, and explicit paging all return `ErrorKind::Unsupported`.
-- [`Factory::vista_for_name`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/models/struct.Factory.html#method.vista_for_name) and [`Factory::vista_from_arn`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/models/struct.Factory.html#method.vista_from_arn) mirror the existing `for_name` / `from_arn` dispatch but return `Vista`s instead of `AnyTable`s.
-- `aws-cli` rewires onto [`vantage_cli_util::vista_cli`](https://docs.rs/vantage-cli-util/0.4/vantage_cli_util/vista_cli/index.html). Picks up the full grammar — operator suffixes (`field:lt=…`), sort selectors (`[+name]`), column overrides (`=col1,col2`), search (`?term`), aggregates (`@count`, `@sum:field`), and `--format=json|ndjson|cbor-diag` for non-table output. The example now lives behind the `vista` feature.
-- S3 `301 PermanentRedirect` errors are translated into an actionable hint that names the bucket's actual region and tells you how to re-run — no more raw XML in the terminal.
-- `TableSource::eq_value_condition` lets `Reference::resolve_from_row` push typed `CborValue` join values through without round-tripping via `to_string`, which mattered for relations whose key isn't text (timestamps, numeric ids).
+- New `vista` cargo feature on `vantage-aws` (off by default) brings in
+  [`vantage_aws::vista`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/vista/index.html). The
+  driver advertises `can_count` only — AWS is read-only at this stage; writes, ordering, search, and
+  explicit paging all return `ErrorKind::Unsupported`.
+- [`Factory::vista_for_name`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/models/struct.Factory.html#method.vista_for_name)
+  and
+  [`Factory::vista_from_arn`](https://docs.rs/vantage-aws/0.4.10/vantage_aws/models/struct.Factory.html#method.vista_from_arn)
+  mirror the existing `for_name` / `from_arn` dispatch but return `Vista`s instead of `AnyTable`s.
+- `aws-cli` rewires onto
+  [`vantage_cli_util::vista_cli`](https://docs.rs/vantage-cli-util/0.4/vantage_cli_util/vista_cli/index.html).
+  Picks up the full grammar — operator suffixes (`field:lt=…`), sort selectors (`[+name]`), column
+  overrides (`=col1,col2`), search (`?term`), aggregates (`@count`, `@sum:field`), and
+  `--format=json|ndjson|cbor-diag` for non-table output. The example now lives behind the `vista`
+  feature.
+- S3 `301 PermanentRedirect` errors are translated into an actionable hint that names the bucket's
+  actual region and tells you how to re-run — no more raw XML in the terminal.
+- `TableSource::eq_value_condition` lets `Reference::resolve_from_row` push typed `CborValue` join
+  values through without round-tripping via `to_string`, which mattered for relations whose key
+  isn't text (timestamps, numeric ids).
 
 ## 0.4.9 — 2026-05-16
 
-- Lambda's `Function` table drops the `with_foreign("log_group", …)` declaration: the typed-Table `with_foreign` mechanism is removed in `vantage-table 0.4.10` (cross-persistence refs move to the Vista layer). The inherent `Function::ref_log_group(aws)` helper still returns a `Table<AwsAccount, LogGroup>` for direct typed use; the universal-Vista form returns once `vantage-aws` gains a Vista factory.
+- Lambda's `Function` table drops the `with_foreign("log_group", …)` declaration: the typed-Table
+  `with_foreign` mechanism is removed in `vantage-table 0.4.10` (cross-persistence refs move to the
+  Vista layer). The inherent `Function::ref_log_group(aws)` helper still returns a
+  `Table<AwsAccount, LogGroup>` for direct typed use; the universal-Vista form returns once
+  `vantage-aws` gains a Vista factory.
 - Pins `vantage-table = "0.4.10"`.
 
 ## 0.4.8 — 2026-05-14
 
-- JSON-1.x `execute` now follows `nextToken` pagination directly (capped at 50 pages) — CloudWatch's `FilterLogEvents` and friends can return `events: []` plus a token while the log group is still being scanned, so a one-shot call would drop matches. Pages are merged under the operation's `array_key` and handed to `parse_records` as one synthesised response. Existing single-page protocols are unaffected. See [`vantage_aws::json1`](https://docs.rs/vantage-aws/0.4.8/vantage_aws/json1/index.html).
-- New [`vantage-aws/TODO.md`](https://github.com/romaninsh/vantage/blob/main/vantage-aws/TODO.md) documents the composite-key `get_value` gap on DynamoDB single-table designs (UI sheets on HASH+RANGE tables hit `ValidationException` today) along with the proposed `DynamoId` widening and condition-merge fix.
+- JSON-1.x `execute` now follows `nextToken` pagination directly (capped at 50 pages) — CloudWatch's
+  `FilterLogEvents` and friends can return `events: []` plus a token while the log group is still
+  being scanned, so a one-shot call would drop matches. Pages are merged under the operation's
+  `array_key` and handed to `parse_records` as one synthesised response. Existing single-page
+  protocols are unaffected. See
+  [`vantage_aws::json1`](https://docs.rs/vantage-aws/0.4.8/vantage_aws/json1/index.html).
+- New [`vantage-aws/TODO.md`](https://github.com/romaninsh/vantage/blob/main/vantage-aws/TODO.md)
+  documents the composite-key `get_value` gap on DynamoDB single-table designs (UI sheets on
+  HASH+RANGE tables hit `ValidationException` today) along with the proposed `DynamoId` widening and
+  condition-merge fix.
 
 ## 0.4.7 — 2026-05-09
 
-Auto-pagination for the JSON-1.x list endpoints — CloudWatch Logs and ECS now walk through `nextToken` until exhausted, so calls like `streams_table(aws).get().await` return every stream in a busy log group instead of just the first page. Behaviour-level breaking: anything that relied on first-page-only as an implicit cap should switch to `with_max_pages(1)`. ([#231](https://github.com/romaninsh/vantage/pull/231))
+Auto-pagination for the JSON-1.x list endpoints — CloudWatch Logs and ECS now walk through
+`nextToken` until exhausted, so calls like `streams_table(aws).get().await` return every stream in a
+busy log group instead of just the first page. Behaviour-level breaking: anything that relied on
+first-page-only as an implicit cap should switch to `with_max_pages(1)`.
+([#231](https://github.com/romaninsh/vantage/pull/231))
 
-- Opt in per-table by appending `@<cursor>` to the `array_key` in the table-name DSL: `json1/logStreams@nextToken:logs/Logs_20140328.DescribeLogStreams`. The bundled `models::ecs` and `models::logs` factories switched over — no caller change needed.
-- New [`AwsAccount::with_max_pages(n)`](https://docs.rs/vantage-aws/0.4.7/vantage_aws/struct.AwsAccount.html#method.with_max_pages) caps the walk for accounts with thousands of resources, or for content-bearing reads where "all of it" isn't what you want. Default is unbounded; pages past the cap are silently dropped, so a caller can lean on it as a safety belt without changing error-handling.
-- Other protocols (Query/IAM, REST-XML/S3, REST-JSON/Lambda) and asymmetric cursors (KMS's `Marker`/`NextMarker`, `GetLogEvents`'s forward/backward tokens) are still single-page — they need their own walk implementations.
+- Opt in per-table by appending `@<cursor>` to the `array_key` in the table-name DSL:
+  `json1/logStreams@nextToken:logs/Logs_20140328.DescribeLogStreams`. The bundled `models::ecs` and
+  `models::logs` factories switched over — no caller change needed.
+- New
+  [`AwsAccount::with_max_pages(n)`](https://docs.rs/vantage-aws/0.4.7/vantage_aws/struct.AwsAccount.html#method.with_max_pages)
+  caps the walk for accounts with thousands of resources, or for content-bearing reads where "all of
+  it" isn't what you want. Default is unbounded; pages past the cap are silently dropped, so a
+  caller can lean on it as a safety belt without changing error-handling.
+- Other protocols (Query/IAM, REST-XML/S3, REST-JSON/Lambda) and asymmetric cursors (KMS's
+  `Marker`/`NextMarker`, `GetLogEvents`'s forward/backward tokens) are still single-page — they need
+  their own walk implementations.
 
 ## 0.4.6 — 2026-05-09
 
-`AwsAccount` finally respects `AWS_PROFILE` and SSO; DynamoDB picks up `begins_with` plus a fix for `find_some` with filters. ([#230](https://github.com/romaninsh/vantage/pull/230))
+`AwsAccount` finally respects `AWS_PROFILE` and SSO; DynamoDB picks up `begins_with` plus a fix for
+`find_some` with filters. ([#230](https://github.com/romaninsh/vantage/pull/230))
 
-- `AwsAccount::from_credentials_file()` reads `AWS_PROFILE` (default `"default"`) instead of always taking `[default]`. For profiles whose creds don't live in `~/.aws/credentials` it shells out to `aws configure export-credentials --format env`, which is the AWS CLI's stable handover format and knows how to materialise SSO tokens, assumed-role chains, and `credential_process` output. So `AWS_PROFILE=<sso-profile> cargo run` works as long as `aws sso login` is current. New [`AwsAccount::from_profile(name)`](https://docs.rs/vantage-aws/0.4.6/vantage_aws/struct.AwsAccount.html#method.from_profile) lets you pick a profile without touching env vars. The README's "no AWS_PROFILE / SSO / assume-role" v0 caveat is now stale.
-- `mise.toml` pins `aws` as a tool dep because of the shell-out — install it via `mise install` if you don't already have it.
-- New [`DynamoCondition::begins_with(field, prefix)`](https://docs.rs/vantage-aws/0.4.6/vantage_aws/dynamodb/enum.DynamoCondition.html#variant.BeginsWith) for sort-key prefix filtering — needed for any single-table design that scopes entities by `SK` prefix.
-- Bug: `find_some` was passing `Limit=1` even when a filter was set. DynamoDB applies `FilterExpression` *after* `Limit`, so `Scan(Limit=1)` with a filter routinely returned zero items even when matches existed further down the partition. Fixed by dropping the limit when a filter is present and letting `transport::scan` paginate; the first match is still consumed.
-- New `vantage-aws/examples/dynamo-single-table.rs` — a worked CLI over one DynamoDB table holding seven logical entities (`product`, `version`, `deployment`, `environment`, `team`, `subscription`, `dataport`) distinguished by `PK` / `SK` prefix conventions. Drives the same `model_cli` runner as `aws-cli`. `vantage-aws/examples/aws-dynamo.rs` is a smaller list-and-scan walker for any DynamoDB account.
-- `DynamoId` is partition-key-only in v0, so listing per-product entities globally collapses entries into the same `IndexMap` key. Traversing through a parent (`product[N] :versions`) narrows scope and the collapse stops mattering. Composite-key `DynamoId` is next.
+- `AwsAccount::from_credentials_file()` reads `AWS_PROFILE` (default `"default"`) instead of always
+  taking `[default]`. For profiles whose creds don't live in `~/.aws/credentials` it shells out to
+  `aws configure export-credentials --format env`, which is the AWS CLI's stable handover format and
+  knows how to materialise SSO tokens, assumed-role chains, and `credential_process` output. So
+  `AWS_PROFILE=<sso-profile> cargo run` works as long as `aws sso login` is current. New
+  [`AwsAccount::from_profile(name)`](https://docs.rs/vantage-aws/0.4.6/vantage_aws/struct.AwsAccount.html#method.from_profile)
+  lets you pick a profile without touching env vars. The README's "no AWS_PROFILE / SSO /
+  assume-role" v0 caveat is now stale.
+- `mise.toml` pins `aws` as a tool dep because of the shell-out — install it via `mise install` if
+  you don't already have it.
+- New
+  [`DynamoCondition::begins_with(field, prefix)`](https://docs.rs/vantage-aws/0.4.6/vantage_aws/dynamodb/enum.DynamoCondition.html#variant.BeginsWith)
+  for sort-key prefix filtering — needed for any single-table design that scopes entities by `SK`
+  prefix.
+- Bug: `find_some` was passing `Limit=1` even when a filter was set. DynamoDB applies
+  `FilterExpression` _after_ `Limit`, so `Scan(Limit=1)` with a filter routinely returned zero items
+  even when matches existed further down the partition. Fixed by dropping the limit when a filter is
+  present and letting `transport::scan` paginate; the first match is still consumed.
+- New `vantage-aws/examples/dynamo-single-table.rs` — a worked CLI over one DynamoDB table holding
+  seven logical entities (`product`, `version`, `deployment`, `environment`, `team`, `subscription`,
+  `dataport`) distinguished by `PK` / `SK` prefix conventions. Drives the same `model_cli` runner as
+  `aws-cli`. `vantage-aws/examples/aws-dynamo.rs` is a smaller list-and-scan walker for any DynamoDB
+  account.
+- `DynamoId` is partition-key-only in v0, so listing per-product entities globally collapses entries
+  into the same `IndexMap` key. Traversing through a parent (`product[N] :versions`) narrows scope
+  and the collapse stops mattering. Composite-key `DynamoId` is next.
 
 ## 0.4.5 — 2026-05-04
 
-A typed DynamoDB persistence backend — sibling to the existing list-API surface in `models::dynamodb`. Items have a typed `AttributeValue` representation, native key/filter expressions, and full CRUD semantics, none of which fold cleanly into the `AwsAccount`-as-`TableSource` shape — so DynamoDB lives as its own [`vantage_aws::dynamodb`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/) module with its own `TableSource` impl.
+A typed DynamoDB persistence backend — sibling to the existing list-API surface in
+`models::dynamodb`. Items have a typed `AttributeValue` representation, native key/filter
+expressions, and full CRUD semantics, none of which fold cleanly into the
+`AwsAccount`-as-`TableSource` shape — so DynamoDB lives as its own
+[`vantage_aws::dynamodb`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/) module with its
+own `TableSource` impl.
 
-- New [`DynamoDB`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/struct.DynamoDB.html) data source: cheap to clone, wraps an existing `AwsAccount` for credentials and signing.
-- New [`AttributeValue`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/enum.AttributeValue.html) typed enum mirrors the wire shape (`S`, `N`, `B`, `BOOL`, `NULL`, `L`, `M`, `SS`, `NS`, `BS`); a `vantage_type_system!` invocation produces the matching `DynamoType` trait, `AnyDynamoType` value, and variants enum, with per-type impls for `String`, `i32`, `i64`, `f64`, `bool`, `Vec<u8>`, and `Option<T>`.
-- Read/write path covers `Scan` (list / count / sample), `GetItem` (point read), `PutItem` (insert and replace), and `DeleteItem`. `delete_table_all_values` walks the scan and deletes per-item — no native bulk delete.
-- New [`DynamoCondition`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/enum.DynamoCondition.html) carries a rendered expression plus its `ExpressionAttributeNames` / `ExpressionAttributeValues` maps; v0 ships `eq` only, with `gt` / `between` / `in_` / `begins_with` landing alongside Scan/Query filter execution.
-- New [`DynamoId`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/struct.DynamoId.html) primary-key type — partition-key-only and string-form in v0; composite (partition + sort) keys are next.
-- New `AwsAccount::with_region(region)` returns a copy with the region overridden — useful when credentials come from `~/.aws/credentials` but the target region differs from the profile default (e.g. a test fixture provisioned in a fixed region regardless of the developer's local config).
+- New [`DynamoDB`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/struct.DynamoDB.html) data
+  source: cheap to clone, wraps an existing `AwsAccount` for credentials and signing.
+- New
+  [`AttributeValue`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/enum.AttributeValue.html)
+  typed enum mirrors the wire shape (`S`, `N`, `B`, `BOOL`, `NULL`, `L`, `M`, `SS`, `NS`, `BS`); a
+  `vantage_type_system!` invocation produces the matching `DynamoType` trait, `AnyDynamoType` value,
+  and variants enum, with per-type impls for `String`, `i32`, `i64`, `f64`, `bool`, `Vec<u8>`, and
+  `Option<T>`.
+- Read/write path covers `Scan` (list / count / sample), `GetItem` (point read), `PutItem` (insert
+  and replace), and `DeleteItem`. `delete_table_all_values` walks the scan and deletes per-item — no
+  native bulk delete.
+- New
+  [`DynamoCondition`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/enum.DynamoCondition.html)
+  carries a rendered expression plus its `ExpressionAttributeNames` / `ExpressionAttributeValues`
+  maps; v0 ships `eq` only, with `gt` / `between` / `in_` / `begins_with` landing alongside
+  Scan/Query filter execution.
+- New [`DynamoId`](https://docs.rs/vantage-aws/0.4.5/vantage_aws/dynamodb/struct.DynamoId.html)
+  primary-key type — partition-key-only and string-form in v0; composite (partition + sort) keys are
+  next.
+- New `AwsAccount::with_region(region)` returns a copy with the region overridden — useful when
+  credentials come from `~/.aws/credentials` but the target region differs from the profile default
+  (e.g. a test fixture provisioned in a fixed region regardless of the developer's local config).
 - Added `paste` dependency (used by the `vantage_type_system!` macro expansion).
-- Live integration tests against a real DynamoDB account (`tests/dynamodb_live.rs`); auto-skip when AWS credentials aren't configured. The accompanying `test-tf/dynamodb.tf` provisions two `PAY_PER_REQUEST` tables (`<name>-products`, `<name>-orders`) for exercising the round-trip.
-- Aggregations (`sum` / `min` / `max`), `patch` (UpdateItem), key-generation insert, relationship traversal, and binary `B` / `BS` wire codec are stubbed — they error loudly so callers can't accidentally rely on them.
+- Live integration tests against a real DynamoDB account (`tests/dynamodb_live.rs`); auto-skip when
+  AWS credentials aren't configured. The accompanying `test-tf/dynamodb.tf` provisions two
+  `PAY_PER_REQUEST` tables (`<name>-products`, `<name>-orders`) for exercising the round-trip.
+- Aggregations (`sum` / `min` / `max`), `patch` (UpdateItem), key-generation insert, relationship
+  traversal, and binary `B` / `BS` wire codec are stubbed — they error loudly so callers can't
+  accidentally rely on them.
 
 ## 0.4.4 — 2026-05-02
 
-Three more AWS wire protocols and three more model trees — S3, Lambda, DynamoDB — wired into the same `Factory` / `from_arn` surface as the IAM/ECS/CloudWatch models. ([#216](https://github.com/romaninsh/vantage/pull/216))
+Three more AWS wire protocols and three more model trees — S3, Lambda, DynamoDB — wired into the
+same `Factory` / `from_arn` surface as the IAM/ECS/CloudWatch models.
+([#216](https://github.com/romaninsh/vantage/pull/216))
 
-- New `restxml/` protocol prefix, used by S3. Target syntax is `restxml/<array_key>:<service>/<METHOD> <path>?<static-query>` — conditions whose name matches a `{Placeholder}` segment fill the path; everything else appends to the query string. The transport adds `x-amz-content-sha256` to the signed headers (mandatory on S3, harmless elsewhere); the response parser strips the XML root and supports dotted lookup so callers can target nested arrays like `Buckets.Bucket`.
-- New `restjson/` protocol prefix, used by Lambda. Same request shape as `restxml/` (reuses the path-template builder) but parses a JSON response. No content-sha256 header — Lambda doesn't require it.
-- New `json10/` protocol prefix, used by DynamoDB. Differs from `json1/` only in the `application/x-amz-json-1.0` content type, so it shares the JSON-1.1 transport via a new `json_aws_call(..., content_type)` helper. Parse path is identical to `json1/`.
-- New `vantage_aws::models::s3` submodule: `buckets_table` (`ListBuckets`) + `objects_table` (`ListObjectsV2`, requires `Bucket`). `Bucket` carries an `objects` `with_many` relation. Path-style addressing only — cross-region buckets surface AWS's 301 verbatim with the home-region endpoint in the error body, so the caller can re-point `AwsAccount`'s region.
-- New `vantage_aws::models::lambda` submodule: `functions_table` (`ListFunctions`) + `aliases_table` / `versions_table` (per function). `Function` carries `aliases` and `versions` `with_many`s plus a cross-service `log_group` `with_foreign` that resolves to the matching CloudWatch group at `/aws/lambda/<FunctionName>` via a deferred expression — projects `FunctionName` from the source row, prefixes it, and hands the result to `logGroupNamePrefix` for AWS-side narrowing.
-- New `vantage_aws::models::dynamodb` submodule: `tables_table` (`ListTables`). The list-side response is just an array of strings, so v0 surfaces `TableName` only; richer `DescribeTable` metadata is a follow-up.
-- `Factory::known_names` picks up six new entries: `s3.bucket(s)`, `lambda.function(s)`, `dynamodb.table(s)`. Sub-resources (`s3.object`, `lambda.alias`, `lambda.version`) intentionally aren't exposed top-level — listing them standalone needs a parent filter, so they're reachable only via traversal. `Factory::from_arn` learns four new ARN shapes (S3 object, S3 bucket, Lambda function, DynamoDB table).
-- `dispatch::lookup_path` — small helper that walks dotted paths through `serde_json::Value`. Adopted by `json1::parse_records` and the new REST parsers so the same `array_key` syntax works across protocols.
+- New `restxml/` protocol prefix, used by S3. Target syntax is
+  `restxml/<array_key>:<service>/<METHOD> <path>?<static-query>` — conditions whose name matches a
+  `{Placeholder}` segment fill the path; everything else appends to the query string. The transport
+  adds `x-amz-content-sha256` to the signed headers (mandatory on S3, harmless elsewhere); the
+  response parser strips the XML root and supports dotted lookup so callers can target nested arrays
+  like `Buckets.Bucket`.
+- New `restjson/` protocol prefix, used by Lambda. Same request shape as `restxml/` (reuses the
+  path-template builder) but parses a JSON response. No content-sha256 header — Lambda doesn't
+  require it.
+- New `json10/` protocol prefix, used by DynamoDB. Differs from `json1/` only in the
+  `application/x-amz-json-1.0` content type, so it shares the JSON-1.1 transport via a new
+  `json_aws_call(..., content_type)` helper. Parse path is identical to `json1/`.
+- New `vantage_aws::models::s3` submodule: `buckets_table` (`ListBuckets`) + `objects_table`
+  (`ListObjectsV2`, requires `Bucket`). `Bucket` carries an `objects` `with_many` relation.
+  Path-style addressing only — cross-region buckets surface AWS's 301 verbatim with the home-region
+  endpoint in the error body, so the caller can re-point `AwsAccount`'s region.
+- New `vantage_aws::models::lambda` submodule: `functions_table` (`ListFunctions`) + `aliases_table`
+  / `versions_table` (per function). `Function` carries `aliases` and `versions` `with_many`s plus a
+  cross-service `log_group` `with_foreign` that resolves to the matching CloudWatch group at
+  `/aws/lambda/<FunctionName>` via a deferred expression — projects `FunctionName` from the source
+  row, prefixes it, and hands the result to `logGroupNamePrefix` for AWS-side narrowing.
+- New `vantage_aws::models::dynamodb` submodule: `tables_table` (`ListTables`). The list-side
+  response is just an array of strings, so v0 surfaces `TableName` only; richer `DescribeTable`
+  metadata is a follow-up.
+- `Factory::known_names` picks up six new entries: `s3.bucket(s)`, `lambda.function(s)`,
+  `dynamodb.table(s)`. Sub-resources (`s3.object`, `lambda.alias`, `lambda.version`) intentionally
+  aren't exposed top-level — listing them standalone needs a parent filter, so they're reachable
+  only via traversal. `Factory::from_arn` learns four new ARN shapes (S3 object, S3 bucket, Lambda
+  function, DynamoDB table).
+- `dispatch::lookup_path` — small helper that walks dotted paths through `serde_json::Value`.
+  Adopted by `json1::parse_records` and the new REST parsers so the same `array_key` syntax works
+  across protocols.
 
 ## 0.4.3 — 2026-04-30
 
-`vantage-aws` picks up a generic, type-erased model factory and the AWS-side machinery to back the new model-driven CLI in `vantage-cli-util`. ([#215](https://github.com/romaninsh/vantage/pull/215))
+`vantage-aws` picks up a generic, type-erased model factory and the AWS-side machinery to back the
+new model-driven CLI in `vantage-cli-util`. ([#215](https://github.com/romaninsh/vantage/pull/215))
 
-- New `vantage_aws::models::Factory` — dotted-string lookup (`iam.user`, `log.group`, `ecs.cluster`, …) to `AnyTable` plus a single `Factory::from_arn` entry point. Singular forms drop into `FactoryMode::Single`, plural into `FactoryMode::List`. Models whose AWS API requires a parent filter aren't exposed top-level; they're reachable via traversal:
-  - `iam.user … :access_keys`        (`ListAccessKeys` needs `UserName`)
-  - `log.group … :streams`           (`DescribeLogStreams` needs `logGroupName`)
-  - `log.group … :events`            (`FilterLogEvents` needs `logGroupName`)
-  - `ecs.cluster … :services`        (`ListServices` needs `cluster`)
-  - `ecs.cluster … :tasks`           (`ListTasks` needs `cluster`)
-- New per-entity `from_arn(arn, aws) -> Option<Table<…>>` on `User`, `Group`, `Role`, `Policy`, `InstanceProfile`, `AccessKey`, `LogGroup`, `LogStream`, `Cluster`. Each parses its own ARN shape and returns a pre-conditioned table. `Factory::from_arn` walks them in order.
-- `ecs::clusters_table` gains the previously-missing `with_many("services", "cluster", services_table)` and `with_many("tasks", "cluster", tasks_table)` so cluster traversal hits the registered relations.
-- Existing IAM / Logs models pick up `with_title_column_of` for the columns worth showing in lists (`Path`, `CreateDate`, `UserName`, `Status`, `PolicyName`, `IsAttachable`, …). Long, noisy, or always-empty columns (`Arn`, `AssumeRolePolicyDocument`, `PasswordLastUsed`, log message body) stay hidden by default and surface when you drill into a single record.
-- New `TableSource::eq_condition` impl on `AwsAccount` — builds an `AwsCondition::Eq` from raw strings so the generic CLI's `add_condition_eq` works without reaching into the backend's expression type.
-- `AwsAccount::list_table_values` now post-filters records by any `Eq` condition whose field appears on the records. AWS APIs only push down their own request-param filters (`PathPrefix`, `logGroupNamePrefix`, `cluster`); eq conditions on actual record fields (`UserName`, `Path`, `clusterArn`) used to be silently dropped on the wire. Fields not on any record are assumed to be request params and skipped (no over-filtering on `PathPrefix` etc.). Also makes the deferred-subquery path under `:relation` resolve correctly when the source is narrowed in-memory.
-- `examples/aws-cli.rs` rewritten as a thin adapter around `vantage_cli_util::model_cli::run` — same end-to-end paths as before plus filters / index / column-overrides / ARN-as-first-argument. The previous clap subcommand surface is gone; everything goes through the generic argv parser.
-- Pins `vantage-table = "0.4.8"` for the new `TableLike` reflection methods + `with_title_column_of`.
+- New `vantage_aws::models::Factory` — dotted-string lookup (`iam.user`, `log.group`, `ecs.cluster`,
+  …) to `AnyTable` plus a single `Factory::from_arn` entry point. Singular forms drop into
+  `FactoryMode::Single`, plural into `FactoryMode::List`. Models whose AWS API requires a parent
+  filter aren't exposed top-level; they're reachable via traversal:
+  - `iam.user … :access_keys` (`ListAccessKeys` needs `UserName`)
+  - `log.group … :streams` (`DescribeLogStreams` needs `logGroupName`)
+  - `log.group … :events` (`FilterLogEvents` needs `logGroupName`)
+  - `ecs.cluster … :services` (`ListServices` needs `cluster`)
+  - `ecs.cluster … :tasks` (`ListTasks` needs `cluster`)
+- New per-entity `from_arn(arn, aws) -> Option<Table<…>>` on `User`, `Group`, `Role`, `Policy`,
+  `InstanceProfile`, `AccessKey`, `LogGroup`, `LogStream`, `Cluster`. Each parses its own ARN shape
+  and returns a pre-conditioned table. `Factory::from_arn` walks them in order.
+- `ecs::clusters_table` gains the previously-missing
+  `with_many("services", "cluster", services_table)` and
+  `with_many("tasks", "cluster", tasks_table)` so cluster traversal hits the registered relations.
+- Existing IAM / Logs models pick up `with_title_column_of` for the columns worth showing in lists
+  (`Path`, `CreateDate`, `UserName`, `Status`, `PolicyName`, `IsAttachable`, …). Long, noisy, or
+  always-empty columns (`Arn`, `AssumeRolePolicyDocument`, `PasswordLastUsed`, log message body)
+  stay hidden by default and surface when you drill into a single record.
+- New `TableSource::eq_condition` impl on `AwsAccount` — builds an `AwsCondition::Eq` from raw
+  strings so the generic CLI's `add_condition_eq` works without reaching into the backend's
+  expression type.
+- `AwsAccount::list_table_values` now post-filters records by any `Eq` condition whose field appears
+  on the records. AWS APIs only push down their own request-param filters (`PathPrefix`,
+  `logGroupNamePrefix`, `cluster`); eq conditions on actual record fields (`UserName`, `Path`,
+  `clusterArn`) used to be silently dropped on the wire. Fields not on any record are assumed to be
+  request params and skipped (no over-filtering on `PathPrefix` etc.). Also makes the
+  deferred-subquery path under `:relation` resolve correctly when the source is narrowed in-memory.
+- `examples/aws-cli.rs` rewritten as a thin adapter around `vantage_cli_util::model_cli::run` — same
+  end-to-end paths as before plus filters / index / column-overrides / ARN-as-first-argument. The
+  previous clap subcommand surface is gone; everything goes through the generic argv parser.
+- Pins `vantage-table = "0.4.8"` for the new `TableLike` reflection methods +
+  `with_title_column_of`.
 
 ## 0.4.2 — 2026-04-29
 
-AWS Query protocol (form-encoded request, XML response) lands alongside the existing JSON-1.1 transport, plus an IAM submodule that uses it. Same `AwsAccount` is the `TableSource` for both — relations span protocols freely. ([#212](https://github.com/romaninsh/vantage/pull/212))
+AWS Query protocol (form-encoded request, XML response) lands alongside the existing JSON-1.1
+transport, plus an IAM submodule that uses it. Same `AwsAccount` is the `TableSource` for both —
+relations span protocols freely. ([#212](https://github.com/romaninsh/vantage/pull/212))
 
-- The protocol is encoded as a prefix in the table name. Existing tables get `json1/` (e.g. `json1/logGroups:logs/Logs_20140328.DescribeLogGroups`); new IAM tables use `query/` (e.g. `query/Users:iam/2010-05-08.ListUsers`). `AwsAccount::execute_rpc` and `parse_records` match on the prefix and dispatch.
-- New `src/query/` mirrors `src/json1/` — `transport.rs` for the signed POST, `mod.rs` with `execute` + `parse_records`. Same hand-rolled SigV4 signer powers both protocols. Responses are XML; `query/xml.rs` normalises them to `serde_json::Value` by stripping `{Action}Response` / `{Action}Result` wrappers and hoisting `<member>` collections into JSON arrays.
-- Global services (IAM today, STS later) get a one-line override in `query/transport.rs`: served from `iam.amazonaws.com` (no region in the host) and signed with `us-east-1` regardless of the configured region.
-- New `vantage_aws::models::iam` submodule with six top-level tables: `users_table`, `groups_table`, `roles_table`, `policies_table`, `access_keys_table`, `instance_profiles_table`. One `AttachedPolicy` struct shared across `ListAttachedUserPolicies` / `ListAttachedGroupPolicies` / `ListAttachedRolePolicies` (same response shape, different action per source).
-- IAM relations on entity factories: `User` → `groups`, `access_keys`, `attached_policies`; `Group` → `attached_policies`; `Role` → `attached_policies`, `instance_profiles`. Both `with_many` traversal and `User::ref_*` / `Group::ref_*` / `Role::ref_*` entity-in-hand forms work — the ref-* form is the right tool for IAM since `ListUsers` / `ListRoles` ignore name filters and return the whole account.
-- **Reorganised**: `models::log_*` collapses into `models::logs::*` — `log_groups_table` becomes `logs::groups_table`, etc. Lets the IAM `groups_table` live cleanly under `models::iam::` without a name clash, and matches the `models::ecs::*` shape from 0.4.1. Existing call sites need to update imports.
-- `query::parse_records` treats an empty string at the array key as an empty array. `<Foo/>` (self-closing) is what IAM returns for an empty list and the XML normaliser surfaces that as `""` — `list-groups` on an account with no IAM groups now returns "No records found." instead of an obscure decode failure.
-- `examples/aws-cli.rs` picks up `list-users`, `list-policies` (`--scope`), `list-roles` (`--path-prefix`), `list-access-keys` (`--user`), `traverse-user-policies`, `traverse-user-access-keys`, `traverse-role-policies`, `traverse-role-profiles`. Log commands renamed to free up `list-groups` for IAM.
+- The protocol is encoded as a prefix in the table name. Existing tables get `json1/` (e.g.
+  `json1/logGroups:logs/Logs_20140328.DescribeLogGroups`); new IAM tables use `query/` (e.g.
+  `query/Users:iam/2010-05-08.ListUsers`). `AwsAccount::execute_rpc` and `parse_records` match on
+  the prefix and dispatch.
+- New `src/query/` mirrors `src/json1/` — `transport.rs` for the signed POST, `mod.rs` with
+  `execute` + `parse_records`. Same hand-rolled SigV4 signer powers both protocols. Responses are
+  XML; `query/xml.rs` normalises them to `serde_json::Value` by stripping `{Action}Response` /
+  `{Action}Result` wrappers and hoisting `<member>` collections into JSON arrays.
+- Global services (IAM today, STS later) get a one-line override in `query/transport.rs`: served
+  from `iam.amazonaws.com` (no region in the host) and signed with `us-east-1` regardless of the
+  configured region.
+- New `vantage_aws::models::iam` submodule with six top-level tables: `users_table`, `groups_table`,
+  `roles_table`, `policies_table`, `access_keys_table`, `instance_profiles_table`. One
+  `AttachedPolicy` struct shared across `ListAttachedUserPolicies` / `ListAttachedGroupPolicies` /
+  `ListAttachedRolePolicies` (same response shape, different action per source).
+- IAM relations on entity factories: `User` → `groups`, `access_keys`, `attached_policies`; `Group`
+  → `attached_policies`; `Role` → `attached_policies`, `instance_profiles`. Both `with_many`
+  traversal and `User::ref_*` / `Group::ref_*` / `Role::ref_*` entity-in-hand forms work — the
+  ref-\* form is the right tool for IAM since `ListUsers` / `ListRoles` ignore name filters and
+  return the whole account.
+- **Reorganised**: `models::log_*` collapses into `models::logs::*` — `log_groups_table` becomes
+  `logs::groups_table`, etc. Lets the IAM `groups_table` live cleanly under `models::iam::` without
+  a name clash, and matches the `models::ecs::*` shape from 0.4.1. Existing call sites need to
+  update imports.
+- `query::parse_records` treats an empty string at the array key as an empty array. `<Foo/>`
+  (self-closing) is what IAM returns for an empty list and the XML normaliser surfaces that as `""`
+  — `list-groups` on an account with no IAM groups now returns "No records found." instead of an
+  obscure decode failure.
+- `examples/aws-cli.rs` picks up `list-users`, `list-policies` (`--scope`), `list-roles`
+  (`--path-prefix`), `list-access-keys` (`--user`), `traverse-user-policies`,
+  `traverse-user-access-keys`, `traverse-role-policies`, `traverse-role-profiles`. Log commands
+  renamed to free up `list-groups` for IAM.
 
 ## 0.4.1 — 2026-04-28
 
-More built-in models — CloudWatch `LogStream`, plus an ECS submodule covering clusters, services, tasks, and task definitions. The `parse_records` path now wraps scalar array elements (which is what AWS's ECS `List*` APIs return) so they look like ordinary single-field rows.
+More built-in models — CloudWatch `LogStream`, plus an ECS submodule covering clusters, services,
+tasks, and task definitions. The `parse_records` path now wraps scalar array elements (which is what
+AWS's ECS `List*` APIs return) so they look like ordinary single-field rows.
 
-- New `vantage_aws::models::log_stream` — `LogStream` + `log_streams_table` (`DescribeLogStreams`, requires `logGroupName`). `LogStream::ref_events` derives the log group from the stream's ARN; `ref_events_in` lets the caller pass it. Both narrow `FilterLogEvents` via `logStreamNamePrefix`.
-- `LogGroup` gains a `streams` `with_many` relation alongside the existing `events` one, plus a typed `LogGroup::ref_streams()`.
+- New `vantage_aws::models::log_stream` — `LogStream` + `log_streams_table` (`DescribeLogStreams`,
+  requires `logGroupName`). `LogStream::ref_events` derives the log group from the stream's ARN;
+  `ref_events_in` lets the caller pass it. Both narrow `FilterLogEvents` via `logStreamNamePrefix`.
+- `LogGroup` gains a `streams` `with_many` relation alongside the existing `events` one, plus a
+  typed `LogGroup::ref_streams()`.
 - New `vantage_aws::models::ecs` submodule:
-  - `Cluster` + `clusters_table` (`ListClusters`). Methods: `name()` (parsed from ARN), `ref_services()`, `ref_tasks()`.
+  - `Cluster` + `clusters_table` (`ListClusters`). Methods: `name()` (parsed from ARN),
+    `ref_services()`, `ref_tasks()`.
   - `Service` + `services_table` (`ListServices`, requires `cluster` condition). `name()` helper.
-  - `Task` + `tasks_table` (`ListTasks`, requires `cluster` condition; supports `serviceName` / `family` / `desiredStatus` filters). `task_id()` helper. `ref_log_events(aws, log_group_name, prefix)` returns a `FilterLogEvents` table narrowed by `logStreamNamePrefix` — caller supplies the prefix because ECS streams put `taskId` at the *end* of the name (`<streamPrefix>/<container>/<taskId>`) and AWS only supports prefix matching.
+  - `Task` + `tasks_table` (`ListTasks`, requires `cluster` condition; supports `serviceName` /
+    `family` / `desiredStatus` filters). `task_id()` helper.
+    `ref_log_events(aws, log_group_name, prefix)` returns a `FilterLogEvents` table narrowed by
+    `logStreamNamePrefix` — caller supplies the prefix because ECS streams put `taskId` at the _end_
+    of the name (`<streamPrefix>/<container>/<taskId>`) and AWS only supports prefix matching.
   - `TaskDefinition` + `task_definitions_table` (`ListTaskDefinitions`).
-- `parse_records` wraps scalar (string / number) array entries as `{<id_field>: value}` records — the ECS `List*` APIs return arrays of ARN strings rather than objects, so without this wrap the response would error.
-- `examples/aws-cli.rs` gains `list-streams`, `traverse-streams`, `list-clusters`, `list-services`, `list-tasks` (with `--service` / `--family` / `--status`), `list-task-defs` (with `--family-prefix`).
+- `parse_records` wraps scalar (string / number) array entries as `{<id_field>: value}` records —
+  the ECS `List*` APIs return arrays of ARN strings rather than objects, so without this wrap the
+  response would error.
+- `examples/aws-cli.rs` gains `list-streams`, `traverse-streams`, `list-clusters`, `list-services`,
+  `list-tasks` (with `--service` / `--family` / `--status`), `list-task-defs` (with
+  `--family-prefix`).
 
 ## 0.4.0 — 2026-04-27
 
-First release — incubating. Read-only AWS JSON-1.1 RPC backend that exposes AWS APIs (CloudWatch Logs, ECS, DynamoDB control plane, KMS, …) as Vantage `TableSource`s. `AwsAccount` *is* the source; per-operation config lives in the table name (`array_key:service/target`).
+First release — incubating. Read-only AWS JSON-1.1 RPC backend that exposes AWS APIs (CloudWatch
+Logs, ECS, DynamoDB control plane, KMS, …) as Vantage `TableSource`s. `AwsAccount` _is_ the source;
+per-operation config lives in the table name (`array_key:service/target`).
 
-- `AwsAccount` with three credential entry points: `from_env()` (standard env vars), `from_credentials_file()` (`[default]` profile in `~/.aws/credentials`; region resolves through `AWS_REGION` → `AWS_DEFAULT_REGION` → `~/.aws/config` `[default]`), and `from_default()` (env first, file fallback). Named profiles, SSO, assume-role, IMDS — out of v0.
-- Hand-rolled SigV4 in `src/sign.rs`, no `aws-sdk-*` / `aws-sigv4` dep — just `hmac` / `sha2` / `hex`. Pinned to AWS's canonical-example fixture. Civil-time conversion is hand-rolled too (Hinnant's `days_from_civil`) so we stay off `chrono` / `time` for one function.
-- `AwsCondition` with `Eq` (folds into the JSON request body), `In` (literal set; must collapse to a single value at execute time), and `Deferred` (subquery, resolved at execute time). AWS APIs only accept exact-match filters, so multi-value conditions error loudly.
-- `AwsOperation` blanket trait so `column.eq(value)` / `column.in_(subquery)` works against any `Expressive<ciborium::Value>`.
-- `TableSource` impl: `list_table_values` with deferred-condition resolution, `column_table_values_expr` for relation traversal, `related_in_condition` so `with_one` / `with_many` traversal works without AWS-side joins. Writes (`insert` / `replace` / `patch` / `delete`) and aggregations (`sum` / `min` / `max`) intentionally error.
-- Built-in CloudWatch models in `vantage_aws::models`: `log_groups_table` / `log_events_table` (`DescribeLogGroups` / `FilterLogEvents`), with an `events` `with_many` relation between them and a typed `LogGroup::ref_events()` for the entity-in-hand case.
-- `examples/aws-cli.rs` — `list-groups`, `list-events`, `traverse`, `--region` override. Output via `vantage_cli_util::print_table`, so the demo exercises the same `Table` / `TableSource` machinery the rest of the framework uses.
-- CI workflow (`.github/workflows/aws.yaml`) runs the demo CLI against a live AWS account (`list-groups`, `list-groups --prefix /aws/lambda/`, `traverse`) on every PR — catches signature regressions and wire-format drift the offline tests miss.
+- `AwsAccount` with three credential entry points: `from_env()` (standard env vars),
+  `from_credentials_file()` (`[default]` profile in `~/.aws/credentials`; region resolves through
+  `AWS_REGION` → `AWS_DEFAULT_REGION` → `~/.aws/config` `[default]`), and `from_default()` (env
+  first, file fallback). Named profiles, SSO, assume-role, IMDS — out of v0.
+- Hand-rolled SigV4 in `src/sign.rs`, no `aws-sdk-*` / `aws-sigv4` dep — just `hmac` / `sha2` /
+  `hex`. Pinned to AWS's canonical-example fixture. Civil-time conversion is hand-rolled too
+  (Hinnant's `days_from_civil`) so we stay off `chrono` / `time` for one function.
+- `AwsCondition` with `Eq` (folds into the JSON request body), `In` (literal set; must collapse to a
+  single value at execute time), and `Deferred` (subquery, resolved at execute time). AWS APIs only
+  accept exact-match filters, so multi-value conditions error loudly.
+- `AwsOperation` blanket trait so `column.eq(value)` / `column.in_(subquery)` works against any
+  `Expressive<ciborium::Value>`.
+- `TableSource` impl: `list_table_values` with deferred-condition resolution,
+  `column_table_values_expr` for relation traversal, `related_in_condition` so `with_one` /
+  `with_many` traversal works without AWS-side joins. Writes (`insert` / `replace` / `patch` /
+  `delete`) and aggregations (`sum` / `min` / `max`) intentionally error.
+- Built-in CloudWatch models in `vantage_aws::models`: `log_groups_table` / `log_events_table`
+  (`DescribeLogGroups` / `FilterLogEvents`), with an `events` `with_many` relation between them and
+  a typed `LogGroup::ref_events()` for the entity-in-hand case.
+- `examples/aws-cli.rs` — `list-groups`, `list-events`, `traverse`, `--region` override. Output via
+  `vantage_cli_util::print_table`, so the demo exercises the same `Table` / `TableSource` machinery
+  the rest of the framework uses.
+- CI workflow (`.github/workflows/aws.yaml`) runs the demo CLI against a live AWS account
+  (`list-groups`, `list-groups --prefix /aws/lambda/`, `traverse`) on every PR — catches signature
+  regressions and wire-format drift the offline tests miss.

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "ciborium",
  "indexmap",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -11,12 +11,12 @@ repository = "https://github.com/romaninsh/vantage"
 readme = "README.md"
 
 [dependencies]
-vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
-vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
+vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
-vantage-vista = { version = "0.4", path = "../vantage-vista" }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }
 
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
@@ -43,7 +43,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 [dev-dependencies]
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-cli-util = { version = "0.5", path = "../vantage-cli-util" }
-vantage-vista = { version = "0.4", path = "../vantage-vista" }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }
 
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }

--- a/vantage-cli-util/CHANGELOG.md
+++ b/vantage-cli-util/CHANGELOG.md
@@ -1,55 +1,123 @@
 # Changelog
 
+## 0.5.3 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.1 — 2026-05-23
 
-- Removed the legacy `model_cli` module (the `AnyTable`-based runner). [`vista_cli`](https://docs.rs/vantage-cli-util/0.5.1/vantage_cli_util/vista_cli/index.html) is now the only CLI runner — it has carried the full token grammar (operators, selectors, search, aggregates) since 0.4.5 and is what every consumer in-tree already uses. Crate-root re-exports `Mode`, `ModelFactory`, `Renderer` are gone; import them from `vista_cli::*` instead.
+- Removed the legacy `model_cli` module (the `AnyTable`-based runner).
+  [`vista_cli`](https://docs.rs/vantage-cli-util/0.5.1/vantage_cli_util/vista_cli/index.html) is now
+  the only CLI runner — it has carried the full token grammar (operators, selectors, search,
+  aggregates) since 0.4.5 and is what every consumer in-tree already uses. Crate-root re-exports
+  `Mode`, `ModelFactory`, `Renderer` are gone; import them from `vista_cli::*` instead.
 
 ## 0.5.0 — 2026-05-23
 
-- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+- Bumped to the 0.5 line to track
+  [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the
+  `AnyTable` decommission cycle. No code changes beyond the dependency pin.
 
 ## 0.4.6 — 2026-05-18
 
-- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. Internal test fixtures build their `Vista` via `Box::new(MockShell::new().with_metadata(metadata))` instead of passing metadata to `Vista::new`. No change to the public CLI surface.
+- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s
+  schema-on-source refactor. Internal test fixtures build their `Vista` via
+  `Box::new(MockShell::new().with_metadata(metadata))` instead of passing metadata to `Vista::new`.
+  No change to the public CLI surface.
 - Pins `vantage-vista = "0.4.10"`.
 
 ## 0.4.5 — 2026-05-17
 
-- Wires the stage-5 vocabulary to real [`Vista`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html) calls now that the methods have landed:
-  - `?keyword` / `?"two words"` calls [`Vista::add_search`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_search).
-  - `[+col]` / `[-col]` (and the sort half of `[+col:N]`) calls [`Vista::add_order`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_order).
-- `field=value` is now coerced against the target column's declared type, not the value-shape heuristic. `name=true` on a `String` column produces `Text("true")`; `is_paying_client=true` on a `bool` column still produces `Bool(true)`. The `#literal` escape hatch still wins when the user wants to force a type. New [`vista_cli::coerce_for_column`](https://docs.rs/vantage-cli-util/0.4.5/vantage_cli_util/vista_cli/fn.coerce_for_column.html) exposes the same coercion for factory implementations that resolve locators to a typed id condition.
-- Drivers without the matching `can_*` capability surface `Unsupported` from the underlying Vista call — same error contract as `Op::Eq`.
-- Still stubbed (no Vista API yet): non-`eq` operator conditions (`:lt=`, `:gt=`, `:like=`, `:in=`, `:null`, `:notnull`), `[N:M]` range slicing (Vista's pagination is page-based, no offset-range primitive), and `@sum`/`@max`/`@min`/`@count` aggregates.
+- Wires the stage-5 vocabulary to real
+  [`Vista`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html) calls now that the
+  methods have landed:
+  - `?keyword` / `?"two words"` calls
+    [`Vista::add_search`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_search).
+  - `[+col]` / `[-col]` (and the sort half of `[+col:N]`) calls
+    [`Vista::add_order`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_order).
+- `field=value` is now coerced against the target column's declared type, not the value-shape
+  heuristic. `name=true` on a `String` column produces `Text("true")`; `is_paying_client=true` on a
+  `bool` column still produces `Bool(true)`. The `#literal` escape hatch still wins when the user
+  wants to force a type. New
+  [`vista_cli::coerce_for_column`](https://docs.rs/vantage-cli-util/0.4.5/vantage_cli_util/vista_cli/fn.coerce_for_column.html)
+  exposes the same coercion for factory implementations that resolve locators to a typed id
+  condition.
+- Drivers without the matching `can_*` capability surface `Unsupported` from the underlying Vista
+  call — same error contract as `Op::Eq`.
+- Still stubbed (no Vista API yet): non-`eq` operator conditions (`:lt=`, `:gt=`, `:like=`, `:in=`,
+  `:null`, `:notnull`), `[N:M]` range slicing (Vista's pagination is page-based, no offset-range
+  primitive), and `@sum`/`@max`/`@min`/`@count` aggregates.
 - Pins `vantage-vista = "0.4.9"`.
 
 ## 0.4.4 — 2026-05-17
 
-- [`vista_cli`](https://docs.rs/vantage-cli-util/0.4.4/vantage_cli_util/vista_cli/index.html) grows the full stage-5 vocabulary as a parser. Operator conditions (`field:lt=`, `:gt=`, `:like=`, `:in=`, `:null`, `:notnull`), combined sort+slice brackets (`[+name:0]`, `[5:15]`, `[-salary]`), search (`?keyword`), aggregates (`@sum:price`, `@count`), and JSON-typed values (`field=#42`, `field=#"42"`, `field=#[1,2,3]`) all parse cleanly today. `Op::Eq` and `[N]` narrow-to-single drive real `Vista` calls; the rest dispatches to a `Renderer::note_stub` hook until `Vista` itself grows the corresponding methods, so callers can wire UIs against the final shape now.
-- New [`output`](https://docs.rs/vantage-cli-util/0.4.4/vantage_cli_util/output/index.html) module: machine-readable formatters for `json`, `ndjson`, and `cbor-diag` (RFC 8949 §8 diagnostic notation). `cbor-diag` is the lossless format used for cross-driver golden tests; `json` is best-effort for `jq` pipelines.
-- `ModelFactory::for_arn` is now `for_locator` — universal resource locators (`arn:…`, `user:abc123`, `urn:…`) instead of AWS-only. The old `for_arn` keeps working via a default forward, so existing implementations compile unchanged.
-- `Renderer` gains `render_scalar` (for aggregate output) and `note_stub` (default no-op); existing implementors only need to add `render_scalar` when they exercise `@…` tokens.
-- Module split: `vista_cli.rs` becomes `vista_cli/{mod,token,parse,value,factory,run}.rs`. All public items are re-exported, so downstream `use vantage_cli_util::vista_cli::{Mode, ModelFactory, Renderer}` keeps working.
+- [`vista_cli`](https://docs.rs/vantage-cli-util/0.4.4/vantage_cli_util/vista_cli/index.html) grows
+  the full stage-5 vocabulary as a parser. Operator conditions (`field:lt=`, `:gt=`, `:like=`,
+  `:in=`, `:null`, `:notnull`), combined sort+slice brackets (`[+name:0]`, `[5:15]`, `[-salary]`),
+  search (`?keyword`), aggregates (`@sum:price`, `@count`), and JSON-typed values (`field=#42`,
+  `field=#"42"`, `field=#[1,2,3]`) all parse cleanly today. `Op::Eq` and `[N]` narrow-to-single
+  drive real `Vista` calls; the rest dispatches to a `Renderer::note_stub` hook until `Vista` itself
+  grows the corresponding methods, so callers can wire UIs against the final shape now.
+- New [`output`](https://docs.rs/vantage-cli-util/0.4.4/vantage_cli_util/output/index.html) module:
+  machine-readable formatters for `json`, `ndjson`, and `cbor-diag` (RFC 8949 §8 diagnostic
+  notation). `cbor-diag` is the lossless format used for cross-driver golden tests; `json` is
+  best-effort for `jq` pipelines.
+- `ModelFactory::for_arn` is now `for_locator` — universal resource locators (`arn:…`,
+  `user:abc123`, `urn:…`) instead of AWS-only. The old `for_arn` keeps working via a default
+  forward, so existing implementations compile unchanged.
+- `Renderer` gains `render_scalar` (for aggregate output) and `note_stub` (default no-op); existing
+  implementors only need to add `render_scalar` when they exercise `@…` tokens.
+- Module split: `vista_cli.rs` becomes `vista_cli/{mod,token,parse,value,factory,run}.rs`. All
+  public items are re-exported, so downstream
+  `use vantage_cli_util::vista_cli::{Mode, ModelFactory, Renderer}` keeps working.
 
 ## 0.4.3 — 2026-05-16
 
-- `vista_cli::run` updated for [`Vista::get_ref`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.get_ref)'s row-based signature: when a `:relation` token appears in `Mode::Single`, the runner now fetches the parent record via `get_some_value` and passes it to `get_ref(relation, &row)` instead of relying on conditions to project the join.
-- After traversal the runner consults [`Vista::list_references`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.list_references) and picks the render mode from the relation's declared cardinality — `HasOne` flips into `Mode::Single` (record card), `HasMany` stays `Mode::List` (grid). `:client` and `:bakery` render as cards; `:clients`, `:orders`, `:products` stay as tables.
+- `vista_cli::run` updated for
+  [`Vista::get_ref`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.get_ref)'s
+  row-based signature: when a `:relation` token appears in `Mode::Single`, the runner now fetches
+  the parent record via `get_some_value` and passes it to `get_ref(relation, &row)` instead of
+  relying on conditions to project the join.
+- After traversal the runner consults
+  [`Vista::list_references`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.list_references)
+  and picks the render mode from the relation's declared cardinality — `HasOne` flips into
+  `Mode::Single` (record card), `HasMany` stays `Mode::List` (grid). `:client` and `:bakery` render
+  as cards; `:clients`, `:orders`, `:products` stay as tables.
 - Pins `vantage-vista = "0.4.7"`.
 
 ## 0.4.2 — 2026-05-14
 
-- New [`vista_cli`](https://docs.rs/vantage-cli-util/0.4.2/vantage_cli_util/vista_cli/index.html) module — the [`Vista`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html) equivalent of `model_cli`. Same token grammar (`<model> [field=value ...] [[N]] [:relation ...] [=col1,col2]`), same `ModelFactory` / `Renderer` traits, but drives a `Vista` end-to-end so traversal goes through [`Vista::get_ref`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html#method.get_ref) and condition pushdown reaches the driver's native condition type. Use this when you've migrated a CLI to the universal Vista surface; `model_cli` stays as the `AnyTable`-flavoured path.
+- New [`vista_cli`](https://docs.rs/vantage-cli-util/0.4.2/vantage_cli_util/vista_cli/index.html)
+  module — the [`Vista`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html)
+  equivalent of `model_cli`. Same token grammar
+  (`<model> [field=value ...] [[N]] [:relation ...] [=col1,col2]`), same `ModelFactory` / `Renderer`
+  traits, but drives a `Vista` end-to-end so traversal goes through
+  [`Vista::get_ref`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html#method.get_ref)
+  and condition pushdown reaches the driver's native condition type. Use this when you've migrated a
+  CLI to the universal Vista surface; `model_cli` stays as the `AnyTable`-flavoured path.
 - Pins `vantage-vista = "0.4.5"` for `Vista::get_ref` and `TableShell::get_ref`.
 
 ## 0.4.1 — 2026-04-30
 
-- New `model_cli` module — generic, model-driven CLI runner over any `AnyTable`. Argv shape: `<model | arn> [field=value ...] [[N]] [:relation [[N]] ...] [=col1,col2 ...]`. Singular vs plural model names drive list/single mode; `id=value` is sugar that resolves to the table's id field and forces single-record mode; `[N]` selects the Nth record and switches into single-record mode by adding `eq(id_field, that_id)`; `:relation` traverses a registered `with_many` / `with_one`; `=col1,col2` overrides the visible columns in list mode. Glued forms (`users[0]`, `:members[0]`, `name=foo[0]`, `=msg,timestamp[0]`) split into a base token plus an index selector.
-- Two new traits the caller implements: `ModelFactory` (resolve a name or ARN to an `AnyTable`) and `Renderer` (render lists / single records). The crate stays UI-/backend-agnostic — actual record rendering is delegated to the caller.
-- New `render_records_columns` helper alongside the existing `render_records_typed`. Takes an explicit column list and does *not* auto-prepend an id column — for the case where the caller spelled out exactly what they want to see (e.g. the `=col1,col2` override path) and an extra id column would just be noise. Existing `render_records` / `render_records_typed` are unchanged.
+- New `model_cli` module — generic, model-driven CLI runner over any `AnyTable`. Argv shape:
+  `<model | arn> [field=value ...] [[N]] [:relation [[N]] ...] [=col1,col2 ...]`. Singular vs plural
+  model names drive list/single mode; `id=value` is sugar that resolves to the table's id field and
+  forces single-record mode; `[N]` selects the Nth record and switches into single-record mode by
+  adding `eq(id_field, that_id)`; `:relation` traverses a registered `with_many` / `with_one`;
+  `=col1,col2` overrides the visible columns in list mode. Glued forms (`users[0]`, `:members[0]`,
+  `name=foo[0]`, `=msg,timestamp[0]`) split into a base token plus an index selector.
+- Two new traits the caller implements: `ModelFactory` (resolve a name or ARN to an `AnyTable`) and
+  `Renderer` (render lists / single records). The crate stays UI-/backend-agnostic — actual record
+  rendering is delegated to the caller.
+- New `render_records_columns` helper alongside the existing `render_records_typed`. Takes an
+  explicit column list and does _not_ auto-prepend an id column — for the case where the caller
+  spelled out exactly what they want to see (e.g. the `=col1,col2` override path) and an extra id
+  column would just be noise. Existing `render_records` / `render_records_typed` are unchanged.
 - New `ciborium` dep (used at the model_cli boundary, where records flow as `Record<CborValue>`).
-- Pins `vantage-table = "0.4.8"` for the new `TableLike` reflection methods (`id_field_name`, `title_field_names`, `column_types`, `get_ref_names`, `add_condition_eq`).
+- Pins `vantage-table = "0.4.8"` for the new `TableLike` reflection methods (`id_field_name`,
+  `title_field_names`, `column_types`, `get_ref_names`, `add_condition_eq`).
 
 ## 0.4.0 — 2026-04-16
 
-- Initial 0.4 release. Generic CLI helpers (`render_records`, `handle_commands`) for driving any vantage backend through a uniform command set.
+- Initial 0.4 release. Generic CLI helpers (`render_records`, `handle_commands`) for driving any
+  vantage backend through a uniform command set.

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-cli-util"
-version = "0.5.2"
+version = "0.5.3"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "CLI utilities for Vantage data framework"
@@ -14,11 +14,11 @@ comfy-table = { version = "7", features = ["custom_styling"] }
 indexmap = "2"
 owo-colors = "4"
 serde_json = "1"
-vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
-vantage-types = { version = "0.4", path = "../vantage-types" }
-vantage-vista = { version = "0.4.10", path = "../vantage-vista" }
+vantage-types = { version = "0.5", path = "../vantage-types" }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/vantage-core/CHANGELOG.md
+++ b/vantage-core/CHANGELOG.md
@@ -1,13 +1,23 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.4.2 — 2026-05-16
 
 - Internal dependency version refresh; no public API changes.
 
 ## 0.4.1 — 2026-05-04
 
-- New error-kind annotators: [`VantageError::is_unimplemented`](https://docs.rs/vantage-core/0.4.1/vantage_core/util/error/struct.VantageError.html) and [`is_unsupported`](https://docs.rs/vantage-core/0.4.1/vantage_core/util/error/struct.VantageError.html). Use them on errors returned from default trait method impls so callers can distinguish "the driver doesn't support this op" from "the driver claims support but the implementation is missing."
+- New error-kind annotators:
+  [`VantageError::is_unimplemented`](https://docs.rs/vantage-core/0.4.1/vantage_core/util/error/struct.VantageError.html)
+  and
+  [`is_unsupported`](https://docs.rs/vantage-core/0.4.1/vantage_core/util/error/struct.VantageError.html).
+  Use them on errors returned from default trait method impls so callers can distinguish "the driver
+  doesn't support this op" from "the driver claims support but the implementation is missing."
 
 ## 0.4.0 — 2026-04-16
 
-- Initial 0.4 release. `VantageError` with structured context, `Result` alias, and the unified error-handling foundation used by every other vantage crate.
+- Initial 0.4 release. `VantageError` with structured context, `Result` alias, and the unified
+  error-handling foundation used by every other vantage crate.

--- a/vantage-core/Cargo.toml
+++ b/vantage-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-core"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Core error types and utilities for the Vantage data framework"

--- a/vantage-csv/CHANGELOG.md
+++ b/vantage-csv/CHANGELOG.md
@@ -1,12 +1,27 @@
 # Changelog
 
+## 0.5.2 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.0 — 2026-05-23
 
-- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+- Bumped to the 0.5 line to track
+  [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the
+  `AnyTable` decommission cycle. No code changes beyond the dependency pin.
 
 ## 0.4.13 — 2026-05-18
 
-- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. `CsvTableShell` now owns its [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implements the new [`columns`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.columns) / [`references`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.references) / [`id_column`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.id_column) shell methods. `csv.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.
+- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s
+  schema-on-source refactor. `CsvTableShell` now owns its
+  [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html)
+  and implements the new
+  [`columns`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.columns)
+  /
+  [`references`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.references)
+  /
+  [`id_column`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.id_column)
+  shell methods. `csv.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.
 - Pins `vantage-vista = "0.4.10"`.
 
 ## 0.4.12 — 2026-05-17

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.5.1"
+version = "0.5.2"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"
@@ -20,15 +20,15 @@ paste = "1.0"
 indexmap = { version = "2", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1", features = ["preserve_order"] }
-vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
-vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
-vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.4.10", path = "../vantage-vista", optional = true }
+vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
+vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.4.10", path = "../vantage-vista" }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }

--- a/vantage-dataset/CHANGELOG.md
+++ b/vantage-dataset/CHANGELOG.md
@@ -1,8 +1,21 @@
 # Changelog
 
+## 0.5.1 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.0 — 2026-05-23
 
-- [`ImDataSource`](https://docs.rs/vantage-dataset/0.5.0/vantage_dataset/im/struct.ImDataSource.html) and [`ImTable`](https://docs.rs/vantage-dataset/0.5.0/vantage_dataset/im/struct.ImTable.html) are now generic over the wire value type `V`. The default stays `serde_json::Value`, so existing call sites compile unchanged. The entity-typed [`ReadableDataSet`](https://docs.rs/vantage-dataset/0.5.0/vantage_dataset/traits/trait.ReadableDataSet.html) / `WritableDataSet` / `InsertableDataSet` impls are only available for `V = serde_json::Value` because they round-trip records through `serde_json` for `try_from_record`; the value-typed valueset impls now work for any `V` with `Clone + Send + Sync + 'static`. Drivers that want a CBOR-typed in-memory store can use `ImDataSource::<CborValue>::new()` directly without bringing serde_json into their value path.
+- [`ImDataSource`](https://docs.rs/vantage-dataset/0.5.0/vantage_dataset/im/struct.ImDataSource.html)
+  and [`ImTable`](https://docs.rs/vantage-dataset/0.5.0/vantage_dataset/im/struct.ImTable.html) are
+  now generic over the wire value type `V`. The default stays `serde_json::Value`, so existing call
+  sites compile unchanged. The entity-typed
+  [`ReadableDataSet`](https://docs.rs/vantage-dataset/0.5.0/vantage_dataset/traits/trait.ReadableDataSet.html)
+  / `WritableDataSet` / `InsertableDataSet` impls are only available for `V = serde_json::Value`
+  because they round-trip records through `serde_json` for `try_from_record`; the value-typed
+  valueset impls now work for any `V` with `Clone + Send + Sync + 'static`. Drivers that want a
+  CBOR-typed in-memory store can use `ImDataSource::<CborValue>::new()` directly without bringing
+  serde_json into their value path.
 - Bumped to the 0.5 line to track the workspace's `AnyTable` decommission cycle.
 
 ## 0.4.3 — 2026-05-16
@@ -11,7 +24,9 @@
 
 ## 0.4.2 — 2026-04-19
 
-- `Operation::is_null()` / `is_not_null()` on the generic trait — SQL backends render `{} IS NULL` / `{} IS NOT NULL`; Mongo gets `{ field: null }` / `{ field: { $ne: null } }`.
+- `Operation::is_null()` / `is_not_null()` on the generic trait — SQL backends render `{} IS NULL` /
+  `{} IS NOT NULL`; Mongo gets `{ field: null }` / `{ field: { $ne: null } }`.
 - `ActiveEntity::reload()` — refetches by stored id; errors if the row was deleted externally.
 - `ActiveEntity::delete()` — deletes by stored id.
-- `ReadableDataSet::get(id)` and `ReadableValueSet::get_value` now return `Result<Option<E>>` / `Result<Option<Record>>` instead of `Err("no row found")` on miss.
+- `ReadableDataSet::get(id)` and `ReadableValueSet::get_value` now return `Result<Option<E>>` /
+  `Result<Option<Record>>` instead of `Err("no row found")` on miss.

--- a/vantage-dataset/Cargo.toml
+++ b/vantage-dataset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-dataset"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Dataset traits for the Vantage data framework"
@@ -21,8 +21,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0.18"
 uuid = { version = "1.23.1", features = ["v4"] }
-vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
+vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["full"] }

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,45 +1,94 @@
 # Changelog
 
+## 0.5.2 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.0 — 2026-05-23
 
-- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+- Bumped to the 0.5 line to track
+  [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the
+  `AnyTable` decommission cycle. No code changes beyond the dependency pin.
 
 ## 0.4.5 — 2026-05-22
 
-- `TableScenery::master_capabilities()` exposes the master Vista's capability flags. Lets UI delegates pick `set_viewport` for random-access masters and `request_load_more` for cursor-only ones.
+- `TableScenery::master_capabilities()` exposes the master Vista's capability flags. Lets UI
+  delegates pick `set_viewport` for random-access masters and `request_load_more` for cursor-only
+  ones.
 - `VistaCapabilities` re-exported from the crate root.
 
 ## 0.4.4 — 2026-05-20
 
-- Viewport loader now edge-anchors the fetch range. When part of the visible window is already cached, the loader anchors the fetch at the cached/uncached boundary and grows it by `page_size` in the uncached direction — so dragging slowly across a cached region stops re-fetching what's already there. Force-load callers (`request_load_more`) still get the exact range they asked for.
-- Viewport loader gained `tracing` spans on the `vantage_diorama::viewport` target — debounce absorbtion, skip reasons, effective range, fetch latency, and cache-after counts — for diagnosing overfetch and stall behaviour in real UIs.
-- BDD coverage extended to the four facade write ops the original `write_path.feature` left out: `tests/features/v3_replace.feature`, `v3_patch.feature`, `v3_delete.feature`, `v3_delete_all.feature`. Each follows the Insert trio — default-route to master, `WriteFailed` on `on_write` error, and the `mock` / `sqlite` Mirror outline.
-- `OnWriteMode::Mirror`'s `WriteOp::Patch` arm in the BDD harness now reads-modifies-writes the cache so the merged row survives an op that omits columns. `cache.insert_value` is a redb full-replace, so the previous arm silently dropped fields outside the partial.
+- Viewport loader now edge-anchors the fetch range. When part of the visible window is already
+  cached, the loader anchors the fetch at the cached/uncached boundary and grows it by `page_size`
+  in the uncached direction — so dragging slowly across a cached region stops re-fetching what's
+  already there. Force-load callers (`request_load_more`) still get the exact range they asked for.
+- Viewport loader gained `tracing` spans on the `vantage_diorama::viewport` target — debounce
+  absorbtion, skip reasons, effective range, fetch latency, and cache-after counts — for diagnosing
+  overfetch and stall behaviour in real UIs.
+- BDD coverage extended to the four facade write ops the original `write_path.feature` left out:
+  `tests/features/v3_replace.feature`, `v3_patch.feature`, `v3_delete.feature`,
+  `v3_delete_all.feature`. Each follows the Insert trio — default-route to master, `WriteFailed` on
+  `on_write` error, and the `mock` / `sqlite` Mirror outline.
+- `OnWriteMode::Mirror`'s `WriteOp::Patch` arm in the BDD harness now reads-modifies-writes the
+  cache so the merged row survives an op that omits columns. `cache.insert_value` is a redb
+  full-replace, so the previous arm silently dropped fields outside the partial.
 
 ## 0.4.3 — 2026-05-20
 
-- `TableScenery` v2: sparse `BTreeMap<usize, Arc<EnrichedRecord>>` storage replaces the dense `Vec`. `row(i)` returns `None` for unloaded indices so virtualised UIs can render a skeleton at that slot.
-- New `LensBuilder` callbacks: `total_provider(&Dio) -> usize` runs once per scenery open and drives `row_count` / `estimated_total` ahead of any rows being paged in; `on_load_chunk(&Dio, Range, ChunkSink)` fetches uncached ranges, with `ChunkSink::push(idx, id, record)` writing to the cache and the scenery's sparse map.
-- New `DioEvent` variants — `ViewportChanged`, `RangeLoaded`, `LoadFailed` — fan out viewport-pipeline progress without colliding with `Invalidated`. The reactor ignores its own events to avoid loops.
-- New `LensDefaults`: `refresh_on_open` (default true) re-fetches the first page in the background at scenery open; `viewport_debounce` (default 50ms) coalesces rapid scroll bursts into a single fetch.
-- `TableSceneryBuilder::page_size` default raised from 50 → 100; `.initial_range(range)` overrides the refresh-on-open viewport.
-- BDD coverage for the three new contracts: `tests/features/v2_total_count.feature`, `v2_sparse_rows.feature`, `v2_viewport.feature`.
-- `src/scenery/table.rs` split into `scenery/table/{mod,builder,state,loader,reactor,helpers}.rs` so the viewport pipeline and reactor can grow without one monolithic file.
+- `TableScenery` v2: sparse `BTreeMap<usize, Arc<EnrichedRecord>>` storage replaces the dense `Vec`.
+  `row(i)` returns `None` for unloaded indices so virtualised UIs can render a skeleton at that
+  slot.
+- New `LensBuilder` callbacks: `total_provider(&Dio) -> usize` runs once per scenery open and drives
+  `row_count` / `estimated_total` ahead of any rows being paged in;
+  `on_load_chunk(&Dio, Range, ChunkSink)` fetches uncached ranges, with
+  `ChunkSink::push(idx, id, record)` writing to the cache and the scenery's sparse map.
+- New `DioEvent` variants — `ViewportChanged`, `RangeLoaded`, `LoadFailed` — fan out
+  viewport-pipeline progress without colliding with `Invalidated`. The reactor ignores its own
+  events to avoid loops.
+- New `LensDefaults`: `refresh_on_open` (default true) re-fetches the first page in the background
+  at scenery open; `viewport_debounce` (default 50ms) coalesces rapid scroll bursts into a single
+  fetch.
+- `TableSceneryBuilder::page_size` default raised from 50 → 100; `.initial_range(range)` overrides
+  the refresh-on-open viewport.
+- BDD coverage for the three new contracts: `tests/features/v2_total_count.feature`,
+  `v2_sparse_rows.feature`, `v2_viewport.feature`.
+- `src/scenery/table.rs` split into `scenery/table/{mod,builder,state,loader,reactor,helpers}.rs` so
+  the viewport pipeline and reactor can grow without one monolithic file.
 
 ## 0.4.2 — 2026-05-19
 
-- BDD harness now covers the full Diorama surface: Lens lifecycle, write path (`on_write` modes, `WriteFailed` events, capability lifting), event path (`ChangeEvent` → `on_event` → cache, `TableScenery` generation contract), `refresh_every` skip-first semantics under virtual time, multi-Dio cache isolation, and read paths against Mock / CSV / in-memory SQLite via a `Scenario Outline`.
-- Event-sequence assertions now use [insta](https://crates.io/crates/insta) snapshots so contract drift shows up in diff review.
-- Fixed a latent bug in `bump_generation` across all three Scenery types: `watch::Sender::send` silently dropped values when no receiver was momentarily subscribed. Switched to `send_replace` so UIs that drop and re-subscribe always see the latest generation.
+- BDD harness now covers the full Diorama surface: Lens lifecycle, write path (`on_write` modes,
+  `WriteFailed` events, capability lifting), event path (`ChangeEvent` → `on_event` → cache,
+  `TableScenery` generation contract), `refresh_every` skip-first semantics under virtual time,
+  multi-Dio cache isolation, and read paths against Mock / CSV / in-memory SQLite via a
+  `Scenario Outline`.
+- Event-sequence assertions now use [insta](https://crates.io/crates/insta) snapshots so contract
+  drift shows up in diff review.
+- Fixed a latent bug in `bump_generation` across all three Scenery types: `watch::Sender::send`
+  silently dropped values when no receiver was momentarily subscribed. Switched to `send_replace` so
+  UIs that drop and re-subscribe always see the latest generation.
 
 ## 0.4.1 — 2026-05-18
 
-- New BDD test harness under `vantage-diorama/tests/` using [cucumber](https://crates.io/crates/cucumber). Scenarios run on a single-threaded paused-clock tokio runtime so refresh/timeout behaviour is deterministic — `tokio::time::advance` is the only thing that moves the clock.
-- Initial features cover the Phase-1 mock-backend wiring (`skeleton.feature`) and the three Lens lifecycle contracts (`lifecycle.feature`): `on_start_blocking=true` parks `make_dio`, `on_start_blocking=false` lets it return, and dropping the last `Dio` handle shuts the write worker down cleanly.
-- Added `#[doc(hidden)]` `Dio::take_write_worker_handle` so the harness can await clean worker exit. Not part of the supported surface — `#[doc(hidden)]` is the contract.
+- New BDD test harness under `vantage-diorama/tests/` using
+  [cucumber](https://crates.io/crates/cucumber). Scenarios run on a single-threaded paused-clock
+  tokio runtime so refresh/timeout behaviour is deterministic — `tokio::time::advance` is the only
+  thing that moves the clock.
+- Initial features cover the Phase-1 mock-backend wiring (`skeleton.feature`) and the three Lens
+  lifecycle contracts (`lifecycle.feature`): `on_start_blocking=true` parks `make_dio`,
+  `on_start_blocking=false` lets it return, and dropping the last `Dio` handle shuts the write
+  worker down cleanly.
+- Added `#[doc(hidden)]` `Dio::take_write_worker_handle` so the harness can await clean worker exit.
+  Not part of the supported surface — `#[doc(hidden)]` is the contract.
 
 ## 0.4.0 — 2026-05-18
 
-- Initial release. `vantage-diorama` adds a cached, composable, reactive surface in front of a `vantage-vista` `Vista`: `Dio::vista()` hands callers a fresh facade Vista that reads through the cache, while writes go to the master and re-emit through the event bus.
-- Designed to pair with the schema-on-source `TableShell` shape introduced in [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/): the facade shell forwards `columns` / `references` / `id_column` to the master, so consumers don't see a stale or duplicated schema.
+- Initial release. `vantage-diorama` adds a cached, composable, reactive surface in front of a
+  `vantage-vista` `Vista`: `Dio::vista()` hands callers a fresh facade Vista that reads through the
+  cache, while writes go to the master and re-emit through the event bus.
+- Designed to pair with the schema-on-source `TableShell` shape introduced in
+  [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/): the facade shell
+  forwards `columns` / `references` / `id_column` to the master, so consumers don't see a stale or
+  duplicated schema.
 - Pre-release: API surface, scenery types, and event-bus semantics will move before 0.5.

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"
@@ -10,9 +10,9 @@ repository = "https://github.com/romaninsh/vantage"
 doctest = false
 
 [dependencies]
-vantage-core = { version = "0.4.1", path = "../vantage-core" }
-vantage-types = { version = "0.4", path = "../vantage-types" }
-vantage-vista = { version = "0.4", path = "../vantage-vista" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-types = { version = "0.5", path = "../vantage-types" }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 

--- a/vantage-expressions/CHANGELOG.md
+++ b/vantage-expressions/CHANGELOG.md
@@ -1,16 +1,19 @@
 # Changelog
 
-## 0.4.4 — 2026-05-16
+## 0.5.0 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
+## 0.4.4 — 2026-05-23
 
 - Internal dependency version refresh; no public API changes.
 
 ## 0.4.3 — 2026-05-03
 
 - `AnyExpression` and `ExpressionLike` moved to the new
-  [`vantage-vista`](https://docs.rs/vantage-vista/0.4.0/vantage_vista/) crate
-  and are re-exported from `vantage-expressions` unchanged. If you import
-  via `vantage_expressions::{AnyExpression, ExpressionLike}` (or the
-  prelude), nothing changes for you.
+  [`vantage-vista`](https://docs.rs/vantage-vista/0.4.0/vantage_vista/) crate and are re-exported
+  from `vantage-expressions` unchanged. If you import via
+  `vantage_expressions::{AnyExpression, ExpressionLike}` (or the prelude), nothing changes for you.
 
 ## 0.4.2 — 2026-04-17
 

--- a/vantage-expressions/Cargo.toml
+++ b/vantage-expressions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-expressions"
-version = "0.4.5"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Database agnostic expressions"
@@ -14,9 +14,9 @@ chrono = { version = "0.4", features = ["serde"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
-vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
-vantage-vista = { version = "0.4", path = "../vantage-vista" }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["full"] }

--- a/vantage-log-writer/CHANGELOG.md
+++ b/vantage-log-writer/CHANGELOG.md
@@ -1,12 +1,22 @@
 # Changelog
 
+## 0.5.2 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.0 — 2026-05-23
 
-- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+- Bumped to the 0.5 line to track
+  [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the
+  `AnyTable` decommission cycle. No code changes beyond the dependency pin.
 
 ## 0.4.2 — 2026-05-18
 
-- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. `LogWriterTableShell` now owns its [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implements the new `columns` / `references` / `id_column` shell methods. `writer.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.
+- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s
+  schema-on-source refactor. `LogWriterTableShell` now owns its
+  [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html)
+  and implements the new `columns` / `references` / `id_column` shell methods.
+  `writer.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.
 - Pins `vantage-vista = "0.4.10"`.
 
 ## 0.4.1 — 2026-05-15

--- a/vantage-log-writer/Cargo.toml
+++ b/vantage-log-writer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-log-writer"
-version = "0.5.1"
+version = "0.5.2"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for append-only log files (JSONL)"
@@ -22,16 +22,16 @@ serde_json = { version = "1", features = ["preserve_order"] }
 tokio = { version = "1.48", features = ["rt", "fs", "sync", "io-util", "macros"] }
 tracing = "0.1"
 ulid = "1"
-vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
-vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
-vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.4.10", path = "../vantage-vista", optional = true }
+vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
+vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"
 tempfile = "3"
 tokio = { version = "1.48", features = ["full"] }
-vantage-vista = { version = "0.4.10", path = "../vantage-vista" }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }

--- a/vantage-mongodb/CHANGELOG.md
+++ b/vantage-mongodb/CHANGELOG.md
@@ -1,64 +1,121 @@
 # Changelog
 
+## 0.5.3 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.2 — 2026-05-23
 
-- Drops the `vantage_table::any::AnyTable` re-export from `prelude` — `AnyTable` is deleted upstream in [vantage-table 0.5.2](https://docs.rs/vantage-table/0.5.2/vantage_table/). Use `MongoDB::vista_factory().from_table(...)` for cross-driver wrapping.
+- Drops the `vantage_table::any::AnyTable` re-export from `prelude` — `AnyTable` is deleted upstream
+  in [vantage-table 0.5.2](https://docs.rs/vantage-table/0.5.2/vantage_table/). Use
+  `MongoDB::vista_factory().from_table(...)` for cross-driver wrapping.
 
 ## 0.5.1 — 2026-05-23
 
-- Tracks [vantage-dataset 0.5.0](https://docs.rs/vantage-dataset/0.5/vantage_dataset/)'s `ImTable` / `ImDataSource` parametrization. No public API change in this crate.
+- Tracks [vantage-dataset 0.5.0](https://docs.rs/vantage-dataset/0.5/vantage_dataset/)'s `ImTable` /
+  `ImDataSource` parametrization. No public API change in this crate.
 
 ## 0.5.0 — 2026-05-23
 
-- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+- Bumped to the 0.5 line to track
+  [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the
+  `AnyTable` decommission cycle. No code changes beyond the dependency pin.
 
 ## 0.4.11 — 2026-05-18
 
-- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. `MongoTableShell` now owns its [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implements the new `columns` / `references` / `id_column` shell methods. `mongodb.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.
+- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s
+  schema-on-source refactor. `MongoTableShell` now owns its
+  [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html)
+  and implements the new `columns` / `references` / `id_column` shell methods.
+  `mongodb.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.
 - Pins `vantage-vista = "0.4.10"`.
 
 ## 0.4.10 — 2026-05-17
 
-- `MongoTableShell` ships the full Stage 5 query surface: [`add_order`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_order) on any column (MongoDB sorts on any field — every column gets the [`ORDERABLE`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/flags/constant.ORDERABLE.html) flag at construction), [`add_search`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_search) via the existing `search_table_condition`, and offset-style pagination ([`set_page_size`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.set_page_size) + [`fetch_page`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_page) / [`fetch_next`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_next), encoding the cursor as a 1-based page number).
-- Capabilities updated: `can_order`, `can_search`, `can_set_page_size`, `can_fetch_page`, `can_fetch_next` all `true`. The retired `paginate_kind` flag is gone — drop it from any direct `VistaCapabilities` construction.
+- `MongoTableShell` ships the full Stage 5 query surface:
+  [`add_order`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_order)
+  on any column (MongoDB sorts on any field — every column gets the
+  [`ORDERABLE`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/flags/constant.ORDERABLE.html)
+  flag at construction),
+  [`add_search`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_search)
+  via the existing `search_table_condition`, and offset-style pagination
+  ([`set_page_size`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.set_page_size) +
+  [`fetch_page`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_page)
+  /
+  [`fetch_next`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_next),
+  encoding the cursor as a 1-based page number).
+- Capabilities updated: `can_order`, `can_search`, `can_set_page_size`, `can_fetch_page`,
+  `can_fetch_next` all `true`. The retired `paginate_kind` flag is gone — drop it from any direct
+  `VistaCapabilities` construction.
 - Pins `vantage-vista = "0.4.9"`, `vantage-table = "0.4.12"`.
 
 ## 0.4.9 — 2026-05-16
 
-- `MongoTableShell` implements [`TableShell::get_ref`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/trait.TableShell.html#method.get_ref) and `get_ref_kinds`: row-based reference traversal at the Vista layer. The shell converts the CBOR parent row into `Record<AnyMongoType>`, delegates to `Reference::resolve_from_row` on the wrapped typed table, and re-wraps via `MongoVistaFactory::from_table`.
-- `MongoDB::eq_value_condition` implemented — builds `doc! { field: bson_value }` directly via `AnyMongoType::to_bson`, sidestepping the `Expression → MongoCondition` coercion that previously needed the panic-stub `From` impl.
+- `MongoTableShell` implements
+  [`TableShell::get_ref`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/trait.TableShell.html#method.get_ref)
+  and `get_ref_kinds`: row-based reference traversal at the Vista layer. The shell converts the CBOR
+  parent row into `Record<AnyMongoType>`, delegates to `Reference::resolve_from_row` on the wrapped
+  typed table, and re-wraps via `MongoVistaFactory::from_table`.
+- `MongoDB::eq_value_condition` implemented — builds `doc! { field: bson_value }` directly via
+  `AnyMongoType::to_bson`, sidestepping the `Expression → MongoCondition` coercion that previously
+  needed the panic-stub `From` impl.
 - Pins `vantage-vista = "0.4.7"`, `vantage-table = "0.4.10"`.
 
 ## 0.4.8 — 2026-05-09
 
-- Pins `vantage-types` to `>= 0.4.2` for consistency with the other backends after the `TerminalRender → RichText` migration.
+- Pins `vantage-types` to `>= 0.4.2` for consistency with the other backends after the
+  `TerminalRender → RichText` migration.
 
 ## 0.4.7 — 2026-05-04
 
-- Implements [`TableShell::driver_name`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.driver_name) — `Vista::driver()` reports `"mongodb"` for collections wrapped through `MongoDB::vista_factory()`.
+- Implements
+  [`TableShell::driver_name`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.driver_name)
+  — `Vista::driver()` reports `"mongodb"` for collections wrapped through
+  `MongoDB::vista_factory()`.
 - Bumps minimum [`vantage-vista`](https://docs.rs/vantage-vista/0.4.4/) requirement to 0.4.4.
 
 ## 0.4.6 — 2026-05-04
 
-- `MongoVistaSource` is now [`MongoTableShell`](https://docs.rs/vantage-mongodb/0.4.6/vantage_mongodb/struct.MongoTableShell.html), tracking the [`vantage-vista 0.4.3`](https://docs.rs/vantage-vista/0.4.3/vantage_vista/trait.TableShell.html) trait rename. The factory's surface is unchanged — `MongoDB::vista_factory().from_table(...)` and `from_yaml(...)` both still produce a `Vista`.
+- `MongoVistaSource` is now
+  [`MongoTableShell`](https://docs.rs/vantage-mongodb/0.4.6/vantage_mongodb/struct.MongoTableShell.html),
+  tracking the
+  [`vantage-vista 0.4.3`](https://docs.rs/vantage-vista/0.4.3/vantage_vista/trait.TableShell.html)
+  trait rename. The factory's surface is unchanged — `MongoDB::vista_factory().from_table(...)` and
+  `from_yaml(...)` both still produce a `Vista`.
 
 ## 0.4.5 — 2026-05-04
 
-New opt-in [`vista`](https://docs.rs/vantage-mongodb/0.4.5/vantage_mongodb/struct.MongoVistaFactory.html) feature: build a [`Vista`](https://docs.rs/vantage-vista/0.4.2/vantage_vista/struct.Vista.html) from a typed `Table<MongoDB, E>` or from YAML, with full read+write CRUD, server-side `eq` filtering, and nested-document column projection.
+New opt-in
+[`vista`](https://docs.rs/vantage-mongodb/0.4.5/vantage_mongodb/struct.MongoVistaFactory.html)
+feature: build a [`Vista`](https://docs.rs/vantage-vista/0.4.2/vantage_vista/struct.Vista.html) from
+a typed `Table<MongoDB, E>` or from YAML, with full read+write CRUD, server-side `eq` filtering, and
+nested-document column projection.
 
-- `MongoDB::vista_factory()` returns a [`MongoVistaFactory`](https://docs.rs/vantage-mongodb/0.4.5/vantage_mongodb/struct.MongoVistaFactory.html); `from_table` and `from_yaml` both produce a `Vista`.
-- YAML `mongo:` block carries `collection`. Per-column `mongo: { field }` renames a single BSON key, `mongo: { nested_path: address.city }` projects out of nested sub-documents — reads walk the path, writes rebuild sibling sub-docs, filters use dot-notation.
-- BSON ↔ CBOR bridge in `vista::cbor`. Lossy paths (`ObjectId`, `DateTime`, `Decimal128`, `Regex`) collapse to their string representation; documented in module docs.
-- Capabilities: `can_count`, `can_insert`, `can_update`, `can_delete` all true. `can_subscribe` deferred to change-streams work.
-- YAML validation: empty `nested_path: ""` and empty segments (`a..b`, `.a`, `a.`) now error at spec load with the offending column named, so the mistake doesn't surface later as a malformed BSON filter.
+- `MongoDB::vista_factory()` returns a
+  [`MongoVistaFactory`](https://docs.rs/vantage-mongodb/0.4.5/vantage_mongodb/struct.MongoVistaFactory.html);
+  `from_table` and `from_yaml` both produce a `Vista`.
+- YAML `mongo:` block carries `collection`. Per-column `mongo: { field }` renames a single BSON key,
+  `mongo: { nested_path: address.city }` projects out of nested sub-documents — reads walk the path,
+  writes rebuild sibling sub-docs, filters use dot-notation.
+- BSON ↔ CBOR bridge in `vista::cbor`. Lossy paths (`ObjectId`, `DateTime`, `Decimal128`, `Regex`)
+  collapse to their string representation; documented in module docs.
+- Capabilities: `can_count`, `can_insert`, `can_update`, `can_delete` all true. `can_subscribe`
+  deferred to change-streams work.
+- YAML validation: empty `nested_path: ""` and empty segments (`a..b`, `.a`, `a.`) now error at spec
+  load with the offending column named, so the mistake doesn't surface later as a malformed BSON
+  filter.
 - Off by default; non-vista users still don't depend on `vantage-vista`.
 
 ## 0.4.4 — 2026-04-25
 
-- `From`/`Into<ciborium::Value>` impls on `AnyMongoType` so MongoDB tables can be wrapped via `AnyTable::from_table`. Round-trips via `serde_json::Value` (Bson and ciborium are both serde-friendly; same lossy bits as the existing JSON bridge).
+- `From`/`Into<ciborium::Value>` impls on `AnyMongoType` so MongoDB tables can be wrapped via
+  `AnyTable::from_table`. Round-trips via `serde_json::Value` (Bson and ciborium are both
+  serde-friendly; same lossy bits as the existing JSON bridge).
 - Pins `vantage-table = "0.4.4"` to keep the pair in lock-step.
 
 ## 0.4.3 — 2026-04-19
 
-- Reference traversal now bridges `ObjectId` and `String` id-field boundaries via `related_in_condition`'s dual push.
-- `impl From<MongoId> for AnyMongoType` so `c.id().eq(MongoId::parse(...))` dispatches to the right BSON type.
+- Reference traversal now bridges `ObjectId` and `String` id-field boundaries via
+  `related_in_condition`'s dual push.
+- `impl From<MongoId> for AnyMongoType` so `c.id().eq(MongoId::parse(...))` dispatches to the right
+  BSON type.

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"
@@ -11,12 +11,12 @@ default = []
 vista = ["dep:vantage-vista"]
 
 [dependencies]
-vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-types = { version = "0.4.2", path = "../vantage-types" }
-vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-types = { version = "0.5", path = "../vantage-types" }
+vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
-vantage-vista = { version = "0.4.10", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
 
 bson = "2"
 ciborium = { version = "0.2", features = ["std"] }
@@ -33,4 +33,4 @@ futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
 pretty_assertions = "1"
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.4.10", path = "../vantage-vista" }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }

--- a/vantage-redb/CHANGELOG.md
+++ b/vantage-redb/CHANGELOG.md
@@ -1,17 +1,32 @@
 # Changelog
 
+## 0.5.2 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.0 — 2026-05-23
 
-- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+- Bumped to the 0.5 line to track
+  [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the
+  `AnyTable` decommission cycle. No code changes beyond the dependency pin.
 
 ## 0.4.0 — 2026-04-26
 
-Full rewrite for the 0.4 trait surface. **Storage format and public API are not compatible with 0.3** — open in a fresh database file.
+Full rewrite for the 0.4 trait surface. **Storage format and public API are not compatible with
+0.3** — open in a fresh database file.
 
-- New `RedbType` type system via `vantage_type_system!` over `ciborium::Value`. `AnyRedbType` round-trips fully typed without needing the entity struct on read.
-- Row bodies stored as variant-tagged CBOR triples; values written untyped get re-tagged from CBOR shape on read.
-- Secondary indexes are opt-in via `ColumnFlag::Indexed` (new variant added in `vantage-table`). Index tables use composite keys `(value_bytes, id)` so non-unique columns work without list encoding.
-- Conditions: minimal `RedbCondition` enum supporting `eq` and `in_`. The id column short-circuits to a direct main-table lookup; conditions on non-indexed columns panic at execution time.
-- `TableSource` impl with full CRUD, atomic index maintenance inside each write transaction, and `related_in_condition` for cross-table relationship traversal.
-- Aggregations (`sum`, `min`, `max`) and `Selectable` are intentionally not implemented — redb has no query language.
-- Drops bincode, the local error tower, and the old `RedbColumn` / `RedbExpression` / `RedbSelect` types.
+- New `RedbType` type system via `vantage_type_system!` over `ciborium::Value`. `AnyRedbType`
+  round-trips fully typed without needing the entity struct on read.
+- Row bodies stored as variant-tagged CBOR triples; values written untyped get re-tagged from CBOR
+  shape on read.
+- Secondary indexes are opt-in via `ColumnFlag::Indexed` (new variant added in `vantage-table`).
+  Index tables use composite keys `(value_bytes, id)` so non-unique columns work without list
+  encoding.
+- Conditions: minimal `RedbCondition` enum supporting `eq` and `in_`. The id column short-circuits
+  to a direct main-table lookup; conditions on non-indexed columns panic at execution time.
+- `TableSource` impl with full CRUD, atomic index maintenance inside each write transaction, and
+  `related_in_condition` for cross-table relationship traversal.
+- Aggregations (`sum`, `min`, `max`) and `Selectable` are intentionally not implemented — redb has
+  no query language.
+- Drops bincode, the local error tower, and the old `RedbColumn` / `RedbExpression` / `RedbSelect`
+  types.

--- a/vantage-redb/Cargo.toml
+++ b/vantage-redb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-redb"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -11,9 +11,9 @@ repository = "https://github.com/romaninsh/vantage"
 readme = "../README.md"
 
 [dependencies]
-vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-types = { version = "0.4", path = "../vantage-types" }
-vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-types = { version = "0.5", path = "../vantage-types" }
+vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,26 +1,52 @@
 # Changelog
 
+## 0.5.3 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.2 — 2026-05-23
 
-- Drops the `vantage_table::any::AnyTable` re-export from `prelude` — `AnyTable` is deleted upstream in [vantage-table 0.5.2](https://docs.rs/vantage-table/0.5.2/vantage_table/). Use the driver's `vista_factory().from_table(...)` for cross-driver wrapping.
+- Drops the `vantage_table::any::AnyTable` re-export from `prelude` — `AnyTable` is deleted upstream
+  in [vantage-table 0.5.2](https://docs.rs/vantage-table/0.5.2/vantage_table/). Use the driver's
+  `vista_factory().from_table(...)` for cross-driver wrapping.
 
 ## 0.5.1 — 2026-05-23
 
-- Tracks [vantage-dataset 0.5.0](https://docs.rs/vantage-dataset/0.5/vantage_dataset/)'s `ImTable` / `ImDataSource` parametrization. No public API change in this crate.
+- Tracks [vantage-dataset 0.5.0](https://docs.rs/vantage-dataset/0.5/vantage_dataset/)'s `ImTable` /
+  `ImDataSource` parametrization. No public API change in this crate.
 
 ## 0.5.0 — 2026-05-23
 
-- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+- Bumped to the 0.5 line to track
+  [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the
+  `AnyTable` decommission cycle. No code changes beyond the dependency pin.
 
 ## 0.4.9 — 2026-05-18
 
-- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. Each SQL `*TableShell` now owns its [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implements the new `columns` / `references` / `id_column` shell methods. Factory entry points (`db.vista_factory().from_table(...)` / `from_yaml(...)`) are unchanged.
+- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s
+  schema-on-source refactor. Each SQL `*TableShell` now owns its
+  [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html)
+  and implements the new `columns` / `references` / `id_column` shell methods. Factory entry points
+  (`db.vista_factory().from_table(...)` / `from_yaml(...)`) are unchanged.
 - Pins `vantage-vista = "0.4.10"`.
 
 ## 0.4.8 — 2026-05-17
 
-- All three SQL `*TableShell`s ship the full Stage 5 query surface: [`add_order`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_order) on any column (every column gets the [`ORDERABLE`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/flags/constant.ORDERABLE.html) flag at factory time), [`add_search`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_search) via the existing `search_table_condition`, and offset-style pagination ([`set_page_size`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.set_page_size) + [`fetch_page`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_page) / [`fetch_next`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_next), encoding the cursor as a 1-based page number).
-- Capabilities updated: `can_order`, `can_search`, `can_set_page_size`, `can_fetch_page`, `can_fetch_next` all `true`. The retired `paginate_kind` flag is gone — drop it from any direct `VistaCapabilities` construction.
+- All three SQL `*TableShell`s ship the full Stage 5 query surface:
+  [`add_order`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_order)
+  on any column (every column gets the
+  [`ORDERABLE`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/flags/constant.ORDERABLE.html)
+  flag at factory time),
+  [`add_search`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_search)
+  via the existing `search_table_condition`, and offset-style pagination
+  ([`set_page_size`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.set_page_size) +
+  [`fetch_page`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_page)
+  /
+  [`fetch_next`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_next),
+  encoding the cursor as a 1-based page number).
+- Capabilities updated: `can_order`, `can_search`, `can_set_page_size`, `can_fetch_page`,
+  `can_fetch_next` all `true`. The retired `paginate_kind` flag is gone — drop it from any direct
+  `VistaCapabilities` construction.
 - Pins `vantage-vista = "0.4.9"`, `vantage-table = "0.4.12"`.
 
 ## 0.4.7 — 2026-05-16
@@ -29,25 +55,47 @@
 
 ## 0.4.6 — 2026-05-16
 
-- All three SQL `*TableShell`s implement [`TableShell::get_ref`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/trait.TableShell.html#method.get_ref) and `get_ref_kinds`: row-based reference traversal at the Vista layer. Each shell converts the CBOR parent row into the driver's `Any*Type` map, calls `Reference::resolve_from_row` on the wrapped typed table, and re-wraps the result via the driver's own `VistaFactory`.
-- `eq_value_condition` implemented on `SqliteDB`, `PostgresDB`, `MysqlDB` via their respective `*Operation::eq` traits, returning the driver's native condition type.
-- Integration tests in `tests/sqlite/6_vista.rs` exercise the new path end-to-end against in-memory SQLite: same-driver `has_many` traversal, `Vista::list_references` cardinality, and the `Vista::with_foreign` lazy-closure invariant.
+- All three SQL `*TableShell`s implement
+  [`TableShell::get_ref`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/trait.TableShell.html#method.get_ref)
+  and `get_ref_kinds`: row-based reference traversal at the Vista layer. Each shell converts the
+  CBOR parent row into the driver's `Any*Type` map, calls `Reference::resolve_from_row` on the
+  wrapped typed table, and re-wraps the result via the driver's own `VistaFactory`.
+- `eq_value_condition` implemented on `SqliteDB`, `PostgresDB`, `MysqlDB` via their respective
+  `*Operation::eq` traits, returning the driver's native condition type.
+- Integration tests in `tests/sqlite/6_vista.rs` exercise the new path end-to-end against in-memory
+  SQLite: same-driver `has_many` traversal, `Vista::list_references` cardinality, and the
+  `Vista::with_foreign` lazy-closure invariant.
 - Pins `vantage-vista = "0.4.7"`, `vantage-table = "0.4.10"`.
 
 ## 0.4.5 — 2026-05-09
 
-- Pins `vantage-types` to `>= 0.4.2`. The `RichText`-returning `TerminalRender` impls landed in 0.4.4 alongside `vantage-types 0.4.2`; without an explicit floor, cargo could resolve `vantage-types` to 0.4.0/0.4.1 and fail to compile against the old trait shape.
+- Pins `vantage-types` to `>= 0.4.2`. The `RichText`-returning `TerminalRender` impls landed in
+  0.4.4 alongside `vantage-types 0.4.2`; without an explicit floor, cargo could resolve
+  `vantage-types` to 0.4.0/0.4.1 and fail to compile against the old trait shape.
 
 ## 0.4.4 — 2026-05-04
 
-- New optional `vista` feature wires SQLite, Postgres, and MySQL into [`vantage-vista`](https://docs.rs/vantage-vista). Call `db.vista_factory().from_table(table)` to expose any typed `Table<…>` as a `Vista`, or load a YAML spec via `build_from_spec` for config-driven setups.
-- Each backend ships its own `*VistaSpec` / `*VistaFactory` / `*TableShell` triple under `mysql::vista`, `postgres::vista`, and `sqlite::vista`, with full read/write/count capabilities and `eq` filtering through the existing typed-column path.
-- Backend-specific `sqlite:` / `postgres:` / `mysql:` blocks in the YAML spec let you override table and column names without leaving the spec.
-- `from_table` now preserves the original entity type instead of erasing to `EmptyEntity` — `Table<Db, E>` survives the wrap so user-defined `with_expression` closures parameterised over `E` still typecheck. The boxed `TableShell` in `Vista` keeps the dyn-erasure boundary at one place.
-- `*TableShell` implements [`driver_name`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.driver_name) so [`Vista::driver()`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html#method.driver) reports `"sqlite"` / `"postgres"` / `"mysql"` for diagnostics.
+- New optional `vista` feature wires SQLite, Postgres, and MySQL into
+  [`vantage-vista`](https://docs.rs/vantage-vista). Call `db.vista_factory().from_table(table)` to
+  expose any typed `Table<…>` as a `Vista`, or load a YAML spec via `build_from_spec` for
+  config-driven setups.
+- Each backend ships its own `*VistaSpec` / `*VistaFactory` / `*TableShell` triple under
+  `mysql::vista`, `postgres::vista`, and `sqlite::vista`, with full read/write/count capabilities
+  and `eq` filtering through the existing typed-column path.
+- Backend-specific `sqlite:` / `postgres:` / `mysql:` blocks in the YAML spec let you override table
+  and column names without leaving the spec.
+- `from_table` now preserves the original entity type instead of erasing to `EmptyEntity` —
+  `Table<Db, E>` survives the wrap so user-defined `with_expression` closures parameterised over `E`
+  still typecheck. The boxed `TableShell` in `Vista` keeps the dyn-erasure boundary at one place.
+- `*TableShell` implements
+  [`driver_name`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.driver_name)
+  so
+  [`Vista::driver()`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html#method.driver)
+  reports `"sqlite"` / `"postgres"` / `"mysql"` for diagnostics.
 - Bumps minimum [`vantage-vista`](https://docs.rs/vantage-vista/0.4.4/) requirement to 0.4.4.
 
 ## 0.4.3 — 2026-04-19
 
-- SQL `is_null` / `is_not_null` operations rendered as `{} IS NULL` / `{} IS NOT NULL` for sqlite, postgres, mysql.
+- SQL `is_null` / `is_not_null` operations rendered as `{} IS NULL` / `{} IS NOT NULL` for sqlite,
+  postgres, mysql.
 - Doc fixes in `docs4`.

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -17,14 +17,14 @@ mysql = ["sqlx/mysql"]
 vista = ["dep:vantage-vista"]
 
 [dependencies]
-vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["serde"] }
-vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
+vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
 paste = "1.0"
 
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 vantage-table = { version = "0.5", path = "../vantage-table" }
-vantage-vista = { version = "0.4.10", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
 async-trait = "0.1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "rust_decimal", "uuid", "chrono"] }
 rust_decimal = "1"
@@ -40,4 +40,4 @@ tokio = { version = "1", features = ["full"] }
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.4.10", path = "../vantage-vista" }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,26 +1,62 @@
 # Changelog
 
+## 0.5.2 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.0 — 2026-05-23
 
-- Bumped to the 0.5 line to track [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the `AnyTable` decommission cycle. No code changes beyond the dependency pin.
+- Bumped to the 0.5 line to track
+  [vantage-table 0.5.0](https://docs.rs/vantage-table/0.5.0/vantage_table/)'s opening of the
+  `AnyTable` decommission cycle. No code changes beyond the dependency pin.
 
 ## 0.4.11 — 2026-05-23
 
-- YAML `references:` blocks now build live traversals. `SurrealVistaFactory::build_from_spec` registers each `has_one` / `has_many` entry as a `with_one` / `with_many` on the underlying [`Table`](https://docs.rs/vantage-table/0.5.0/vantage_table/table/struct.Table.html), so `vista.get_ref("clients", &row)` returns a fully-typed child Vista — no Rust glue per relation.
-- New [`SurrealSpecResolver`](https://docs.rs/vantage-surrealdb/0.4.11/vantage_surrealdb/vista/type.SurrealSpecResolver.html) (`Arc<dyn Fn(&str) -> Option<SurrealVistaSpec>>`) plus [`SurrealVistaFactory::with_resolver`](https://docs.rs/vantage-surrealdb/0.4.11/vantage_surrealdb/vista/struct.SurrealVistaFactory.html#method.with_resolver): pass in a name-to-spec lookup and child tables get their columns from the resolved spec at traversal time, not from a single pre-built registry.
-- Many-to-many drops out of chained `has_many` / `has_one` traversal — no new YAML keyword needed. See `tests/7_vista_refs.rs` for `client → bakery → clients`.
-- Without a resolver the references still parse and surface in [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html), but traversed children come back column-less; the next query then fails loudly.
+- YAML `references:` blocks now build live traversals. `SurrealVistaFactory::build_from_spec`
+  registers each `has_one` / `has_many` entry as a `with_one` / `with_many` on the underlying
+  [`Table`](https://docs.rs/vantage-table/0.5.0/vantage_table/table/struct.Table.html), so
+  `vista.get_ref("clients", &row)` returns a fully-typed child Vista — no Rust glue per relation.
+- New
+  [`SurrealSpecResolver`](https://docs.rs/vantage-surrealdb/0.4.11/vantage_surrealdb/vista/type.SurrealSpecResolver.html)
+  (`Arc<dyn Fn(&str) -> Option<SurrealVistaSpec>>`) plus
+  [`SurrealVistaFactory::with_resolver`](https://docs.rs/vantage-surrealdb/0.4.11/vantage_surrealdb/vista/struct.SurrealVistaFactory.html#method.with_resolver):
+  pass in a name-to-spec lookup and child tables get their columns from the resolved spec at
+  traversal time, not from a single pre-built registry.
+- Many-to-many drops out of chained `has_many` / `has_one` traversal — no new YAML keyword needed.
+  See `tests/7_vista_refs.rs` for `client → bakery → clients`.
+- Without a resolver the references still parse and surface in
+  [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html),
+  but traversed children come back column-less; the next query then fails loudly.
 
 ## 0.4.10 — 2026-05-18
 
-- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s schema-on-source refactor. `SurrealTableShell` now owns its [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html) and implements the new `columns` / `references` / `id_column` shell methods. `surrealdb.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.
+- Tracks [vantage-vista 0.4.10](https://docs.rs/vantage-vista/0.4.10/vantage_vista/)'s
+  schema-on-source refactor. `SurrealTableShell` now owns its
+  [`VistaMetadata`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.VistaMetadata.html)
+  and implements the new `columns` / `references` / `id_column` shell methods.
+  `surrealdb.vista_factory().from_table(...)` / `from_yaml(...)` surface unchanged.
 - Pins `vantage-vista = "0.4.10"`.
 
 ## 0.4.9 — 2026-05-17
 
-- `SurrealTableShell` ships the full Stage 5 query surface: [`add_order`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_order) on any column (every column gets the [`ORDERABLE`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/flags/constant.ORDERABLE.html) flag), [`add_search`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_search) via the existing `search_table_condition`, and offset-style pagination ([`set_page_size`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.set_page_size) + [`fetch_page`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_page) / [`fetch_next`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_next), encoding the cursor as a 1-based page number).
-- `SurrealDB::search_table_condition` now actually fans out across columns — OR of case-insensitive `string::contains(string::lowercase(<string>field), needle)` for every column, instead of the SEARCH-stub placeholder. Drives `Vista::add_search` end-to-end.
-- Capabilities updated: `can_order`, `can_search`, `can_set_page_size`, `can_fetch_page`, `can_fetch_next` all `true`. The retired `paginate_kind` flag is gone — drop it from any direct `VistaCapabilities` construction.
+- `SurrealTableShell` ships the full Stage 5 query surface:
+  [`add_order`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_order)
+  on any column (every column gets the
+  [`ORDERABLE`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/flags/constant.ORDERABLE.html)
+  flag),
+  [`add_search`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_search)
+  via the existing `search_table_condition`, and offset-style pagination
+  ([`set_page_size`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.set_page_size) +
+  [`fetch_page`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_page)
+  /
+  [`fetch_next`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_next),
+  encoding the cursor as a 1-based page number).
+- `SurrealDB::search_table_condition` now actually fans out across columns — OR of case-insensitive
+  `string::contains(string::lowercase(<string>field), needle)` for every column, instead of the
+  SEARCH-stub placeholder. Drives `Vista::add_search` end-to-end.
+- Capabilities updated: `can_order`, `can_search`, `can_set_page_size`, `can_fetch_page`,
+  `can_fetch_next` all `true`. The retired `paginate_kind` flag is gone — drop it from any direct
+  `VistaCapabilities` construction.
 - Pins `vantage-vista = "0.4.9"`, `vantage-table = "0.4.12"`.
 
 ## 0.4.8 — 2026-05-16
@@ -29,25 +65,49 @@
 
 ## 0.4.7 — 2026-05-16
 
-- `SurrealTableShell` implements [`TableShell::get_ref`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/trait.TableShell.html#method.get_ref) and `get_ref_kinds`: row-based reference traversal at the Vista layer. The shell converts the CBOR parent row into `Record<AnySurrealType>`, calls `Reference::resolve_from_row` on the wrapped typed table, and re-wraps via `SurrealVistaFactory::from_table`.
+- `SurrealTableShell` implements
+  [`TableShell::get_ref`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/trait.TableShell.html#method.get_ref)
+  and `get_ref_kinds`: row-based reference traversal at the Vista layer. The shell converts the CBOR
+  parent row into `Record<AnySurrealType>`, calls `Reference::resolve_from_row` on the wrapped typed
+  table, and re-wraps via `SurrealVistaFactory::from_table`.
 - `SurrealDB::eq_value_condition` implemented via `SurrealOperation::eq`.
 - Pins `vantage-vista = "0.4.7"`, `vantage-table = "0.4.10"`.
 
 ## 0.4.6 — 2026-05-14
 
-- Drop the `arbitrary_precision` feature flag from the `serde_json` dependency. It enabled a global mode that wraps numbers as `{"$serde_json::private::Number": "..."}` objects, which broke ad-hoc JSON inspection and forced every consumer of vantage-surrealdb's `serde_json::Value` outputs to opt into the same flag. `preserve_order` and `raw_value` are retained.
+- Drop the `arbitrary_precision` feature flag from the `serde_json` dependency. It enabled a global
+  mode that wraps numbers as `{"$serde_json::private::Number": "..."}` objects, which broke ad-hoc
+  JSON inspection and forced every consumer of vantage-surrealdb's `serde_json::Value` outputs to
+  opt into the same flag. `preserve_order` and `raw_value` are retained.
 
 ## 0.4.5 — 2026-05-10
 
-New opt-in [`vista`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/vista/struct.SurrealVistaFactory.html) feature: build a [`Vista`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html) from a typed `Table<SurrealDB, E>` or from YAML, with full read+write CRUD and server-side `eq` push-down.
+New opt-in
+[`vista`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/vista/struct.SurrealVistaFactory.html)
+feature: build a [`Vista`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html) from
+a typed `Table<SurrealDB, E>` or from YAML, with full read+write CRUD and server-side `eq`
+push-down.
 
-- `SurrealDB::vista_factory()` returns a [`SurrealVistaFactory`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/vista/struct.SurrealVistaFactory.html); `from_table` and `from_yaml` both produce a `Vista`. `from_table` preserves the entity type so `with_expression` closures still typecheck.
-- YAML `surreal:` block carries `table` (override the SurrealDB table name); per-column `surreal: { field }` aliases the field name. The `thing` / `record` column type maps to [`Thing`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/thing/struct.Thing.html); `datetime` and `decimal` round-trip via `AnySurrealType`.
-- Vista's string id boundary translates `"table:id"` straight to `Thing`; bare ids get prefixed with the wrapped table's name, so `vista.get_value("biff")` works the same as `vista.get_value("client:biff")`.
-- [`TableShell::add_eq_condition`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.add_eq_condition) translates `(field, CborValue)` into `column.eq(value)` and pushes onto the wrapped table — `WHERE` is server-side.
-- Capabilities: `can_count`, `can_insert`, `can_update`, `can_delete` all true. `can_subscribe` deferred to a later live-query pass.
+- `SurrealDB::vista_factory()` returns a
+  [`SurrealVistaFactory`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/vista/struct.SurrealVistaFactory.html);
+  `from_table` and `from_yaml` both produce a `Vista`. `from_table` preserves the entity type so
+  `with_expression` closures still typecheck.
+- YAML `surreal:` block carries `table` (override the SurrealDB table name); per-column
+  `surreal: { field }` aliases the field name. The `thing` / `record` column type maps to
+  [`Thing`](https://docs.rs/vantage-surrealdb/0.4.5/vantage_surrealdb/thing/struct.Thing.html);
+  `datetime` and `decimal` round-trip via `AnySurrealType`.
+- Vista's string id boundary translates `"table:id"` straight to `Thing`; bare ids get prefixed with
+  the wrapped table's name, so `vista.get_value("biff")` works the same as
+  `vista.get_value("client:biff")`.
+- [`TableShell::add_eq_condition`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.add_eq_condition)
+  translates `(field, CborValue)` into `column.eq(value)` and pushes onto the wrapped table —
+  `WHERE` is server-side.
+- Capabilities: `can_count`, `can_insert`, `can_update`, `can_delete` all true. `can_subscribe`
+  deferred to a later live-query pass.
 - Off by default; non-vista users still don't depend on `vantage-vista`.
-- Bug fix: `get_table_value` now treats `SELECT FROM ONLY ... NONE` (CBOR `Tag(6, _)`) as "no row" alongside the existing `Null` case, so missing-record lookups consistently return `None` instead of erroring downstream.
+- Bug fix: `get_table_value` now treats `SELECT FROM ONLY ... NONE` (CBOR `Tag(6, _)`) as "no row"
+  alongside the existing `Null` case, so missing-record lookups consistently return `None` instead
+  of erroring downstream.
 
 ## 0.4.4 — 2026-05-09
 

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.5.1"
+version = "0.5.2"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"
@@ -16,13 +16,13 @@ vista = ["dep:vantage-vista"]
 
 [dependencies]
 async-trait = "0.1"
-vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-expressions = { version = "0.4", path = "../vantage-expressions", features = ["chrono"] }
+vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-expressions = { version = "0.5", path = "../vantage-expressions", features = ["chrono"] }
 vantage-table = { version = "0.5", path = "../vantage-table" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
-vantage-types = { version = "0.4.2", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.4.10", path = "../vantage-vista", optional = true }
-surreal-client = { version = "0.4", path = "../surreal-client" }
+vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
+vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
+surreal-client = { version = "0.5", path = "../surreal-client" }
 
 ciborium = "0.2"
 hex = "0.4"
@@ -84,7 +84,7 @@ test = false
 [dev-dependencies]
 bakery_model3 = { path = "../bakery_model3" }
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.4.10", path = "../vantage-vista" }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }
 
 [[example]]
 name = "expr"

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,46 +1,68 @@
 # Changelog
 
+## 0.5.3 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.5.2 — 2026-05-23
 
-The `AnyTable` type-erasing carrier is gone. Type erasure for cross-driver
-work now lives one layer up in [`vantage_vista::Vista`](https://docs.rs/vantage-vista/0.4/vantage_vista/struct.Vista.html) — wrap any
-typed `Table<T, E>` with `T::vista_factory().from_table(...)` to get a
-`Vista` carrying `Record<ciborium::Value>` regardless of the underlying
-driver.
+The `AnyTable` type-erasing carrier is gone. Type erasure for cross-driver work now lives one layer
+up in [`vantage_vista::Vista`](https://docs.rs/vantage-vista/0.4/vantage_vista/struct.Vista.html) —
+wrap any typed `Table<T, E>` with `T::vista_factory().from_table(...)` to get a `Vista` carrying
+`Record<ciborium::Value>` regardless of the underlying driver.
 
 ### Removed
 
-- The `vantage_table::any` module — `AnyTable`, `AnyRecord`, `CborAdapter`, and the inline tests are all deleted.
+- The `vantage_table::any` module — `AnyTable`, `AnyRecord`, `CborAdapter`, and the inline tests are
+  all deleted.
 - `Reference::resolve_as_any` — the AnyTable-returning trait method on `Reference`.
-- `Table::get_ref` — the legacy method returning `AnyTable`. The typed `Table::get_ref_as` and `Table::get_subquery_as` survive; for the row-driven case prefer `Table::get_ref_from_row`.
-- `TableLike::get_ref` — the AnyTable-returning default on the `TableLike` trait. The trait itself stays (it's used independently by `Box<dyn TableLike>` consumers).
-- The commented-out `vantage_table::models_macro` and the `AnyTable`-only `with_pagination` test block.
-- The `ref_example` example — the AnyTable-flavoured demo it covered is folded into `vantage-vista`'s mock-shell + driver factory examples.
+- `Table::get_ref` — the legacy method returning `AnyTable`. The typed `Table::get_ref_as` and
+  `Table::get_subquery_as` survive; for the row-driven case prefer `Table::get_ref_from_row`.
+- `TableLike::get_ref` — the AnyTable-returning default on the `TableLike` trait. The trait itself
+  stays (it's used independently by `Box<dyn TableLike>` consumers).
+- The commented-out `vantage_table::models_macro` and the `AnyTable`-only `with_pagination` test
+  block.
+- The `ref_example` example — the AnyTable-flavoured demo it covered is folded into
+  `vantage-vista`'s mock-shell + driver factory examples.
 
 ### Carried over
 
-- `Table::get_ref_as` and `Table::get_subquery_as` continue to work — their internals route through `Reference::build_target` and return typed `Table<T, E2>`, no `AnyTable` involvement.
+- `Table::get_ref_as` and `Table::get_subquery_as` continue to work — their internals route through
+  `Reference::build_target` and return typed `Table<T, E2>`, no `AnyTable` involvement.
 
 ## 0.5.1 — 2026-05-23
 
-- Restored `tests/table_like.rs`. The previous AnyTable-on-`MockTableSource` tests were disabled during the CBOR swap; the file now runs as Vista smoke tests against [`MockShell`](https://docs.rs/vantage-vista/0.4/vantage_vista/mocks/struct.MockShell.html) — six tests covering table-name/column metadata, value round-trip via `ReadableValueSet` / `WritableValueSet` / `InsertableValueSet`, count, and `get_some_value`. These tests survive the AnyTable removal scheduled for the next release.
-- `MockTableSource` stays JSON-typed for now. The original plan called for converting it to `ciborium::Value` so it could bridge into the (about-to-be-removed) `AnyTable`, but with `AnyTable` going away that's no longer needed — Vista-flavoured tests use [`vantage_vista::mocks::MockShell`](https://docs.rs/vantage-vista/0.4/vantage_vista/mocks/struct.MockShell.html) directly.
+- Restored `tests/table_like.rs`. The previous AnyTable-on-`MockTableSource` tests were disabled
+  during the CBOR swap; the file now runs as Vista smoke tests against
+  [`MockShell`](https://docs.rs/vantage-vista/0.4/vantage_vista/mocks/struct.MockShell.html) — six
+  tests covering table-name/column metadata, value round-trip via `ReadableValueSet` /
+  `WritableValueSet` / `InsertableValueSet`, count, and `get_some_value`. These tests survive the
+  AnyTable removal scheduled for the next release.
+- `MockTableSource` stays JSON-typed for now. The original plan called for converting it to
+  `ciborium::Value` so it could bridge into the (about-to-be-removed) `AnyTable`, but with
+  `AnyTable` going away that's no longer needed — Vista-flavoured tests use
+  [`vantage_vista::mocks::MockShell`](https://docs.rs/vantage-vista/0.4/vantage_vista/mocks/struct.MockShell.html)
+  directly.
 
 ## 0.5.0 — 2026-05-23
 
-Opens the 0.5 cycle. No code changes in this release beyond a docstring
-tidy; the version bump marks the start of the `AnyTable` decommission —
-the `AnyTable` carrier, the legacy `Table::get_ref` / `get_ref_as` /
-`get_subquery_as` methods, and `Reference::resolve_as_any` /
-`build_target` are scheduled for removal across the 0.5.x line.
+Opens the 0.5 cycle. No code changes in this release beyond a docstring tidy; the version bump marks
+the start of the `AnyTable` decommission — the `AnyTable` carrier, the legacy `Table::get_ref` /
+`get_ref_as` / `get_subquery_as` methods, and `Reference::resolve_as_any` / `build_target` are
+scheduled for removal across the 0.5.x line.
 
-- Dropped a stale cross-link to `vantage_live::LiveTable` from the
-  `AnyTable::from_table_like` docstring — the `vantage-live` crate has
-  been removed from the workspace (superseded by `vantage-diorama`).
+- Dropped a stale cross-link to `vantage_live::LiveTable` from the `AnyTable::from_table_like`
+  docstring — the `vantage-live` crate has been removed from the workspace (superseded by
+  `vantage-diorama`).
 
 ## 0.4.12 — 2026-05-17
 
-- New [`Table::clear_orders`](https://docs.rs/vantage-table/0.4.12/vantage_table/struct.Table.html#method.clear_orders) drops every order clause — both permanent and temporary. Vista's [`add_order`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_order) is replace-semantics; this is the primitive its driver shells use to wipe state before pushing the new order.
+- New
+  [`Table::clear_orders`](https://docs.rs/vantage-table/0.4.12/vantage_table/struct.Table.html#method.clear_orders)
+  drops every order clause — both permanent and temporary. Vista's
+  [`add_order`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_order)
+  is replace-semantics; this is the primitive its driver shells use to wipe state before pushing the
+  new order.
 
 ## 0.4.11 — 2026-05-16
 
@@ -50,47 +72,97 @@ the `AnyTable` carrier, the legacy `Table::get_ref` / `get_ref_as` /
 
 Row-based reference traversal lands at the typed layer; `HasForeign` retires.
 
-- New [`Table::get_ref_from_row<E2>(relation, &row)`](https://docs.rs/vantage-table/0.4.10/vantage_table/struct.Table.html#method.get_ref_from_row) — reads the join field out of a known parent record and returns `Table<T, E2>` narrowed by one eq-condition. No subquery, no deferred fetch.
-- New [`Table::with_id(id)`](https://docs.rs/vantage-table/0.4.10/vantage_table/struct.Table.html#method.with_id) convenience — pairs with `get_some_value` for the "I only know an id" workflow.
-- New [`Reference::resolve_from_row`](https://docs.rs/vantage-table/0.4.10/vantage_table/references/trait.Reference.html#tymethod.resolve_from_row) and [`Reference::cardinality`](https://docs.rs/vantage-table/0.4.10/vantage_table/references/trait.Reference.html#tymethod.cardinality) trait methods. `HasOne` / `HasMany` implement both; the row-based path lives here and is called by the typed `get_ref_from_row` and by every Vista shell. `cardinality()` returns [`vantage_vista::ReferenceKind`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/enum.ReferenceKind.html) directly — drivers don't need a translation step. Adds `vantage-vista` as a direct dep (was already transitive via `vantage-expressions`).
-- New [`TableSource::eq_value_condition(&self, field, value)`](https://docs.rs/vantage-table/0.4.10/vantage_table/traits/table_source/trait.TableSource.html#method.eq_value_condition) — typed-value sibling of `eq_condition`. Default errors; backends that participate in row-based traversal override.
-- New `Table::ref_kinds() -> Vec<(String, ReferenceKind)>` and `Table::ref_cardinality(relation) -> Result<ReferenceKind>` for inspecting registered references with cardinality.
-- **Breaking**: `HasForeign`, `Table::with_foreign`, `Table::is_foreign_ref`, and `Reference::is_foreign` are removed. Cross-persistence refs now live at the Vista layer ([`Vista::with_foreign`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.with_foreign)) — `vantage-table` stays single-backend by construction. The one in-tree caller (`vantage-aws` Lambda's `log_group`) migrated to a Vista-side registration; out-of-tree callers move their closure to `Vista::with_foreign` at the factory site.
-- Legacy `Table::get_ref` / `get_ref_as` / `get_subquery_as` and `Reference::resolve_as_any` / `build_target` stay for now — slated for deletion in Stage 9 alongside `AnyTable`.
+- New
+  [`Table::get_ref_from_row<E2>(relation, &row)`](https://docs.rs/vantage-table/0.4.10/vantage_table/struct.Table.html#method.get_ref_from_row)
+  — reads the join field out of a known parent record and returns `Table<T, E2>` narrowed by one
+  eq-condition. No subquery, no deferred fetch.
+- New
+  [`Table::with_id(id)`](https://docs.rs/vantage-table/0.4.10/vantage_table/struct.Table.html#method.with_id)
+  convenience — pairs with `get_some_value` for the "I only know an id" workflow.
+- New
+  [`Reference::resolve_from_row`](https://docs.rs/vantage-table/0.4.10/vantage_table/references/trait.Reference.html#tymethod.resolve_from_row)
+  and
+  [`Reference::cardinality`](https://docs.rs/vantage-table/0.4.10/vantage_table/references/trait.Reference.html#tymethod.cardinality)
+  trait methods. `HasOne` / `HasMany` implement both; the row-based path lives here and is called by
+  the typed `get_ref_from_row` and by every Vista shell. `cardinality()` returns
+  [`vantage_vista::ReferenceKind`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/enum.ReferenceKind.html)
+  directly — drivers don't need a translation step. Adds `vantage-vista` as a direct dep (was
+  already transitive via `vantage-expressions`).
+- New
+  [`TableSource::eq_value_condition(&self, field, value)`](https://docs.rs/vantage-table/0.4.10/vantage_table/traits/table_source/trait.TableSource.html#method.eq_value_condition)
+  — typed-value sibling of `eq_condition`. Default errors; backends that participate in row-based
+  traversal override.
+- New `Table::ref_kinds() -> Vec<(String, ReferenceKind)>` and
+  `Table::ref_cardinality(relation) -> Result<ReferenceKind>` for inspecting registered references
+  with cardinality.
+- **Breaking**: `HasForeign`, `Table::with_foreign`, `Table::is_foreign_ref`, and
+  `Reference::is_foreign` are removed. Cross-persistence refs now live at the Vista layer
+  ([`Vista::with_foreign`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.with_foreign))
+  — `vantage-table` stays single-backend by construction. The one in-tree caller (`vantage-aws`
+  Lambda's `log_group`) migrated to a Vista-side registration; out-of-tree callers move their
+  closure to `Vista::with_foreign` at the factory site.
+- Legacy `Table::get_ref` / `get_ref_as` / `get_subquery_as` and `Reference::resolve_as_any` /
+  `build_target` stay for now — slated for deletion in Stage 9 alongside `AnyTable`.
 
 ## 0.4.9 — 2026-05-15
 
-- New [`TableLike::set_table_name(String)`](https://docs.rs/vantage-table/0.4.9/vantage_table/traits/table_like/trait.TableLike.html#method.set_table_name) trait method (default no-op) and matching inherent [`Table::set_table_name`](https://docs.rs/vantage-table/0.4.9/vantage_table/struct.Table.html#method.set_table_name). `AnyTable` forwards. Lets drivers that use the `table_name` field as a request-shape (REST API endpoints, URI templates) swap it at reference-traversal time without rebuilding the table.
+- New
+  [`TableLike::set_table_name(String)`](https://docs.rs/vantage-table/0.4.9/vantage_table/traits/table_like/trait.TableLike.html#method.set_table_name)
+  trait method (default no-op) and matching inherent
+  [`Table::set_table_name`](https://docs.rs/vantage-table/0.4.9/vantage_table/struct.Table.html#method.set_table_name).
+  `AnyTable` forwards. Lets drivers that use the `table_name` field as a request-shape (REST API
+  endpoints, URI templates) swap it at reference-traversal time without rebuilding the table.
 
 ## 0.4.8 — 2026-04-30
 
-- `TableLike` gains five reflection / mutation methods so type-erased callers (the new model-driven CLI in `vantage-cli-util`, anything else holding an `AnyTable`) can reach metadata that previously only existed on the typed side. All have default impls so existing implementors compile unchanged.
+- `TableLike` gains five reflection / mutation methods so type-erased callers (the new model-driven
+  CLI in `vantage-cli-util`, anything else holding an `AnyTable`) can reach metadata that previously
+  only existed on the typed side. All have default impls so existing implementors compile unchanged.
   - `id_field_name() -> Option<String>`
   - `title_field_names() -> Vec<String>`
   - `column_types() -> IndexMap<String, &'static str>`
   - `get_ref_names() -> Vec<String>`
   - `add_condition_eq(field, value) -> Result<()>`
-- New `TableSource::eq_condition(field, value) -> Result<Self::Condition>` (default: error). Backends that support textual eq filtering override; `add_condition_eq` dispatches through it.
-- New `Table::with_title_column_of::<Type>(name)` builder — adds a typed column and records its name in an ordered `title_fields: Vec<String>` on the table. `title_field_names()` returns that vec, then unions in any columns that carry `ColumnFlag::TitleField` directly.
-- `AnyTable` and the internal `CborAdapter` forward all five new methods through to the wrapped table.
+- New `TableSource::eq_condition(field, value) -> Result<Self::Condition>` (default: error).
+  Backends that support textual eq filtering override; `add_condition_eq` dispatches through it.
+- New `Table::with_title_column_of::<Type>(name)` builder — adds a typed column and records its name
+  in an ordered `title_fields: Vec<String>` on the table. `title_field_names()` returns that vec,
+  then unions in any columns that carry `ColumnFlag::TitleField` directly.
+- `AnyTable` and the internal `CborAdapter` forward all five new methods through to the wrapped
+  table.
 
 ## 0.4.7 — 2026-04-29
 
-- New `AnyTable::get_ref(relation) -> Result<AnyTable>`. Lets reference traversal continue on the type-erased side — previously `get_ref` only existed on the typed `Table<T, E>`, so once you wrapped a table into `AnyTable` the relation graph was unreachable.
-- `TableLike` gains a `get_ref` method with a default impl that errors out (`"get_ref not supported on this TableLike"`). `Table<T, E>` overrides to delegate to the inherent; `AnyTable` and the internal `CborAdapter` forward to the wrapped table; downstream wrappers like `vantage_live::LiveTable` override to forward through to their master.
-- The trait method is sync — `Reference::resolve_as_any` is sync (no IO), so callers don't need an `.await`.
+- New `AnyTable::get_ref(relation) -> Result<AnyTable>`. Lets reference traversal continue on the
+  type-erased side — previously `get_ref` only existed on the typed `Table<T, E>`, so once you
+  wrapped a table into `AnyTable` the relation graph was unreachable.
+- `TableLike` gains a `get_ref` method with a default impl that errors out
+  (`"get_ref not supported on this TableLike"`). `Table<T, E>` overrides to delegate to the
+  inherent; `AnyTable` and the internal `CborAdapter` forward to the wrapped table; downstream
+  wrappers like `vantage_live::LiveTable` override to forward through to their master.
+- The trait method is sync — `Reference::resolve_as_any` is sync (no IO), so callers don't need an
+  `.await`.
 
 ## 0.4.6 — 2026-04-26
 
-- New `AnyTable::from_table_like<T: TableLike<…>>` constructor. Wraps any table-like type that already speaks `Value = CborValue, Id = String` — needed by `vantage-live::LiveTable`, which is `TableLike` but not a `Table<T, E>` instance.
+- New `AnyTable::from_table_like<T: TableLike<…>>` constructor. Wraps any table-like type that
+  already speaks `Value = CborValue, Id = String` — needed by `vantage-live::LiveTable`, which is
+  `TableLike` but not a `Table<T, E>` instance.
 
 ## 0.4.5 — 2026-04-26
 
-- New `ColumnFlag::Indexed` variant. UI hint that a column is cheap to sort or filter on; `vantage-redb` is the only backend that uses it for actual index maintenance.
+- New `ColumnFlag::Indexed` variant. UI hint that a column is cheap to sort or filter on;
+  `vantage-redb` is the only backend that uses it for actual index maintenance.
 
 ## 0.4.4 — 2026-04-25
 
-- **Breaking**: `AnyTable` now carries `ciborium::Value` instead of `serde_json::Value`. Backends already store CBOR (surreal/sql) or BSON (mongo) internally; this drops the last lossy JSON hop at the type-erased boundary.
-- Renames the internal `JsonAdapter` to `CborAdapter`. Constructor signatures (`AnyTable::new` / `AnyTable::from_table`) unchanged at call sites.
-- New `CborValueExt` trait re-exported from `prelude` — adds `as_str()`, `as_i64()`, `as_u64()`, `as_f64()`, `get(&str)`, `get_mut(&str)` so consumer code stays one-liner-shaped on top of `Record<ciborium::Value>`.
-- Migration: AnyTable consumers that matched on JSON variants need to either match on `ciborium::Value` arms or call `serde_json::to_value(&record)?` at the consumer edge.
+- **Breaking**: `AnyTable` now carries `ciborium::Value` instead of `serde_json::Value`. Backends
+  already store CBOR (surreal/sql) or BSON (mongo) internally; this drops the last lossy JSON hop at
+  the type-erased boundary.
+- Renames the internal `JsonAdapter` to `CborAdapter`. Constructor signatures (`AnyTable::new` /
+  `AnyTable::from_table`) unchanged at call sites.
+- New `CborValueExt` trait re-exported from `prelude` — adds `as_str()`, `as_i64()`, `as_u64()`,
+  `as_f64()`, `get(&str)`, `get_mut(&str)` so consumer code stays one-liner-shaped on top of
+  `Record<ciborium::Value>`.
+- Migration: AnyTable consumers that matched on JSON variants need to either match on
+  `ciborium::Value` arms or call `serde_json::to_value(&record)?` at the consumer edge.

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"
@@ -16,10 +16,10 @@ doctest = false
 
 
 [dependencies]
-vantage-core = { version = "0.4", path = "../vantage-core" }
-vantage-types = { version = "0.4", path = "../vantage-types" }
-vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
-vantage-vista = { version = "0.4.7", path = "../vantage-vista" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-types = { version = "0.5", path = "../vantage-types" }
+vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 async-stream = "0.3"
 async-trait = "0.1"
@@ -36,9 +36,9 @@ rust_decimal = { version = "1.42.0", features = ["macros", "serde"] }
 [dev-dependencies]
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "sync"] }
 serde_json = "1.0"
-vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
+vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
 # vantage-surrealdb = { path = "../vantage-surrealdb" }
-surreal-client = { version = "0.4", path = "../surreal-client" }
+surreal-client = { version = "0.5", path = "../surreal-client" }
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }
 url = { version = "2.5", features = ["serde"] }

--- a/vantage-table/src/references.rs
+++ b/vantage-table/src/references.rs
@@ -29,9 +29,9 @@ pub trait Reference: Send + Sync {
 
     /// Produce a fresh target table (no conditions applied), wrapped in
     /// `Box<dyn Any>` so callers can downcast back to the concrete
-    /// `Table<T, TargetE>`. Used by [`Table::get_ref_as`] and
-    /// [`Table::get_subquery_as`] to build the target before applying the
-    /// join condition.
+    /// `Table<T, TargetE>`. Used by [`crate::table::Table::get_ref_as`] and
+    /// [`crate::table::Table::get_subquery_as`] to build the target before
+    /// applying the join condition.
     fn build_target(&self, data_source: &dyn Any) -> Box<dyn Any>;
 
     /// Cardinality of this relation. `HasOne` if traversing yields at most

--- a/vantage-types/CHANGELOG.md
+++ b/vantage-types/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.4.4 — 2026-05-23
 
-- Doc comment refresh on the `Entity<ciborium::Value>` blanket — references the `Vista` boundary now that [vantage-table 0.5.2](https://docs.rs/vantage-table/0.5.2/vantage_table/) drops `AnyTable`.
+- Doc comment refresh on the `Entity<ciborium::Value>` blanket — references the `Vista` boundary now
+  that [vantage-table 0.5.2](https://docs.rs/vantage-table/0.5.2/vantage_table/) drops `AnyTable`.
 
 ## 0.4.3 — 2026-05-16
 
@@ -10,12 +15,22 @@
 
 ## 0.4.2 — 2026-04-30
 
-Catches up the crates.io release with the additions that landed locally in [#214](https://github.com/romaninsh/vantage/pull/214) but never got their own version bump.
+Catches up the crates.io release with the additions that landed locally in
+[#214](https://github.com/romaninsh/vantage/pull/214) but never got their own version bump.
 
-- New `RichText` / `Span` / `Style` types and a refactored `TerminalRender` trait — `render() -> RichText` instead of `render() -> String` plus a separate `color_hint()`. `Style` is semantic (`Default`, `Dim`, `Muted`, `Strong`, `Success`, `Error`, `Warning`, `Info`) — UI layers map to native presentation. `RichText` impls `Display` (writes the plain text), so existing string-shaped consumers keep compiling without code changes.
-- Default `TerminalRender` impls migrated for `String`, `&str`, `i32` / `i64` / `f64`, `bool`, `Option<T>`, `serde_json::Value`, and `ciborium::Value`. Booleans render as `Style::Success` / `Style::Error`; nulls render as a dim em-dash.
+- New `RichText` / `Span` / `Style` types and a refactored `TerminalRender` trait —
+  `render() -> RichText` instead of `render() -> String` plus a separate `color_hint()`. `Style` is
+  semantic (`Default`, `Dim`, `Muted`, `Strong`, `Success`, `Error`, `Warning`, `Info`) — UI layers
+  map to native presentation. `RichText` impls `Display` (writes the plain text), so existing
+  string-shaped consumers keep compiling without code changes.
+- Default `TerminalRender` impls migrated for `String`, `&str`, `i32` / `i64` / `f64`, `bool`,
+  `Option<T>`, `serde_json::Value`, and `ciborium::Value`. Booleans render as `Style::Success` /
+  `Style::Error`; nulls render as a dim em-dash.
 
 ## 0.4.1 — 2026-04-25
 
-- `TerminalRender` impl for `ciborium::Value` so generic CLI/UI rendering keeps working when records flow through `AnyTable`.
-- Blanket `From<ciborium::Value> for Record<ciborium::Value>` (and reverse), plus serde-blanket `IntoRecord<CborValue>` / `TryFromRecord<CborValue>` so any `Serialize + DeserializeOwned` entity auto-implements `Entity<CborValue>`.
+- `TerminalRender` impl for `ciborium::Value` so generic CLI/UI rendering keeps working when records
+  flow through `AnyTable`.
+- Blanket `From<ciborium::Value> for Record<ciborium::Value>` (and reverse), plus serde-blanket
+  `IntoRecord<CborValue>` / `TryFromRecord<CborValue>` so any `Serialize + DeserializeOwned` entity
+  auto-implements `Entity<CborValue>`.

--- a/vantage-types/Cargo.toml
+++ b/vantage-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-types"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Type system and Record types for the Vantage data framework"
@@ -13,12 +13,12 @@ serde = ["dep:serde", "dep:serde_json", "vantage-types-entity/serde"]
 
 [dependencies]
 paste = "1.0"
-vantage-types-entity = { version = "0.4", path = "./entity" }
+vantage-types-entity = { version = "0.5", path = "./entity" }
 indexmap = "2.14"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0.149", optional = true }
 ciborium = { version = "0.2", features = ["std"] }
-vantage-core = { version = "0.4", path = "../vantage-core" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
 
 [dev-dependencies]
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-types/entity/Cargo.toml
+++ b/vantage-types/entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-types-entity"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Entity proc macro for the Vantage type system"

--- a/vantage-ui-adapters/Cargo.toml
+++ b/vantage-ui-adapters/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dataset-ui-adapters"
 version = "0.5.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 # Core dependencies always included

--- a/vantage-ui-adapters/src/lib.rs
+++ b/vantage-ui-adapters/src/lib.rs
@@ -272,8 +272,11 @@ impl VantageTableAdapter {
             })
             .collect();
 
-        let records: IndexMap<String, Record<CborValue>> =
-            vista.source.list_vista_values(&vista).await.unwrap_or_default();
+        let records: IndexMap<String, Record<CborValue>> = vista
+            .source
+            .list_vista_values(&vista)
+            .await
+            .unwrap_or_default();
         let cached_data: Vec<TableRow> = records
             .into_values()
             .map(|record| {

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,29 +1,84 @@
 # Changelog
 
+## 0.5.0 — 2026-05-23
+
+- Align all internal dependency versions to 0.5+. No public API changes.
+
 ## 0.4.12 — 2026-05-23
 
-- Doc comment touch-up on [`TableShell`](https://docs.rs/vantage-vista/0.4.12/vantage_vista/trait.TableShell.html) — drops the `AnyTable` reference now that [vantage-table 0.5.2](https://docs.rs/vantage-table/0.5.2/vantage_table/) removes it. No code change.
+- Doc comment touch-up on
+  [`TableShell`](https://docs.rs/vantage-vista/0.4.12/vantage_vista/trait.TableShell.html) — drops
+  the `AnyTable` reference now that
+  [vantage-table 0.5.2](https://docs.rs/vantage-table/0.5.2/vantage_table/) removes it. No code
+  change.
 
 ## 0.4.11 — 2026-05-23
 
-- Dep-pin bump on `vantage-dataset` to 0.5; tracks the `ImTable` / `ImDataSource` parametrization. No public API change.
+- Dep-pin bump on `vantage-dataset` to 0.5; tracks the `ImTable` / `ImDataSource` parametrization.
+  No public API change.
 
 ## 0.4.10 — 2026-05-18
 
-- **Breaking**: schema moves to the shell. [`TableShell`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html) gains three required methods — [`columns`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.columns), [`references`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.references), [`id_column`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.id_column) — and [`Vista::new(name, source)`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.Vista.html#method.new) loses its `VistaMetadata` parameter. Driver shells store the metadata themselves and answer schema queries directly; `Vista` forwards every metadata accessor to the shell, and `Vista::get_ref_kinds` derives from `shell.references()` by default. Driver crates that wrap a typed `Table` are already updated.
+- **Breaking**: schema moves to the shell.
+  [`TableShell`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html) gains
+  three required methods —
+  [`columns`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.columns),
+  [`references`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.references),
+  [`id_column`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/trait.TableShell.html#tymethod.id_column)
+  — and
+  [`Vista::new(name, source)`](https://docs.rs/vantage-vista/0.4.10/vantage_vista/struct.Vista.html#method.new)
+  loses its `VistaMetadata` parameter. Driver shells store the metadata themselves and answer schema
+  queries directly; `Vista` forwards every metadata accessor to the shell, and
+  `Vista::get_ref_kinds` derives from `shell.references()` by default. Driver crates that wrap a
+  typed `Table` are already updated.
 
 ## 0.4.9 — 2026-05-17
 
-Stage 5 query primitives arrive at the universal surface — sort, quicksearch, and pagination on every Vista.
+Stage 5 query primitives arrive at the universal surface — sort, quicksearch, and pagination on
+every Vista.
 
-- New [`Vista::add_order(column, dir)`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_order) and [`Vista::clear_orders`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.clear_orders) push a single ORDER BY clause down to the driver. Replace-semantics: calling `add_order` again wipes the previous one. V1 is single-column; the signature stays for when multi-column lands. Columns must carry the new [`ORDERABLE`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/flags/constant.ORDERABLE.html) flag; otherwise the call surfaces `Unsupported` (DynamoDB-style sort-key-only backends use this).
-- New [`Vista::add_search(text)`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_search) and [`Vista::clear_search`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.clear_search) — one string fans out across the columns the driver considers searchable (typically those flagged [`SEARCHABLE`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/flags/constant.SEARCHABLE.html)). Also replace-semantics.
-- New pagination triple: [`Vista::set_page_size(n)`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.set_page_size), [`Vista::fetch_page(page)`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_page) (offset-style, 1-based), and [`Vista::fetch_next(token)`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_next) (cursor-style; opaque driver-private token). Drivers advertise which they support — DynamoDB and most token-paginated REST APIs only get `fetch_next`; SQL gets all three.
-- New [`SortDirection`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/enum.SortDirection.html) at the Vista boundary, mirroring `vantage-table`'s `SortDirection` without depending on it.
-- **Breaking**: [`VistaCapabilities`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.VistaCapabilities.html) loses `paginate_kind: PaginateKind` and gains five flat booleans: `can_order`, `can_search`, `can_set_page_size`, `can_fetch_page`, `can_fetch_next`. The old enum collapsed the matrix; the new shape lets a driver advertise "yes I paginate but you can't pick the page size" or "yes random-access pages and forward cursor". The `PaginateKind` enum is removed from the public re-exports.
-- Matching `TableShell` trait methods (`set_page_size`, `fetch_page`, `fetch_next`, `add_search`, `clear_search`, `add_order`, `clear_orders`) — all default to the capability-honest error pair (`Unimplemented` when the flag is `true`, `Unsupported` when `false`).
-- `TableShell::default_error` no longer takes the `&Vista` parameter; drivers that override methods to fall back to it should drop the argument at the call site.
-- [`MockShell`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/mocks/struct.MockShell.html) implements `add_order` / `clear_orders` / `add_search` / `clear_search` end-to-end (single-column sort, case-insensitive substring search across text fields) and defaults `can_order` / `can_search` to `true`, so consumers can exercise the new vocabulary against the mock without standing up a real driver.
+- New
+  [`Vista::add_order(column, dir)`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_order)
+  and
+  [`Vista::clear_orders`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.clear_orders)
+  push a single ORDER BY clause down to the driver. Replace-semantics: calling `add_order` again
+  wipes the previous one. V1 is single-column; the signature stays for when multi-column lands.
+  Columns must carry the new
+  [`ORDERABLE`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/flags/constant.ORDERABLE.html)
+  flag; otherwise the call surfaces `Unsupported` (DynamoDB-style sort-key-only backends use this).
+- New
+  [`Vista::add_search(text)`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.add_search)
+  and
+  [`Vista::clear_search`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.clear_search)
+  — one string fans out across the columns the driver considers searchable (typically those flagged
+  [`SEARCHABLE`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/flags/constant.SEARCHABLE.html)).
+  Also replace-semantics.
+- New pagination triple:
+  [`Vista::set_page_size(n)`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.set_page_size),
+  [`Vista::fetch_page(page)`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_page)
+  (offset-style, 1-based), and
+  [`Vista::fetch_next(token)`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.Vista.html#method.fetch_next)
+  (cursor-style; opaque driver-private token). Drivers advertise which they support — DynamoDB and
+  most token-paginated REST APIs only get `fetch_next`; SQL gets all three.
+- New [`SortDirection`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/enum.SortDirection.html)
+  at the Vista boundary, mirroring `vantage-table`'s `SortDirection` without depending on it.
+- **Breaking**:
+  [`VistaCapabilities`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/struct.VistaCapabilities.html)
+  loses `paginate_kind: PaginateKind` and gains five flat booleans: `can_order`, `can_search`,
+  `can_set_page_size`, `can_fetch_page`, `can_fetch_next`. The old enum collapsed the matrix; the
+  new shape lets a driver advertise "yes I paginate but you can't pick the page size" or "yes
+  random-access pages and forward cursor". The `PaginateKind` enum is removed from the public
+  re-exports.
+- Matching `TableShell` trait methods (`set_page_size`, `fetch_page`, `fetch_next`, `add_search`,
+  `clear_search`, `add_order`, `clear_orders`) — all default to the capability-honest error pair
+  (`Unimplemented` when the flag is `true`, `Unsupported` when `false`).
+- `TableShell::default_error` no longer takes the `&Vista` parameter; drivers that override methods
+  to fall back to it should drop the argument at the call site.
+- [`MockShell`](https://docs.rs/vantage-vista/0.4.9/vantage_vista/mocks/struct.MockShell.html)
+  implements `add_order` / `clear_orders` / `add_search` / `clear_search` end-to-end (single-column
+  sort, case-insensitive substring search across text fields) and defaults `can_order` /
+  `can_search` to `true`, so consumers can exercise the new vocabulary against the mock without
+  standing up a real driver.
 
 ## 0.4.8 — 2026-05-16
 
@@ -33,100 +88,168 @@ Stage 5 query primitives arrive at the universal surface — sort, quicksearch, 
 
 Row-based reference traversal arrives at the universal surface, replacing the AnyTable-bridged path.
 
-- **Breaking**: [`Vista::get_ref`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.get_ref) signature is now `(relation, &Record<CborValue>)` — pass in the parent row, get back a child Vista narrowed by one eq-condition. Drops the subquery-based path and the deferred-fetch dance. [`TableShell::get_ref`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/trait.TableShell.html#method.get_ref) gets the matching signature; the unused `vista: &Vista` parameter was dropped — shells holding a typed `Table` don't consult Vista metadata to traverse.
-- New [`Vista::with_foreign(name, kind, closure)`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.with_foreign) — cross-persistence reference declaration at the Vista layer. The closure is *stored, never invoked* at registration so mutually-referencing Vistas don't recurse at construction; it fires lazily on `get_ref`. `kind: ReferenceKind` records cardinality so consumers can render record-card vs list-grid.
-- New [`Vista::with_id(id)`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.with_id) convenience — narrow by id, pair with `get_some_value` for the "I only know an id" workflow.
-- New [`Vista::list_references()`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.list_references) returns `Vec<(name, ReferenceKind)>`. Combines foreign resolvers, YAML metadata, and the wrapped table's typed refs surfaced via the new [`TableShell::get_ref_kinds`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/trait.TableShell.html#method.get_ref_kinds).
-- **Breaking**: `ReferenceKind::HasForeign` is removed — the enum is `HasOne | HasMany`. Cross-persistence-ness is no longer encoded in the kind; it's determined at resolution time by whether the target Vista lives in the same driver or a different one (the inventory loader knows). YAML files using `kind: has_foreign` migrate to `kind: has_one` or `kind: has_many` depending on cardinality.
-- Step 8 of the Vista integration guide gets a new "References delegate too" section plus an Optional-overrides walkthrough — `docs4/src/new-persistence/step8-vista-integration.md`.
+- **Breaking**:
+  [`Vista::get_ref`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.get_ref)
+  signature is now `(relation, &Record<CborValue>)` — pass in the parent row, get back a child Vista
+  narrowed by one eq-condition. Drops the subquery-based path and the deferred-fetch dance.
+  [`TableShell::get_ref`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/trait.TableShell.html#method.get_ref)
+  gets the matching signature; the unused `vista: &Vista` parameter was dropped — shells holding a
+  typed `Table` don't consult Vista metadata to traverse.
+- New
+  [`Vista::with_foreign(name, kind, closure)`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.with_foreign)
+  — cross-persistence reference declaration at the Vista layer. The closure is _stored, never
+  invoked_ at registration so mutually-referencing Vistas don't recurse at construction; it fires
+  lazily on `get_ref`. `kind: ReferenceKind` records cardinality so consumers can render record-card
+  vs list-grid.
+- New
+  [`Vista::with_id(id)`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.with_id)
+  convenience — narrow by id, pair with `get_some_value` for the "I only know an id" workflow.
+- New
+  [`Vista::list_references()`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/struct.Vista.html#method.list_references)
+  returns `Vec<(name, ReferenceKind)>`. Combines foreign resolvers, YAML metadata, and the wrapped
+  table's typed refs surfaced via the new
+  [`TableShell::get_ref_kinds`](https://docs.rs/vantage-vista/0.4.7/vantage_vista/trait.TableShell.html#method.get_ref_kinds).
+- **Breaking**: `ReferenceKind::HasForeign` is removed — the enum is `HasOne | HasMany`.
+  Cross-persistence-ness is no longer encoded in the kind; it's determined at resolution time by
+  whether the target Vista lives in the same driver or a different one (the inventory loader knows).
+  YAML files using `kind: has_foreign` migrate to `kind: has_one` or `kind: has_many` depending on
+  cardinality.
+- Step 8 of the Vista integration guide gets a new "References delegate too" section plus an
+  Optional-overrides walkthrough — `docs4/src/new-persistence/step8-vista-integration.md`.
 
 ## 0.4.6 — 2026-05-15
 
-- New [`Vista::add_raw_condition<C>(condition: C)`](https://docs.rs/vantage-vista/0.4.6/vantage_vista/struct.Vista.html#method.add_raw_condition) and matching [`TableShell::add_raw_condition`](https://docs.rs/vantage-vista/0.4.6/vantage_vista/trait.TableShell.html#method.add_raw_condition) trait method (default returns `Unimplemented`). Drivers can downcast the boxed value to their own `T::Condition` and push it directly into the wrapped table. Used by YAML factories that need to inject deferred-FK eq conditions (where the value is read out of a parent record at fetch time), which the scalar `add_condition_eq` channel can't express.
+- New
+  [`Vista::add_raw_condition<C>(condition: C)`](https://docs.rs/vantage-vista/0.4.6/vantage_vista/struct.Vista.html#method.add_raw_condition)
+  and matching
+  [`TableShell::add_raw_condition`](https://docs.rs/vantage-vista/0.4.6/vantage_vista/trait.TableShell.html#method.add_raw_condition)
+  trait method (default returns `Unimplemented`). Drivers can downcast the boxed value to their own
+  `T::Condition` and push it directly into the wrapped table. Used by YAML factories that need to
+  inject deferred-FK eq conditions (where the value is read out of a parent record at fetch time),
+  which the scalar `add_condition_eq` channel can't express.
 
 ## 0.4.5 — 2026-05-14
 
-- New [`Vista::get_ref`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html#method.get_ref) traverses a named reference and returns the related `Vista`. The driver does the work — it consults its wrapped typed table's `with_one` / `with_many` registry, applies the join condition, and wraps the result back into a `Vista` so callers stay on the universal surface.
-- New [`TableShell::get_ref`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/trait.TableShell.html#method.get_ref) trait method (default returns `Unimplemented`) — drivers wrapping a typed `Table<T, E>` can delegate to `Table::get_ref` and the rest is automatic. The first driver opting in is [`vantage-api-client 0.1.4`](https://docs.rs/vantage-api-client/0.1.4/).
+- New
+  [`Vista::get_ref`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/struct.Vista.html#method.get_ref)
+  traverses a named reference and returns the related `Vista`. The driver does the work — it
+  consults its wrapped typed table's `with_one` / `with_many` registry, applies the join condition,
+  and wraps the result back into a `Vista` so callers stay on the universal surface.
+- New
+  [`TableShell::get_ref`](https://docs.rs/vantage-vista/0.4.5/vantage_vista/trait.TableShell.html#method.get_ref)
+  trait method (default returns `Unimplemented`) — drivers wrapping a typed `Table<T, E>` can
+  delegate to `Table::get_ref` and the rest is automatic. The first driver opting in is
+  [`vantage-api-client 0.1.4`](https://docs.rs/vantage-api-client/0.1.4/).
 
 ## 0.4.4 — 2026-05-04
 
-- New [`Vista::driver()`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html#method.driver) returns a short label for the backing driver (`"csv"`, `"sqlite"`, `"postgres"`, `"mysql"`, `"mongodb"`) — handy for diagnostics and CLI output.
-- New [`TableShell::driver_name`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.driver_name) trait method (default `"unknown"`) drives the above; in-tree drivers all override.
+- New
+  [`Vista::driver()`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html#method.driver)
+  returns a short label for the backing driver (`"csv"`, `"sqlite"`, `"postgres"`, `"mysql"`,
+  `"mongodb"`) — handy for diagnostics and CLI output.
+- New
+  [`TableShell::driver_name`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.driver_name)
+  trait method (default `"unknown"`) drives the above; in-tree drivers all override.
 
 ## 0.4.3 — 2026-05-04
 
 Renames the driver-facing trait so its name describes what it actually is.
 
-- The trait formerly known as `VistaSource` is now [`TableShell`](https://docs.rs/vantage-vista/0.4.3/vantage_vista/trait.TableShell.html). It wraps a typed `Table<T, E>` and exposes it through the CBOR/`String` boundary — "shell" reads more accurately than "source", which already meant something else in `TableSource`.
-- The in-tree mock follows: `MockVistaSource` → [`MockShell`](https://docs.rs/vantage-vista/0.4.3/vantage_vista/mocks/struct.MockShell.html).
-- **Breaking** for anyone naming the trait directly. Existing in-tree drivers (`vantage-csv`, `vantage-mongodb`) move with the rename in lock-step; downstream drivers need a one-line change at their `impl` site and at every `Box<dyn VistaSource>`.
-- New driver-author guide at [Step 8: Vista Integration](https://romaninsh.github.io/vantage/new-persistence/step8-vista-integration.html) — distilled from the CSV and MongoDB rollouts, covering the factory split, the `column_paths` pattern for nested fields, the capability honesty contract, and the tests that catch the common mistakes.
+- The trait formerly known as `VistaSource` is now
+  [`TableShell`](https://docs.rs/vantage-vista/0.4.3/vantage_vista/trait.TableShell.html). It wraps
+  a typed `Table<T, E>` and exposes it through the CBOR/`String` boundary — "shell" reads more
+  accurately than "source", which already meant something else in `TableSource`.
+- The in-tree mock follows: `MockVistaSource` →
+  [`MockShell`](https://docs.rs/vantage-vista/0.4.3/vantage_vista/mocks/struct.MockShell.html).
+- **Breaking** for anyone naming the trait directly. Existing in-tree drivers (`vantage-csv`,
+  `vantage-mongodb`) move with the rename in lock-step; downstream drivers need a one-line change at
+  their `impl` site and at every `Box<dyn VistaSource>`.
+- New driver-author guide at
+  [Step 8: Vista Integration](https://romaninsh.github.io/vantage/new-persistence/step8-vista-integration.html)
+  — distilled from the CSV and MongoDB rollouts, covering the factory split, the `column_paths`
+  pattern for nested fields, the capability honesty contract, and the tests that catch the common
+  mistakes.
 
 ## 0.4.2 — 2026-05-04
 
 Conditions now delegate to the driver instead of being stashed on `Vista`.
 
-- [`Vista::add_condition_eq`](https://docs.rs/vantage-vista/0.4.2/vantage_vista/struct.Vista.html#method.add_condition_eq) returns `Result<()>` and forwards to the source. The internal `eq_conditions` vec is gone — Vista carries no condition state.
-- New [`TableShell::add_eq_condition`](https://docs.rs/vantage-vista/0.4.2/vantage_vista/trait.TableShell.html#method.add_eq_condition) trait method (default impl returns `Unimplemented`). Drivers translate `(field, CborValue)` into their native condition type and push it onto the wrapped table — server-side push-down is automatic wherever the backend supports it.
-- **Breaking** for in-tree `TableShell` implementors: `add_condition_eq` now returns `Result`, so callers need `?` (or `.unwrap()`) at every call site. `Vista::eq_conditions()` accessor removed.
-- Requires `vantage-core 0.4.1` for the new `is_unimplemented` / `is_unsupported` annotators on default-impl errors.
+- [`Vista::add_condition_eq`](https://docs.rs/vantage-vista/0.4.2/vantage_vista/struct.Vista.html#method.add_condition_eq)
+  returns `Result<()>` and forwards to the source. The internal `eq_conditions` vec is gone — Vista
+  carries no condition state.
+- New
+  [`TableShell::add_eq_condition`](https://docs.rs/vantage-vista/0.4.2/vantage_vista/trait.TableShell.html#method.add_eq_condition)
+  trait method (default impl returns `Unimplemented`). Drivers translate `(field, CborValue)` into
+  their native condition type and push it onto the wrapped table — server-side push-down is
+  automatic wherever the backend supports it.
+- **Breaking** for in-tree `TableShell` implementors: `add_condition_eq` now returns `Result`, so
+  callers need `?` (or `.unwrap()`) at every call site. `Vista::eq_conditions()` accessor removed.
+- Requires `vantage-core 0.4.1` for the new `is_unimplemented` / `is_unsupported` annotators on
+  default-impl errors.
 
 ## 0.4.1 — 2026-05-03
 
 Stage 3 — universal YAML loader.
 
-- New [`VistaSpec<T, C, R>`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/struct.VistaSpec.html) is the YAML-facing schema. Three generic parameters carry driver-specific extras at the table, column, and reference level (use [`NoExtras`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/struct.NoExtras.html) when a driver has none). Sugar form `references: products` parses as a [`ReferenceSugar::Sugar`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/enum.ReferenceSugar.html) and the full form deserialises a `ReferenceSpec`.
-- [`VistaFactory`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/trait.VistaFactory.html) gains three associated `Extras` types and a new `build_from_spec` method. The default `from_yaml` parses with `serde_yaml_ng` and dispatches — drivers only need to implement `build_from_spec`.
-- New [`flags`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/flags/index.html) module: `ID`, `TITLE`, `SEARCHABLE`, `MANDATORY`, `HIDDEN`. The vocabulary is open `Vec<String>`; these constants name the values vista's own accessors understand.
-- **Breaking**: `Column::hidden: bool` is replaced by `Column::flags: Vec<String>`. Use `Column::with_flag`, `is_hidden`, `is_id`, `is_title` instead. `VistaMetadata::with_title_columns` is gone — title columns are derived from the `title` flag at runtime via `Vista::get_title_columns()`. Driver factories that translated `ColumnFlag::Hidden` need to call `with_flag(flags::HIDDEN)` instead of `Column::hidden()`.
+- New
+  [`VistaSpec<T, C, R>`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/struct.VistaSpec.html) is
+  the YAML-facing schema. Three generic parameters carry driver-specific extras at the table,
+  column, and reference level (use
+  [`NoExtras`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/struct.NoExtras.html) when a driver
+  has none). Sugar form `references: products` parses as a
+  [`ReferenceSugar::Sugar`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/enum.ReferenceSugar.html)
+  and the full form deserialises a `ReferenceSpec`.
+- [`VistaFactory`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/trait.VistaFactory.html) gains
+  three associated `Extras` types and a new `build_from_spec` method. The default `from_yaml` parses
+  with `serde_yaml_ng` and dispatches — drivers only need to implement `build_from_spec`.
+- New [`flags`](https://docs.rs/vantage-vista/0.4.1/vantage_vista/flags/index.html) module: `ID`,
+  `TITLE`, `SEARCHABLE`, `MANDATORY`, `HIDDEN`. The vocabulary is open `Vec<String>`; these
+  constants name the values vista's own accessors understand.
+- **Breaking**: `Column::hidden: bool` is replaced by `Column::flags: Vec<String>`. Use
+  `Column::with_flag`, `is_hidden`, `is_id`, `is_title` instead. `VistaMetadata::with_title_columns`
+  is gone — title columns are derived from the `title` flag at runtime via
+  `Vista::get_title_columns()`. Driver factories that translated `ColumnFlag::Hidden` need to call
+  `with_flag(flags::HIDDEN)` instead of `Column::hidden()`.
 
 ## 0.4.0 — 2026-05-03
 
-First release — incubating. New crate housing `Vista`, the universal,
-schema-bearing data handle that drivers, scripting, UI, and agents will
-consume in place of `AnyTable`. This stage is shape-only — no driver wiring,
-no YAML loader, no hooks; the trait surface and metadata structs land first
-so downstream stages can build against a stable API.
+First release — incubating. New crate housing `Vista`, the universal, schema-bearing data handle
+that drivers, scripting, UI, and agents will consume in place of `AnyTable`. This stage is
+shape-only — no driver wiring, no YAML loader, no hooks; the trait surface and metadata structs land
+first so downstream stages can build against a stable API.
 
-- `Vista` — concrete struct that owns universal metadata (name, columns,
-  references, capabilities, current eq-conditions) plus a boxed `TableShell`
-  executor. Mutators: `add_column`, `add_reference`, `set_id_column`,
-  `set_title_columns`, `add_condition_eq`. Purpose-bucketed accessors:
-  `get_id_column`, `get_title_columns`, `get_column_names`, `get_column`,
+- `Vista` — concrete struct that owns universal metadata (name, columns, references, capabilities,
+  current eq-conditions) plus a boxed `TableShell` executor. Mutators: `add_column`,
+  `add_reference`, `set_id_column`, `set_title_columns`, `add_condition_eq`. Purpose-bucketed
+  accessors: `get_id_column`, `get_title_columns`, `get_column_names`, `get_column`,
   `get_references`, `get_reference`. Plus an inherent `get_count`.
-- `TableShell` — async trait drivers implement to back a `Vista`. Methods
-  named with the `_vista_` infix (`list_vista_values`, `get_vista_value`,
-  `get_vista_some_value`, `stream_vista_values` (default impl wrapping
-  `list`), `insert_vista_value`, `replace_vista_value`, `patch_vista_value`,
+- `TableShell` — async trait drivers implement to back a `Vista`. Methods named with the `_vista_`
+  infix (`list_vista_values`, `get_vista_value`, `get_vista_some_value`, `stream_vista_values`
+  (default impl wrapping `list`), `insert_vista_value`, `replace_vista_value`, `patch_vista_value`,
   `delete_vista_value`, `delete_vista_all_values`, `insert_vista_return_id_value`,
-  `get_vista_count`, `capabilities`) — mirrors the `_table_` convention on
-  `TableSource` so the delegation pattern is identical.
-- `Vista` impls `vantage_dataset::ValueSet` / `ReadableValueSet` /
-  `WritableValueSet` / `InsertableValueSet`. `Id = String, Value =
-  ciborium::Value` matches `AnyTable`'s existing pragma — `IndexMap<Self::Id, …>`
-  needs `Hash + Eq` and `ciborium::Value` has neither, so backend-native ids
-  (Mongo `ObjectId`, Surreal `Thing`) stringify at the source boundary.
-- `VistaCapabilities` — explicit struct with named fields (`can_count`,
-  `can_insert`, `can_update`, `can_delete`, `can_subscribe`, `can_invalidate`,
-  `paginate_kind`). UI code branches on these instead of probing methods.
-- `Column` — vista-side display metadata only (`name`, `original_type`,
-  `hidden`). `vantage_table::ColumnFlag` does not come along — driver
-  factories translate flags into Vista's purpose accessors during
-  construction.
-- `Reference` + `ReferenceKind` (`HasOne` / `HasMany` / `HasForeign`) —
-  metadata-only relation descriptors.
-- `VistaFactory` trait — single method `from_yaml(&str) -> Result<Vista>` for
-  the universal loader (stage 3). `from_table<E>(Table<DriverSource, E>)` is
-  intentionally an inherent method on each driver's concrete factory rather
-  than a trait method, to avoid a `vantage-vista → vantage-table →
-  vantage-expressions → vantage-vista` dependency cycle.
-- `AnyExpression` + `ExpressionLike` move here from `vantage-expressions`,
-  which now `pub use`s them. The seven existing call sites
-  (`vantage-table` x3, `vantage-live` x2, `vantage-ui` adapter, the
-  `vantage-expressions` prelude) compile unchanged.
-- `MockShell` — in-memory `IndexMap<String, Record<CborValue>>` source
-  for tests. Filters `list_vista_values` by `Vista::eq_conditions`,
-  auto-generates sequential string ids on `insert_vista_return_id_value`.
-- 11 unit tests cover metadata accessors, the eq-condition list filter, and
-  the full `WritableValueSet` / `InsertableValueSet` round-trip via the mock.
+  `get_vista_count`, `capabilities`) — mirrors the `_table_` convention on `TableSource` so the
+  delegation pattern is identical.
+- `Vista` impls `vantage_dataset::ValueSet` / `ReadableValueSet` / `WritableValueSet` /
+  `InsertableValueSet`. `Id = String, Value = ciborium::Value` matches `AnyTable`'s existing pragma
+  — `IndexMap<Self::Id, …>` needs `Hash + Eq` and `ciborium::Value` has neither, so backend-native
+  ids (Mongo `ObjectId`, Surreal `Thing`) stringify at the source boundary.
+- `VistaCapabilities` — explicit struct with named fields (`can_count`, `can_insert`, `can_update`,
+  `can_delete`, `can_subscribe`, `can_invalidate`, `paginate_kind`). UI code branches on these
+  instead of probing methods.
+- `Column` — vista-side display metadata only (`name`, `original_type`, `hidden`).
+  `vantage_table::ColumnFlag` does not come along — driver factories translate flags into Vista's
+  purpose accessors during construction.
+- `Reference` + `ReferenceKind` (`HasOne` / `HasMany` / `HasForeign`) — metadata-only relation
+  descriptors.
+- `VistaFactory` trait — single method `from_yaml(&str) -> Result<Vista>` for the universal loader
+  (stage 3). `from_table<E>(Table<DriverSource, E>)` is intentionally an inherent method on each
+  driver's concrete factory rather than a trait method, to avoid a
+  `vantage-vista → vantage-table → vantage-expressions → vantage-vista` dependency cycle.
+- `AnyExpression` + `ExpressionLike` move here from `vantage-expressions`, which now `pub use`s
+  them. The seven existing call sites (`vantage-table` x3, `vantage-live` x2, `vantage-ui` adapter,
+  the `vantage-expressions` prelude) compile unchanged.
+- `MockShell` — in-memory `IndexMap<String, Record<CborValue>>` source for tests. Filters
+  `list_vista_values` by `Vista::eq_conditions`, auto-generates sequential string ids on
+  `insert_vista_return_id_value`.
+- 11 unit tests cover metadata accessors, the eq-condition list filter, and the full
+  `WritableValueSet` / `InsertableValueSet` round-trip via the mock.

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.4.12"
+version = "0.5.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"
@@ -10,8 +10,8 @@ repository = "https://github.com/romaninsh/vantage"
 doctest = false
 
 [dependencies]
-vantage-core = { version = "0.4.1", path = "../vantage-core" }
-vantage-types = { version = "0.4", path = "../vantage-types" }
+vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-types = { version = "0.5", path = "../vantage-types" }
 vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
 ciborium = { version = "0.2", features = ["std"] }
 indexmap = { version = "2.14", features = ["serde"] }


### PR DESCRIPTION
Fix the CI failures from recent main pushes:

- vantage-table rustdoc broken intra-doc links (Main Workspace docs check on main)
- vantage-ui-adapters cargo fmt drift (UI Adapters Tests)
- vantage-aws workflow uses removed `vista` feature flag (AWS Backend Tests)
- vantage-ui-adapters `publish = false` so the publish-on-merge workflow skips it (git-only `gpui` dep cannot publish)