### PR TITLE
Rhai-scripted reference traversal for Vistas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4842,7 +4842,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4869,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "async-trait",
  "bakery_model3",
@@ -4950,13 +4950,14 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-stream",
  "async-trait",
  "ciborium",
  "futures-core",
  "indexmap",
+ "rhai",
  "serde",
  "serde_yaml_ng",
  "thiserror 2.0.18",

--- a/vantage-cmd/Cargo.lock
+++ b/vantage-cmd/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.5.2"
+version = "0.5.4"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.5 — 2026-06-07
+
+- Pass the new `VistaCapabilities::can_build_ref_via_script` flag through the `Dio` cache
+  shell, so a scripted-reference-capable master Vista keeps advertising the capability when
+  wrapped for caching. Tracks `vantage-vista` 0.5.4.
+
 ## 0.5.4 — 2026-06-02
 
 - BDD cache assertions (`cache_record_field`, `cache_record_absent`, `cache_row_count`) now poll

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/shell.rs
+++ b/vantage-diorama/src/dio/shell.rs
@@ -45,6 +45,7 @@ impl DioShell {
             // Dio cache does not add or remove traversal modes.
             can_traverse_to_record: master_caps.can_traverse_to_record,
             can_traverse_to_set: master_caps.can_traverse_to_set,
+            can_build_ref_via_script: master_caps.can_build_ref_via_script,
         };
         Self { dio, capabilities }
     }

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.9 — 2026-06-07
+
+### Changed
+
+- `register_engine!` is split so its registrations live in a reusable
+  `__register_engine_onto(&mut Engine)`; the macro and `__create_engine` call it. Prepares the
+  SQL backend for the conventional Rhai-scripted reference traversal added in
+  `vantage-vista` 0.5.4. No behavior change for existing engine call sites.
+
 ## 0.5.8 — 2026-06-06
 
 ### Changed

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/rhai_engine/mod.rs
+++ b/vantage-sql/src/rhai_engine/mod.rs
@@ -43,9 +43,14 @@ macro_rules! register_engine {
         type Win = $crate::rhai_engine::RhaiWindow<$V>;
         type Cas = $crate::rhai_engine::RhaiCase<$V>;
 
-        fn __create_engine() -> rhai::Engine {
-            let mut engine = rhai::Engine::new();
-
+        // Register the full SQL vocabulary onto an existing engine. Split out of
+        // `__create_engine` so the same registrations can later be layered onto
+        // vantage-vista's conventional engine for scripted reference traversal
+        // (mirrors SurrealDB's `register_surreal_onto`). Wiring a per-shell
+        // target resolver is the follow-up that flips SQL's
+        // `can_build_ref_via_script` on; until then this only backs
+        // `__create_engine`.
+        fn __register_engine_onto(engine: &mut rhai::Engine) {
             $crate::register_types!(engine, value: $V, select: $Select, join: $Join, cond: $Cond);
             $crate::register_convert!(value: $V);
             $crate::register_constructors!(engine, value: $V);
@@ -56,9 +61,13 @@ macro_rules! register_engine {
 
             // Future phases:
             // $crate::register_aggregates!(engine, value: $V);
-            // $crate::register_window_case!(engine, value: $V);
 
             engine.set_max_expr_depths(256, 256);
+        }
+
+        fn __create_engine() -> rhai::Engine {
+            let mut engine = rhai::Engine::new();
+            __register_engine_onto(&mut engine);
             engine
         }
     };

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.5.9 — 2026-06-07
+
+### Added
+
+- SurrealDB vendor vocabulary for the new Rhai-scripted reference traversal (requires the
+  `rhai` feature, which now also implies `vista` + `vantage-vista/rhai`).
+  - Per-reference `surreal: { rhai: "…" }` block (`SurrealReferenceExtras` / `SurrealRefBlock`):
+    a script that builds the traversal target — conditions (including vendor expressions like
+    `ident("client") == row.id`), order, and search — evaluated lazily with the parent `row`
+    in scope, instead of the default foreign-key eq-condition path.
+  - `surreal: { modify: "…" }` on a table block: a Rhai script applied to the *built* vista as
+    a final step (exposed as `self`), so a script can narrow it with vendor expressions YAML
+    can't represent. Composes with `table`/`rhai`/`base` and runs last.
+  - `SurrealTableShell` overrides `register_rhai_extensions` (registers the Surreal engine
+    vocabulary plus a `with_condition(<expr>)` builtin) and implements `add_raw_condition`,
+    routing a boxed backend-native `Expr` through the type-erased condition path.
+
+### Changed
+
+- `register_surreal_engine!` is split so its registrations live in a reusable
+  `register_surreal_onto(&mut Engine)`; the macro and `__create_engine` call it (no behavior
+  change for existing engine call sites).
+
 ## 0.5.8 — 2026-06-03
 
 - Query-sourced and derived vistas for SurrealDB, mirroring the SQL-backend features from PR #277:

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.5.8"
+version = "0.5.9"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"
@@ -13,7 +13,11 @@ autoexamples = false
 default = ["decimal"]
 decimal = ["surreal-client/decimal", "rust_decimal"]
 vista = ["dep:vantage-vista"]
-rhai = ["dep:rhai"]
+# `rhai` powers both the standalone query DSL and (with `vista`) scripted
+# reference traversal, so it pulls in the vista layer and its conventional
+# engine. Keeping them coupled means `register_rhai_extensions` always has the
+# `vantage-vista` rhai vocabulary to layer onto.
+rhai = ["dep:rhai", "vista", "vantage-vista/rhai"]
 
 [dependencies]
 async-trait = "0.1"

--- a/vantage-surrealdb/src/rhai_engine/mod.rs
+++ b/vantage-surrealdb/src/rhai_engine/mod.rs
@@ -18,123 +18,128 @@ pub mod types;
 #[cfg(feature = "rhai")]
 pub use types::{RhaiCase, RhaiExpr, RhaiIdent, RhaiSelect};
 
+/// Register the full SurrealDB query-building vocabulary onto `engine`.
+///
+/// Shared by two entry points:
+/// - the [`register_surreal_engine!`] macro, whose `__create_engine` wraps this
+///   in a fresh `Engine` (back-compat for the standalone Rhai tests/examples and
+///   the `rhai:` vista source);
+/// - `SurrealTableShell::register_rhai_extensions`, which layers it on top of
+///   vantage-vista's conventional `Vista` verbs so a reference build-script can
+///   use `ident`/`==`/`fx`/graph syntax and `with_condition`.
 #[cfg(feature = "rhai")]
-#[macro_export]
-macro_rules! register_surreal_engine {
-    () => {
-        use $crate::AnySurrealType as AST;
-        use $crate::rhai_engine::types::{RhaiExpr as Ex, RhaiIdent as Id, RhaiSelect as Sel};
+pub fn register_surreal_onto(engine: &mut rhai::Engine) {
+    use crate::AnySurrealType as AST;
+    use crate::rhai_engine::types::{RhaiExpr as Ex, RhaiIdent as Id};
 
-        fn __create_engine() -> rhai::Engine {
-            let mut engine = rhai::Engine::new();
-
-            // ── Register types ────────────────────────────────────
-            engine.register_type::<Sel>();
+    {
+        // ── Register types ────────────────────────────────────
+        engine.register_type::<crate::rhai_engine::types::RhaiSelect>();
             engine.register_type::<Id>();
             engine.register_type::<Ex>();
-            engine.register_type::<$crate::rhai_engine::types::RhaiCase>();
+            engine.register_type::<crate::rhai_engine::types::RhaiCase>();
 
             // ── Constructors ──────────────────────────────────────
-            engine.register_fn("ident", $crate::rhai_engine::constructors::make_rhai_ident);
-            engine.register_fn("table", $crate::rhai_engine::constructors::make_rhai_ident);
-            engine.register_fn("expr", $crate::rhai_engine::constructors::make_expr0);
-            engine.register_fn("expr", $crate::rhai_engine::constructors::make_expr);
-            engine.register_fn("fx", $crate::rhai_engine::constructors::make_fx);
+            engine.register_fn("ident", crate::rhai_engine::constructors::make_rhai_ident);
+            engine.register_fn("table", crate::rhai_engine::constructors::make_rhai_ident);
+            engine.register_fn("expr", crate::rhai_engine::constructors::make_expr0);
+            engine.register_fn("expr", crate::rhai_engine::constructors::make_expr);
+            engine.register_fn("fx", crate::rhai_engine::constructors::make_fx);
 
             // ── Aggregates ────────────────────────────────────────
-            engine.register_fn("count", $crate::rhai_engine::constructors::fn_count_expr);
-            engine.register_fn("count", $crate::rhai_engine::constructors::fn_count_of);
+            engine.register_fn("count", crate::rhai_engine::constructors::fn_count_expr);
+            engine.register_fn("count", crate::rhai_engine::constructors::fn_count_of);
             engine.register_fn(
                 "count_distinct",
-                $crate::rhai_engine::constructors::fn_count_distinct,
+                crate::rhai_engine::constructors::fn_count_distinct,
             );
-            engine.register_fn("sum", $crate::rhai_engine::constructors::fn_sum);
-            engine.register_fn("avg", $crate::rhai_engine::constructors::fn_avg);
-            engine.register_fn("min", $crate::rhai_engine::constructors::fn_min);
-            engine.register_fn("max", $crate::rhai_engine::constructors::fn_max);
+            engine.register_fn("sum", crate::rhai_engine::constructors::fn_sum);
+            engine.register_fn("avg", crate::rhai_engine::constructors::fn_avg);
+            engine.register_fn("min", crate::rhai_engine::constructors::fn_min);
+            engine.register_fn("max", crate::rhai_engine::constructors::fn_max);
 
             // ── Tier 1 shared scalar/conditional primitives ───────
-            engine.register_fn("round", $crate::rhai_engine::constructors::fn_round);
-            engine.register_fn("round", $crate::rhai_engine::constructors::fn_round_to);
-            engine.register_fn("coalesce", $crate::rhai_engine::constructors::fn_coalesce);
-            engine.register_fn("nullif", $crate::rhai_engine::constructors::fn_nullif);
-            engine.register_fn("cast", $crate::rhai_engine::constructors::fn_cast);
+            engine.register_fn("round", crate::rhai_engine::constructors::fn_round);
+            engine.register_fn("round", crate::rhai_engine::constructors::fn_round_to);
+            engine.register_fn("coalesce", crate::rhai_engine::constructors::fn_coalesce);
+            engine.register_fn("nullif", crate::rhai_engine::constructors::fn_nullif);
+            engine.register_fn("cast", crate::rhai_engine::constructors::fn_cast);
             engine.register_fn(
                 "date_format",
-                $crate::rhai_engine::constructors::fn_date_format,
+                crate::rhai_engine::constructors::fn_date_format,
             );
 
             // ── Tier 2 surreal-specific scalar/collection functions ───
-            engine.register_fn("first", $crate::rhai_engine::constructors::fn_first);
-            engine.register_fn("len", $crate::rhai_engine::constructors::fn_len);
-            engine.register_fn("stddev", $crate::rhai_engine::constructors::fn_stddev);
-            engine.register_fn("median", $crate::rhai_engine::constructors::fn_median);
-            engine.register_fn("lower", $crate::rhai_engine::constructors::fn_lower);
-            engine.register_fn("words", $crate::rhai_engine::constructors::fn_words);
+            engine.register_fn("first", crate::rhai_engine::constructors::fn_first);
+            engine.register_fn("len", crate::rhai_engine::constructors::fn_len);
+            engine.register_fn("stddev", crate::rhai_engine::constructors::fn_stddev);
+            engine.register_fn("median", crate::rhai_engine::constructors::fn_median);
+            engine.register_fn("lower", crate::rhai_engine::constructors::fn_lower);
+            engine.register_fn("words", crate::rhai_engine::constructors::fn_words);
             engine.register_fn(
                 "object_entries",
-                $crate::rhai_engine::constructors::fn_object_entries,
+                crate::rhai_engine::constructors::fn_object_entries,
             );
             engine.register_fn(
                 "object_values",
-                $crate::rhai_engine::constructors::fn_object_values,
+                crate::rhai_engine::constructors::fn_object_values,
             );
             engine.register_fn(
                 "time_group",
-                $crate::rhai_engine::constructors::fn_time_group,
+                crate::rhai_engine::constructors::fn_time_group,
             );
             engine.register_fn(
                 "similarity",
-                $crate::rhai_engine::constructors::fn_similarity,
+                crate::rhai_engine::constructors::fn_similarity,
             );
 
             // ── case_when().when().else_().expr() → IF … END ──────
-            engine.register_fn("case_when", $crate::rhai_engine::constructors::fn_case_new);
-            engine.register_fn("when", $crate::rhai_engine::constructors::fn_case_when);
-            engine.register_fn("else_", $crate::rhai_engine::constructors::fn_case_else);
-            engine.register_fn("expr", $crate::rhai_engine::constructors::fn_case_expr);
+            engine.register_fn("case_when", crate::rhai_engine::constructors::fn_case_new);
+            engine.register_fn("when", crate::rhai_engine::constructors::fn_case_when);
+            engine.register_fn("else_", crate::rhai_engine::constructors::fn_case_else);
+            engine.register_fn("expr", crate::rhai_engine::constructors::fn_case_expr);
             engine.register_fn(
                 "clone",
-                |c: $crate::rhai_engine::types::RhaiCase| -> $crate::rhai_engine::types::RhaiCase {
+                |c: crate::rhai_engine::types::RhaiCase| -> crate::rhai_engine::types::RhaiCase {
                     c
                 },
             );
 
             // ── Arithmetic ────────────────────────────────────────
-            engine.register_fn("mul", $crate::rhai_engine::constructors::fn_mul);
-            engine.register_fn("add", $crate::rhai_engine::constructors::fn_add);
-            engine.register_fn("sub", $crate::rhai_engine::constructors::fn_sub);
-            engine.register_fn("div", $crate::rhai_engine::constructors::fn_div);
+            engine.register_fn("mul", crate::rhai_engine::constructors::fn_mul);
+            engine.register_fn("add", crate::rhai_engine::constructors::fn_add);
+            engine.register_fn("sub", crate::rhai_engine::constructors::fn_sub);
+            engine.register_fn("div", crate::rhai_engine::constructors::fn_div);
 
             // ── SurrealDB-specific constructors ───────────────────
-            engine.register_fn("thing", $crate::rhai_engine::constructors::fn_thing);
-            engine.register_fn("param", $crate::rhai_engine::constructors::fn_param);
-            engine.register_fn("parent", $crate::rhai_engine::constructors::fn_parent);
-            engine.register_fn("parent", $crate::rhai_engine::constructors::fn_parent_bare);
+            engine.register_fn("thing", crate::rhai_engine::constructors::fn_thing);
+            engine.register_fn("param", crate::rhai_engine::constructors::fn_param);
+            engine.register_fn("parent", crate::rhai_engine::constructors::fn_parent);
+            engine.register_fn("parent", crate::rhai_engine::constructors::fn_parent_bare);
             engine.register_fn(
                 "array_group",
-                $crate::rhai_engine::constructors::fn_array_group,
+                crate::rhai_engine::constructors::fn_array_group,
             );
-            engine.register_fn("time_now", $crate::rhai_engine::constructors::fn_time_now);
+            engine.register_fn("time_now", crate::rhai_engine::constructors::fn_time_now);
             engine.register_fn(
                 "string_len",
-                $crate::rhai_engine::constructors::fn_string_len,
+                crate::rhai_engine::constructors::fn_string_len,
             );
             engine.register_fn(
                 "type_float",
-                $crate::rhai_engine::constructors::fn_type_float,
+                crate::rhai_engine::constructors::fn_type_float,
             );
-            engine.register_fn("type_int", $crate::rhai_engine::constructors::fn_type_int);
+            engine.register_fn("type_int", crate::rhai_engine::constructors::fn_type_int);
 
             // ── Ident methods ─────────────────────────────────────
             engine.register_fn("dot_of", |id: &mut Id, field: &str| -> Id {
-                $crate::rhai_engine::constructors::ident_dot(id.0.clone(), field)
+                crate::rhai_engine::constructors::ident_dot(id.0.clone(), field)
             });
             // Aliasing a name/path projects it: `dept.name AS department`. Lifts the
             // ident into the expression layer (the alias lives there), so it composes
             // like any other `.alias()` on an Ex.
             engine.register_fn("alias", |id: &mut Id, alias: &str| -> Ex {
-                Ex($crate::rhai_engine::constructors::ident_as_alias(
+                Ex(crate::rhai_engine::constructors::ident_as_alias(
                     id.0.clone(),
                     alias,
                 ))
@@ -142,23 +147,23 @@ macro_rules! register_surreal_engine {
 
             // ── Expr methods ──────────────────────────────────────
             engine.register_fn("alias", |e: &mut Ex, alias: &str| -> Ex {
-                $crate::rhai_engine::types::RhaiExpr(
-                    $crate::rhai_engine::constructors::expr_as_alias(e.0.clone(), alias),
+                crate::rhai_engine::types::RhaiExpr(
+                    crate::rhai_engine::constructors::expr_as_alias(e.0.clone(), alias),
                 )
             });
 
             // ── Indexer: t["col"] / expr["field"] ─────────────────
             engine.register_indexer_get(|id: &mut Id, col: &str| -> Id {
-                $crate::rhai_engine::constructors::ident_index(id.0.clone(), col)
+                crate::rhai_engine::constructors::ident_index(id.0.clone(), col)
             });
             engine.register_indexer_get(|e: &mut Ex, col: &str| -> Ex {
-                Ex($crate::rhai_engine::constructors::expr_index(
+                Ex(crate::rhai_engine::constructors::expr_index(
                     e.0.clone(),
                     col,
                 ))
             });
             engine.register_indexer_get(|e: &mut Ex, n: i64| -> Ex {
-                Ex($crate::rhai_engine::constructors::expr_index_at(
+                Ex(crate::rhai_engine::constructors::expr_index_at(
                     e.0.clone(),
                     n,
                 ))
@@ -172,9 +177,9 @@ macro_rules! register_surreal_engine {
                         |a: rhai::Dynamic,
                          b: rhai::Dynamic|
                          -> Result<Ex, Box<rhai::EvalAltResult>> {
-                            let la = $crate::rhai_engine::operators::to_expr(a)?;
-                            let rb = $crate::rhai_engine::operators::to_expr(b)?;
-                            Ok($crate::rhai_engine::operators::cmp_binary(
+                            let la = crate::rhai_engine::operators::to_expr(a)?;
+                            let rb = crate::rhai_engine::operators::to_expr(b)?;
+                            Ok(crate::rhai_engine::operators::cmp_binary(
                                 $surreal_op,
                                 la,
                                 rb,
@@ -196,33 +201,33 @@ macro_rules! register_surreal_engine {
             macro_rules! reg_arith {
                 ($op:expr) => {{
                     engine.register_fn($op, |a: Ex, b: Ex| -> Ex {
-                        $crate::rhai_engine::operators::arith($op, a.0, b.0)
+                        crate::rhai_engine::operators::arith($op, a.0, b.0)
                     });
                     engine.register_fn($op, |a: Ex, b: i64| -> Ex {
-                        $crate::rhai_engine::operators::arith(
+                        crate::rhai_engine::operators::arith(
                             $op,
                             a.0,
-                            $crate::rhai_engine::operators::scalar(AST::from(b)),
+                            crate::rhai_engine::operators::scalar(AST::from(b)),
                         )
                     });
                     engine.register_fn($op, |a: i64, b: Ex| -> Ex {
-                        $crate::rhai_engine::operators::arith(
+                        crate::rhai_engine::operators::arith(
                             $op,
-                            $crate::rhai_engine::operators::scalar(AST::from(a)),
+                            crate::rhai_engine::operators::scalar(AST::from(a)),
                             b.0,
                         )
                     });
                     engine.register_fn($op, |a: Ex, b: f64| -> Ex {
-                        $crate::rhai_engine::operators::arith(
+                        crate::rhai_engine::operators::arith(
                             $op,
                             a.0,
-                            $crate::rhai_engine::operators::scalar(AST::from(b)),
+                            crate::rhai_engine::operators::scalar(AST::from(b)),
                         )
                     });
                     engine.register_fn($op, |a: f64, b: Ex| -> Ex {
-                        $crate::rhai_engine::operators::arith(
+                        crate::rhai_engine::operators::arith(
                             $op,
-                            $crate::rhai_engine::operators::scalar(AST::from(a)),
+                            crate::rhai_engine::operators::scalar(AST::from(a)),
                             b.0,
                         )
                     });
@@ -234,89 +239,89 @@ macro_rules! register_surreal_engine {
             reg_arith!("/");
 
             // ── Select constructor ────────────────────────────────
-            engine.register_fn("select", $crate::rhai_engine::select_methods::select_new);
+            engine.register_fn("select", crate::rhai_engine::select_methods::select_new);
 
             // ── Select methods ────────────────────────────────────
-            engine.register_fn("from", $crate::rhai_engine::select_methods::select_from);
-            engine.register_fn("from", $crate::rhai_engine::select_methods::select_from_id);
+            engine.register_fn("from", crate::rhai_engine::select_methods::select_from);
+            engine.register_fn("from", crate::rhai_engine::select_methods::select_from_id);
             engine.register_fn(
                 "from",
-                $crate::rhai_engine::select_methods::select_from_expr,
+                crate::rhai_engine::select_methods::select_from_expr,
             );
-            engine.register_fn("field", $crate::rhai_engine::select_methods::select_field);
+            engine.register_fn("field", crate::rhai_engine::select_methods::select_field);
             engine.register_fn(
                 "clear_fields",
-                $crate::rhai_engine::select_methods::select_clear_fields,
+                crate::rhai_engine::select_methods::select_clear_fields,
             );
             engine.register_fn(
                 "expression",
-                $crate::rhai_engine::select_methods::select_expression,
+                crate::rhai_engine::select_methods::select_expression,
             );
             engine.register_fn(
                 "expression",
-                $crate::rhai_engine::select_methods::select_expression_id,
+                crate::rhai_engine::select_methods::select_expression_id,
             );
-            engine.register_fn("where", $crate::rhai_engine::select_methods::select_where);
+            engine.register_fn("where", crate::rhai_engine::select_methods::select_where);
             engine.register_fn(
                 "group_by",
-                $crate::rhai_engine::select_methods::select_group_by,
+                crate::rhai_engine::select_methods::select_group_by,
             );
             engine.register_fn(
                 "group_by",
-                $crate::rhai_engine::select_methods::select_group_by_id,
+                crate::rhai_engine::select_methods::select_group_by_id,
             );
             engine.register_fn(
                 "order_by",
-                $crate::rhai_engine::select_methods::select_order_by,
+                crate::rhai_engine::select_methods::select_order_by,
             );
             engine.register_fn(
                 "order_by",
-                $crate::rhai_engine::select_methods::select_order_by_id,
+                crate::rhai_engine::select_methods::select_order_by_id,
             );
             engine.register_fn(
                 "distinct",
-                $crate::rhai_engine::select_methods::select_distinct,
+                crate::rhai_engine::select_methods::select_distinct,
             );
             engine.register_fn(
                 "group_all",
-                $crate::rhai_engine::select_methods::select_group_all,
+                crate::rhai_engine::select_methods::select_group_all,
             );
-            engine.register_fn("split", $crate::rhai_engine::select_methods::select_split);
+            engine.register_fn("split", crate::rhai_engine::select_methods::select_split);
             engine.register_fn(
                 "split",
-                $crate::rhai_engine::select_methods::select_split_id,
+                crate::rhai_engine::select_methods::select_split_id,
             );
-            engine.register_fn("limit", $crate::rhai_engine::select_methods::select_limit);
+            engine.register_fn("limit", crate::rhai_engine::select_methods::select_limit);
 
             // ── SurrealDB-specific select methods ─────────────────
-            engine.register_fn("only", $crate::rhai_engine::select_methods::select_only);
-            engine.register_fn("value", $crate::rhai_engine::select_methods::select_value);
+            engine.register_fn("only", crate::rhai_engine::select_methods::select_only);
+            engine.register_fn("value", crate::rhai_engine::select_methods::select_value);
             engine.register_fn(
                 "subquery",
-                $crate::rhai_engine::select_methods::select_subquery,
+                crate::rhai_engine::select_methods::select_subquery,
             );
 
             // ── Graph traversal ───────────────────────────────────
-            engine.register_fn("arrow", $crate::rhai_engine::select_methods::graph_arrow);
-            engine.register_fn("back", $crate::rhai_engine::select_methods::graph_back);
+            engine.register_fn("arrow", crate::rhai_engine::select_methods::graph_arrow);
+            engine.register_fn("back", crate::rhai_engine::select_methods::graph_back);
             engine.register_fn(
                 "arrow_field",
-                $crate::rhai_engine::select_methods::graph_arrow_field,
+                crate::rhai_engine::select_methods::graph_arrow_field,
             );
 
             // graph(me, "edge", "table", …) — direction set by `me`'s position
-            engine.register_fn("graph", $crate::rhai_engine::constructors::fn_graph2);
-            engine.register_fn("graph", $crate::rhai_engine::constructors::fn_graph3);
-            engine.register_fn("graph", $crate::rhai_engine::constructors::fn_graph4);
-            engine.register_fn("graph", $crate::rhai_engine::constructors::fn_graph5);
-            engine.register_fn("graph", $crate::rhai_engine::constructors::fn_graph6);
-            engine.register_fn("graph", $crate::rhai_engine::constructors::fn_graph7);
-            engine.register_fn("recurse", $crate::rhai_engine::constructors::fn_recurse);
+            engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph2);
+            engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph3);
+            engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph4);
+            engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph5);
+            engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph6);
+            engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph7);
+            engine.register_fn("recurse", crate::rhai_engine::constructors::fn_recurse);
 
             // ── Embedded-array closures: .map / .fold / .filter ───────────
-            engine.register_fn("map", $crate::rhai_engine::constructors::fn_map);
-            engine.register_fn("fold", $crate::rhai_engine::constructors::fn_fold);
-            engine.register_fn("filter", $crate::rhai_engine::constructors::fn_filter);
+            engine.register_fn("map", crate::rhai_engine::constructors::fn_map);
+            engine.register_fn("fold", crate::rhai_engine::constructors::fn_fold);
+            engine.register_fn("filter", crate::rhai_engine::constructors::fn_filter);
 
             // `me` — the current-record anchor, available as a bare constant.
             // `on_var` is marked volatile (not deprecated) by rhai; silence the lint.
@@ -324,7 +329,7 @@ macro_rules! register_surreal_engine {
             {
                 engine.on_var(|name, _index, _context| {
                     if name == "me" {
-                        Ok(Some(rhai::Dynamic::from(Ex($crate::primitives::me()))))
+                        Ok(Some(rhai::Dynamic::from(Ex(crate::primitives::me()))))
                     } else {
                         Ok(None)
                     }
@@ -335,7 +340,22 @@ macro_rules! register_surreal_engine {
             engine.register_fn("clone", |e: Ex| -> Ex { e });
             engine.register_fn("clone", |id: Id| -> Id { id });
 
-            engine.set_max_expr_depths(256, 256);
+        engine.set_max_expr_depths(256, 256);
+    }
+}
+
+#[cfg(feature = "rhai")]
+#[macro_export]
+macro_rules! register_surreal_engine {
+    () => {
+        // Back-compat: callers still reference these aliases (e.g. `Sel`) after
+        // invoking the macro, so keep them in scope.
+        use $crate::AnySurrealType as AST;
+        use $crate::rhai_engine::types::{RhaiExpr as Ex, RhaiIdent as Id, RhaiSelect as Sel};
+
+        fn __create_engine() -> rhai::Engine {
+            let mut engine = rhai::Engine::new();
+            $crate::rhai_engine::register_surreal_onto(&mut engine);
             engine
         }
     };

--- a/vantage-surrealdb/src/rhai_engine/mod.rs
+++ b/vantage-surrealdb/src/rhai_engine/mod.rs
@@ -35,310 +35,301 @@ pub fn register_surreal_onto(engine: &mut rhai::Engine) {
     {
         // ── Register types ────────────────────────────────────
         engine.register_type::<crate::rhai_engine::types::RhaiSelect>();
-            engine.register_type::<Id>();
-            engine.register_type::<Ex>();
-            engine.register_type::<crate::rhai_engine::types::RhaiCase>();
+        engine.register_type::<Id>();
+        engine.register_type::<Ex>();
+        engine.register_type::<crate::rhai_engine::types::RhaiCase>();
 
-            // ── Constructors ──────────────────────────────────────
-            engine.register_fn("ident", crate::rhai_engine::constructors::make_rhai_ident);
-            engine.register_fn("table", crate::rhai_engine::constructors::make_rhai_ident);
-            engine.register_fn("expr", crate::rhai_engine::constructors::make_expr0);
-            engine.register_fn("expr", crate::rhai_engine::constructors::make_expr);
-            engine.register_fn("fx", crate::rhai_engine::constructors::make_fx);
+        // ── Constructors ──────────────────────────────────────
+        engine.register_fn("ident", crate::rhai_engine::constructors::make_rhai_ident);
+        engine.register_fn("table", crate::rhai_engine::constructors::make_rhai_ident);
+        engine.register_fn("expr", crate::rhai_engine::constructors::make_expr0);
+        engine.register_fn("expr", crate::rhai_engine::constructors::make_expr);
+        engine.register_fn("fx", crate::rhai_engine::constructors::make_fx);
 
-            // ── Aggregates ────────────────────────────────────────
-            engine.register_fn("count", crate::rhai_engine::constructors::fn_count_expr);
-            engine.register_fn("count", crate::rhai_engine::constructors::fn_count_of);
-            engine.register_fn(
-                "count_distinct",
-                crate::rhai_engine::constructors::fn_count_distinct,
-            );
-            engine.register_fn("sum", crate::rhai_engine::constructors::fn_sum);
-            engine.register_fn("avg", crate::rhai_engine::constructors::fn_avg);
-            engine.register_fn("min", crate::rhai_engine::constructors::fn_min);
-            engine.register_fn("max", crate::rhai_engine::constructors::fn_max);
+        // ── Aggregates ────────────────────────────────────────
+        engine.register_fn("count", crate::rhai_engine::constructors::fn_count_expr);
+        engine.register_fn("count", crate::rhai_engine::constructors::fn_count_of);
+        engine.register_fn(
+            "count_distinct",
+            crate::rhai_engine::constructors::fn_count_distinct,
+        );
+        engine.register_fn("sum", crate::rhai_engine::constructors::fn_sum);
+        engine.register_fn("avg", crate::rhai_engine::constructors::fn_avg);
+        engine.register_fn("min", crate::rhai_engine::constructors::fn_min);
+        engine.register_fn("max", crate::rhai_engine::constructors::fn_max);
 
-            // ── Tier 1 shared scalar/conditional primitives ───────
-            engine.register_fn("round", crate::rhai_engine::constructors::fn_round);
-            engine.register_fn("round", crate::rhai_engine::constructors::fn_round_to);
-            engine.register_fn("coalesce", crate::rhai_engine::constructors::fn_coalesce);
-            engine.register_fn("nullif", crate::rhai_engine::constructors::fn_nullif);
-            engine.register_fn("cast", crate::rhai_engine::constructors::fn_cast);
-            engine.register_fn(
-                "date_format",
-                crate::rhai_engine::constructors::fn_date_format,
-            );
+        // ── Tier 1 shared scalar/conditional primitives ───────
+        engine.register_fn("round", crate::rhai_engine::constructors::fn_round);
+        engine.register_fn("round", crate::rhai_engine::constructors::fn_round_to);
+        engine.register_fn("coalesce", crate::rhai_engine::constructors::fn_coalesce);
+        engine.register_fn("nullif", crate::rhai_engine::constructors::fn_nullif);
+        engine.register_fn("cast", crate::rhai_engine::constructors::fn_cast);
+        engine.register_fn(
+            "date_format",
+            crate::rhai_engine::constructors::fn_date_format,
+        );
 
-            // ── Tier 2 surreal-specific scalar/collection functions ───
-            engine.register_fn("first", crate::rhai_engine::constructors::fn_first);
-            engine.register_fn("len", crate::rhai_engine::constructors::fn_len);
-            engine.register_fn("stddev", crate::rhai_engine::constructors::fn_stddev);
-            engine.register_fn("median", crate::rhai_engine::constructors::fn_median);
-            engine.register_fn("lower", crate::rhai_engine::constructors::fn_lower);
-            engine.register_fn("words", crate::rhai_engine::constructors::fn_words);
-            engine.register_fn(
-                "object_entries",
-                crate::rhai_engine::constructors::fn_object_entries,
-            );
-            engine.register_fn(
-                "object_values",
-                crate::rhai_engine::constructors::fn_object_values,
-            );
-            engine.register_fn(
-                "time_group",
-                crate::rhai_engine::constructors::fn_time_group,
-            );
-            engine.register_fn(
-                "similarity",
-                crate::rhai_engine::constructors::fn_similarity,
-            );
+        // ── Tier 2 surreal-specific scalar/collection functions ───
+        engine.register_fn("first", crate::rhai_engine::constructors::fn_first);
+        engine.register_fn("len", crate::rhai_engine::constructors::fn_len);
+        engine.register_fn("stddev", crate::rhai_engine::constructors::fn_stddev);
+        engine.register_fn("median", crate::rhai_engine::constructors::fn_median);
+        engine.register_fn("lower", crate::rhai_engine::constructors::fn_lower);
+        engine.register_fn("words", crate::rhai_engine::constructors::fn_words);
+        engine.register_fn(
+            "object_entries",
+            crate::rhai_engine::constructors::fn_object_entries,
+        );
+        engine.register_fn(
+            "object_values",
+            crate::rhai_engine::constructors::fn_object_values,
+        );
+        engine.register_fn(
+            "time_group",
+            crate::rhai_engine::constructors::fn_time_group,
+        );
+        engine.register_fn(
+            "similarity",
+            crate::rhai_engine::constructors::fn_similarity,
+        );
 
-            // ── case_when().when().else_().expr() → IF … END ──────
-            engine.register_fn("case_when", crate::rhai_engine::constructors::fn_case_new);
-            engine.register_fn("when", crate::rhai_engine::constructors::fn_case_when);
-            engine.register_fn("else_", crate::rhai_engine::constructors::fn_case_else);
-            engine.register_fn("expr", crate::rhai_engine::constructors::fn_case_expr);
-            engine.register_fn(
-                "clone",
-                |c: crate::rhai_engine::types::RhaiCase| -> crate::rhai_engine::types::RhaiCase {
-                    c
-                },
-            );
+        // ── case_when().when().else_().expr() → IF … END ──────
+        engine.register_fn("case_when", crate::rhai_engine::constructors::fn_case_new);
+        engine.register_fn("when", crate::rhai_engine::constructors::fn_case_when);
+        engine.register_fn("else_", crate::rhai_engine::constructors::fn_case_else);
+        engine.register_fn("expr", crate::rhai_engine::constructors::fn_case_expr);
+        engine.register_fn(
+            "clone",
+            |c: crate::rhai_engine::types::RhaiCase| -> crate::rhai_engine::types::RhaiCase { c },
+        );
 
-            // ── Arithmetic ────────────────────────────────────────
-            engine.register_fn("mul", crate::rhai_engine::constructors::fn_mul);
-            engine.register_fn("add", crate::rhai_engine::constructors::fn_add);
-            engine.register_fn("sub", crate::rhai_engine::constructors::fn_sub);
-            engine.register_fn("div", crate::rhai_engine::constructors::fn_div);
+        // ── Arithmetic ────────────────────────────────────────
+        engine.register_fn("mul", crate::rhai_engine::constructors::fn_mul);
+        engine.register_fn("add", crate::rhai_engine::constructors::fn_add);
+        engine.register_fn("sub", crate::rhai_engine::constructors::fn_sub);
+        engine.register_fn("div", crate::rhai_engine::constructors::fn_div);
 
-            // ── SurrealDB-specific constructors ───────────────────
-            engine.register_fn("thing", crate::rhai_engine::constructors::fn_thing);
-            engine.register_fn("param", crate::rhai_engine::constructors::fn_param);
-            engine.register_fn("parent", crate::rhai_engine::constructors::fn_parent);
-            engine.register_fn("parent", crate::rhai_engine::constructors::fn_parent_bare);
-            engine.register_fn(
-                "array_group",
-                crate::rhai_engine::constructors::fn_array_group,
-            );
-            engine.register_fn("time_now", crate::rhai_engine::constructors::fn_time_now);
-            engine.register_fn(
-                "string_len",
-                crate::rhai_engine::constructors::fn_string_len,
-            );
-            engine.register_fn(
-                "type_float",
-                crate::rhai_engine::constructors::fn_type_float,
-            );
-            engine.register_fn("type_int", crate::rhai_engine::constructors::fn_type_int);
+        // ── SurrealDB-specific constructors ───────────────────
+        engine.register_fn("thing", crate::rhai_engine::constructors::fn_thing);
+        engine.register_fn("param", crate::rhai_engine::constructors::fn_param);
+        engine.register_fn("parent", crate::rhai_engine::constructors::fn_parent);
+        engine.register_fn("parent", crate::rhai_engine::constructors::fn_parent_bare);
+        engine.register_fn(
+            "array_group",
+            crate::rhai_engine::constructors::fn_array_group,
+        );
+        engine.register_fn("time_now", crate::rhai_engine::constructors::fn_time_now);
+        engine.register_fn(
+            "string_len",
+            crate::rhai_engine::constructors::fn_string_len,
+        );
+        engine.register_fn(
+            "type_float",
+            crate::rhai_engine::constructors::fn_type_float,
+        );
+        engine.register_fn("type_int", crate::rhai_engine::constructors::fn_type_int);
 
-            // ── Ident methods ─────────────────────────────────────
-            engine.register_fn("dot_of", |id: &mut Id, field: &str| -> Id {
-                crate::rhai_engine::constructors::ident_dot(id.0.clone(), field)
-            });
-            // Aliasing a name/path projects it: `dept.name AS department`. Lifts the
-            // ident into the expression layer (the alias lives there), so it composes
-            // like any other `.alias()` on an Ex.
-            engine.register_fn("alias", |id: &mut Id, alias: &str| -> Ex {
-                Ex(crate::rhai_engine::constructors::ident_as_alias(
-                    id.0.clone(),
-                    alias,
-                ))
-            });
+        // ── Ident methods ─────────────────────────────────────
+        engine.register_fn("dot_of", |id: &mut Id, field: &str| -> Id {
+            crate::rhai_engine::constructors::ident_dot(id.0.clone(), field)
+        });
+        // Aliasing a name/path projects it: `dept.name AS department`. Lifts the
+        // ident into the expression layer (the alias lives there), so it composes
+        // like any other `.alias()` on an Ex.
+        engine.register_fn("alias", |id: &mut Id, alias: &str| -> Ex {
+            Ex(crate::rhai_engine::constructors::ident_as_alias(
+                id.0.clone(),
+                alias,
+            ))
+        });
 
-            // ── Expr methods ──────────────────────────────────────
-            engine.register_fn("alias", |e: &mut Ex, alias: &str| -> Ex {
-                crate::rhai_engine::types::RhaiExpr(
-                    crate::rhai_engine::constructors::expr_as_alias(e.0.clone(), alias),
-                )
-            });
+        // ── Expr methods ──────────────────────────────────────
+        engine.register_fn("alias", |e: &mut Ex, alias: &str| -> Ex {
+            crate::rhai_engine::types::RhaiExpr(crate::rhai_engine::constructors::expr_as_alias(
+                e.0.clone(),
+                alias,
+            ))
+        });
 
-            // ── Indexer: t["col"] / expr["field"] ─────────────────
-            engine.register_indexer_get(|id: &mut Id, col: &str| -> Id {
-                crate::rhai_engine::constructors::ident_index(id.0.clone(), col)
-            });
-            engine.register_indexer_get(|e: &mut Ex, col: &str| -> Ex {
-                Ex(crate::rhai_engine::constructors::expr_index(
-                    e.0.clone(),
-                    col,
-                ))
-            });
-            engine.register_indexer_get(|e: &mut Ex, n: i64| -> Ex {
-                Ex(crate::rhai_engine::constructors::expr_index_at(
-                    e.0.clone(),
-                    n,
-                ))
-            });
+        // ── Indexer: t["col"] / expr["field"] ─────────────────
+        engine.register_indexer_get(|id: &mut Id, col: &str| -> Id {
+            crate::rhai_engine::constructors::ident_index(id.0.clone(), col)
+        });
+        engine.register_indexer_get(|e: &mut Ex, col: &str| -> Ex {
+            Ex(crate::rhai_engine::constructors::expr_index(
+                e.0.clone(),
+                col,
+            ))
+        });
+        engine.register_indexer_get(|e: &mut Ex, n: i64| -> Ex {
+            Ex(crate::rhai_engine::constructors::expr_index_at(
+                e.0.clone(),
+                n,
+            ))
+        });
 
-            // ── Comparison operators ──────────────────────────────
-            macro_rules! reg_op {
-                ($rhai_op:expr, $surreal_op:expr) => {
-                    engine.register_fn(
-                        $rhai_op,
-                        |a: rhai::Dynamic,
-                         b: rhai::Dynamic|
-                         -> Result<Ex, Box<rhai::EvalAltResult>> {
-                            let la = crate::rhai_engine::operators::to_expr(a)?;
-                            let rb = crate::rhai_engine::operators::to_expr(b)?;
-                            Ok(crate::rhai_engine::operators::cmp_binary(
-                                $surreal_op,
-                                la,
-                                rb,
-                            ))
-                        },
-                    );
-                };
-            }
-            reg_op!("==", "=");
-            reg_op!("!=", "!=");
-            reg_op!("<", "<");
-            reg_op!(">", ">");
-            reg_op!("<=", "<=");
-            reg_op!(">=", ">=");
+        // ── Comparison operators ──────────────────────────────
+        macro_rules! reg_op {
+            ($rhai_op:expr, $surreal_op:expr) => {
+                engine.register_fn(
+                    $rhai_op,
+                    |a: rhai::Dynamic, b: rhai::Dynamic| -> Result<Ex, Box<rhai::EvalAltResult>> {
+                        let la = crate::rhai_engine::operators::to_expr(a)?;
+                        let rb = crate::rhai_engine::operators::to_expr(b)?;
+                        Ok(crate::rhai_engine::operators::cmp_binary(
+                            $surreal_op,
+                            la,
+                            rb,
+                        ))
+                    },
+                );
+            };
+        }
+        reg_op!("==", "=");
+        reg_op!("!=", "!=");
+        reg_op!("<", "<");
+        reg_op!(">", ">");
+        reg_op!("<=", "<=");
+        reg_op!(">=", ">=");
 
-            // ── Arithmetic operators on Ex (closure bodies, ad-hoc maths) ──
-            // Only combos involving an Ex are registered, so native numeric
-            // arithmetic (i64*i64, …) is untouched. Each renders parenthesized.
-            macro_rules! reg_arith {
-                ($op:expr) => {{
-                    engine.register_fn($op, |a: Ex, b: Ex| -> Ex {
-                        crate::rhai_engine::operators::arith($op, a.0, b.0)
-                    });
-                    engine.register_fn($op, |a: Ex, b: i64| -> Ex {
-                        crate::rhai_engine::operators::arith(
-                            $op,
-                            a.0,
-                            crate::rhai_engine::operators::scalar(AST::from(b)),
-                        )
-                    });
-                    engine.register_fn($op, |a: i64, b: Ex| -> Ex {
-                        crate::rhai_engine::operators::arith(
-                            $op,
-                            crate::rhai_engine::operators::scalar(AST::from(a)),
-                            b.0,
-                        )
-                    });
-                    engine.register_fn($op, |a: Ex, b: f64| -> Ex {
-                        crate::rhai_engine::operators::arith(
-                            $op,
-                            a.0,
-                            crate::rhai_engine::operators::scalar(AST::from(b)),
-                        )
-                    });
-                    engine.register_fn($op, |a: f64, b: Ex| -> Ex {
-                        crate::rhai_engine::operators::arith(
-                            $op,
-                            crate::rhai_engine::operators::scalar(AST::from(a)),
-                            b.0,
-                        )
-                    });
-                }};
-            }
-            reg_arith!("*");
-            reg_arith!("+");
-            reg_arith!("-");
-            reg_arith!("/");
-
-            // ── Select constructor ────────────────────────────────
-            engine.register_fn("select", crate::rhai_engine::select_methods::select_new);
-
-            // ── Select methods ────────────────────────────────────
-            engine.register_fn("from", crate::rhai_engine::select_methods::select_from);
-            engine.register_fn("from", crate::rhai_engine::select_methods::select_from_id);
-            engine.register_fn(
-                "from",
-                crate::rhai_engine::select_methods::select_from_expr,
-            );
-            engine.register_fn("field", crate::rhai_engine::select_methods::select_field);
-            engine.register_fn(
-                "clear_fields",
-                crate::rhai_engine::select_methods::select_clear_fields,
-            );
-            engine.register_fn(
-                "expression",
-                crate::rhai_engine::select_methods::select_expression,
-            );
-            engine.register_fn(
-                "expression",
-                crate::rhai_engine::select_methods::select_expression_id,
-            );
-            engine.register_fn("where", crate::rhai_engine::select_methods::select_where);
-            engine.register_fn(
-                "group_by",
-                crate::rhai_engine::select_methods::select_group_by,
-            );
-            engine.register_fn(
-                "group_by",
-                crate::rhai_engine::select_methods::select_group_by_id,
-            );
-            engine.register_fn(
-                "order_by",
-                crate::rhai_engine::select_methods::select_order_by,
-            );
-            engine.register_fn(
-                "order_by",
-                crate::rhai_engine::select_methods::select_order_by_id,
-            );
-            engine.register_fn(
-                "distinct",
-                crate::rhai_engine::select_methods::select_distinct,
-            );
-            engine.register_fn(
-                "group_all",
-                crate::rhai_engine::select_methods::select_group_all,
-            );
-            engine.register_fn("split", crate::rhai_engine::select_methods::select_split);
-            engine.register_fn(
-                "split",
-                crate::rhai_engine::select_methods::select_split_id,
-            );
-            engine.register_fn("limit", crate::rhai_engine::select_methods::select_limit);
-
-            // ── SurrealDB-specific select methods ─────────────────
-            engine.register_fn("only", crate::rhai_engine::select_methods::select_only);
-            engine.register_fn("value", crate::rhai_engine::select_methods::select_value);
-            engine.register_fn(
-                "subquery",
-                crate::rhai_engine::select_methods::select_subquery,
-            );
-
-            // ── Graph traversal ───────────────────────────────────
-            engine.register_fn("arrow", crate::rhai_engine::select_methods::graph_arrow);
-            engine.register_fn("back", crate::rhai_engine::select_methods::graph_back);
-            engine.register_fn(
-                "arrow_field",
-                crate::rhai_engine::select_methods::graph_arrow_field,
-            );
-
-            // graph(me, "edge", "table", …) — direction set by `me`'s position
-            engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph2);
-            engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph3);
-            engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph4);
-            engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph5);
-            engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph6);
-            engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph7);
-            engine.register_fn("recurse", crate::rhai_engine::constructors::fn_recurse);
-
-            // ── Embedded-array closures: .map / .fold / .filter ───────────
-            engine.register_fn("map", crate::rhai_engine::constructors::fn_map);
-            engine.register_fn("fold", crate::rhai_engine::constructors::fn_fold);
-            engine.register_fn("filter", crate::rhai_engine::constructors::fn_filter);
-
-            // `me` — the current-record anchor, available as a bare constant.
-            // `on_var` is marked volatile (not deprecated) by rhai; silence the lint.
-            #[allow(deprecated)]
-            {
-                engine.on_var(|name, _index, _context| {
-                    if name == "me" {
-                        Ok(Some(rhai::Dynamic::from(Ex(crate::primitives::me()))))
-                    } else {
-                        Ok(None)
-                    }
+        // ── Arithmetic operators on Ex (closure bodies, ad-hoc maths) ──
+        // Only combos involving an Ex are registered, so native numeric
+        // arithmetic (i64*i64, …) is untouched. Each renders parenthesized.
+        macro_rules! reg_arith {
+            ($op:expr) => {{
+                engine.register_fn($op, |a: Ex, b: Ex| -> Ex {
+                    crate::rhai_engine::operators::arith($op, a.0, b.0)
                 });
-            }
+                engine.register_fn($op, |a: Ex, b: i64| -> Ex {
+                    crate::rhai_engine::operators::arith(
+                        $op,
+                        a.0,
+                        crate::rhai_engine::operators::scalar(AST::from(b)),
+                    )
+                });
+                engine.register_fn($op, |a: i64, b: Ex| -> Ex {
+                    crate::rhai_engine::operators::arith(
+                        $op,
+                        crate::rhai_engine::operators::scalar(AST::from(a)),
+                        b.0,
+                    )
+                });
+                engine.register_fn($op, |a: Ex, b: f64| -> Ex {
+                    crate::rhai_engine::operators::arith(
+                        $op,
+                        a.0,
+                        crate::rhai_engine::operators::scalar(AST::from(b)),
+                    )
+                });
+                engine.register_fn($op, |a: f64, b: Ex| -> Ex {
+                    crate::rhai_engine::operators::arith(
+                        $op,
+                        crate::rhai_engine::operators::scalar(AST::from(a)),
+                        b.0,
+                    )
+                });
+            }};
+        }
+        reg_arith!("*");
+        reg_arith!("+");
+        reg_arith!("-");
+        reg_arith!("/");
 
-            // ── Clone ─────────────────────────────────────────────
-            engine.register_fn("clone", |e: Ex| -> Ex { e });
-            engine.register_fn("clone", |id: Id| -> Id { id });
+        // ── Select constructor ────────────────────────────────
+        engine.register_fn("select", crate::rhai_engine::select_methods::select_new);
+
+        // ── Select methods ────────────────────────────────────
+        engine.register_fn("from", crate::rhai_engine::select_methods::select_from);
+        engine.register_fn("from", crate::rhai_engine::select_methods::select_from_id);
+        engine.register_fn("from", crate::rhai_engine::select_methods::select_from_expr);
+        engine.register_fn("field", crate::rhai_engine::select_methods::select_field);
+        engine.register_fn(
+            "clear_fields",
+            crate::rhai_engine::select_methods::select_clear_fields,
+        );
+        engine.register_fn(
+            "expression",
+            crate::rhai_engine::select_methods::select_expression,
+        );
+        engine.register_fn(
+            "expression",
+            crate::rhai_engine::select_methods::select_expression_id,
+        );
+        engine.register_fn("where", crate::rhai_engine::select_methods::select_where);
+        engine.register_fn(
+            "group_by",
+            crate::rhai_engine::select_methods::select_group_by,
+        );
+        engine.register_fn(
+            "group_by",
+            crate::rhai_engine::select_methods::select_group_by_id,
+        );
+        engine.register_fn(
+            "order_by",
+            crate::rhai_engine::select_methods::select_order_by,
+        );
+        engine.register_fn(
+            "order_by",
+            crate::rhai_engine::select_methods::select_order_by_id,
+        );
+        engine.register_fn(
+            "distinct",
+            crate::rhai_engine::select_methods::select_distinct,
+        );
+        engine.register_fn(
+            "group_all",
+            crate::rhai_engine::select_methods::select_group_all,
+        );
+        engine.register_fn("split", crate::rhai_engine::select_methods::select_split);
+        engine.register_fn("split", crate::rhai_engine::select_methods::select_split_id);
+        engine.register_fn("limit", crate::rhai_engine::select_methods::select_limit);
+
+        // ── SurrealDB-specific select methods ─────────────────
+        engine.register_fn("only", crate::rhai_engine::select_methods::select_only);
+        engine.register_fn("value", crate::rhai_engine::select_methods::select_value);
+        engine.register_fn(
+            "subquery",
+            crate::rhai_engine::select_methods::select_subquery,
+        );
+
+        // ── Graph traversal ───────────────────────────────────
+        engine.register_fn("arrow", crate::rhai_engine::select_methods::graph_arrow);
+        engine.register_fn("back", crate::rhai_engine::select_methods::graph_back);
+        engine.register_fn(
+            "arrow_field",
+            crate::rhai_engine::select_methods::graph_arrow_field,
+        );
+
+        // graph(me, "edge", "table", …) — direction set by `me`'s position
+        engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph2);
+        engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph3);
+        engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph4);
+        engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph5);
+        engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph6);
+        engine.register_fn("graph", crate::rhai_engine::constructors::fn_graph7);
+        engine.register_fn("recurse", crate::rhai_engine::constructors::fn_recurse);
+
+        // ── Embedded-array closures: .map / .fold / .filter ───────────
+        engine.register_fn("map", crate::rhai_engine::constructors::fn_map);
+        engine.register_fn("fold", crate::rhai_engine::constructors::fn_fold);
+        engine.register_fn("filter", crate::rhai_engine::constructors::fn_filter);
+
+        // `me` — the current-record anchor, available as a bare constant.
+        // `on_var` is marked volatile (not deprecated) by rhai; silence the lint.
+        #[allow(deprecated)]
+        {
+            engine.on_var(|name, _index, _context| {
+                if name == "me" {
+                    Ok(Some(rhai::Dynamic::from(Ex(crate::primitives::me()))))
+                } else {
+                    Ok(None)
+                }
+            });
+        }
+
+        // ── Clone ─────────────────────────────────────────────
+        engine.register_fn("clone", |e: Ex| -> Ex { e });
+        engine.register_fn("clone", |id: Id| -> Id { id });
 
         engine.set_max_expr_depths(256, 256);
     }

--- a/vantage-surrealdb/src/vista/factory.rs
+++ b/vantage-surrealdb/src/vista/factory.rs
@@ -10,15 +10,17 @@ use vantage_table::table::Table;
 use vantage_table::traits::column_like::ColumnLike;
 use vantage_types::{EmptyEntity, Entity};
 use vantage_vista::{
-    Column as VistaColumn, NoExtras, ReferenceKind, Vista, VistaCapabilities, VistaFactory,
-    VistaMetadata, flags as vista_flags, reference::Reference as VistaReferenceMeta,
+    Column as VistaColumn, ReferenceKind, Vista, VistaCapabilities, VistaFactory, VistaMetadata,
+    flags as vista_flags, reference::Reference as VistaReferenceMeta,
 };
 
 use crate::surrealdb::SurrealDB;
 use crate::thing::Thing;
 use crate::types::AnySurrealType;
 use crate::vista::source::SurrealTableShell;
-use crate::vista::spec::{SurrealColumnExtras, SurrealTableExtras, SurrealVistaSpec};
+use crate::vista::spec::{
+    SurrealColumnExtras, SurrealReferenceExtras, SurrealTableExtras, SurrealVistaSpec,
+};
 
 /// Resolves a YAML spec by table name. The factory hands clones of this
 /// into each `with_one` / `with_many` closure so child tables can be
@@ -83,6 +85,10 @@ impl SurrealVistaFactory {
                 can_fetch_next: true,
                 can_traverse_to_record: true,
                 can_traverse_to_set: true,
+                // Per-reference scripted traversal only works when the script
+                // engine is compiled in; without `rhai`, any `build_script` is
+                // ignored and the FK eq-condition path still serves.
+                can_build_ref_via_script: cfg!(feature = "rhai"),
                 ..VistaCapabilities::default()
             },
             metadata,
@@ -103,7 +109,7 @@ impl SurrealVistaFactory {
 impl VistaFactory for SurrealVistaFactory {
     type TableExtras = SurrealTableExtras;
     type ColumnExtras = SurrealColumnExtras;
-    type ReferenceExtras = NoExtras;
+    type ReferenceExtras = SurrealReferenceExtras;
 
     fn build_from_spec(&self, spec: SurrealVistaSpec) -> Result<Vista> {
         let vista_name = spec.name.clone();
@@ -122,16 +128,54 @@ impl VistaFactory for SurrealVistaFactory {
                 .foreign_key
                 .clone()
                 .unwrap_or_else(|| rel_name.clone());
-            metadata = metadata.with_reference(VistaReferenceMeta::new(
-                rel_name.clone(),
-                ref_spec.table.clone(),
-                ref_spec.kind,
-                fk,
-            ));
+            let mut reference =
+                VistaReferenceMeta::new(rel_name.clone(), ref_spec.table.clone(), ref_spec.kind, fk);
+            if let Some(script) = ref_spec.driver.surreal.as_ref().and_then(|b| b.rhai.clone()) {
+                reference = reference.with_build_script(script);
+            }
+            metadata = metadata.with_reference(reference);
         }
         let mut vista = self.wrap(table, vista_name.clone(), metadata, read_only);
         vista.set_name(vista_name);
+
+        // Final step: a `surreal: { modify }` script tweaks the just-built vista
+        // (e.g. an expression condition YAML can't express). Runs last, so it
+        // composes with `table`/`rhai`/`base`.
+        #[cfg(feature = "rhai")]
+        if let Some(code) = spec.driver.surreal.as_ref().and_then(|b| b.modify.clone()) {
+            vista = self.apply_modify(vista, &code)?;
+        }
+
         Ok(vista)
+    }
+}
+
+#[cfg(feature = "rhai")]
+impl SurrealVistaFactory {
+    /// Run a `surreal: { modify }` script against an already-built vista,
+    /// layering SurrealDB's expression vocabulary plus the conventional verbs
+    /// onto a fresh engine. `table(name)` inside the script resolves through the
+    /// factory's spec resolver (if attached); `self` is the built vista.
+    fn apply_modify(&self, vista: Vista, code: &str) -> Result<Vista> {
+        let db = self.db.clone();
+        let resolver = self.resolver.clone();
+        let target_resolver: vantage_vista::TargetResolver = Arc::new(move |name| {
+            let resolver = resolver
+                .as_ref()
+                .ok_or_else(|| error!("modify script `table()` requires a spec resolver"))?;
+            let spec = resolver(name)
+                .ok_or_else(|| error!("modify script: unknown table", table = name))?;
+            SurrealVistaFactory::new(db.clone())
+                .with_resolver(resolver.clone())
+                .build_from_spec(spec)
+        });
+
+        // Vendor vocab first, conventional second (so `table` resolves a Vista,
+        // not SurrealDB's `ident` alias — same ordering as scripted traversal).
+        let mut engine = rhai::Engine::new();
+        vista.source.register_rhai_extensions(&mut engine);
+        vantage_vista::register_conventional_onto(&mut engine, target_resolver);
+        vantage_vista::eval_modify_script(&engine, code, vista)
     }
 }
 
@@ -508,6 +552,140 @@ columns:
         cols.sort();
         assert_eq!(cols, vec!["bakery", "id", "name", "price"]);
         assert_eq!(child.get_id_column(), Some("id"));
+    }
+
+    #[cfg(feature = "rhai")]
+    #[test]
+    fn scripted_reference_builds_target_via_rhai() {
+        let bakery_yaml = r#"
+name: bakery
+columns:
+  id: { type: thing, flags: [id] }
+references:
+  products:
+    table: product
+    kind: has_many
+    foreign_key: bakery
+    surreal:
+      rhai: |
+        table("product").add_condition_eq("bakery", row.id)
+"#;
+        let product_yaml = r#"
+name: product
+columns:
+  id: { type: thing, flags: [id] }
+  name: { type: string, flags: [title] }
+  price: { type: int }
+  bakery: { type: thing }
+"#;
+        let bakery_spec = parse(bakery_yaml);
+        let product_spec = parse(product_yaml);
+        let resolver = registry_resolver(vec![
+            ("bakery".into(), bakery_spec.clone()),
+            ("product".into(), product_spec),
+        ]);
+
+        let factory = SurrealVistaFactory::new(test_db()).with_resolver(resolver);
+        let bakery = factory.build_from_spec(bakery_spec).expect("build bakery");
+
+        // The build_script rode through the extras slot onto the Reference, and
+        // the backend advertises the scripted-traversal capability.
+        assert!(bakery.capabilities().can_build_ref_via_script);
+        let reference = bakery.get_reference("products").expect("products ref");
+        assert!(reference.build_script.is_some());
+
+        // Traversal evaluates the script: `table("product")` resolves a fresh
+        // product Vista (proving the script path fired, not the FK path).
+        let mut row: vantage_types::Record<ciborium::Value> = vantage_types::Record::new();
+        row.insert(
+            "id".into(),
+            ciborium::Value::Text("bakery:hill_valley".into()),
+        );
+        let child = bakery
+            .get_ref("products", &row)
+            .expect("scripted traverse products");
+
+        let mut cols = child.get_column_names();
+        cols.sort();
+        assert_eq!(cols, vec!["bakery", "id", "name", "price"]);
+        assert_eq!(child.name(), "product");
+    }
+
+    #[cfg(feature = "rhai")]
+    #[test]
+    fn scripted_reference_routes_vendor_condition() {
+        // `with_condition(<surreal expr>)` boxes an `Expression<AnySurrealType>`
+        // and routes it through the type-erased `add_raw_condition`. A clean eval
+        // proves the boxed type and the downcast type match (a mismatch would
+        // surface as an `Unimplemented` error here).
+        let bakery_yaml = r#"
+name: bakery
+columns:
+  id: { type: thing, flags: [id] }
+references:
+  products:
+    table: product
+    kind: has_many
+    foreign_key: bakery
+    surreal:
+      rhai: |
+        table("product").with_condition(ident("bakery") == row.id)
+"#;
+        let product_yaml = r#"
+name: product
+columns:
+  id: { type: thing, flags: [id] }
+  name: { type: string, flags: [title] }
+  bakery: { type: thing }
+"#;
+        let bakery_spec = parse(bakery_yaml);
+        let resolver = registry_resolver(vec![
+            ("bakery".into(), bakery_spec.clone()),
+            ("product".into(), parse(product_yaml)),
+        ]);
+        let factory = SurrealVistaFactory::new(test_db()).with_resolver(resolver);
+        let bakery = factory.build_from_spec(bakery_spec).expect("build bakery");
+
+        let mut row: vantage_types::Record<ciborium::Value> = vantage_types::Record::new();
+        row.insert(
+            "id".into(),
+            ciborium::Value::Text("bakery:hill_valley".into()),
+        );
+        let child = bakery
+            .get_ref("products", &row)
+            .expect("vendor-condition traverse");
+        assert_eq!(child.name(), "product");
+    }
+
+    #[cfg(feature = "rhai")]
+    #[test]
+    fn modify_script_tweaks_built_vista_with_vendor_condition() {
+        // The YAML builds a normal, writable `client` table; the `modify` script
+        // then narrows it with an expression condition YAML can't express. A
+        // clean build proves the post-build hook ran and the vendor condition
+        // routed through `add_raw_condition`.
+        let yaml = r#"
+name: client
+columns:
+  id: { type: thing, flags: [id] }
+  name: { type: string, flags: [title] }
+  is_paying_client: { type: bool }
+surreal:
+  table: clients
+  modify: |
+    self.with_condition(ident("is_paying_client") == true)
+       .add_order("name", "asc")
+"#;
+        let spec = parse(yaml);
+        let factory = SurrealVistaFactory::new(test_db());
+        let vista = factory.build_from_spec(spec).expect("build + modify");
+
+        // The base table stays writable (a condition narrows, it doesn't make
+        // the vista read-only), and the schema is intact.
+        assert!(vista.capabilities().can_insert);
+        let mut cols = vista.get_column_names();
+        cols.sort();
+        assert_eq!(cols, vec!["id", "is_paying_client", "name"]);
     }
 
     #[test]

--- a/vantage-surrealdb/src/vista/factory.rs
+++ b/vantage-surrealdb/src/vista/factory.rs
@@ -128,9 +128,18 @@ impl VistaFactory for SurrealVistaFactory {
                 .foreign_key
                 .clone()
                 .unwrap_or_else(|| rel_name.clone());
-            let mut reference =
-                VistaReferenceMeta::new(rel_name.clone(), ref_spec.table.clone(), ref_spec.kind, fk);
-            if let Some(script) = ref_spec.driver.surreal.as_ref().and_then(|b| b.rhai.clone()) {
+            let mut reference = VistaReferenceMeta::new(
+                rel_name.clone(),
+                ref_spec.table.clone(),
+                ref_spec.kind,
+                fk,
+            );
+            if let Some(script) = ref_spec
+                .driver
+                .surreal
+                .as_ref()
+                .and_then(|b| b.rhai.clone())
+            {
                 reference = reference.with_build_script(script);
             }
             metadata = metadata.with_reference(reference);

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -35,7 +35,7 @@ use crate::surreal_expr;
 use crate::surrealdb::SurrealDB;
 use crate::thing::Thing;
 use crate::types::{AnySurrealType, SurrealType};
-use crate::vista::factory::SurrealSpecResolver;
+use crate::vista::factory::{SurrealSpecResolver, SurrealVistaFactory};
 
 pub struct SurrealTableShell<E = EmptyEntity>
 where
@@ -226,13 +226,42 @@ where
         Ok(())
     }
 
+    /// Route a boxed driver-native condition onto the wrapped table. The boxed
+    /// value must be a SurrealDB [`crate::Expr`] (`Expression<AnySurrealType>`,
+    /// the table's `Condition` type) — the type a Rhai `with_condition(...)`
+    /// expression lowers to. Used by scripted reference traversal.
+    fn add_raw_condition(
+        &mut self,
+        condition: Box<dyn std::any::Any + Send + Sync>,
+    ) -> Result<()> {
+        let condition = condition.downcast::<crate::Expr>().map_err(|_| {
+            error!(
+                "add_raw_condition expected a SurrealDB Expression<AnySurrealType>",
+                source_type = std::any::type_name::<Self>()
+            )
+        })?;
+        self.table.add_condition(*condition);
+        Ok(())
+    }
+
     fn get_ref(&self, relation: &str, row: &Record<CborValue>) -> Result<Vista> {
+        // A reference carrying a Rhai `build_script` resolves through the script
+        // engine instead of the fixed FK eq-condition path below.
+        #[cfg(feature = "rhai")]
+        if let Some(script) = self
+            .metadata
+            .references
+            .get(relation)
+            .and_then(|r| r.build_script.clone())
+        {
+            return self.get_ref_via_script(&script, row);
+        }
+
         let native_row = to_native_record(row);
         let target = self
             .table
             .get_ref_from_row::<EmptyEntity>(relation, &native_row)?;
-        let mut factory =
-            crate::vista::factory::SurrealVistaFactory::new(self.table.data_source().clone());
+        let mut factory = SurrealVistaFactory::new(self.table.data_source().clone());
         if let Some(resolver) = &self.resolver {
             factory = factory.with_resolver(resolver.clone());
         }
@@ -394,5 +423,61 @@ where
 
     fn driver_name(&self) -> &'static str {
         "surrealdb"
+    }
+
+    /// Layer SurrealDB's expression vocabulary on top of vantage-vista's
+    /// conventional `Vista` verbs, plus a `with_condition(<expr>)` builder that
+    /// routes a native `Expression` through [`add_raw_condition`](Self::add_raw_condition).
+    #[cfg(feature = "rhai")]
+    fn register_rhai_extensions(&self, engine: &mut rhai::Engine) {
+        use vantage_vista::RhaiVista;
+
+        crate::rhai_engine::register_surreal_onto(engine);
+
+        engine.register_fn(
+            "with_condition",
+            |v: &mut RhaiVista,
+             cond: crate::rhai_engine::RhaiExpr|
+             -> std::result::Result<RhaiVista, Box<rhai::EvalAltResult>> {
+                v.apply(|vista| vista.add_raw_condition(cond.0))
+            },
+        );
+    }
+}
+
+#[cfg(feature = "rhai")]
+impl<E> SurrealTableShell<E>
+where
+    E: Entity<AnySurrealType> + 'static,
+{
+    /// Build a reference's traversal target by evaluating its Rhai
+    /// `build_script`. The conventional `Vista` vocabulary plus SurrealDB's
+    /// vendor extensions are registered onto a fresh engine; `table(name)`
+    /// resolves a fresh target through the shell's spec resolver, and the parent
+    /// `row` is exposed to the script.
+    fn get_ref_via_script(&self, script: &str, row: &Record<CborValue>) -> Result<Vista> {
+        use vantage_vista::VistaFactory;
+
+        let db = self.table.data_source().clone();
+        let resolver = self.resolver.clone();
+        let target_resolver: vantage_vista::TargetResolver = std::sync::Arc::new(move |name| {
+            let resolver = resolver.as_ref().ok_or_else(|| {
+                error!("scripted reference traversal requires a spec resolver on the factory")
+            })?;
+            let spec = resolver(name)
+                .ok_or_else(|| error!("scripted reference traversal: unknown table", table = name))?;
+            SurrealVistaFactory::new(db.clone())
+                .with_resolver(resolver.clone())
+                .build_from_spec(spec)
+        });
+
+        // Vendor vocab first, conventional second: this makes the conventional
+        // `table(name) -> Vista` win over SurrealDB's `table` alias for `ident`
+        // (which stays reachable as `ident(...)`), so a build-script's
+        // `table("order")` resolves a Vista rather than an identifier.
+        let mut engine = rhai::Engine::new();
+        self.register_rhai_extensions(&mut engine);
+        vantage_vista::register_conventional_onto(&mut engine, target_resolver);
+        vantage_vista::eval_ref_script(&engine, script, row)
     }
 }

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -230,10 +230,7 @@ where
     /// value must be a SurrealDB [`crate::Expr`] (`Expression<AnySurrealType>`,
     /// the table's `Condition` type) — the type a Rhai `with_condition(...)`
     /// expression lowers to. Used by scripted reference traversal.
-    fn add_raw_condition(
-        &mut self,
-        condition: Box<dyn std::any::Any + Send + Sync>,
-    ) -> Result<()> {
+    fn add_raw_condition(&mut self, condition: Box<dyn std::any::Any + Send + Sync>) -> Result<()> {
         let condition = condition.downcast::<crate::Expr>().map_err(|_| {
             error!(
                 "add_raw_condition expected a SurrealDB Expression<AnySurrealType>",
@@ -464,8 +461,9 @@ where
             let resolver = resolver.as_ref().ok_or_else(|| {
                 error!("scripted reference traversal requires a spec resolver on the factory")
             })?;
-            let spec = resolver(name)
-                .ok_or_else(|| error!("scripted reference traversal: unknown table", table = name))?;
+            let spec = resolver(name).ok_or_else(|| {
+                error!("scripted reference traversal: unknown table", table = name)
+            })?;
             SurrealVistaFactory::new(db.clone())
                 .with_resolver(resolver.clone())
                 .build_from_spec(spec)

--- a/vantage-surrealdb/src/vista/spec.rs
+++ b/vantage-surrealdb/src/vista/spec.rs
@@ -1,7 +1,7 @@
 //! YAML-facing types for the SurrealDB Vista driver.
 
 use serde::{Deserialize, Serialize};
-use vantage_vista::{NoExtras, VistaSpec};
+use vantage_vista::VistaSpec;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -35,6 +35,14 @@ pub struct SurrealTableBlock {
     /// alongside `base`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inherit: Option<InheritBlock>,
+    /// A Rhai script applied to the *built* vista as a final step, after the
+    /// YAML table (columns/references/source) is constructed. The vista is
+    /// exposed as `self`; the script narrows or tweaks it with the conventional
+    /// verbs plus vendor expression conditions YAML can't express, e.g.
+    /// `self.with_condition(ident("is_paying_client") == true)`. Composes with
+    /// `table`/`rhai`/`base` (it runs last). Requires the `rhai` feature.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modify: Option<String>,
 }
 
 /// Selects which parts of a `base` vista a derived vista inherits.
@@ -66,7 +74,30 @@ pub struct SurrealColumnBlock {
     pub field: Option<String>,
 }
 
-pub type SurrealVistaSpec = VistaSpec<SurrealTableExtras, SurrealColumnExtras, NoExtras>;
+/// Per-reference SurrealDB block. Mirrors [`SurrealTableExtras`]/
+/// [`SurrealColumnExtras`]: the vendor block nests under a `surreal:` key so it
+/// rides in `ReferenceSpec`'s flattened `driver` slot without colliding with the
+/// uniform `table`/`kind`/`foreign_key` keys.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SurrealReferenceExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub surreal: Option<SurrealRefBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SurrealRefBlock {
+    /// Rhai script that builds the traversal target for this reference, instead
+    /// of the default foreign-key eq-condition path. Evaluated lazily at
+    /// traversal time with the parent `row` in scope. Requires the `rhai`
+    /// feature; ignored by builds without it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rhai: Option<String>,
+}
+
+pub type SurrealVistaSpec =
+    VistaSpec<SurrealTableExtras, SurrealColumnExtras, SurrealReferenceExtras>;
 
 #[cfg(test)]
 mod tests {

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.5.4 — 2026-06-07
+
+### Added
+
+- Rhai-scripted reference traversal (escape hatch over the fixed foreign-key path). YAML
+  stays the primary table-definition format; a per-reference Rhai script is a targeted,
+  serializable override that builds the relationship's target `Vista` at traversal time.
+  Gated behind the new optional `rhai` feature.
+  - `Reference::build_script: Option<String>` plus `Reference::with_build_script(..)`, carrying
+    the per-reference script lowered from the backend extras slot. Lazy: it only evaluates on
+    traversal, so self/cyclic relations cost nothing until walked.
+  - `VistaCapabilities::can_build_ref_via_script` advertises the capability, mirroring the
+    `can_traverse_to_set` precedent.
+  - `TableShell::register_rhai_extensions(&self, &mut rhai::Engine)` — default no-op hook
+    backends override to contribute vendor vocabulary (expression syntax, `with_condition`).
+  - New `rhai_conventional` module owns the engine with a *conventional, uniform* vocabulary
+    over the type-erased `Vista` (`table`, `with_id`, `add_condition_eq`, `add_order`,
+    `add_search`, `set_page_size`, `get_ref`), so any datasource — even engine-less ones —
+    supports the script vocabulary and only loses vendor expression syntax (graceful
+    degradation). Exposes `RhaiVista`, `TargetResolver`, `register_conventional_onto`,
+    `eval_ref_script`, and `eval_modify_script` (the last applies a script to an
+    already-built vista).
+
 ## 0.5.3 — 2026-06-06
 
 ### Removed

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"
@@ -21,6 +21,14 @@ futures-core = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"
 thiserror = "2.0"
+rhai = { version = "1.25", optional = true }
+
+[features]
+# Conventional Rhai vocabulary over the type-erased `Vista` (the engine and
+# builder verbs that back scripted reference traversal). Backends opt in and
+# layer their vendor-specific expression vocabulary on top via
+# `TableShell::register_rhai_extensions`.
+rhai = ["dep:rhai"]
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }

--- a/vantage-vista/src/capabilities.rs
+++ b/vantage-vista/src/capabilities.rs
@@ -46,4 +46,11 @@ pub struct VistaCapabilities {
     /// `get_ref_as` / reports path). Requires the backend to support
     /// subqueries; SQL and SurrealDB do, CSV/Mongo/REST do not.
     pub can_traverse_to_set: bool,
+    /// Per-reference Rhai-scripted traversal — a reference carrying a
+    /// `build_script` resolves through the script engine
+    /// ([`TableShell::register_rhai_extensions`](crate::TableShell::register_rhai_extensions))
+    /// rather than the fixed FK eq-condition path. Backends with a script
+    /// engine *and* a by-name target resolver advertise `true`; others leave
+    /// it `false` and ignore any `build_script` (the FK path still works).
+    pub can_build_ref_via_script: bool,
 }

--- a/vantage-vista/src/capabilities.rs
+++ b/vantage-vista/src/capabilities.rs
@@ -47,9 +47,9 @@ pub struct VistaCapabilities {
     /// subqueries; SQL and SurrealDB do, CSV/Mongo/REST do not.
     pub can_traverse_to_set: bool,
     /// Per-reference Rhai-scripted traversal — a reference carrying a
-    /// `build_script` resolves through the script engine
-    /// ([`TableShell::register_rhai_extensions`](crate::TableShell::register_rhai_extensions))
-    /// rather than the fixed FK eq-condition path. Backends with a script
+    /// `build_script` resolves through the script engine (the
+    /// `TableShell::register_rhai_extensions` hook, available with the `rhai`
+    /// feature) rather than the fixed FK eq-condition path. Backends with a script
     /// engine *and* a by-name target resolver advertise `true`; others leave
     /// it `false` and ignore any `build_script` (the FK path still works).
     pub can_build_ref_via_script: bool,

--- a/vantage-vista/src/lib.rs
+++ b/vantage-vista/src/lib.rs
@@ -11,6 +11,8 @@ pub mod insert;
 pub mod metadata;
 pub mod mocks;
 pub mod reference;
+#[cfg(feature = "rhai")]
+pub mod rhai_conventional;
 pub mod sort;
 pub mod source;
 pub mod spec;
@@ -25,6 +27,10 @@ pub use contained::{
 pub use factory::VistaFactory;
 pub use metadata::VistaMetadata;
 pub use reference::{ContainedKind, ContainedSpec, Reference, ReferenceKind};
+#[cfg(feature = "rhai")]
+pub use rhai_conventional::{
+    RhaiVista, TargetResolver, eval_modify_script, eval_ref_script, register_conventional_onto,
+};
 pub use sort::SortDirection;
 pub use source::TableShell;
 pub use spec::{

--- a/vantage-vista/src/reference.rs
+++ b/vantage-vista/src/reference.rs
@@ -10,8 +10,9 @@ pub struct Reference {
     pub foreign_key: String,
     /// Optional Rhai script that *builds* the traversal target itself, in place
     /// of the default foreign-key eq-condition path. Evaluated lazily at
-    /// traversal time with the parent `row` in scope (see
-    /// [`crate::rhai_conventional`]). `None` keeps the conventional FK path.
+    /// traversal time with the parent `row` in scope (see the
+    /// `rhai_conventional` module, available with the `rhai` feature). `None`
+    /// keeps the conventional FK path.
     /// Lowered from the per-reference YAML extras slot by each backend factory.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build_script: Option<String>,

--- a/vantage-vista/src/reference.rs
+++ b/vantage-vista/src/reference.rs
@@ -8,6 +8,13 @@ pub struct Reference {
     pub target: String,
     pub kind: ReferenceKind,
     pub foreign_key: String,
+    /// Optional Rhai script that *builds* the traversal target itself, in place
+    /// of the default foreign-key eq-condition path. Evaluated lazily at
+    /// traversal time with the parent `row` in scope (see
+    /// [`crate::rhai_conventional`]). `None` keeps the conventional FK path.
+    /// Lowered from the per-reference YAML extras slot by each backend factory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_script: Option<String>,
 }
 
 /// Schema for a **contained** relation — records embedded in a column of the
@@ -73,7 +80,16 @@ impl Reference {
             target: target.into(),
             kind,
             foreign_key: foreign_key.into(),
+            build_script: None,
         }
+    }
+
+    /// Attach a Rhai build script that constructs the traversal target,
+    /// overriding the default foreign-key eq-condition path. See
+    /// [`build_script`](Self::build_script).
+    pub fn with_build_script(mut self, script: impl Into<String>) -> Self {
+        self.build_script = Some(script.into());
+        self
     }
 }
 

--- a/vantage-vista/src/rhai_conventional.rs
+++ b/vantage-vista/src/rhai_conventional.rs
@@ -1,0 +1,440 @@
+//! Conventional Rhai vocabulary over the type-erased [`Vista`].
+//!
+//! vantage-vista owns Rhai engine construction with a *backend-agnostic*
+//! vocabulary: `table(name)` resolves a fresh target [`Vista`] through an
+//! injected [`TargetResolver`], and a small set of builder verbs narrow it in
+//! place. Backends layer their vendor-specific vocabulary (expression syntax,
+//! `with_condition`) on top by overriding
+//! [`TableShell::register_rhai_extensions`](crate::TableShell::register_rhai_extensions).
+//!
+//! This keeps Rhai out of vantage-table and lets engine-less datasources
+//! (CSV/Mongo/REST) still script the conventional verbs — they only lose the
+//! vendor expression syntax. Graceful degradation, not all-or-nothing.
+//!
+//! Everything here uses only [`Vista`]'s public API, preserving the one-way
+//! `vantage-table → vantage-vista` dependency (Rhai is a leaf).
+
+use std::sync::{Arc, Mutex};
+
+use ciborium::Value as CborValue;
+use rhai::{Dynamic, Engine, EvalAltResult, Map as RhaiMap, Scope};
+use vantage_core::{Result, error};
+use vantage_types::Record;
+
+use crate::{sort::SortDirection, vista::Vista};
+
+/// A [`Vista`] handle usable from Rhai: `Clone + Send + Sync + 'static` via
+/// `Arc<Mutex<…>>`, with interior mutability so the builder verbs narrow it in
+/// place and return the same handle for chaining. The inner `Option` lets
+/// [`eval_ref_script`] move the finished `Vista` out even if the script kept
+/// extra references.
+///
+/// `Arc<Mutex<…>>` (not `Rc<RefCell<…>>`) so the type satisfies Rhai's
+/// `Send + Sync` bound when a consumer compiles Rhai with its `sync` feature —
+/// `Vista` is itself `Send + Sync` (its `TableShell` is), so nothing is lost.
+#[derive(Clone)]
+pub struct RhaiVista(pub Arc<Mutex<Option<Vista>>>);
+
+impl RhaiVista {
+    /// Wrap a `Vista` for use inside a script.
+    pub fn wrap(vista: Vista) -> Self {
+        RhaiVista(Arc::new(Mutex::new(Some(vista))))
+    }
+
+    /// Apply an in-place mutation to the wrapped `Vista` and return the same
+    /// handle for chaining. Backends call this from
+    /// [`TableShell::register_rhai_extensions`](crate::TableShell::register_rhai_extensions)
+    /// to add vendor verbs (e.g. `with_condition`) without re-deriving the
+    /// borrow/`Option` bookkeeping.
+    pub fn apply<F>(&self, f: F) -> std::result::Result<RhaiVista, Box<EvalAltResult>>
+    where
+        F: FnOnce(&mut Vista) -> Result<()>,
+    {
+        with_inner(self, f)
+    }
+}
+
+/// Resolve a table name to a fresh, unconditioned target [`Vista`]. Injected by
+/// the backend, which owns the by-name catalog; vantage-vista stays
+/// backend-agnostic behind this boxed closure.
+pub type TargetResolver = Arc<dyn Fn(&str) -> Result<Vista> + Send + Sync>;
+
+/// Register the conventional `Vista` vocabulary onto `engine`.
+///
+/// Adds the `table(name)` constructor (backed by `resolver`) and the in-place
+/// builder verbs (`with_id`, `add_condition_eq`, `add_order`, `add_search`,
+/// `set_page_size`, `get_ref`). Each verb returns the same handle so scripts can
+/// chain: `table("order").add_condition_eq("client", row.id).add_order("date", "desc")`.
+pub fn register_conventional_onto(engine: &mut Engine, resolver: TargetResolver) {
+    engine.register_type_with_name::<RhaiVista>("Vista");
+
+    engine.register_fn(
+        "table",
+        move |name: &str| -> std::result::Result<RhaiVista, Box<EvalAltResult>> {
+            let vista = resolver(name).map_err(to_rhai_err)?;
+            Ok(RhaiVista::wrap(vista))
+        },
+    );
+
+    engine.register_fn(
+        "with_id",
+        |v: &mut RhaiVista, id: Dynamic| -> std::result::Result<RhaiVista, Box<EvalAltResult>> {
+            let cbor = dynamic_to_cbor(id)?;
+            with_inner(v, |vista| vista.with_id(cbor).map(|_| ()))
+        },
+    );
+
+    engine.register_fn(
+        "add_condition_eq",
+        |v: &mut RhaiVista,
+         field: &str,
+         value: Dynamic|
+         -> std::result::Result<RhaiVista, Box<EvalAltResult>> {
+            let cbor = dynamic_to_cbor(value)?;
+            let field = field.to_string();
+            with_inner(v, move |vista| vista.add_condition_eq(field, cbor))
+        },
+    );
+
+    engine.register_fn(
+        "add_order",
+        |v: &mut RhaiVista,
+         column: &str,
+         dir: &str|
+         -> std::result::Result<RhaiVista, Box<EvalAltResult>> {
+            let direction = parse_dir(dir)?;
+            let column = column.to_string();
+            with_inner(v, move |vista| vista.add_order(&column, direction))
+        },
+    );
+
+    // Single-arg form defaults to ascending.
+    engine.register_fn(
+        "add_order",
+        |v: &mut RhaiVista, column: &str| -> std::result::Result<RhaiVista, Box<EvalAltResult>> {
+            let column = column.to_string();
+            with_inner(v, move |vista| {
+                vista.add_order(&column, SortDirection::Ascending)
+            })
+        },
+    );
+
+    engine.register_fn(
+        "add_search",
+        |v: &mut RhaiVista, text: &str| -> std::result::Result<RhaiVista, Box<EvalAltResult>> {
+            let text = text.to_string();
+            with_inner(v, move |vista| vista.add_search(text))
+        },
+    );
+
+    engine.register_fn(
+        "set_page_size",
+        |v: &mut RhaiVista, size: i64| -> std::result::Result<RhaiVista, Box<EvalAltResult>> {
+            if size <= 0 {
+                return Err("set_page_size: page size must be > 0".into());
+            }
+            with_inner(v, move |vista| vista.set_page_size(size as usize))
+        },
+    );
+
+    engine.register_fn(
+        "get_ref",
+        |v: &mut RhaiVista,
+         relation: &str,
+         row: RhaiMap|
+         -> std::result::Result<RhaiVista, Box<EvalAltResult>> {
+            let record = map_to_record(row)?;
+            let guard = lock(v)?;
+            let vista = guard
+                .as_ref()
+                .ok_or_else(|| Box::<EvalAltResult>::from("get_ref: vista already consumed"))?;
+            let target = vista.get_ref(relation, &record).map_err(to_rhai_err)?;
+            Ok(RhaiVista::wrap(target))
+        },
+    );
+}
+
+/// Evaluate a reference build-script and return the `Vista` it produced.
+///
+/// `engine` must already have the conventional vocabulary (via
+/// [`register_conventional_onto`]) plus any vendor extensions registered. The
+/// parent `row` is exposed to the script as the `row` map. The script's final
+/// expression must evaluate to a `Vista` (e.g. `table("order").add_…(…)`).
+pub fn eval_ref_script(engine: &Engine, code: &str, row: &Record<CborValue>) -> Result<Vista> {
+    let mut scope = Scope::new();
+    scope.push_dynamic("row", record_to_dynamic(row));
+
+    let result: RhaiVista = engine
+        .eval_with_scope(&mut scope, code)
+        .map_err(|e| error!(format!("rhai reference build-script failed: {e}")))?;
+
+    result
+        .0
+        .lock()
+        .map_err(|_| error!("rhai reference build-script: result mutex poisoned"))?
+        .take()
+        .ok_or_else(|| error!("rhai reference build-script did not return a Vista"))
+}
+
+/// Evaluate a *modify* script against an already-built [`Vista`], applying extra
+/// modifications in place and returning it. The vista is exposed to the script
+/// as `self`.
+///
+/// Unlike [`eval_ref_script`] (which *builds* a target and returns it), this
+/// runs the script for its side effects on `self` and ignores the script's
+/// return value — the canonical "the YAML built the table, now a sneaky Rhai
+/// tweak narrows it" use-case:
+///
+/// ```rhai
+/// self.with_condition(ident("is_paying_client") == true)
+/// ```
+///
+/// `engine` must already carry the conventional vocabulary (via
+/// [`register_conventional_onto`]) plus any vendor extensions.
+pub fn eval_modify_script(engine: &Engine, code: &str, vista: Vista) -> Result<Vista> {
+    let handle = RhaiVista::wrap(vista);
+    let mut scope = Scope::new();
+    scope.push("self", handle.clone());
+
+    engine
+        .run_with_scope(&mut scope, code)
+        .map_err(|e| error!(format!("rhai modify script failed: {e}")))?;
+
+    // `take()` succeeds regardless of the scope's lingering `Arc` clone — it
+    // empties the shared `Option`, not the `Arc`.
+    handle
+        .0
+        .lock()
+        .map_err(|_| error!("rhai modify script: result mutex poisoned"))?
+        .take()
+        .ok_or_else(|| error!("rhai modify script consumed `self`"))
+}
+
+// ---- helpers --------------------------------------------------------------
+
+type Guard<'a> = std::sync::MutexGuard<'a, Option<Vista>>;
+
+fn lock(v: &RhaiVista) -> std::result::Result<Guard<'_>, Box<EvalAltResult>> {
+    v.0.lock()
+        .map_err(|_| Box::<EvalAltResult>::from("RhaiVista mutex poisoned"))
+}
+
+/// Apply an in-place mutation to the wrapped `Vista` and return the same handle
+/// for chaining.
+fn with_inner<F>(v: &RhaiVista, f: F) -> std::result::Result<RhaiVista, Box<EvalAltResult>>
+where
+    F: FnOnce(&mut Vista) -> Result<()>,
+{
+    {
+        let mut guard = lock(v)?;
+        let vista = guard
+            .as_mut()
+            .ok_or_else(|| Box::<EvalAltResult>::from("vista already consumed in script"))?;
+        f(vista).map_err(to_rhai_err)?;
+    }
+    Ok(v.clone())
+}
+
+fn parse_dir(dir: &str) -> std::result::Result<SortDirection, Box<EvalAltResult>> {
+    match dir.to_ascii_lowercase().as_str() {
+        "asc" | "ascending" => Ok(SortDirection::Ascending),
+        "desc" | "descending" => Ok(SortDirection::Descending),
+        other => Err(format!("invalid sort direction '{other}' (expected 'asc' or 'desc')").into()),
+    }
+}
+
+fn to_rhai_err(e: vantage_core::VantageError) -> Box<EvalAltResult> {
+    Box::<EvalAltResult>::from(e.to_string())
+}
+
+/// Convert a scalar Rhai value into the universal CBOR carrier.
+fn dynamic_to_cbor(d: Dynamic) -> std::result::Result<CborValue, Box<EvalAltResult>> {
+    if d.is_unit() {
+        Ok(CborValue::Null)
+    } else if d.is::<bool>() {
+        Ok(CborValue::Bool(d.cast::<bool>()))
+    } else if d.is::<i64>() {
+        Ok(CborValue::Integer(d.cast::<i64>().into()))
+    } else if d.is::<f64>() {
+        Ok(CborValue::Float(d.cast::<f64>()))
+    } else if d.is::<String>() {
+        Ok(CborValue::Text(d.cast::<String>()))
+    } else {
+        Err(format!(
+            "cannot convert rhai value of type '{}' into a condition value",
+            d.type_name()
+        )
+        .into())
+    }
+}
+
+/// Convert a CBOR value into a Rhai `Dynamic` (used when seeding the parent
+/// `row` map for the script).
+fn cbor_to_dynamic(v: &CborValue) -> Dynamic {
+    match v {
+        CborValue::Null => Dynamic::UNIT,
+        CborValue::Bool(b) => Dynamic::from_bool(*b),
+        CborValue::Integer(i) => {
+            let n: i128 = (*i).into();
+            Dynamic::from_int(n as i64)
+        }
+        CborValue::Float(f) => Dynamic::from_float(*f),
+        CborValue::Text(s) => Dynamic::from(s.clone()),
+        CborValue::Bytes(b) => Dynamic::from_blob(b.clone()),
+        CborValue::Array(a) => {
+            let arr: rhai::Array = a.iter().map(cbor_to_dynamic).collect();
+            Dynamic::from_array(arr)
+        }
+        CborValue::Map(m) => {
+            let mut map = RhaiMap::new();
+            for (k, val) in m {
+                if let CborValue::Text(key) = k {
+                    map.insert(key.as_str().into(), cbor_to_dynamic(val));
+                }
+            }
+            Dynamic::from_map(map)
+        }
+        // ciborium::Value is non-exhaustive (tags, etc.); unknowns become unit.
+        _ => Dynamic::UNIT,
+    }
+}
+
+fn record_to_dynamic(row: &Record<CborValue>) -> Dynamic {
+    let mut map = RhaiMap::new();
+    for (k, v) in row.iter() {
+        map.insert(k.as_str().into(), cbor_to_dynamic(v));
+    }
+    Dynamic::from_map(map)
+}
+
+fn map_to_record(map: RhaiMap) -> std::result::Result<Record<CborValue>, Box<EvalAltResult>> {
+    let mut out: Vec<(String, CborValue)> = Vec::with_capacity(map.len());
+    for (k, v) in map {
+        out.push((k.to_string(), dynamic_to_cbor(v)?));
+    }
+    Ok(out.into_iter().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Column, VistaMetadata, mocks::MockShell};
+    use vantage_dataset::ReadableValueSet;
+
+    fn cbor_text(s: &str) -> CborValue {
+        CborValue::Text(s.into())
+    }
+
+    fn record(pairs: &[(&str, CborValue)]) -> Record<CborValue> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect()
+    }
+
+    /// Fresh `users` Vista with three seeded rows (two VIPs). Built anew on each
+    /// call so the resolver hands out an unconditioned target every time.
+    fn users_vista() -> Vista {
+        let source = MockShell::new()
+            .with_record(
+                "1",
+                record(&[
+                    ("id", cbor_text("1")),
+                    ("name", cbor_text("Alice")),
+                    ("vip_flag", CborValue::Bool(true)),
+                ]),
+            )
+            .with_record(
+                "2",
+                record(&[
+                    ("id", cbor_text("2")),
+                    ("name", cbor_text("Bob")),
+                    ("vip_flag", CborValue::Bool(false)),
+                ]),
+            )
+            .with_record(
+                "3",
+                record(&[
+                    ("id", cbor_text("3")),
+                    ("name", cbor_text("Carol")),
+                    ("vip_flag", CborValue::Bool(true)),
+                ]),
+            );
+        let metadata = VistaMetadata::new()
+            .with_column(Column::new("id", "String").with_flag("id"))
+            .with_column(Column::new("name", "String").with_flag("title"))
+            .with_column(Column::new("vip_flag", "bool"))
+            .with_id_column("id");
+        Vista::new("users", Box::new(source.with_metadata(metadata)))
+    }
+
+    fn engine() -> Engine {
+        let resolver: TargetResolver = Arc::new(|name: &str| {
+            if name == "users" {
+                Ok(users_vista())
+            } else {
+                Err(error!("unknown table in test resolver", table = name))
+            }
+        });
+        let mut engine = Engine::new();
+        register_conventional_onto(&mut engine, resolver);
+        engine
+    }
+
+    #[tokio::test]
+    async fn script_narrows_target_with_literal_condition() {
+        let row = record(&[("id", cbor_text("1"))]);
+        let vista = eval_ref_script(
+            &engine(),
+            r#"table("users").add_condition_eq("vip_flag", true)"#,
+            &row,
+        )
+        .unwrap();
+
+        let rows = vista.list_values().await.unwrap();
+        assert_eq!(rows.len(), 2, "only the two VIP rows should survive");
+        assert!(rows.contains_key("1") && rows.contains_key("3"));
+    }
+
+    #[tokio::test]
+    async fn script_can_read_the_parent_row() {
+        let row = record(&[("id", cbor_text("3"))]);
+        let vista = eval_ref_script(
+            &engine(),
+            r#"table("users").add_condition_eq("id", row.id)"#,
+            &row,
+        )
+        .unwrap();
+
+        let rows = vista.list_values().await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows["3"].get("name"), Some(&cbor_text("Carol")));
+    }
+
+    #[tokio::test]
+    async fn modify_script_tweaks_an_existing_vista() {
+        // The YAML built `users`; a post-build modify script narrows it in place
+        // via `self`, with no parent row in scope.
+        let vista = users_vista();
+        let modified = eval_modify_script(
+            &engine(),
+            r#"self.add_condition_eq("vip_flag", true)"#,
+            vista,
+        )
+        .unwrap();
+
+        let rows = modified.list_values().await.unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.contains_key("1") && rows.contains_key("3"));
+    }
+
+    #[test]
+    fn unknown_table_surfaces_resolver_error() {
+        let row = record(&[]);
+        let err = match eval_ref_script(&engine(), r#"table("ghosts")"#, &row) {
+            Ok(_) => panic!("expected the resolver to reject an unknown table"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("unknown table"));
+    }
+}

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -365,7 +365,7 @@ pub trait TableShell: Send + Sync + 'static {
 
     /// Contribute backend-specific vocabulary to a Rhai engine that
     /// vantage-vista has already seeded with the conventional `Vista` verbs
-    /// (see [`crate::rhai_conventional`]). Backends with an expression engine
+    /// (see the `rhai_conventional` module). Backends with an expression engine
     /// (SurrealDB, SQL) override this to register `ident`/`==`/`fx`/graph
     /// constructors plus a `with_condition(<backend expr>)` builder that routes
     /// a boxed native condition through [`add_raw_condition`](Self::add_raw_condition).

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -361,6 +361,21 @@ pub trait TableShell: Send + Sync + 'static {
         "unknown"
     }
 
+    // ---- Scripting ---------------------------------------------------------
+
+    /// Contribute backend-specific vocabulary to a Rhai engine that
+    /// vantage-vista has already seeded with the conventional `Vista` verbs
+    /// (see [`crate::rhai_conventional`]). Backends with an expression engine
+    /// (SurrealDB, SQL) override this to register `ident`/`==`/`fx`/graph
+    /// constructors plus a `with_condition(<backend expr>)` builder that routes
+    /// a boxed native condition through [`add_raw_condition`](Self::add_raw_condition).
+    ///
+    /// Default is a no-op: engine-less datasources (CSV/Mongo/REST) still get
+    /// the conventional verbs and only lose the vendor expression syntax —
+    /// graceful degradation, not all-or-nothing.
+    #[cfg(feature = "rhai")]
+    fn register_rhai_extensions(&self, _engine: &mut rhai::Engine) {}
+
     // ---- Capability advertisement -----------------------------------------
 
     fn capabilities(&self) -> &VistaCapabilities;
@@ -382,6 +397,9 @@ pub trait TableShell: Send + Sync + 'static {
             "can_set_page_size" => caps.can_set_page_size,
             "can_fetch_page" => caps.can_fetch_page,
             "can_fetch_next" => caps.can_fetch_next,
+            "can_traverse_to_record" => caps.can_traverse_to_record,
+            "can_traverse_to_set" => caps.can_traverse_to_set,
+            "can_build_ref_via_script" => caps.can_build_ref_via_script,
             _ => false,
         }
     }


### PR DESCRIPTION
## What

Adds a serializable **escape hatch** for Vista relationship traversal: a per-reference Rhai script that builds the relationship's target table itself — conditions (including vendor expressions YAML can't represent), order, search, further drill-downs — evaluated lazily at traversal time with the parent `row` in scope. Plus a post-build `modify` script that tweaks an already-built vista.

YAML stays the primary table-definition format. Rhai is a targeted override, gated behind a new optional `rhai` feature; builds without it degrade gracefully.

## How it works

Engine ownership lives in `vantage-vista`, which registers a **conventional, uniform** vocabulary over the type-erased `Vista` (`table`, `with_id`, `add_condition_eq`, `add_order`, `add_search`, `set_page_size`, `get_ref`). So any datasource — even an engine-less one — supports the script vocabulary; it only loses vendor expression syntax.

Backends contribute vendor vocabulary through a default-no-op hook `TableShell::register_rhai_extensions(&mut Engine)`. SurrealDB overrides it to register expression syntax (`ident(..) == ..`) and a `with_condition(<expr>)` builtin that routes a boxed backend-native condition through the type-erased `add_raw_condition` path — `vantage-vista` never sees the backend types.

```
references:
  orders:
    table: order
    kind: has_many
    rhai: |
      table("order").add_condition_eq("client", row.id)
```

## Crates

- **vantage-vista 0.5.4** — `rhai` feature; `Reference::build_script` + `with_build_script`; `VistaCapabilities::can_build_ref_via_script`; `register_rhai_extensions` hook; new `rhai_conventional` module (`RhaiVista`, `TargetResolver`, `register_conventional_onto`, `eval_ref_script`, `eval_modify_script`).
- **vantage-surrealdb 0.5.9** — per-reference `surreal: { rhai }` and table `surreal: { modify }`; `register_rhai_extensions` / `with_condition` / `add_raw_condition`; `register_surreal_onto` extraction. `rhai` now implies `vista` + `vantage-vista/rhai`.
- **vantage-sql 0.5.9** — `register_engine!` split to also generate `__register_engine_onto`; no behavior change (prepares SQL for later enablement).
- **vantage-diorama 0.5.5** — passes `can_build_ref_via_script` through the Dio cache shell.

## Tests

- `vantage-vista` conventional-engine unit tests (literal condition, parent-row read, modify, resolver error).
- `vantage-surrealdb` factory tests: `scripted_reference_builds_target_via_rhai`, `scripted_reference_routes_vendor_condition`, `modify_script_tweaks_built_vista_with_vendor_condition`.
- Default (no-rhai) workspace build verified for graceful degradation; existing engine call sites unchanged.