### PR TITLE
fix flaky bdd cache assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.4 — 2026-06-02
+
+- BDD cache assertions (`cache_record_field`, `cache_record_absent`, `cache_row_count`) now poll
+  with bounded retry instead of single-shot asserts, fixing flaky mirror-write scenarios on loaded
+  CI where `spawn_blocking` (redb) ops can outlast the virtual-time drain window.
+
 ## 0.5.3 — 2026-05-31
 
 - `Dio::removed(id)` clears cached rows before publishing `RecordRemoved`.

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/tests/bdd_support/steps/event_path.rs
+++ b/vantage-diorama/tests/bdd_support/steps/event_path.rs
@@ -40,7 +40,27 @@ async fn invalidate_all(w: &mut DioramaWorld) {
 
 #[then(regex = r#"^the cache record "([^"]+)" has (\w+) "([^"]+)"$"#)]
 async fn cache_record_field(w: &mut DioramaWorld, id: String, field: String, expected: String) {
+    // Poll the cache for the expected value. The mirror on_write callback
+    // may still be draining spawn_blocking (redb) ops after drain_write_queue's
+    // virtual-time advances — bounded busy-poll with tiny advances gives the
+    // blocking pool real wall-clock time to catch up.
     let dio = w.dio.as_ref().expect("dio not created");
+    for _ in 0..200 {
+        if let Some(row) = dio.cache().get_value(&id).await.expect("cache get_value") {
+            let got = row
+                .get(&field)
+                .and_then(|v| match v {
+                    CborValue::Text(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .unwrap_or_default();
+            if got == expected {
+                return;
+            }
+        }
+        tokio::time::advance(std::time::Duration::from_micros(1)).await;
+    }
+    // Final attempt — fail with diagnostic if still not converged.
     let row = dio
         .cache()
         .get_value(&id)
@@ -62,7 +82,15 @@ async fn cache_record_field(w: &mut DioramaWorld, id: String, field: String, exp
 
 #[then(regex = r#"^the cache record "([^"]+)" is absent$"#)]
 async fn cache_record_absent(w: &mut DioramaWorld, id: String) {
+    // Poll for absence — same reasoning as cache_record_field.
     let dio = w.dio.as_ref().expect("dio not created");
+    for _ in 0..200 {
+        let row = dio.cache().get_value(&id).await.expect("cache get_value");
+        if row.is_none() {
+            return;
+        }
+        tokio::time::advance(std::time::Duration::from_micros(1)).await;
+    }
     let row = dio.cache().get_value(&id).await.expect("cache get_value");
     assert!(
         row.is_none(),

--- a/vantage-diorama/tests/bdd_support/steps/write_path.rs
+++ b/vantage-diorama/tests/bdd_support/steps/write_path.rs
@@ -172,9 +172,17 @@ async fn master_row_count(w: &mut DioramaWorld, n: u64) {
     );
 }
 
-#[then(regex = r"^the cache (?:still )?(?:has|contains) (\d+) rows?$")]
+#[then(regex = r#"^the cache (?:still )?(?:has|contains) (\d+) rows?$"#)]
 async fn cache_row_count(w: &mut DioramaWorld, n: u64) {
+    // Poll for expected count — same reasoning as cache_record_field.
     let dio = w.dio.as_ref().expect("dio not created");
+    for _ in 0..200 {
+        let got = dio.cache().count().await.expect("cache count") as u64;
+        if got == n {
+            return;
+        }
+        tokio::time::advance(std::time::Duration::from_micros(1)).await;
+    }
     let got = dio.cache().count().await.expect("cache count") as u64;
     assert_eq!(got, n, "expected {n} cache rows, got {got}");
 }


### PR DESCRIPTION
Cache assertion steps (`cache_record_field`, `cache_record_absent`, `cache_row_count`) were single-shot asserts that could race against the mirror `on_write` callback's `spawn_blocking` (redb) ops still draining after `drain_write_queue`'s virtual-time advances.

Made all three poll-based with bounded retry (200 iterations × 1μs advance), matching the pattern already used by `scenery_generation_is`.

The flaky scenario was `Patch path works against real backends` on sqlite — the mirror callback does 3 cache ops (get + merge + insert) vs 1 for Insert/Replace/Delete, making it most susceptible. On loaded CI, the blocking thread pool could outlast the 200μs drain window.

Reduces failure rate from ~20% to near-zero (1/20 residual in local testing, likely a different edge case).