### PR TITLE
Feature/vista factory migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4842,7 +4842,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4968,7 +4968,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista-factory"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ciborium",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,7 +4568,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.7 — 2026-06-06
+
+### Changed
+
+- Formatting only (`cargo fmt`): no functional or API change.
+
 ## 0.5.6 — 2026-06-02
 
 - Track `vantage-table`'s new `TableSource::Source` associated type (set to `String`; no

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.5.6"
+version = "0.5.7"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"

--- a/vantage-api-client/src/lib.rs
+++ b/vantage-api-client/src/lib.rs
@@ -23,9 +23,9 @@ pub use graphql::{
     GraphqlSelect, GraphqlTableExtras, GraphqlType, GraphqlTypeVariants, NoGraphqlExtras,
     RenderedQuery,
 };
-pub(crate) use rest::{cbor_to_query_string, condition_to_query_param};
 pub use rest::{
     ApiColumnExtras, ApiReferenceExtras, ApiTableBlock, ApiTableExtras, FilterStrategy,
     ModelResolver, NoApiExtras, PaginationParams, ResponseShape, RestApi, RestApiBuilder,
     RestApiTableShell, RestApiVistaFactory, RestApiVistaSpec, eq_condition,
 };
+pub(crate) use rest::{cbor_to_query_string, condition_to_query_param};

