### PR TITLE
vista nested insert through relations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "bson",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-mongodb/CHANGELOG.md
+++ b/vantage-mongodb/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.4 — 2026-05-30
+
+- `MongoTableShell` implements
+  [`TableShell::get_ref_target`](https://docs.rs/vantage-vista/0.5.1/vantage_vista/trait.TableShell.html),
+  and the factory populates `VistaMetadata::references` — enabling
+  [vantage-vista 0.5.1](https://docs.rs/vantage-vista/0.5.1/vantage_vista/)'s nested insert through
+  relations. Tracks [vantage-table 0.5.4](https://docs.rs/vantage-table/0.5.4/vantage_table/).
+
 ## 0.5.3 — 2026-05-23
 
 - Align all internal dependency versions to 0.5+. No public API changes.

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"

--- a/vantage-mongodb/src/vista/factory.rs
+++ b/vantage-mongodb/src/vista/factory.rs
@@ -220,6 +220,9 @@ where
             col.flags.push(vista_flags::TITLE.to_string());
         }
     }
+    for reference in table.vista_references() {
+        metadata = metadata.with_reference(reference);
+    }
     metadata
 }
 

--- a/vantage-mongodb/src/vista/source.rs
+++ b/vantage-mongodb/src/vista/source.rs
@@ -292,6 +292,13 @@ impl TableShell for MongoTableShell {
         factory.from_table(target)
     }
 
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let factory =
+            crate::vista::factory::MongoVistaFactory::new(self.table.data_source().clone());
+        factory.from_table(target)
+    }
+
     fn get_ref_kinds(&self) -> Vec<(String, vantage_vista::ReferenceKind)> {
         self.table.ref_kinds()
     }

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.4 — 2026-05-30
+
+- The SQLite, PostgreSQL, and MySQL shells implement
+  [`TableShell::get_ref_target`](https://docs.rs/vantage-vista/0.5.1/vantage_vista/trait.TableShell.html),
+  and their factories populate `VistaMetadata::references` — enabling
+  [vantage-vista 0.5.1](https://docs.rs/vantage-vista/0.5.1/vantage_vista/)'s nested insert through
+  relations. Tracks [vantage-table 0.5.4](https://docs.rs/vantage-table/0.5.4/vantage_table/).
+
 ## 0.5.3 — 2026-05-23
 
 - Align all internal dependency versions to 0.5+. No public API changes.

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/mysql/vista/factory.rs
+++ b/vantage-sql/src/mysql/vista/factory.rs
@@ -184,5 +184,8 @@ where
             col.flags.push(vista_flags::TITLE.to_string());
         }
     }
+    for reference in table.vista_references() {
+        metadata = metadata.with_reference(reference);
+    }
     metadata
 }

--- a/vantage-sql/src/mysql/vista/source.rs
+++ b/vantage-sql/src/mysql/vista/source.rs
@@ -191,6 +191,13 @@ where
         factory.from_table(target)
     }
 
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let factory =
+            crate::mysql::vista::factory::MysqlVistaFactory::new(self.table.data_source().clone());
+        factory.from_table(target)
+    }
+
     fn get_ref_kinds(&self) -> Vec<(String, vantage_vista::ReferenceKind)> {
         self.table.ref_kinds()
     }

--- a/vantage-sql/src/postgres/vista/factory.rs
+++ b/vantage-sql/src/postgres/vista/factory.rs
@@ -187,5 +187,8 @@ where
             col.flags.push(vista_flags::TITLE.to_string());
         }
     }
+    for reference in table.vista_references() {
+        metadata = metadata.with_reference(reference);
+    }
     metadata
 }

--- a/vantage-sql/src/postgres/vista/source.rs
+++ b/vantage-sql/src/postgres/vista/source.rs
@@ -192,6 +192,14 @@ where
         factory.from_table(target)
     }
 
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let factory = crate::postgres::vista::factory::PostgresVistaFactory::new(
+            self.table.data_source().clone(),
+        );
+        factory.from_table(target)
+    }
+
     fn get_ref_kinds(&self) -> Vec<(String, vantage_vista::ReferenceKind)> {
         self.table.ref_kinds()
     }

