### PR TITLE
Add vantage-vista-factory crate + reference-traversal foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4869,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.5.6"
+version = "0.5.8"
 dependencies = [
  "async-trait",
  "bakery_model3",
@@ -4964,6 +4964,19 @@ dependencies = [
  "vantage-core",
  "vantage-dataset",
  "vantage-types",
+]
+
+[[package]]
+name = "vantage-vista-factory"
+version = "0.5.0"
+dependencies = [
+ "ciborium",
+ "indexmap",
+ "tokio",
+ "vantage-core",
+ "vantage-dataset",
+ "vantage-types",
+ "vantage-vista",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "vantage-csv",
     "vantage-types", "learn-1", "learn-2", "learn-3",
     "vantage-vista",
+    "vantage-vista-factory",
     "vantage-diorama",
     "vantage-log-writer",
     "vantage-sql",
@@ -31,5 +32,6 @@ exclude = [
     "example_*",
     "vantage-ui-adapters",
     "test-api-server",
+    "vantage-cmd",
 ]
 resolver = "2"

--- a/vantage-api-client/src/graphql/vista/factory.rs
+++ b/vantage-api-client/src/graphql/vista/factory.rs
@@ -53,6 +53,7 @@ impl GraphqlApiVistaFactory {
             any_table,
             VistaCapabilities {
                 can_count: true,
+                can_traverse_to_record: true,
                 ..VistaCapabilities::default()
             },
             metadata,

--- a/vantage-api-client/src/lib.rs
+++ b/vantage-api-client/src/lib.rs
@@ -23,9 +23,9 @@ pub use graphql::{
     GraphqlSelect, GraphqlTableExtras, GraphqlType, GraphqlTypeVariants, NoGraphqlExtras,
     RenderedQuery,
 };
-pub(crate) use rest::condition_to_query_param;
+pub(crate) use rest::{cbor_to_query_string, condition_to_query_param};
 pub use rest::{
-    ApiColumnExtras, ApiReferenceExtras, ApiTableBlock, ApiTableExtras, ModelResolver, NoApiExtras,
-    PaginationParams, ResponseShape, RestApi, RestApiBuilder, RestApiTableShell,
-    RestApiVistaFactory, RestApiVistaSpec, eq_condition,
+    ApiColumnExtras, ApiReferenceExtras, ApiTableBlock, ApiTableExtras, FilterStrategy,
+    ModelResolver, NoApiExtras, PaginationParams, ResponseShape, RestApi, RestApiBuilder,
+    RestApiTableShell, RestApiVistaFactory, RestApiVistaSpec, eq_condition,
 };

--- a/vantage-api-client/src/rest/api.rs
+++ b/vantage-api-client/src/rest/api.rs
@@ -81,6 +81,25 @@ impl Default for PaginationParams {
 /// [`ResponseShape`] for the supported variants.
 ///
 /// Currently read-only — write operations return errors.
+/// How a table's conditions are applied to a request.
+///
+/// URL `{placeholder}` path segments are always filled from matching
+/// eq-conditions regardless of strategy; this governs what happens to
+/// the *remaining* (non-path) eq-conditions.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FilterStrategy {
+    /// Append remaining eq-conditions as `?field=value` query params
+    /// (JSON-Server semantics). The default.
+    #[default]
+    Query,
+    /// Apply remaining eq-conditions as in-memory row filters after the
+    /// fetch, never as query params. For APIs whose only server-side
+    /// filters are path segments and that reject (or ignore) unknown
+    /// query params — e.g. the Mercury control-API, whose CLI likewise
+    /// filters version/env client-side after fetching by product path.
+    Client,
+}
+
 #[derive(Clone, Debug)]
 pub struct RestApi {
     base_url: String,
@@ -95,6 +114,9 @@ pub struct RestApi {
     /// first chunk. Useful for FastAPI/Pydantic services that treat
     /// unknown query params as strict filters.
     no_pagination: bool,
+    /// How non-path eq-conditions are applied — query params vs.
+    /// in-memory post-fetch filtering. See [`FilterStrategy`].
+    filter_strategy: FilterStrategy,
 }
 
 impl RestApi {
@@ -267,10 +289,29 @@ impl RestApi {
         }
         let conds: Vec<&Expression<CborValue>> = resolved.iter().collect();
         let (endpoint, consumed) = self.endpoint_url(table_name, &conds)?;
+
+        // Under `FilterStrategy::Client`, non-path eq-conditions are
+        // applied to the fetched rows in memory rather than sent as query
+        // params (the API rejects/ignores unknown params). Collect them,
+        // and keep them out of the query string by marking every
+        // condition as consumed for query-building purposes.
+        let (query_consumed, client_filters): (Vec<usize>, Vec<(String, String)>) =
+            if self.filter_strategy == FilterStrategy::Client {
+                let filters = conds
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| !consumed.contains(i))
+                    .filter_map(|(_, c)| crate::condition_to_query_param(c))
+                    .collect();
+                ((0..conds.len()).collect(), filters)
+            } else {
+                (consumed, Vec::new())
+            };
+
         let url = format!(
             "{}{}",
             endpoint,
-            self.build_query_string(pagination, &conds, &consumed)
+            self.build_query_string(pagination, &conds, &query_consumed)
         );
 
         let mut request = self.client.get(&url);
@@ -330,6 +371,22 @@ impl RestApi {
             }
 
             records.insert(id, record);
+        }
+
+        // Client-side filtering (FilterStrategy::Client): drop rows that
+        // don't match the non-path eq-conditions. A condition whose field
+        // is absent from a row is treated as a pass (it was a path/request
+        // param, not a record field) — mirroring the AWS connector and the
+        // Mercury CLI's own post-fetch `_filter_deployments`.
+        if !client_filters.is_empty() {
+            records.retain(|_id, record| {
+                client_filters.iter().all(|(field, want)| {
+                    match record.get(field) {
+                        Some(v) => crate::cbor_to_query_string(v).as_deref() == Some(want.as_str()),
+                        None => true,
+                    }
+                })
+            });
         }
 
         Ok(records)
@@ -419,6 +476,7 @@ pub struct RestApiBuilder {
     response_shape: ResponseShape,
     pagination: PaginationParams,
     no_pagination: bool,
+    filter_strategy: FilterStrategy,
 }
 
 impl RestApiBuilder {
@@ -429,6 +487,7 @@ impl RestApiBuilder {
             response_shape: ResponseShape::default(),
             pagination: PaginationParams::default(),
             no_pagination: false,
+            filter_strategy: FilterStrategy::default(),
         }
     }
 
@@ -462,6 +521,15 @@ impl RestApiBuilder {
         self
     }
 
+    /// Choose how non-path eq-conditions are applied. Default is
+    /// [`FilterStrategy::Query`]; use [`FilterStrategy::Client`] for
+    /// APIs that only filter via path segments and reject/ignore unknown
+    /// query params (the conditions are then applied in memory).
+    pub fn filter_strategy(mut self, strategy: FilterStrategy) -> Self {
+        self.filter_strategy = strategy;
+        self
+    }
+
     pub fn build(self) -> RestApi {
         RestApi {
             base_url: self.base_url,
@@ -470,6 +538,7 @@ impl RestApiBuilder {
             response_shape: self.response_shape,
             pagination: self.pagination,
             no_pagination: self.no_pagination,
+            filter_strategy: self.filter_strategy,
         }
     }
 }

--- a/vantage-api-client/src/rest/mod.rs
+++ b/vantage-api-client/src/rest/mod.rs
@@ -13,8 +13,8 @@ pub mod operation;
 pub mod table_source;
 pub mod vista;
 
-pub use api::{PaginationParams, ResponseShape, RestApi, RestApiBuilder};
-pub(crate) use operation::condition_to_query_param;
+pub use api::{FilterStrategy, PaginationParams, ResponseShape, RestApi, RestApiBuilder};
+pub(crate) use operation::{cbor_to_query_string, condition_to_query_param};
 pub use operation::eq_condition;
 pub use vista::{
     ApiColumnExtras, ApiReferenceExtras, ApiTableBlock, ApiTableExtras, ModelResolver, NoApiExtras,

--- a/vantage-api-client/src/rest/operation.rs
+++ b/vantage-api-client/src/rest/operation.rs
@@ -63,7 +63,7 @@ pub(crate) fn condition_to_query_param(cond: &Expression<CborValue>) -> Option<(
 /// query parameter. Compound values (arrays, maps) have no single-key
 /// representation, so they fall through as `None` and the condition
 /// is dropped from the query string.
-fn cbor_to_query_string(v: &CborValue) -> Option<String> {
+pub(crate) fn cbor_to_query_string(v: &CborValue) -> Option<String> {
     match v {
         CborValue::Bool(b) => Some(b.to_string()),
         CborValue::Integer(i) => Some(i128::from(*i).to_string()),

--- a/vantage-api-client/src/rest/vista/factory.rs
+++ b/vantage-api-client/src/rest/vista/factory.rs
@@ -103,6 +103,7 @@ impl RestApiVistaFactory {
             any_table,
             VistaCapabilities {
                 can_count: true,
+                can_traverse_to_record: true,
                 ..VistaCapabilities::default()
             },
             metadata,
@@ -179,6 +180,7 @@ impl VistaFactory for RestApiVistaFactory {
                         .foreign_key
                         .clone()
                         .unwrap_or_else(|| rel_name.clone()),
+                    keys: ref_spec.keys.clone(),
                 },
             );
         }
@@ -187,6 +189,7 @@ impl VistaFactory for RestApiVistaFactory {
             table,
             VistaCapabilities {
                 can_count: true,
+                can_traverse_to_record: true,
                 ..VistaCapabilities::default()
             },
             metadata,

--- a/vantage-api-client/src/rest/vista/source.rs
+++ b/vantage-api-client/src/rest/vista/source.rs
@@ -21,8 +21,8 @@ use vantage_table::table::Table;
 use vantage_table::traits::table_like::TableLike;
 use vantage_types::{EmptyEntity, Record};
 use vantage_vista::{
-    Column as VistaColumn, Reference as VistaReference, TableShell, Vista, VistaCapabilities,
-    VistaMetadata,
+    Column as VistaColumn, JoinKey, Reference as VistaReference, TableShell, Vista,
+    VistaCapabilities, VistaMetadata,
 };
 
 use super::factory::{ModelResolver, RestApiVistaFactory};
@@ -37,6 +37,12 @@ pub(crate) struct YamlReference {
     pub target: String,
     pub kind: YamlReferenceKind,
     pub foreign_key: String,
+    /// Multi-key join. When non-empty it fully describes the join (each
+    /// pair reads a parent-row column and constrains a child column),
+    /// superseding `foreign_key`. Lets a child be narrowed by more than
+    /// one parent field — e.g. a deployment by both product_id and
+    /// version_id.
+    pub keys: Vec<JoinKey>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -143,6 +149,25 @@ impl TableShell for RestApiTableShell {
             })?;
 
             let mut child = resolver(&yref.target)?;
+
+            // Multi-key join: read each parent-row column and constrain the
+            // matching child column. Every key becomes an eq-condition on
+            // the child; how each one is applied (URL path placeholder,
+            // query param, or in-memory row filter) is the child data
+            // source's concern at fetch time.
+            if !yref.keys.is_empty() {
+                for key in &yref.keys {
+                    let value = row.get(&key.from).cloned().ok_or_else(|| {
+                        error!(
+                            "YAML reference: parent row missing join field",
+                            relation = relation,
+                            source_column = key.from.as_str()
+                        )
+                    })?;
+                    child.add_condition_eq(key.to.clone(), value)?;
+                }
+                return Ok(child);
+            }
 
             // For `has_many` the parent's id flows onto the child's FK
             // column; for `has_one` the parent's FK column value becomes

--- a/vantage-csv/src/vista/factory.rs
+++ b/vantage-csv/src/vista/factory.rs
@@ -41,6 +41,7 @@ impl CsvVistaFactory {
             any_table,
             VistaCapabilities {
                 can_count: true,
+                can_traverse_to_record: true,
                 ..VistaCapabilities::default()
             },
             metadata,

--- a/vantage-diorama/src/dio/shell.rs
+++ b/vantage-diorama/src/dio/shell.rs
@@ -41,6 +41,10 @@ impl DioShell {
             can_set_page_size: master_caps.can_set_page_size,
             can_fetch_page: master_caps.can_fetch_page,
             can_fetch_next: master_caps.can_fetch_next,
+            // Traversal capabilities pass through from the master vista; the
+            // Dio cache does not add or remove traversal modes.
+            can_traverse_to_record: master_caps.can_traverse_to_record,
+            can_traverse_to_set: master_caps.can_traverse_to_set,
         };
         Self { dio, capabilities }
     }

--- a/vantage-mongodb/src/vista/factory.rs
+++ b/vantage-mongodb/src/vista/factory.rs
@@ -66,6 +66,7 @@ impl MongoVistaFactory {
                 can_set_page_size: true,
                 can_fetch_page: true,
                 can_fetch_next: true,
+                can_traverse_to_record: true,
                 ..VistaCapabilities::default()
             },
             metadata,

--- a/vantage-sql/src/mysql/vista/factory.rs
+++ b/vantage-sql/src/mysql/vista/factory.rs
@@ -66,6 +66,8 @@ impl MysqlVistaFactory {
                 can_insert: !read_only,
                 can_update: !read_only,
                 can_delete: !read_only,
+                can_traverse_to_record: true,
+                can_traverse_to_set: true,
                 ..VistaCapabilities::default()
             },
             metadata,

--- a/vantage-sql/src/postgres/vista/factory.rs
+++ b/vantage-sql/src/postgres/vista/factory.rs
@@ -66,6 +66,8 @@ impl PostgresVistaFactory {
                 can_insert: !read_only,
                 can_update: !read_only,
                 can_delete: !read_only,
+                can_traverse_to_record: true,
+                can_traverse_to_set: true,
                 ..VistaCapabilities::default()
             },
             metadata,

--- a/vantage-sql/src/sqlite/vista/factory.rs
+++ b/vantage-sql/src/sqlite/vista/factory.rs
@@ -75,6 +75,8 @@ impl SqliteVistaFactory {
                 can_set_page_size: true,
                 can_fetch_page: true,
                 can_fetch_next: true,
+                can_traverse_to_record: true,
+                can_traverse_to_set: true,
                 ..VistaCapabilities::default()
             },
             metadata,

--- a/vantage-surrealdb/src/vista/factory.rs
+++ b/vantage-surrealdb/src/vista/factory.rs
@@ -81,6 +81,8 @@ impl SurrealVistaFactory {
                 can_set_page_size: true,
                 can_fetch_page: true,
                 can_fetch_next: true,
+                can_traverse_to_record: true,
+                can_traverse_to_set: true,
                 ..VistaCapabilities::default()
             },
             metadata,

--- a/vantage-vista-factory/Cargo.toml
+++ b/vantage-vista-factory/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "vantage-vista-factory"
+version = "0.5.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Multi-datasource Vista catalog and cross-persistence reference traversal for the Vantage data framework"
+repository = "https://github.com/romaninsh/vantage"
+
+[lib]
+doctest = false
+
+[dependencies]
+vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-types = { version = "0.5", path = "../vantage-types" }
+vantage-vista = { version = "0.5", path = "../vantage-vista" }
+ciborium = { version = "0.2", features = ["std"] }
+indexmap = { version = "2.14" }
+
+[dev-dependencies]
+vantage-dataset = { version = "0.5", path = "../vantage-dataset" }
+tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }

--- a/vantage-vista-factory/src/lib.rs
+++ b/vantage-vista-factory/src/lib.rs
@@ -1,0 +1,314 @@
+//! `vantage-vista-factory` — a multi-datasource [`Vista`] catalog and the home of
+//! **cross-persistence** reference traversal.
+//!
+//! A single [`Vista`] reads one table from one driver and can traverse its
+//! own *same-persistence* references (forwarded to the typed `Table`'s
+//! `with_one`/`with_many`, gated by
+//! [`VistaCapabilities::can_traverse_to_record`](vantage_vista::VistaCapabilities)).
+//! It deliberately knows nothing about *other* datasources.
+//!
+//! [`VistaCatalog`] sits one layer up: it is given the set of models in the
+//! system (a "folder of models", resolved to name → loader), can build any of
+//! them by name regardless of which driver backs it, and traverses references
+//! whose target lives in a *different* persistence. It is the single home for
+//! what used to be three or four separate name→Vista resolvers:
+//! `vantage-cli-util`'s `ModelFactory`, `vantage-api-client`'s `ModelResolver`,
+//! and the UI backend's `ResolverContext::load_target_vista`.
+//!
+//! The catalog is deliberately **config-agnostic** and **driver-agnostic**:
+//! it holds [`ModelLoader`] closures keyed by model name (registration-based,
+//! so no dependency on any driver crate or on a particular config schema).
+//! Callers populate it however they like — from a YAML inventory folder, from
+//! hand-built typed tables, or from a test fixture.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_types::Record;
+use vantage_vista::{ReferenceKind, Vista};
+
+/// Produces a fresh, unconditioned target [`Vista`] on demand.
+///
+/// One per model name. Called every time a model is built or traversed to, so
+/// the returned Vista is always pristine — the caller (or [`VistaCatalog`]) is
+/// free to narrow it with conditions afterwards. This is the same role filled
+/// today by `ModelFactory::for_name` (CLI), `ModelResolver` (api-client), and
+/// `ResolverContext::load_target_vista` (UI).
+pub type ModelLoader = Arc<dyn Fn() -> Result<Vista> + Send + Sync>;
+
+/// A cross-persistence relation: the target is another model resolved **by
+/// name** through the catalog, then narrowed by reading join values out of a
+/// known parent row.
+///
+/// Mirrors the UI backend's `UiRelation` so lowering a YAML `references:` /
+/// `has_many:` block into this type is a field-for-field copy.
+#[derive(Clone, Debug)]
+pub struct Relation {
+    /// Relation name as the consumer addresses it (`"bakery"`, `"orders"`).
+    pub name: String,
+    /// Catalog key of the target model this relation resolves to.
+    pub target_model: String,
+    /// Cardinality — drives whether a consumer renders a record or a list.
+    pub kind: ReferenceKind,
+    /// `(child_column, parent_column)` pairs for a multi-key join. Empty for
+    /// single-key relations, which use [`foreign_key`](Self::foreign_key) /
+    /// [`narrow_via`](Self::narrow_via) instead.
+    pub keys: Vec<(String, String)>,
+    /// Single-key: the target column constrained by the parent's value.
+    pub foreign_key: String,
+    /// Single-key: the parent-row field whose value is read for the join.
+    pub narrow_via: String,
+}
+
+impl Relation {
+    /// A single-key relation: `target.foreign_key == parent_row[narrow_via]`.
+    pub fn single_key(
+        name: impl Into<String>,
+        target_model: impl Into<String>,
+        kind: ReferenceKind,
+        foreign_key: impl Into<String>,
+        narrow_via: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            target_model: target_model.into(),
+            kind,
+            keys: Vec::new(),
+            foreign_key: foreign_key.into(),
+            narrow_via: narrow_via.into(),
+        }
+    }
+
+    /// A multi-key relation: every `(child, parent)` pair must match.
+    pub fn multi_key(
+        name: impl Into<String>,
+        target_model: impl Into<String>,
+        kind: ReferenceKind,
+        keys: Vec<(String, String)>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            target_model: target_model.into(),
+            kind,
+            keys,
+            foreign_key: String::new(),
+            narrow_via: String::new(),
+        }
+    }
+}
+
+/// A name → [`Vista`] catalog spanning many datasources, plus
+/// cross-persistence reference traversal between the models it holds.
+#[derive(Default, Clone)]
+pub struct VistaCatalog {
+    loaders: IndexMap<String, ModelLoader>,
+    /// Cross-persistence relations keyed by *source* model name.
+    relations: HashMap<String, Vec<Relation>>,
+}
+
+impl VistaCatalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register how to build a model by name. Replaces any prior loader for
+    /// the same name.
+    pub fn register(&mut self, model: impl Into<String>, loader: ModelLoader) -> &mut Self {
+        self.loaders.insert(model.into(), loader);
+        self
+    }
+
+    /// Register a cross-persistence relation that originates from `source_model`.
+    pub fn register_relation(
+        &mut self,
+        source_model: impl Into<String>,
+        relation: Relation,
+    ) -> &mut Self {
+        self.relations
+            .entry(source_model.into())
+            .or_default()
+            .push(relation);
+        self
+    }
+
+    /// Whether a model with this name is registered.
+    pub fn has_model(&self, name: &str) -> bool {
+        self.loaders.contains_key(name)
+    }
+
+    /// All registered model names, in registration order.
+    pub fn model_names(&self) -> impl Iterator<Item = &str> {
+        self.loaders.keys().map(String::as_str)
+    }
+
+    /// Cross-persistence relations registered for a source model.
+    pub fn relations_for(&self, source_model: &str) -> &[Relation] {
+        self.relations
+            .get(source_model)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Build a fresh, unconditioned [`Vista`] for a model.
+    pub fn build_vista(&self, name: &str) -> Result<Vista> {
+        let loader = self
+            .loaders
+            .get(name)
+            .ok_or_else(|| error!("model not in catalog", model = name))?;
+        loader()
+    }
+
+    /// Resolve a cross-persistence [`Relation`] from a known parent row into a
+    /// narrowed target [`Vista`].
+    ///
+    /// Builds the target by name, then constrains it by every join key, reading
+    /// each parent value out of `parent_row`. How each eq-condition is honoured
+    /// (SQL `WHERE`, in-memory filter, REST path/query param) is the target
+    /// driver's concern at fetch time.
+    pub fn traverse(&self, relation: &Relation, parent_row: &Record<CborValue>) -> Result<Vista> {
+        let mut target = self.build_vista(&relation.target_model)?;
+        if relation.keys.is_empty() {
+            let value = parent_row.get(&relation.narrow_via).cloned().ok_or_else(|| {
+                error!(
+                    "parent row missing narrow_via field",
+                    field = relation.narrow_via.as_str()
+                )
+            })?;
+            target.add_condition_eq(relation.foreign_key.clone(), value)?;
+        } else {
+            for (child_col, parent_col) in &relation.keys {
+                let value = parent_row.get(parent_col).cloned().ok_or_else(|| {
+                    error!("parent row missing join field", field = parent_col.as_str())
+                })?;
+                target.add_condition_eq(child_col.clone(), value)?;
+            }
+        }
+        Ok(target)
+    }
+
+    /// Unified traversal from a parent [`Vista`] + row.
+    ///
+    /// Prefers the parent's own **same-persistence** reference when the parent
+    /// shell declares it and advertises
+    /// [`can_traverse_to_record`](vantage_vista::VistaCapabilities::can_traverse_to_record)
+    /// — that path stays entirely inside one driver. Otherwise falls back to a
+    /// registered **cross-persistence** [`Relation`] for `source_model`.
+    pub fn traverse_from(
+        &self,
+        parent: &Vista,
+        source_model: &str,
+        relation: &str,
+        parent_row: &Record<CborValue>,
+    ) -> Result<Vista> {
+        let same_persistence = parent.capabilities().can_traverse_to_record
+            && parent.get_references().iter().any(|r| r == relation);
+        if same_persistence {
+            return parent.get_ref(relation, parent_row);
+        }
+        let rel = self
+            .relations_for(source_model)
+            .iter()
+            .find(|r| r.name == relation)
+            .ok_or_else(|| {
+                error!(
+                    "relation not found in catalog",
+                    relation = relation,
+                    model = source_model
+                )
+            })?;
+        self.traverse(rel, parent_row)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vantage_dataset::ReadableValueSet;
+    use vantage_vista::mocks::MockShell;
+    use vantage_vista::{Column, VistaMetadata};
+
+    fn text(s: &str) -> CborValue {
+        CborValue::Text(s.into())
+    }
+
+    fn record(pairs: &[(&str, CborValue)]) -> Record<CborValue> {
+        let mut r = Record::new();
+        for (k, v) in pairs {
+            r.insert((*k).to_string(), v.clone());
+        }
+        r
+    }
+
+    /// Two models in two (notionally different) stores: `client` and `bakery`.
+    /// A client carries `bakery_id`; bakery is keyed by `id`.
+    fn catalog() -> VistaCatalog {
+        let mut cat = VistaCatalog::new();
+
+        cat.register(
+            "bakery",
+            Arc::new(|| {
+                let meta = VistaMetadata::new()
+                    .with_column(Column::new("id", "String").with_flag("id"))
+                    .with_column(Column::new("name", "String"))
+                    .with_id_column("id");
+                let source = MockShell::new()
+                    .with_metadata(meta)
+                    .with_record("b1", record(&[("id", text("b1")), ("name", text("Marty's"))]))
+                    .with_record("b2", record(&[("id", text("b2")), ("name", text("Other"))]));
+                Ok(Vista::new("bakery", Box::new(source)))
+            }),
+        );
+
+        cat.register(
+            "client",
+            Arc::new(|| {
+                let meta = VistaMetadata::new()
+                    .with_column(Column::new("id", "String").with_flag("id"))
+                    .with_column(Column::new("bakery_id", "String"))
+                    .with_id_column("id");
+                let source = MockShell::new().with_metadata(meta);
+                Ok(Vista::new("client", Box::new(source)))
+            }),
+        );
+
+        cat.register_relation(
+            "client",
+            Relation::single_key("bakery", "bakery", ReferenceKind::HasOne, "id", "bakery_id"),
+        );
+        cat
+    }
+
+    #[test]
+    fn build_vista_resolves_by_name() {
+        let cat = catalog();
+        assert!(cat.has_model("bakery"));
+        assert!(!cat.has_model("nope"));
+        let v = cat.build_vista("bakery").unwrap();
+        assert_eq!(v.name(), "bakery");
+        assert!(cat.build_vista("nope").is_err());
+    }
+
+    #[tokio::test]
+    async fn traverse_cross_persistence_narrows_target() {
+        let cat = catalog();
+        let marty = record(&[("id", text("c1")), ("bakery_id", text("b1"))]);
+        let rel = &cat.relations_for("client")[0];
+
+        let bakery = cat.traverse(rel, &marty).unwrap();
+        // The eq-condition on bakery.id = "b1" must select exactly one row.
+        let rows = bakery.list_values().await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(rows.contains_key("b1"));
+    }
+
+    #[test]
+    fn traverse_missing_join_field_errors() {
+        let cat = catalog();
+        let rel = &cat.relations_for("client")[0];
+        let bad = record(&[("id", text("c1"))]); // no bakery_id
+        assert!(cat.traverse(rel, &bad).is_err());
+    }
+}

--- a/vantage-vista/src/capabilities.rs
+++ b/vantage-vista/src/capabilities.rs
@@ -36,4 +36,14 @@ pub struct VistaCapabilities {
     /// the weakest of the three pagination primitives. DynamoDB and
     /// most token-paginated REST APIs only support this.
     pub can_fetch_next: bool,
+    /// Record-level reference traversal via `get_ref(relation, row)` — read
+    /// the join value out of a known row and narrow the target with a plain
+    /// eq-condition. Every backend that can filter by equality supports this
+    /// (SQL, CSV, Mongo, Surreal, REST/GraphQL).
+    pub can_traverse_to_record: bool,
+    /// Set-level reference traversal — narrow the target with an
+    /// `IN (subquery)` derived from the parent's own conditions (the
+    /// `get_ref_as` / reports path). Requires the backend to support
+    /// subqueries; SQL and SurrealDB do, CSV/Mongo/REST do not.
+    pub can_traverse_to_set: bool,
 }

--- a/vantage-vista/src/lib.rs
+++ b/vantage-vista/src/lib.rs
@@ -27,7 +27,9 @@ pub use metadata::VistaMetadata;
 pub use reference::{ContainedKind, ContainedSpec, Reference, ReferenceKind};
 pub use sort::SortDirection;
 pub use source::TableShell;
-pub use spec::{ColumnSpec, ContainedYaml, NoExtras, ReferenceSpec, ReferenceSugar, VistaSpec};
+pub use spec::{
+    ColumnSpec, ContainedYaml, JoinKey, NoExtras, ReferenceSpec, ReferenceSugar, VistaSpec,
+};
 pub use vista::Vista;
 
 /// Convenience alias for the carrier type used at the `TableShell` boundary.

--- a/vantage-vista/src/spec.rs
+++ b/vantage-vista/src/spec.rs
@@ -132,8 +132,27 @@ pub struct ReferenceSpec<R = NoExtras> {
     pub kind: ReferenceKind,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub foreign_key: Option<String>,
+    /// Extra join keys for row-supplied traversal. When non-empty these
+    /// fully describe the join: each maps a parent (locked-row) column to
+    /// a child column, and the child is constrained by all of them. This
+    /// lets a child be narrowed by more than one parent field (e.g. a
+    /// deployment narrowed by both `product_id` and `version_id`). When
+    /// empty, the single `foreign_key` sugar applies.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keys: Vec<JoinKey>,
     #[serde(flatten, default)]
     pub driver: R,
+}
+
+/// One condition contributed by a reference during row-supplied
+/// traversal: read the parent (locked) row's `from` column and constrain
+/// the child's `to` column to that value.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JoinKey {
+    /// Child column to constrain.
+    pub to: String,
+    /// Parent column whose value (from the locked source row) is used.
+    pub from: String,
 }
 
 /// Sugar form for inline column references.


### PR DESCRIPTION
Introduces the additive foundation for the reference-traversal refactor, keeping the workspace green and changing no existing behaviour.

vantage-vista:
- VistaCapabilities gains can_traverse_to_record (eq-from-row; every backend that filters by equality) and can_traverse_to_set (IN-subquery; SQL/SurrealDB only). Each driver advertises them honestly.
- Spec gains multi-key JoinKey ({to, from}) on ReferenceSpec so a child can be narrowed by more than one parent field during row traversal.

vantage-vista-factory (new crate):
- VistaCatalog: a config- and driver-agnostic, registration-based name -> Vista catalog plus cross-persistence reference traversal (build_vista, traverse, traverse_from). Depends on no driver crate.

vantage-api-client (REST):
- FilterStrategy::Client applies non-path eq-conditions as in-memory post-fetch filters, for path-only APIs that reject unknown query params.