### PR TITLE
Add Dio removal helper and order status seed fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4648,7 +4648,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4799,7 +4799,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "bakery_model3",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.3 — 2026-05-31
+
+- `Dio::removed(id)` clears cached rows before publishing `RecordRemoved`.
+
 ## 0.5.2 — 2026-05-23
 
 - Align all internal dependency versions to 0.5+. No public API changes.

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -209,6 +209,23 @@ impl Dio {
         Ok(())
     }
 
+    /// Remove `id` from the cache and publish [`DioEvent::RecordRemoved`].
+    /// Symmetric to [`patched`](Self::patched) — call after a successful
+    /// master-side delete so subscribed Sceneries drop the row from
+    /// their view. Without the cache wipe, the bus event still fires
+    /// but Sceneries that reseed from the cache (e.g. TableScenery)
+    /// re-include the row, leaving the grid out of sync with the
+    /// master until the next `refresh()` / `invalidate_all()`.
+    ///
+    /// `Ok(())` if the row wasn't in the cache to begin with —
+    /// idempotent.
+    pub async fn removed(&self, id: impl Into<String>) -> Result<()> {
+        let id = id.into();
+        self.inner.cache.delete_value(&id).await?;
+        let _ = self.inner.event_bus.send(DioEvent::RecordRemoved { id });
+        Ok(())
+    }
+
     /// Fire the `on_refresh` callback synchronously. Errors propagate
     /// to the caller (the scheduled refresh task only logs them).
     ///

--- a/vantage-diorama/tests/table_scenery.rs
+++ b/vantage-diorama/tests/table_scenery.rs
@@ -201,6 +201,48 @@ async fn patched_updates_visible_rows() -> Result<()> {
     Ok(())
 }
 