--- a/vantage-sql/src/sqlite/vista/factory.rs
+++ b/vantage-sql/src/sqlite/vista/factory.rs
@@ -201,5 +201,8 @@ where
             col.flags.push(vista_flags::TITLE.to_string());
         }
     }
+    for reference in table.vista_references() {
+        metadata = metadata.with_reference(reference);
+    }
     metadata
 }

--- a/vantage-sql/src/sqlite/vista/source.rs
+++ b/vantage-sql/src/sqlite/vista/source.rs
@@ -328,6 +328,14 @@ where
         factory.from_table(target)
     }
 
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let factory = crate::sqlite::vista::factory::SqliteVistaFactory::new(
+            self.table.data_source().clone(),
+        );
+        factory.from_table(target)
+    }
+
     fn get_ref_kinds(&self) -> Vec<(String, vantage_vista::ReferenceKind)> {
         self.table.ref_kinds()
     }

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.5.4 — 2026-05-30
+
+Support for [vantage-vista 0.5.1](https://docs.rs/vantage-vista/0.5.1/vantage_vista/)'s nested insert.
+
+### Added
+
+- `Table::get_ref_target::<E2>(relation)` — builds a relation's target table with **no** join
+  condition (the bare table a new related row is inserted into), complementing the row-conditioned
+  `get_ref_from_row` / `get_ref_as`.
+- `Table::vista_references()` — snapshots the table's relations as `vantage_vista::Reference`s (name,
+  target, cardinality, foreign key) for driver factories to fold into `VistaMetadata`.
+- `Reference::foreign_key()` on the `Reference` trait — exposes the relation's FK column. **Note:** a
+  new required trait method; external `Reference` impls (beyond the built-in `HasOne` / `HasMany`)
+  must add it.
+
 ## 0.5.3 — 2026-05-23
 
 - Align all internal dependency versions to 0.5+. No public API changes.

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/references.rs
+++ b/vantage-table/src/references.rs
@@ -27,6 +27,13 @@ pub trait Reference: Send + Sync {
     /// Given source and target id field names, return (source_column, target_column).
     fn columns(&self, source_id: &str, target_id: &str) -> (String, String);
 
+    /// The foreign-key column carried by this relation. For `HasOne` it names a
+    /// column on the *source* table (set to the related row's id after the
+    /// related row is inserted); for `HasMany` it names a column on the *target*
+    /// table (set to the parent's id when inserting each child). Drives nested
+    /// insert at the Vista layer.
+    fn foreign_key(&self) -> &str;
+
     /// Produce a fresh target table (no conditions applied), wrapped in
     /// `Box<dyn Any>` so callers can downcast back to the concrete
     /// `Table<T, TargetE>`. Used by [`crate::table::Table::get_ref_as`] and

--- a/vantage-table/src/references/many.rs
+++ b/vantage-table/src/references/many.rs
@@ -68,6 +68,10 @@ where
         (source_id.to_string(), self.target_foreign_key.clone())
     }
 
+    fn foreign_key(&self) -> &str {
+        &self.target_foreign_key
+    }
+
     fn build_target(&self, data_source: &dyn Any) -> Box<dyn Any> {
         let ds = data_source
             .downcast_ref::<T>()

--- a/vantage-table/src/references/one.rs
+++ b/vantage-table/src/references/one.rs
@@ -72,6 +72,10 @@ where
         (self.foreign_key.clone(), target_id.to_string())
     }
 
+    fn foreign_key(&self) -> &str {
+        &self.foreign_key
+    }
+
     fn build_target(&self, data_source: &dyn Any) -> Box<dyn Any> {
         let ds = data_source
             .downcast_ref::<T>()

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -77,6 +77,28 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
         }
     }
 