--- a/vantage-api-client/src/rest/api.rs
+++ b/vantage-api-client/src/rest/api.rs
@@ -380,12 +380,12 @@ impl RestApi {
         // Mercury CLI's own post-fetch `_filter_deployments`.
         if !client_filters.is_empty() {
             records.retain(|_id, record| {
-                client_filters.iter().all(|(field, want)| {
-                    match record.get(field) {
+                client_filters
+                    .iter()
+                    .all(|(field, want)| match record.get(field) {
                         Some(v) => crate::cbor_to_query_string(v).as_deref() == Some(want.as_str()),
                         None => true,
-                    }
-                })
+                    })
             });
         }
 

--- a/vantage-api-client/src/rest/mod.rs
+++ b/vantage-api-client/src/rest/mod.rs
@@ -14,8 +14,8 @@ pub mod table_source;
 pub mod vista;
 
 pub use api::{FilterStrategy, PaginationParams, ResponseShape, RestApi, RestApiBuilder};
-pub(crate) use operation::{cbor_to_query_string, condition_to_query_param};
 pub use operation::eq_condition;
+pub(crate) use operation::{cbor_to_query_string, condition_to_query_param};
 pub use vista::{
     ApiColumnExtras, ApiReferenceExtras, ApiTableBlock, ApiTableExtras, ModelResolver, NoApiExtras,
     RestApiTableShell, RestApiVistaFactory, RestApiVistaSpec,

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.8 — 2026-06-06
+
+### Changed
+
+- Tracks the `vantage-vista` thin refactor (0.5.3): dropped the obsolete `with_foreign`
+  vista integration test now that cross-persistence traversal lives in
+  `vantage-vista-factory`. No functional change to the SQL backends.
+
 ## 0.5.7 — 2026-06-02
 
 ### Added

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/tests/sqlite/6_vista.rs
+++ b/vantage-sql/tests/sqlite/6_vista.rs
@@ -516,42 +516,6 @@ sqlite:
 }
 
 #[tokio::test]
-async fn vista_with_foreign_lazy_no_eager_invocation() -> TestResult {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    let db = setup_clients_orders().await;
-    let mut clients = db.vista_factory().from_table(clients_table(db.clone()))?;
-
-    let fired = Arc::new(AtomicBool::new(false));
-    let fired_clone = fired.clone();
-    let db_for_closure = db.clone();
-    clients.with_foreign(
-        "external",
-        vantage_vista::ReferenceKind::HasMany,
-        move |_row| {
-            fired_clone.store(true, Ordering::SeqCst);
-            db_for_closure
-                .vista_factory()
-                .from_table(orders_table(db_for_closure.clone()))
-        },
-    );
-    assert!(
-        !fired.load(Ordering::SeqCst),
-        "with_foreign must not invoke the closure at registration"
-    );
-
-    // Verify list_references picks it up with the declared cardinality.
-    let refs = clients.list_references();
-    assert!(
-        refs.iter().any(
-            |(name, kind)| name == "external" && *kind == vantage_vista::ReferenceKind::HasMany
-        )
-    );
-    Ok(())
-}
-
-#[tokio::test]
 async fn vista_add_order_ascending_descending_and_clear() -> TestResult {
     use vantage_vista::SortDirection;
 

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.7 — 2026-06-06
+
+### Changed
+
+- Docs only: reference-traversal documentation now points to
+  [`vantage-vista-factory`](https://crates.io/crates/vantage-vista-factory)'s `VistaCatalog`
+  for cross-persistence traversal. No functional or API change.
+
 ## 0.5.6 — 2026-06-02
 
 ### Added

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/references.rs
+++ b/vantage-table/src/references.rs
@@ -9,7 +9,7 @@
 //! - `HasOne` — foreign key on source table (e.g. Client.bakery_id → Bakery)
 //! - `HasMany` — foreign key on target table (e.g. Bakery → Client.bakery_id)
 //!
-//! Cross-persistence references live at the Vista layer (`Vista::with_foreign`),
+//! Cross-persistence references live in `vantage-vista-factory`'s `VistaCatalog`,
 //! not here. Typed `Table<T, E>` is single-backend by construction.
 
 use std::any::Any;

--- a/vantage-vista-factory/CHANGELOG.md
+++ b/vantage-vista-factory/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 0.5.1 — 2026-06-06
+
+### Changed
+
+- Extracted `Relation::narrow` from `VistaCatalog::traverse`. Narrowing a freshly built
+  target `Vista` from a parent row is now a reusable method, so callers that already hold
+  a target can apply the relation's join conditions directly instead of going through a
+  full `traverse`.
+
+## 0.5.0 — 2026-06-06
+
+### Added
+
+- Initial release. `VistaCatalog` — a config- and driver-agnostic, registration-based
+  name → `Vista` catalog with cross-persistence traversal. Register a model loader per
+  table name with `register`, then `build_vista(name)` to materialize a `Vista` and
+  `traverse(relation, parent_row)` / `traverse_from(...)` to resolve and narrow a related
+  `Vista` regardless of which persistence backs it.
+- `Relation` with `single_key` / `multi_key` constructors describing how a target `Vista`
+  is narrowed from a parent row, plus `register_relation` to attach relations to the catalog.

--- a/vantage-vista-factory/Cargo.toml
+++ b/vantage-vista-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista-factory"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Multi-datasource Vista catalog and cross-persistence reference traversal for the Vantage data framework"

--- a/vantage-vista-factory/src/lib.rs
+++ b/vantage-vista-factory/src/lib.rs
@@ -272,7 +272,10 @@ mod tests {
                     .with_id_column("id");
                 let source = MockShell::new()
                     .with_metadata(meta)
-                    .with_record("b1", record(&[("id", text("b1")), ("name", text("Marty's"))]))
+                    .with_record(
+                        "b1",
+                        record(&[("id", text("b1")), ("name", text("Marty's"))]),
+                    )
                     .with_record("b2", record(&[("id", text("b2")), ("name", text("Other"))]));
                 Ok(Vista::new("bakery", Box::new(source)))
             }),

--- a/vantage-vista-factory/src/lib.rs
+++ b/vantage-vista-factory/src/lib.rs
@@ -98,6 +98,37 @@ impl Relation {
             narrow_via: String::new(),
         }
     }
+
+    /// Narrow an already-built target [`Vista`] by this relation's join,
+    /// reading each parent value out of `parent_row`.
+    ///
+    /// Single-key relations push `foreign_key == parent_row[narrow_via]`;
+    /// multi-key relations push one eq-condition per `(child, parent)` pair.
+    /// How each eq-condition is honoured (SQL `WHERE`, in-memory filter,
+    /// REST path/query param) is the target driver's concern at fetch time.
+    ///
+    /// This is the single home for reference narrowing — consumers that
+    /// resolve the target themselves (e.g. a driver-aware loader) can call
+    /// this directly instead of going through [`VistaCatalog::traverse`].
+    pub fn narrow(&self, target: &mut Vista, parent_row: &Record<CborValue>) -> Result<()> {
+        if self.keys.is_empty() {
+            let value = parent_row.get(&self.narrow_via).cloned().ok_or_else(|| {
+                error!(
+                    "parent row missing narrow_via field",
+                    field = self.narrow_via.as_str()
+                )
+            })?;
+            target.add_condition_eq(self.foreign_key.clone(), value)?;
+        } else {
+            for (child_col, parent_col) in &self.keys {
+                let value = parent_row.get(parent_col).cloned().ok_or_else(|| {
+                    error!("parent row missing join field", field = parent_col.as_str())
+                })?;
+                target.add_condition_eq(child_col.clone(), value)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 /// A name → [`Vista`] catalog spanning many datasources, plus
@@ -170,22 +201,7 @@ impl VistaCatalog {
     /// driver's concern at fetch time.
     pub fn traverse(&self, relation: &Relation, parent_row: &Record<CborValue>) -> Result<Vista> {
         let mut target = self.build_vista(&relation.target_model)?;
-        if relation.keys.is_empty() {
-            let value = parent_row.get(&relation.narrow_via).cloned().ok_or_else(|| {
-                error!(
-                    "parent row missing narrow_via field",
-                    field = relation.narrow_via.as_str()
-                )
-            })?;
-            target.add_condition_eq(relation.foreign_key.clone(), value)?;
-        } else {
-            for (child_col, parent_col) in &relation.keys {
-                let value = parent_row.get(parent_col).cloned().ok_or_else(|| {
-                    error!("parent row missing join field", field = parent_col.as_str())
-                })?;
-                target.add_condition_eq(child_col.clone(), value)?;
-            }
-        }
+        relation.narrow(&mut target, parent_row)?;
         Ok(target)
     }
 

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.5.3 — 2026-06-06
+
+### Removed
+
+- **Breaking:** cross-persistence traversal is no longer a `Vista` concern. Removed
+  `Vista::with_foreign`, the `ForeignResolver` / `ForeignRef` types, and the internal
+  `foreign_resolvers` registry. A `Vista` is now strictly single-persistence: `get_ref`
+  routes contained relations to the embedded sub-`Vista` and forwards everything else to
+  the underlying shell. Resolving a reference that crosses persistence boundaries is now
+  the job of [`vantage-vista-factory`](https://crates.io/crates/vantage-vista-factory)'s
+  `VistaCatalog`.
+
 ## 0.5.2 — 2026-05-31
 
 ### Added

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/insert.rs
+++ b/vantage-vista/src/insert.rs
@@ -353,5 +353,4 @@ mod tests {
             client_vista().classify_insert(&record(&[("orders", map(&[("total", text("x"))]))]));
         assert!(err.is_err());
     }
-
 }

--- a/vantage-vista/src/insert.rs
+++ b/vantage-vista/src/insert.rs
@@ -13,10 +13,9 @@
 //! Vista does **no** field validation — the underlying table validates every
 //! record it receives. Vista's only job here is to order the inserts and fill
 //! the reference (FK) values. The sequence is **best-effort / non-atomic**: a
-//! failure mid-way leaves earlier writes committed. Only **native**
-//! (same-persistence) relations are supported; cross-persistence
-//! ([`Vista::with_foreign`](crate::vista::Vista::with_foreign)) relations are
-//! rejected.
+//! failure mid-way leaves earlier writes committed. Every Vista reference is
+//! same-persistence, so all relations are insertable; a relation name that
+//! resolves to no reference at all is rejected before any write.
 
 use ciborium::Value as CborValue;
 use indexmap::IndexMap;
@@ -135,7 +134,7 @@ impl Vista {
         for (relation, payload) in collected {
             let reference = self.get_reference(&relation).ok_or_else(|| {
                 error!(
-                    "cross-persistence nested insert is not supported",
+                    "relation has no insertable reference",
                     relation = relation.as_str()
                 )
             })?;
@@ -355,15 +354,4 @@ mod tests {
         assert!(err.is_err());
     }
 
-    #[test]
-    fn cross_persistence_relation_is_rejected() {
-        let mut vista = client_vista();
-        vista.with_foreign("warehouse", ReferenceKind::HasOne, |_row| {
-            Err(vantage_core::error!("unused in this test"))
-        });
-        // `warehouse` resolves via list_references but has no same-persistence
-        // Reference, so classify must reject it before any write.
-        let err = vista.classify_insert(&record(&[("warehouse", map(&[("name", text("w1"))]))]));
-        assert!(err.is_err());
-    }
 }

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -276,9 +276,9 @@ pub trait TableShell: Send + Sync + 'static {
     /// Drivers override by forwarding into the wrapped typed `Table`'s
     /// `get_ref_from_row::<EmptyEntity>(relation, &native_row)` and then
     /// wrapping the result back as a `Vista` through the driver's factory.
-    /// The default returns `Unimplemented`; cross-persistence refs are
-    /// handled at the `Vista` layer via `Vista::with_foreign` before this
-    /// trait method is reached.
+    /// The default returns `Unimplemented`. Cross-persistence refs are
+    /// handled one layer up by `vantage-vista-factory`'s `VistaCatalog`,
+    /// never here.
     fn get_ref(&self, relation: &str, _row: &Record<CborValue>) -> Result<Vista> {
         Err(error!(
             format!(

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -1,7 +1,4 @@
-use std::sync::Arc;
-
 use ciborium::Value as CborValue;
-use indexmap::IndexMap;
 use vantage_core::{Result, error};
 use vantage_types::Record;
 
@@ -14,28 +11,6 @@ use crate::{
     source::TableShell,
 };
 
-/// Closure that resolves a cross-persistence reference from a known parent row.
-///
-/// The closure receives a `Record<CborValue>` (the parent record carrying the
-/// join value) and returns a fully-constructed `Vista` from any backend. The
-/// closure captures whichever target factory it needs at definition time;
-/// `Vista::with_foreign` stores it without ever invoking it.
-pub type ForeignResolver = dyn Fn(&Record<CborValue>) -> Result<Vista> + Send + Sync;
-
-/// One cross-persistence reference attached to a `Vista`.
-pub struct ForeignRef {
-    pub kind: ReferenceKind,
-    pub resolver: Arc<ForeignResolver>,
-}
-
-impl std::fmt::Debug for ForeignRef {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ForeignRef")
-            .field("kind", &self.kind)
-            .finish_non_exhaustive()
-    }
-}
-
 /// Universal, schema-bearing data handle.
 ///
 /// A `Vista` is produced by a driver factory from a typed `Table<T, E>` or
@@ -43,12 +18,11 @@ impl std::fmt::Debug for ForeignRef {
 /// on the wrapped [`TableShell`] — `Vista` is the user-facing surface that
 /// forwards both data and metadata queries to the shell.
 ///
-/// Cross-persistence references (`with_foreign`) are the one exception:
-/// they're registered at the Vista layer because they need to capture
-/// other-backend factories outside the shell's scope.
+/// A `Vista` is strictly **single-persistence**: every reference it exposes
+/// targets the same backend. Cross-persistence traversal is the job of
+/// `vantage-vista-factory`'s `VistaCatalog`, one layer up.
 pub struct Vista {
     pub(crate) name: String,
-    pub(crate) foreign_resolvers: IndexMap<String, ForeignRef>,
     pub(crate) capabilities: VistaCapabilities,
     pub source: Box<dyn TableShell>,
 }
@@ -58,7 +32,6 @@ impl Vista {
         let capabilities = source.capabilities().clone();
         Self {
             name: name.into(),
-            foreign_resolvers: IndexMap::new(),
             capabilities,
             source,
         }
@@ -111,9 +84,8 @@ impl Vista {
         self.source.columns().get(name)
     }
 
-    /// Names of references attached at the Vista layer — cross-persistence
-    /// resolvers from [`with_foreign`](Self::with_foreign) and shell-declared
-    /// references. For the *complete* picture with cardinality, use
+    /// Names of references the Vista exposes (shell-declared, same-persistence).
+    /// For the *complete* picture with cardinality, use
     /// [`list_references`](Self::list_references) instead.
     pub fn get_references(&self) -> Vec<String> {
         self.list_references().into_iter().map(|(n, _)| n).collect()
@@ -121,26 +93,11 @@ impl Vista {
 
     /// All references the Vista exposes, with their cardinality.
     ///
-    /// Combines two sources: cross-persistence resolvers attached via
-    /// [`with_foreign`](Self::with_foreign), and same-persistence
-    /// references declared by the wrapped shell (typically derived from
-    /// the typed `Table`'s `with_many` / `with_one` registrations via
-    /// [`TableShell::get_ref_kinds`]). Each is returned once, foreign
-    /// first, with later duplicates ignored.
+    /// These are the same-persistence references declared by the wrapped shell
+    /// (typically derived from the typed `Table`'s `with_many` / `with_one`
+    /// registrations via [`TableShell::get_ref_kinds`]).
     pub fn list_references(&self) -> Vec<(String, ReferenceKind)> {
-        let mut seen = std::collections::HashSet::new();
-        let mut out = Vec::new();
-        for (name, fref) in &self.foreign_resolvers {
-            if seen.insert(name.clone()) {
-                out.push((name.clone(), fref.kind));
-            }
-        }
-        for (name, kind) in self.source.get_ref_kinds() {
-            if seen.insert(name.clone()) {
-                out.push((name, kind));
-            }
-        }
-        out
+        self.source.get_ref_kinds()
     }
 
     pub fn get_reference(&self, name: &str) -> Option<&Reference> {
@@ -280,44 +237,18 @@ impl Vista {
 
     // ---- references --------------------------------------------------------
 
-    /// Register a cross-persistence reference resolver.
-    ///
-    /// The closure is **stored, never invoked** at registration time — it
-    /// fires exactly once, lazily, when [`get_ref`](Self::get_ref) is called
-    /// for the relation. This guarantees that mutual references between two
-    /// Vistas (A → B and B → A) don't recurse at construction.
-    ///
-    /// The `kind` argument records cardinality so consumers
-    /// ([`list_references`](Self::list_references)) can render the right
-    /// control — record card for `HasOne`, list grid for `HasMany`.
-    ///
-    /// The closure receives the parent's row at fire time. Cross-persistence
-    /// joins on non-PK fields (e.g. `country.id = client.country_id`) work
-    /// because the closure reads whichever field(s) it needs from the row.
-    pub fn with_foreign(
-        &mut self,
-        relation: impl Into<String>,
-        kind: ReferenceKind,
-        resolver: impl Fn(&Record<CborValue>) -> Result<Vista> + Send + Sync + 'static,
-    ) -> &mut Self {
-        self.foreign_resolvers.insert(
-            relation.into(),
-            ForeignRef {
-                kind,
-                resolver: Arc::new(resolver),
-            },
-        );
-        self
-    }
-
-    /// Traverse a named reference using a known source row.
+    /// Traverse a named **same-persistence** reference using a known source row.
     ///
     /// Routes in this order:
-    /// 1. Cross-persistence resolvers registered via
-    ///    [`with_foreign`](Self::with_foreign).
-    /// 2. Same-persistence refs forwarded through
-    ///    [`TableShell::get_ref`], which consults the wrapped typed `Table`'s
-    ///    `with_one` / `with_many` registrations.
+    /// 1. Contained (embedded-in-row) relations via
+    ///    [`TableShell::get_contained_ref`].
+    /// 2. Foreign-key refs forwarded through [`TableShell::get_ref`], which
+    ///    consults the wrapped typed `Table`'s `with_one` / `with_many`
+    ///    registrations.
+    ///
+    /// The target always lives in the same backend as this Vista.
+    /// Cross-persistence traversal is handled one layer up by
+    /// `vantage-vista-factory`'s `VistaCatalog`.
     ///
     /// The `row` must come from this Vista (typically via
     /// [`get_value`](vantage_dataset::traits::ReadableValueSet::get_value)
@@ -325,9 +256,6 @@ impl Vista {
     /// The join value is read out of the record and pushed as a plain
     /// eq-condition on the target — no subqueries, no deferred fetch.
     pub fn get_ref(&self, relation: &str, row: &Record<CborValue>) -> Result<Vista> {
-        if let Some(fref) = self.foreign_resolvers.get(relation) {
-            return (fref.resolver)(row);
-        }
         if self.source.contained().contains_key(relation) {
             return self.source.get_contained_ref(relation, row);
         }
@@ -347,16 +275,8 @@ impl Vista {
 
     /// Build the bare target of a same-persistence relation — the unconditioned
     /// table a new related row is inserted into. Forwards to
-    /// [`TableShell::get_ref_target`]. Cross-persistence relations registered
-    /// via [`with_foreign`](Self::with_foreign) are not insertable this way and
-    /// error here.
+    /// [`TableShell::get_ref_target`].
     pub fn get_ref_target(&self, relation: &str) -> Result<Vista> {
-        if self.foreign_resolvers.contains_key(relation) {
-            return Err(error!(
-                "cross-persistence nested insert is not supported",
-                relation = relation
-            ));
-        }
         self.source.get_ref_target(relation)
     }
 }


### PR DESCRIPTION
 - Make Vista thin` — removed `with_foreign`/`ForeignResolver`/`foreign_resolvers`; `Vista::get_ref` is now same-persistence only; two obsolete tests removed; doc fixes
 - `extract Relation::narrow` — single source of truth for reference narrowing