### PR TITLE
vantage-cmd: Cmd::with_base_dir for relative command paths and child cwd

### DIFF
--- a/vantage-cmd/CHANGELOG.md
+++ b/vantage-cmd/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.1 — 2026-06-07
+
+- `Cmd::with_base_dir` — set a base directory for the data source. A relative
+  `command` path containing a separator (e.g. `./scripts/gh-stats.py`) is
+  resolved against it; bare names (`gh`) stay on `PATH` and absolute paths pass
+  through. When set, every table's child process also runs with this directory
+  as its working directory, so a script can resolve sibling files relative to
+  it. Lets an inventory ship its own helper scripts and reference them by a
+  path relative to the inventory root.
+
 ## 0.5.0 — 2026-06-06
 
 First release — incubating. A read-only persistence backend that fetches data by **running a local

--- a/vantage-cmd/Cargo.toml
+++ b/vantage-cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-cmd"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-cmd/src/cmd.rs
+++ b/vantage-cmd/src/cmd.rs
@@ -1,6 +1,7 @@
 //! The [`Cmd`] datasource — a locked command, declared env, and a
 //! registry of per-table Rhai scripts.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use indexmap::IndexMap;
@@ -49,6 +50,7 @@ pub struct Cmd {
     command: Arc<str>,
     env: Arc<IndexMap<String, String>>,
     pass_path: bool,
+    base_dir: Option<Arc<Path>>,
     scripts: Arc<IndexMap<String, CmdSpec>>,
 }
 
@@ -59,6 +61,7 @@ impl Cmd {
             command: command.into(),
             env: Arc::new(IndexMap::new()),
             pass_path: true,
+            base_dir: None,
             scripts: Arc::new(IndexMap::new()),
         }
     }
