### PR TITLE
Release vantage-diorama 0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 0.5.5 — 2026-06-07
+## 0.5.6 — 2026-06-07
 
 - Pass the new `VistaCapabilities::can_build_ref_via_script` flag through the `Dio` cache
   shell, so a scripted-reference-capable master Vista keeps advertising the capability when
-  wrapped for caching. Tracks `vantage-vista` 0.5.4.
+  wrapped for caching. Tracks `vantage-vista` 0.5.4. (Version 0.5.5 was already on crates.io
+  without this change; 0.5.6 is the release that actually ships it.)
 
 ## 0.5.4 — 2026-06-02
 

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"


### PR DESCRIPTION
crates.io vantage-diorama 0.5.5 predates PR #284, so the publish of the can_build_ref_via_script passthrough silently no-op'd — the registry's 0.5.5 does not compile against vantage-vista 0.5.4 (missing field in the VistaCapabilities initializer). This bumps to 0.5.6 so the change actually ships.

- vantage-diorama 0.5.5 -> 0.5.6
- Changelog entry relabeled to 0.5.6 with a note about the skipped version
- No code change beyond the version bump; the passthrough landed in #284