+/// `dio.removed(id)` wipes the cache entry AND publishes the bus
+/// event so a subscribed TableScenery's reseed actually drops the
+/// row. The bare `invalidate_record(id)` path leaves the cache
+/// untouched — sceneries would reload the deleted row right back in.
+#[tokio::test]
+async fn removed_drops_row_from_visible_set() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let lens = build_lens(tmp.path().join("cache.redb")).await?;
+    let dio = lens.make_dio(seeded_master()).await?;
+
+    let scenery = dio.table_scenery().open().await?;
+    let mut gen_rx = scenery.subscribe();
+    let initial = u64::from(*gen_rx.borrow_and_update());
+    assert_eq!(scenery.row_count(), 3);
+
+    dio.removed("b").await?;
+    wait_for_gen(&mut gen_rx, initial).await;
+
+    assert_eq!(scenery.row_count(), 2);
+    let names: Vec<_> = (0..scenery.row_count())
+        .filter_map(|i| scenery.row(i))
+        .filter_map(|r| r.record.get("name").cloned())
+        .collect();
+    assert!(names.contains(&cbor_text("alpha")));
+    assert!(!names.contains(&cbor_text("beta")));
+    Ok(())
+}
+
+/// `dio.removed(id)` is idempotent — calling on an absent id is a
+/// no-op (still publishes the event so any reseed-style scenery
+/// re-syncs harmlessly).
+#[tokio::test]
+async fn removed_is_idempotent_on_missing_id() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let lens = build_lens(tmp.path().join("cache.redb")).await?;
+    let dio = lens.make_dio(seeded_master()).await?;
+
+    let _scenery = dio.table_scenery().open().await?;
+    dio.removed("does-not-exist").await?;
+    Ok(())
+}
+
 #[tokio::test]
 async fn scenery_outlives_dio_handle_drop() -> Result<()> {
     let tmp = TempDir::new().unwrap();

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.4 — 2026-05-31
+
+- SurrealDB v2 seed defines order lifecycle status and cancellation fields.
+
 ## 0.5.3 — 2026-05-31
 
 - Contained relations backed by native nested objects and arrays: an order's embedded `lines`

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.5.3"
+version = "0.5.4"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/scripts/db/v2.surql
+++ b/vantage-surrealdb/scripts/db/v2.surql
@@ -9,13 +9,16 @@
 -- SCHEMA DEFINITIONS
 -- =====================================================
 
--- Bakery table (schema-full for core business data)
-DEFINE TABLE bakery SCHEMAFULL;
+-- Bakery table — schemaless so vantage-ui's inventory YAML is the
+-- source of truth for columns; new fields land via patch_value
+-- without needing a corresponding DEFINE FIELD.
+DEFINE TABLE bakery SCHEMALESS;
 DEFINE FIELD name ON bakery TYPE string;
 DEFINE FIELD profit_margin ON bakery TYPE int ASSERT $value >= 0 AND $value <= 100;
 
--- Client table (schema-full with flexible metadata field)
-DEFINE TABLE client SCHEMAFULL;
+-- Client table — schemaless (was SCHEMAFULL; lets inventory-driven
+-- columns like `password_hash` land without DDL edits here).
+DEFINE TABLE client SCHEMALESS;
 DEFINE FIELD email ON client TYPE string;
 DEFINE FIELD name ON client TYPE string;
 DEFINE FIELD contact_details ON client TYPE string;
@@ -26,7 +29,7 @@ DEFINE FIELD metadata ON client TYPE option<object> FLEXIBLE; -- For future exte
 DEFINE INDEX unique_email ON client FIELDS email UNIQUE;
 
 -- Product table (schema-full with embedded inventory)
-DEFINE TABLE product SCHEMAFULL;
+DEFINE TABLE product SCHEMALESS;
 DEFINE FIELD name ON product TYPE string;
 DEFINE FIELD calories ON product TYPE int ASSERT $value >= 0;
 DEFINE FIELD price ON product TYPE int ASSERT $value > 0;
@@ -37,11 +40,20 @@ DEFINE FIELD inventory ON product TYPE object;
 DEFINE FIELD inventory.stock ON product TYPE int DEFAULT 0;
 
 -- Order table (schema-full with embedded line items)
-DEFINE TABLE order SCHEMAFULL;
+DEFINE TABLE order SCHEMALESS;
 DEFINE FIELD client ON order TYPE record<client>; -- Direct link to client
 DEFINE FIELD bakery ON order TYPE record<bakery>; -- Direct link to bakery
 DEFINE FIELD is_deleted ON order TYPE bool DEFAULT false;
 DEFINE FIELD created_at ON order TYPE datetime DEFAULT time::now();
+-- Lifecycle state + cancellation metadata. Catalog YAML
+-- (`examples/surreal-bakery/table/bakery-surreal/order.yaml`)
+-- carries the human-readable choices. `option<string>` so old rows
+-- without a cancellation reason don't trip the type.
+DEFINE FIELD status ON order TYPE string DEFAULT "placed"
+    ASSERT $value IN ["placed", "confirmed", "in_production", "ready",
+                      "delivered", "picked_up", "paid", "cancelled"];
+DEFINE FIELD cancellation_reason ON order TYPE option<string>;
+DEFINE FIELD cancellation_note ON order TYPE option<string>;
 -- Embedded order lines instead of separate table
 DEFINE FIELD lines ON order TYPE array<object> DEFAULT [];
 DEFINE FIELD lines.*.product ON order TYPE record<product>;
@@ -130,11 +142,15 @@ CREATE product:hover_cookies SET
     inventory = { stock: 40 };
 
 
--- Create orders with embedded line items
--- Order 1: Marty's order
+-- Create orders with embedded line items. Status values seed the
+-- lifecycle at different points so the right-click menu demos every
+-- transition gate (placed → confirmed → in_production → ready →
+-- delivered/picked_up → paid).
+-- Order 1: Marty's order — fresh placement
 CREATE order:order1 SET
     client = client:marty,
     bakery = bakery:hill_valley,
+    status = "placed",
     lines = [
         {
             product: product:flux_cupcake,
@@ -153,10 +169,11 @@ CREATE order:order1 SET
         }
     ];
 
--- Order 2: Doc's order
+-- Order 2: Doc's order — mid-flight (ready for delivery / pickup)
 CREATE order:order2 SET
     client = client:doc,
     bakery = bakery:hill_valley,
+    status = "ready",
     lines = [
         {
             product: product:time_tart,
@@ -165,10 +182,11 @@ CREATE order:order2 SET
         }
     ];
 
--- Order 3: Doc's second order
+-- Order 3: Doc's second order — delivered, awaiting payment
 CREATE order:order3 SET
     client = client:doc,
     bakery = bakery:hill_valley,
+    status = "delivered",
     lines = [
         {
             product: product:hover_cookies,


### PR DESCRIPTION
Adds a Dio removal helper that clears cached rows before publishing `RecordRemoved`, so subscribed table scenery no longer rehydrates deleted rows from stale cache. 

Also SurrealDB v2 bakery seed which allows us to to have more felxble schema.