+    /// Snapshot the table's relations as Vista references (name, target type,
+    /// cardinality, foreign key). Driver factories fold this into
+    /// `VistaMetadata` so the erased `Vista` carries enough to drive nested
+    /// insert and relation traversal.
+    pub fn vista_references(&self) -> Vec<vantage_vista::Reference> {
+        self.refs
+            .as_ref()
+            .map(|refs| {
+                refs.iter()
+                    .map(|(name, r)| {
+                        vantage_vista::Reference::new(
+                            name.clone(),
+                            r.target_type_name().to_string(),
+                            r.cardinality(),
+                            r.foreign_key().to_string(),
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     /// Use a callback with a builder pattern for configuration
     pub fn with<F>(mut self, func: F) -> Self
     where

--- a/vantage-table/src/table/impls/refereces.rs
+++ b/vantage-table/src/table/impls/refereces.rs
@@ -216,6 +216,30 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
         Ok(target)
     }
 
+    /// Build the relation's target table with **no condition** applied.
+    ///
+    /// Unlike [`Self::get_ref_from_row`] / [`Self::get_ref_as`] (which select
+    /// the related rows for a known parent), this returns the bare target — the
+    /// table you'd insert a new related row into. Used by Vista's nested insert
+    /// to obtain the destination for a has-one/has-many child before any join
+    /// value exists.
+    pub fn get_ref_target<E2: Entity<T::Value> + 'static>(
+        &self,
+        relation: &str,
+    ) -> Result<Table<T, E2>> {
+        let (reference, relation_str) = self.lookup_ref(relation)?;
+        let target: Table<T, E2> = *reference
+            .build_target(self.data_source() as &dyn std::any::Any)
+            .downcast::<Table<T, E2>>()
+            .map_err(|_| {
+                error!(
+                    "Failed to downcast related table",
+                    relation = relation_str.as_str()
+                )
+            })?;
+        Ok(target)
+    }
+
     /// Add a computed expression field using builder pattern.
     ///
     /// The closure receives `&Table<T, E>` and returns an `Expression<T::Value>`.

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.5.1 — 2026-05-30
+
+### Added
+
+- **Nested insert through relations.** `insert_value` / `insert_return_id_value` now accept a record
+  whose keys name a **relation** instead of a column, and sequence the writes so foreign keys are
+  populated automatically: a **has-one** child (`inventory` as a map, or grouped `inventory.count` /
+  `inventory.flag` keys) is inserted first and its id stamped into the parent's FK column; **has-many**
+  children (`orders` as a list of maps) are inserted after the parent with the parent's id stamped
+  into each child's FK column. Arbitrary depth, native (same-persistence) relations only. Best-effort
+  and non-atomic — a mid-sequence failure leaves earlier writes committed. Vista does no field
+  validation; the underlying table validates each record. Cross-persistence
+  ([`with_foreign`](https://docs.rs/vantage-vista/0.5.1/vantage_vista/struct.Vista.html#method.with_foreign))
+  relations are rejected.
+- [`TableShell::get_ref_target`](https://docs.rs/vantage-vista/0.5.1/vantage_vista/trait.TableShell.html)
+  and `Vista::get_ref_target` — build the **bare** (unconditioned) target of a relation, i.e. the
+  table a new related row is inserted into. Default impl returns `Unimplemented`.
+
+### Changed
+
+- Driver factories now populate `VistaMetadata::references`, so `Vista::get_reference` carries the
+  relation's `foreign_key` for code-first vistas (previously empty). Requires
+  [vantage-table 0.5.4](https://docs.rs/vantage-table/0.5.4/vantage_table/).
+
 ## 0.5.0 — 2026-05-23
 
 - Align all internal dependency versions to 0.5+. No public API changes.

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/impls/insertable_value_set.rs
+++ b/vantage-vista/src/impls/insertable_value_set.rs
@@ -9,6 +9,6 @@ use crate::vista::Vista;
 #[async_trait]
 impl InsertableValueSet for Vista {
     async fn insert_return_id_value(&self, record: &Record<CborValue>) -> Result<String> {
-        self.source.insert_vista_return_id_value(self, record).await
+        self.insert_nested_return_id(record).await
     }
 }

--- a/vantage-vista/src/impls/writable_value_set.rs
+++ b/vantage-vista/src/impls/writable_value_set.rs
@@ -13,7 +13,7 @@ impl WritableValueSet for Vista {
         id: &String,
         record: &Record<CborValue>,
     ) -> Result<Record<CborValue>> {
-        self.source.insert_vista_value(self, id, record).await
+        self.insert_nested_value(id, record).await
     }
 
     async fn replace_value(

--- a/vantage-vista/src/insert.rs
+++ b/vantage-vista/src/insert.rs
@@ -1,0 +1,363 @@
+//! Nested record insert.
+//!
+//! A flat insert sends one record to one table. This module lets a single
+//! insert carry related records too: keys that name a **relation** (rather than
+//! a column) hold the child data, and Vista sequences the writes so foreign
+//! keys are populated automatically.
+//!
+//! - **has-one** (`inventory` / `inventory.count`): the child is inserted
+//!   *first*, then its id is stamped into the parent's foreign-key column.
+//! - **has-many** (`orders`): the parent is inserted *first*, then each child is
+//!   inserted with the parent's id stamped into the child's foreign-key column.
+//!
+//! Vista does **no** field validation — the underlying table validates every
+//! record it receives. Vista's only job here is to order the inserts and fill
+//! the reference (FK) values. The sequence is **best-effort / non-atomic**: a
+//! failure mid-way leaves earlier writes committed. Only **native**
+//! (same-persistence) relations are supported; cross-persistence
+//! ([`Vista::with_foreign`](crate::vista::Vista::with_foreign)) relations are
+//! rejected.
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_dataset::traits::InsertableValueSet;
+use vantage_types::Record;
+
+use crate::{reference::ReferenceKind, vista::Vista};
+
+/// A relation's child data, peeled off an insert record before classification.
+enum Collected {
+    /// A single child record — from a bare map value or grouped `rel.col` keys.
+    Map(Record<CborValue>),
+    /// An ordered list of child records — from a bare CBOR list value.
+    List(Vec<Record<CborValue>>),
+}
+
+/// A has-one child to insert before the main row: `(relation, foreign_key, child)`.
+type HasOneChild = (String, String, Record<CborValue>);
+/// A has-many group to insert after the main row: `(relation, foreign_key, children)`.
+type HasManyGroup = (String, String, Vec<Record<CborValue>>);
+
+impl Vista {
+    /// Split an insert record into the main row's fields and the per-relation
+    /// child payloads, then classify each relation as has-one / has-many.
+    ///
+    /// Returns `(main, has_one, has_many)`. A relation key that resolves to no
+    /// same-persistence reference (i.e. cross-persistence or unknown) is an
+    /// error, raised before any write happens.
+    fn classify_insert(
+        &self,
+        record: &Record<CborValue>,
+    ) -> Result<(Record<CborValue>, Vec<HasOneChild>, Vec<HasManyGroup>)> {
+        let relation_names: std::collections::HashSet<String> =
+            self.list_references().into_iter().map(|(n, _)| n).collect();
+
+        let mut main: Record<CborValue> = Record::new();
+        let mut collected: IndexMap<String, Collected> = IndexMap::new();
+
+        for (key, value) in record.iter() {
+            // has-one shorthand: `relation.column = scalar`
+            if let Some((prefix, rest)) = key.split_once('.')
+                && relation_names.contains(prefix)
+            {
+                match collected
+                    .entry(prefix.to_string())
+                    .or_insert_with(|| Collected::Map(Record::new()))
+                {
+                    Collected::Map(child) => {
+                        child.insert(rest.to_string(), value.clone());
+                    }
+                    Collected::List(_) => {
+                        return Err(error!(
+                            "relation given both a list and dotted fields",
+                            relation = prefix
+                        ));
+                    }
+                }
+                continue;
+            }
+
+            // bare relation key: map (has-one) or list of maps (has-many)
+            if relation_names.contains(key.as_str()) {
+                match value {
+                    CborValue::Map(_) => {
+                        let incoming = Record::<CborValue>::from(value.clone());
+                        match collected
+                            .entry(key.clone())
+                            .or_insert_with(|| Collected::Map(Record::new()))
+                        {
+                            Collected::Map(child) => {
+                                for (k, v) in incoming {
+                                    child.insert(k, v);
+                                }
+                            }
+                            Collected::List(_) => {
+                                return Err(error!(
+                                    "relation given both a list and a map",
+                                    relation = key
+                                ));
+                            }
+                        }
+                    }
+                    CborValue::Array(items) => {
+                        if collected.contains_key(key.as_str()) {
+                            return Err(error!(
+                                "relation given more than once",
+                                relation = key
+                            ));
+                        }
+                        let mut children = Vec::with_capacity(items.len());
+                        for item in items {
+                            if !matches!(item, CborValue::Map(_)) {
+                                return Err(error!(
+                                    "has-many relation items must be maps",
+                                    relation = key
+                                ));
+                            }
+                            children.push(Record::<CborValue>::from(item.clone()));
+                        }
+                        collected.insert(key.clone(), Collected::List(children));
+                    }
+                    _ => {
+                        return Err(error!(
+                            "relation value must be a map (has-one) or a list of maps (has-many)",
+                            relation = key
+                        ));
+                    }
+                }
+                continue;
+            }
+
+            // plain field → main row, untouched (the table validates it)
+            main.insert(key.clone(), value.clone());
+        }
+
+        let mut has_one: Vec<HasOneChild> = Vec::new();
+        let mut has_many: Vec<HasManyGroup> = Vec::new();
+        for (relation, payload) in collected {
+            let reference = self.get_reference(&relation).ok_or_else(|| {
+                error!(
+                    "cross-persistence nested insert is not supported",
+                    relation = relation.as_str()
+                )
+            })?;
+            let foreign_key = reference.foreign_key.clone();
+            match reference.kind {
+                ReferenceKind::HasOne => match payload {
+                    Collected::Map(child) => has_one.push((relation, foreign_key, child)),
+                    Collected::List(_) => {
+                        return Err(error!(
+                            "has-one relation expects a single record, got a list",
+                            relation = relation.as_str()
+                        ));
+                    }
+                },
+                ReferenceKind::HasMany => match payload {
+                    Collected::List(children) => has_many.push((relation, foreign_key, children)),
+                    Collected::Map(_) => {
+                        return Err(error!(
+                            "has-many relation expects a list of records",
+                            relation = relation.as_str()
+                        ));
+                    }
+                },
+            }
+        }
+
+        Ok((main, has_one, has_many))
+    }
+
+    /// Insert each has-one child into its bare target and stamp the returned id
+    /// into the main record's foreign-key column. Run before the main row.
+    async fn insert_has_one_children(
+        &self,
+        main: &mut Record<CborValue>,
+        has_one: Vec<HasOneChild>,
+    ) -> Result<()> {
+        for (relation, foreign_key, child) in has_one {
+            let target = self.get_ref_target(&relation)?;
+            let child_id = target.insert_return_id_value(&child).await?;
+            main.insert(foreign_key, CborValue::Text(child_id));
+        }
+        Ok(())
+    }
+
+    /// Insert each has-many child into its bare target with `parent_id` stamped
+    /// into the child's foreign-key column. Run after the main row.
+    async fn insert_has_many_children(
+        &self,
+        parent_id: &str,
+        has_many: Vec<HasManyGroup>,
+    ) -> Result<()> {
+        for (relation, foreign_key, children) in has_many {
+            let target = self.get_ref_target(&relation)?;
+            for mut child in children {
+                child.insert(foreign_key.clone(), CborValue::Text(parent_id.to_string()));
+                target.insert_return_id_value(&child).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Nested insert returning the main row's id (the `insert_return_id_value`
+    /// path). Children with auto-assigned ids; main row id chosen by the driver.
+    pub(crate) async fn insert_nested_return_id(
+        &self,
+        record: &Record<CborValue>,
+    ) -> Result<String> {
+        let (mut main, has_one, has_many) = self.classify_insert(record)?;
+        self.insert_has_one_children(&mut main, has_one).await?;
+        let parent_id = self.source.insert_vista_return_id_value(self, &main).await?;
+        self.insert_has_many_children(&parent_id, has_many).await?;
+        Ok(parent_id)
+    }
+
+    /// Nested insert for an explicitly-keyed main row (the `insert_value` path).
+    /// Returns the inserted main record as the driver stored it.
+    pub(crate) async fn insert_nested_value(
+        &self,
+        id: &String,
+        record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        let (mut main, has_one, has_many) = self.classify_insert(record)?;
+        self.insert_has_one_children(&mut main, has_one).await?;
+        let inserted = self.source.insert_vista_value(self, id, &main).await?;
+        self.insert_has_many_children(id, has_many).await?;
+        Ok(inserted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        Column, Reference, ReferenceKind, VistaMetadata, mocks::mock_shell::MockShell,
+    };
+
+    /// Vista over a `client` table: scalar columns plus a has-one `bakery`
+    /// (FK `bakery_id` on this row) and a has-many `orders` (FK `client_id` on
+    /// the order row).
+    fn client_vista() -> Vista {
+        let metadata = VistaMetadata::new()
+            .with_column(Column::new("id", "String").with_flag("id"))
+            .with_column(Column::new("name", "String"))
+            .with_id_column("id")
+            .with_reference(Reference::new(
+                "bakery",
+                "bakery",
+                ReferenceKind::HasOne,
+                "bakery_id",
+            ))
+            .with_reference(Reference::new(
+                "orders",
+                "order",
+                ReferenceKind::HasMany,
+                "client_id",
+            ));
+        Vista::new("client", Box::new(MockShell::new().with_metadata(metadata)))
+    }
+
+    fn text(s: &str) -> CborValue {
+        CborValue::Text(s.into())
+    }
+
+    fn map(pairs: &[(&str, CborValue)]) -> CborValue {
+        CborValue::Map(
+            pairs
+                .iter()
+                .map(|(k, v)| (CborValue::Text((*k).into()), v.clone()))
+                .collect(),
+        )
+    }
+
+    fn record(pairs: &[(&str, CborValue)]) -> Record<CborValue> {
+        pairs.iter().map(|(k, v)| ((*k).into(), v.clone())).collect()
+    }
+
+    #[test]
+    fn flat_record_has_no_relations() {
+        let (main, has_one, has_many) = client_vista()
+            .classify_insert(&record(&[("name", text("John")), ("bakery_id", text("b1"))]))
+            .unwrap();
+        assert_eq!(main.get("name"), Some(&text("John")));
+        assert_eq!(main.get("bakery_id"), Some(&text("b1")));
+        assert!(has_one.is_empty());
+        assert!(has_many.is_empty());
+    }
+
+    #[test]
+    fn dotted_keys_group_into_one_has_one_child() {
+        let (main, has_one, has_many) = client_vista()
+            .classify_insert(&record(&[
+                ("name", text("John")),
+                ("bakery.name", text("New Bakery")),
+                ("bakery.profit_margin", CborValue::Integer(10.into())),
+            ]))
+            .unwrap();
+        assert_eq!(main.get("name"), Some(&text("John")));
+        assert!(main.get("bakery.name").is_none());
+        assert!(has_many.is_empty());
+        assert_eq!(has_one.len(), 1);
+        let (relation, fk, child) = &has_one[0];
+        assert_eq!(relation, "bakery");
+        assert_eq!(fk, "bakery_id");
+        assert_eq!(child.get("name"), Some(&text("New Bakery")));
+        assert_eq!(child.get("profit_margin"), Some(&CborValue::Integer(10.into())));
+    }
+
+    #[test]
+    fn bare_map_is_a_has_one_child() {
+        let (_main, has_one, _has_many) = client_vista()
+            .classify_insert(&record(&[("bakery", map(&[("name", text("New Bakery"))]))]))
+            .unwrap();
+        assert_eq!(has_one.len(), 1);
+        assert_eq!(has_one[0].2.get("name"), Some(&text("New Bakery")));
+    }
+
+    #[test]
+    fn bare_list_is_a_has_many_group() {
+        let (_main, has_one, has_many) = client_vista()
+            .classify_insert(&record(&[(
+                "orders",
+                CborValue::Array(vec![
+                    map(&[("total", CborValue::Integer(1.into()))]),
+                    map(&[("total", CborValue::Integer(2.into()))]),
+                ]),
+            )]))
+            .unwrap();
+        assert!(has_one.is_empty());
+        assert_eq!(has_many.len(), 1);
+        let (relation, fk, children) = &has_many[0];
+        assert_eq!(relation, "orders");
+        assert_eq!(fk, "client_id");
+        assert_eq!(children.len(), 2);
+    }
+
+    #[test]
+    fn has_one_given_a_list_is_an_error() {
+        let err = client_vista()
+            .classify_insert(&record(&[("bakery", CborValue::Array(vec![map(&[])]))]));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn has_many_given_a_map_is_an_error() {
+        let err =
+            client_vista().classify_insert(&record(&[("orders", map(&[("total", text("x"))]))]));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn cross_persistence_relation_is_rejected() {
+        let mut vista = client_vista();
+        vista.with_foreign("warehouse", ReferenceKind::HasOne, |_row| {
+            Err(vantage_core::error!("unused in this test"))
+        });
+        // `warehouse` resolves via list_references but has no same-persistence
+        // Reference, so classify must reject it before any write.
+        let err =
+            vista.classify_insert(&record(&[("warehouse", map(&[("name", text("w1"))]))]));
+        assert!(err.is_err());
+    }
+}

--- a/vantage-vista/src/insert.rs
+++ b/vantage-vista/src/insert.rs
@@ -102,10 +102,7 @@ impl Vista {
                     }
                     CborValue::Array(items) => {
                         if collected.contains_key(key.as_str()) {
-                            return Err(error!(
-                                "relation given more than once",
-                                relation = key
-                            ));
+                            return Err(error!("relation given more than once", relation = key));
                         }
                         let mut children = Vec::with_capacity(items.len());
                         for item in items {
@@ -208,7 +205,10 @@ impl Vista {
     ) -> Result<String> {
         let (mut main, has_one, has_many) = self.classify_insert(record)?;
         self.insert_has_one_children(&mut main, has_one).await?;
-        let parent_id = self.source.insert_vista_return_id_value(self, &main).await?;
+        let parent_id = self
+            .source
+            .insert_vista_return_id_value(self, &main)
+            .await?;
         self.insert_has_many_children(&parent_id, has_many).await?;
         Ok(parent_id)
     }
@@ -231,9 +231,7 @@ impl Vista {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        Column, Reference, ReferenceKind, VistaMetadata, mocks::mock_shell::MockShell,
-    };
+    use crate::{Column, Reference, ReferenceKind, VistaMetadata, mocks::mock_shell::MockShell};
 
     /// Vista over a `client` table: scalar columns plus a has-one `bakery`
     /// (FK `bakery_id` on this row) and a has-many `orders` (FK `client_id` on
@@ -272,13 +270,19 @@ mod tests {
     }
 
     fn record(pairs: &[(&str, CborValue)]) -> Record<CborValue> {
-        pairs.iter().map(|(k, v)| ((*k).into(), v.clone())).collect()
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).into(), v.clone()))
+            .collect()
     }
 
     #[test]
     fn flat_record_has_no_relations() {
         let (main, has_one, has_many) = client_vista()
-            .classify_insert(&record(&[("name", text("John")), ("bakery_id", text("b1"))]))
+            .classify_insert(&record(&[
+                ("name", text("John")),
+                ("bakery_id", text("b1")),
+            ]))
             .unwrap();
         assert_eq!(main.get("name"), Some(&text("John")));
         assert_eq!(main.get("bakery_id"), Some(&text("b1")));
@@ -303,7 +307,10 @@ mod tests {
         assert_eq!(relation, "bakery");
         assert_eq!(fk, "bakery_id");
         assert_eq!(child.get("name"), Some(&text("New Bakery")));
-        assert_eq!(child.get("profit_margin"), Some(&CborValue::Integer(10.into())));
+        assert_eq!(
+            child.get("profit_margin"),
+            Some(&CborValue::Integer(10.into()))
+        );
     }
 
     #[test]
@@ -356,8 +363,7 @@ mod tests {
         });
         // `warehouse` resolves via list_references but has no same-persistence
         // Reference, so classify must reject it before any write.
-        let err =
-            vista.classify_insert(&record(&[("warehouse", map(&[("name", text("w1"))]))]));
+        let err = vista.classify_insert(&record(&[("warehouse", map(&[("name", text("w1"))]))]));
         assert!(err.is_err());
     }
 }

--- a/vantage-vista/src/lib.rs
+++ b/vantage-vista/src/lib.rs
@@ -6,6 +6,7 @@ pub mod column;
 pub mod factory;
 pub mod flags;
 pub mod impls;
+pub mod insert;
 pub mod metadata;
 pub mod mocks;
 pub mod reference;

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -289,6 +289,30 @@ pub trait TableShell: Send + Sync + 'static {
         .is_unimplemented())
     }
 
+    /// Build the **bare** target of a same-persistence relation as a `Vista` —
+    /// the table a new related row would be inserted into, with no join
+    /// condition applied. Used by Vista's nested insert to reach a has-one /
+    /// has-many child's destination.
+    ///
+    /// Drivers override by forwarding into the wrapped typed `Table`'s
+    /// `get_ref_target::<EmptyEntity>(relation)` and wrapping the result back
+    /// through the driver's factory — the same path as [`get_ref`](Self::get_ref)
+    /// minus the row-derived condition. The default returns `Unimplemented`;
+    /// cross-persistence relations are rejected at the `Vista` layer before
+    /// this is reached.
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        Err(error!(
+            format!(
+                "get_ref_target not implemented for '{}'",
+                std::any::type_name::<Self>()
+            ),
+            method = "get_ref_target",
+            relation = relation,
+            source_type = std::any::type_name::<Self>()
+        )
+        .is_unimplemented())
+    }
+
     /// Names + cardinalities of the shell's same-persistence references.
     /// Derived from [`references`](Self::references) by default; impls
     /// should rarely need to override.

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -330,4 +330,19 @@ impl Vista {
         }
         self.source.get_ref(relation, row)
     }
+
+    /// Build the bare target of a same-persistence relation — the unconditioned
+    /// table a new related row is inserted into. Forwards to
+    /// [`TableShell::get_ref_target`]. Cross-persistence relations registered
+    /// via [`with_foreign`](Self::with_foreign) are not insertable this way and
+    /// error here.
+    pub fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        if self.foreign_resolvers.contains_key(relation) {
+            return Err(error!(
+                "cross-persistence nested insert is not supported",
+                relation = relation
+            ));
+        }
+        self.source.get_ref_target(relation)
+    }
 }


### PR DESCRIPTION
Inserting a row together with its related rows used to mean several calls and stamping foreign keys by hand. Now a single `insert_value` / `insert_return_id_value` on a `Vista` can carry the whole graph: name a relation in the record where you'd normally put a column, and Vista sequences the writes and fills the FKs for you.

```rust
client_vista.insert_value(&id, &record![
    "name"        => "John",
    "bakery"      => record!["name" => "New Bakery"],          // has-one
    "orders"      => vec![record!["total" => 10], record!["total" => 20]], // has-many
]).await?;
```

A has-one child is inserted first, its id stamped into the parent's FK column; has-many children go in after the parent, each stamped with the parent's id. You can pass a has-one child as a bare map, as grouped dotted keys (`bakery.name`, `bakery.profit_margin`), or — for has-many — a list of maps. Nesting goes to arbitrary depth.

It's deliberately **best-effort and non-atomic** — a failure mid-sequence leaves the earlier writes committed. There's no transaction wrapping the graph yet; if you need all-or-nothing, that's the thing to reach for next. Vista itself does no field validation here: each record is validated by the table it lands in. Only native (same-persistence) relations are insertable this way; cross-persistence `with_foreign` relations are rejected up front.

### New trait method on `Reference`

`Reference::foreign_key()` is now required on the `vantage-table` `Reference` trait — it exposes the relation's FK column so the nested insert knows where to stamp ids. The built-in `HasOne` / `HasMany` impls already have it; any external `Reference` impl must add one. Alongside it, `Table::get_ref_target` builds a relation's bare (unconditioned) target table, and `Table::vista_references` snapshots relations into [`VistaMetadata`](https://docs.rs/vantage-vista/0.5.1/vantage_vista/) so driver-erased vistas carry the FK info. SQLite, PostgreSQL, MySQL and MongoDB shells all wire this through.