@@ -75,6 +78,20 @@ impl Cmd {
     /// an absolute command path and a fully-declared environment.
     pub fn with_pass_path(mut self, pass_path: bool) -> Self {
         self.pass_path = pass_path;
+        self
+    }
+
+    /// Set the base directory used to resolve a relative `command` *path*
+    /// and as the child process's working directory.
+    ///
+    /// A `command` that contains a path separator but isn't absolute (e.g.
+    /// `./scripts/gh-stats.py`) is resolved against this directory; bare
+    /// names (e.g. `gh`) are left untouched for `PATH` lookup, and absolute
+    /// paths pass through. When set, every table's child process also runs
+    /// with this directory as its working directory, so a script can resolve
+    /// sibling files relative to it.
+    pub fn with_base_dir(mut self, base_dir: impl Into<PathBuf>) -> Self {
+        self.base_dir = Some(Arc::from(base_dir.into()));
         self
     }
 
@@ -96,6 +113,10 @@ impl Cmd {
 
     pub(crate) fn pass_path(&self) -> bool {
         self.pass_path
+    }
+
+    pub(crate) fn base_dir(&self) -> Option<Arc<Path>> {
+        self.base_dir.clone()
     }
 
     pub(crate) fn spec_for(&self, name: &str) -> Result<&CmdSpec> {

--- a/vantage-cmd/src/exec.rs
+++ b/vantage-cmd/src/exec.rs
@@ -5,6 +5,8 @@
 //! the async runtime. The child gets a *cleared* environment plus only
 //! the declared vars (and optionally `PATH`/`HOME`).
 
+use std::path::{Path, PathBuf};
+
 use indexmap::IndexMap;
 use vantage_core::{Result, error};
 
@@ -16,18 +18,38 @@ pub struct CmdOutput {
     pub exit_code: i32,
 }
 
+/// Resolve the program to execute. A `command` that contains a path
+/// separator but isn't absolute (e.g. `./scripts/gh-stats.py`) is resolved
+/// against `base_dir`; bare names (e.g. `gh`) are left untouched so the OS
+/// can find them on `PATH`, and absolute paths pass through.
+fn resolve_program(command: &str, base_dir: Option<&Path>) -> PathBuf {
+    match base_dir {
+        Some(dir) if command.contains('/') && !Path::new(command).is_absolute() => {
+            dir.join(command)
+        }
+        _ => PathBuf::from(command),
+    }
+}
+
 /// Run `command` with `args`, passing only `env` (plus `PATH`/`HOME` when
-/// `pass_path`). Returns the captured output; a non-zero exit is *not* an
+/// `pass_path`). When `base_dir` is set it resolves a relative `command`
+/// path against it and runs the child with `base_dir` as its working
+/// directory. Returns the captured output; a non-zero exit is *not* an
 /// error here — the Rhai script decides what to do with `exit_code`.
 pub fn run_command(
     command: &str,
     args: &[String],
     env: &IndexMap<String, String>,
     pass_path: bool,
+    base_dir: Option<&Path>,
 ) -> Result<CmdOutput> {
-    let mut cmd = std::process::Command::new(command);
+    let mut cmd = std::process::Command::new(resolve_program(command, base_dir));
     cmd.args(args);
     cmd.env_clear();
+
+    if let Some(dir) = base_dir {
+        cmd.current_dir(dir);
+    }
 
     if pass_path {
         if let Ok(path) = std::env::var("PATH") {
@@ -54,4 +76,47 @@ pub fn run_command(
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         exit_code: output.status.code().unwrap_or(-1),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_name_is_left_for_path_lookup() {
+        // No base dir, and with one: a bare command name is never rewritten.
+        assert_eq!(resolve_program("gh", None), PathBuf::from("gh"));
+        assert_eq!(
+            resolve_program("gh", Some(Path::new("/inv"))),
+            PathBuf::from("gh")
+        );
+    }
+
+    #[test]
+    fn relative_path_resolves_against_base_dir() {
+        assert_eq!(
+            resolve_program("./scripts/gh-stats.py", Some(Path::new("/inv"))),
+            PathBuf::from("/inv/./scripts/gh-stats.py")
+        );
+        assert_eq!(
+            resolve_program("scripts/gh-stats.py", Some(Path::new("/inv"))),
+            PathBuf::from("/inv/scripts/gh-stats.py")
+        );
+    }
+
+    #[test]
+    fn relative_path_without_base_dir_is_unchanged() {
+        assert_eq!(
+            resolve_program("./scripts/x.py", None),
+            PathBuf::from("./scripts/x.py")
+        );
+    }
+
+    #[test]
+    fn absolute_path_passes_through() {
+        assert_eq!(
+            resolve_program("/usr/bin/gh", Some(Path::new("/inv"))),
+            PathBuf::from("/usr/bin/gh")
+        );
+    }
 }

--- a/vantage-cmd/src/rhai_engine.rs
+++ b/vantage-cmd/src/rhai_engine.rs
@@ -6,6 +6,9 @@
 //! `tokio::task::spawn_blocking` — the engine and the subprocess call
 //! never cross a thread boundary, so the async runtime stays unblocked.
 
+use std::path::Path;
+use std::sync::Arc;
+
 use indexmap::IndexMap;
 use rhai::{Dynamic, Engine, EvalAltResult, Map, Position, Scope};
 use serde_json::Value as JsonValue;
@@ -46,6 +49,7 @@ pub(crate) fn eval_rows(
     command: String,
     env: IndexMap<String, String>,
     pass_path: bool,
+    base_dir: Option<Arc<Path>>,
     script: &str,
     ctx: QueryContext,
 ) -> Result<Vec<JsonValue>> {
@@ -82,7 +86,7 @@ pub(crate) fn eval_rows(
         "run",
         move |args: rhai::Array| -> std::result::Result<Map, Box<EvalAltResult>> {
             let argv: Vec<String> = args.into_iter().map(dynamic_to_arg).collect();
-            let out = run_command(&command, &argv, &env, pass_path)
+            let out = run_command(&command, &argv, &env, pass_path, base_dir.as_deref())
                 .map_err(|e| runtime_err(e.to_string()))?;
             let mut map = Map::new();
             map.insert("stdout".into(), out.stdout.into());

--- a/vantage-cmd/src/table_source.rs
+++ b/vantage-cmd/src/table_source.rs
@@ -104,6 +104,7 @@ impl TableSource for Cmd {
         let command = self.effective_command(&spec);
         let env = self.effective_env(&spec);
         let pass_path = self.pass_path();
+        let base_dir = self.base_dir();
         let script = spec.script.clone();
 
         let id_field = table.id_field().map(|c| c.name().to_string());
@@ -143,10 +144,11 @@ impl TableSource for Cmd {
             id_column: id_field.clone(),
         };
 
-        let rows: Vec<JsonValue> =
-            tokio::task::spawn_blocking(move || eval_rows(command, env, pass_path, &script, ctx))
-                .await
-                .map_err(|e| error!("command task failed to join", detail = e.to_string()))??;
+        let rows: Vec<JsonValue> = tokio::task::spawn_blocking(move || {
+            eval_rows(command, env, pass_path, base_dir, &script, ctx)
+        })
+        .await
+        .map_err(|e| error!("command task failed to join", detail = e.to_string()))??;
 
         let mut records: IndexMap<String, Record<CborValue>> = IndexMap::new();
         for (idx, row) in rows.into_iter().enumerate() {

--- a/vantage-cmd/tests/fixtures/read_sibling.sh
+++ b/vantage-cmd/tests/fixtures/read_sibling.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Test stub: proves the child runs with base_dir as its cwd by reading a
+# sibling file via a relative path, then emitting it as a JSON row.
+name=$(cat ./sibling.txt)
+printf '{"items":[{"name":"%s"}]}\n' "$name"

--- a/vantage-cmd/tests/fixtures/sibling.txt
+++ b/vantage-cmd/tests/fixtures/sibling.txt
@@ -1,0 +1,1 @@
+cwd-sibling

--- a/vantage-cmd/tests/rhai_table.rs
+++ b/vantage-cmd/tests/rhai_table.rs
@@ -14,6 +14,29 @@ fn fixtures_dir() -> String {
 }
 
 #[tokio::test]
+async fn base_dir_resolves_relative_command_and_sets_cwd() {
+    // A relative command path resolves against `base_dir`, and the child runs
+    // with `base_dir` as its cwd — so the fixture can read its sibling file by
+    // a relative path and echo it back as a row.
+    let script = r#"
+        let out = run([]);
+        if out.exit_code != 0 { throw out.stderr; }
+        parse_json(out.stdout).items
+    "#;
+    let cmd = Cmd::new("./read_sibling.sh")
+        .with_base_dir(fixtures_dir())
+        .with_script("items", script);
+    let table = Table::<Cmd, EmptyEntity>::new("items", cmd).with_id_column("name");
+
+    let rows = table.list_values().await.unwrap();
+    assert!(
+        rows.contains_key("cwd-sibling"),
+        "got: {:?}",
+        rows.keys().collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
 async fn lists_rows_from_command_output() {
     let script = r#"
         let out = run([]);


### PR DESCRIPTION
## What

Adds `Cmd::with_base_dir(dir)` to the `vantage-cmd` data source.

When a base directory is set:

- A relative `command` *path* containing a separator (e.g. `./scripts/gh-stats.py`) is resolved against it.
- Bare command names (e.g. `gh`) are left untouched for `PATH` lookup; absolute paths pass through.
- Every table's child process runs with the base directory as its **working directory**, so a script can resolve sibling files relative to it.

## Why

Lets an inventory ship its own helper scripts and reference them by a path relative to the inventory root, instead of requiring absolute paths or a binary already on `PATH`. The resolution + cwd logic belongs in `vantage-cmd` (it owns command execution) rather than in the consumer's connect-layer glue.

## Changes

- `Cmd`: new `base_dir` field, `with_base_dir` builder, internal accessor.
- `exec::run_command`: new `base_dir` param; `resolve_program` helper resolves the relative program path and the child runs with `current_dir(base_dir)`.
- Threaded through `rhai_engine::eval_rows` and `table_source`.
- Tests: unit tests for `resolve_program` (bare / relative / absolute / no-base) and an end-to-end test proving a relative command resolves and the child's cwd is the base dir (reads a sibling fixture file).
- `0.5.0 → 0.5.1` + CHANGELOG entry.