### PR TITLE
Two-pass progressive loading + cmd detail scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cmd"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4693,6 +4693,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "tokio",
+ "tracing",
  "vantage-core",
  "vantage-dataset",
  "vantage-expressions",
@@ -4757,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4992,7 +4993,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1946,7 +1946,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2342,6 +2342,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+dependencies = [
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -3035,9 +3044,11 @@ checksum = "dd4dd0f8c36625202a4ba553c416c19b719947cd2a31d1bda06126e4a5727daf"
 dependencies = [
  "ahash 0.8.12",
  "bitflags",
+ "no-std-compat",
  "num-traits",
  "once_cell",
  "rhai_codegen",
+ "serde",
  "smallvec",
  "smartstring",
  "thin-vec",
@@ -3547,6 +3558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
 dependencies = [
  "autocfg",
+ "serde",
  "static_assertions",
  "version_check",
 ]
@@ -3566,6 +3578,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -4018,6 +4036,9 @@ name = "thin-vec"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "thiserror"
@@ -4661,6 +4682,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "vantage-cmd"
+version = "0.5.1"
+dependencies = [
+ "async-trait",
+ "ciborium",
+ "indexmap",
+ "rhai",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "tokio",
+ "vantage-core",
+ "vantage-dataset",
+ "vantage-expressions",
+ "vantage-table",
+ "vantage-types",
+ "vantage-vista",
+]
+
+[[package]]
 name = "vantage-core"
 version = "0.5.0"
 dependencies = [
@@ -4731,6 +4772,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "vantage-cmd",
  "vantage-core",
  "vantage-csv",
  "vantage-dataset",

--- a/vantage-cmd/CHANGELOG.md
+++ b/vantage-cmd/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.2 — 2026-06-07
+
+- Reuse the rhai `Engine` and compiled `AST` across calls instead of rebuilding
+  and re-parsing per call (removes the N re-parses a per-row detail loop incurred).
+- Two-role scripts: a table can declare a `list` script (the default) and a
+  separate `detail` script. `get_table_value(id)` runs the detail script with the
+  id — and the cached list-pass row — injected into scope (`row` map in
+  `QueryContext`), so the detail script can read cheap columns already fetched.
+  `Vista::get_value` routes through the detail script; `get_table_value_with_row` /
+  `get_vista_value_with_row` feed the cached row down.
+- Surface child-process stderr into the tracing log (WARN on non-zero exit, DEBUG
+  otherwise) so tool diagnostics are visible to the host app.
+
 ## 0.5.1 — 2026-06-07
 
 - `Cmd::with_base_dir` — set a base directory for the data source. A relative

--- a/vantage-cmd/Cargo.lock
+++ b/vantage-cmd/Cargo.lock
@@ -1384,6 +1384,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "tokio",
+ "tracing",
  "vantage-cli-util",
  "vantage-core",
  "vantage-dataset",

--- a/vantage-cmd/Cargo.lock
+++ b/vantage-cmd/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cmd"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-cmd/Cargo.lock
+++ b/vantage-cmd/Cargo.lock
@@ -624,6 +624,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +873,7 @@ checksum = "dd4dd0f8c36625202a4ba553c416c19b719947cd2a31d1bda06126e4a5727daf"
 dependencies = [
  "ahash 0.8.12",
  "bitflags",
+ "no-std-compat",
  "num-traits",
  "once_cell",
  "rhai_codegen",
@@ -1094,6 +1104,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "static_assertions"
@@ -1357,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cmd"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/vantage-cmd/Cargo.toml
+++ b/vantage-cmd/Cargo.toml
@@ -36,6 +36,9 @@ async-trait = "0.1"
 # Universal value carrier across the type-erased Vista boundary.
 ciborium = "0.2"
 
+# Surface command stderr/exit into the host app's tracing log.
+tracing = "0.1"
+
 # The Rhai eval (including the synchronous subprocess call) runs on a
 # blocking thread so the async runtime is never blocked.
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/vantage-cmd/Cargo.toml
+++ b/vantage-cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-cmd"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-cmd/Cargo.toml
+++ b/vantage-cmd/Cargo.toml
@@ -25,7 +25,7 @@ vantage-vista = { version = "0.5", path = "../vantage-vista" }
 
 # Rhai builds the argv and parses the output. "serde" gives us the
 # serde_json::Value <-> Dynamic bridge used by `parse_json`.
-rhai = { version = "1.21", features = ["serde"] }
+rhai = { version = "1.21", features = ["serde", "sync"] }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/vantage-cmd/src/cmd.rs
+++ b/vantage-cmd/src/cmd.rs
@@ -1,11 +1,14 @@
 //! The [`Cmd`] datasource — a locked command, declared env, and a
 //! registry of per-table Rhai scripts.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use indexmap::IndexMap;
 use vantage_core::{Result, error};
+
+use crate::rhai_engine::CompiledScript;
 
 /// Per-table configuration registered on a [`Cmd`]: the Rhai script that
 /// builds the argv and parses the output, plus optional command / env
@@ -13,6 +16,12 @@ use vantage_core::{Result, error};
 #[derive(Clone, Debug)]
 pub struct CmdSpec {
     pub script: Arc<str>,
+    /// Optional per-row detail script. When set, the table loads in two
+    /// passes: `script` lists id stubs, and `detail` hydrates one record at
+    /// a time (with `id` in scope) via `get_value`. Both run the same locked
+    /// command — only the argv the script builds differs (e.g. gh's `runs`
+    /// vs `stats`). When `None`, the table is single-pass as before.
+    pub detail: Option<Arc<str>>,
     pub command: Option<String>,
     pub env: IndexMap<String, String>,
 }
@@ -21,9 +30,16 @@ impl CmdSpec {
     pub fn new(script: impl Into<Arc<str>>) -> Self {
         Self {
             script: script.into(),
+            detail: None,
             command: None,
             env: IndexMap::new(),
         }
+    }
+
+    /// Register a per-row detail script (opt into two-pass loading).
+    pub fn with_detail(mut self, detail: impl Into<Arc<str>>) -> Self {
+        self.detail = Some(detail.into());
+        self
     }
 
     /// Override the locked command for this table only.
@@ -45,13 +61,32 @@ impl CmdSpec {
 /// Cheap to clone (everything is `Arc`-backed). The `command` and `env`
 /// here are the locked defaults; individual tables can be registered with
 /// their own [`CmdSpec`] overrides via [`Cmd::with_table`].
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Cmd {
     command: Arc<str>,
     env: Arc<IndexMap<String, String>>,
     pass_path: bool,
     base_dir: Option<Arc<Path>>,
     scripts: Arc<IndexMap<String, CmdSpec>>,
+    /// Memoized compiled scripts, keyed by script name. Shared across
+    /// clones so a per-row detail loop reuses one engine + AST. Built
+    /// lazily on first use (see [`Cmd::compiled_script`]).
+    compiled: Arc<Mutex<HashMap<String, Arc<CompiledScript>>>>,
+    /// How many times each named script has actually been compiled —
+    /// diagnostics / test instrumentation for the reuse guarantee.
+    compile_counts: Arc<Mutex<HashMap<String, usize>>>,
+}
+
+impl std::fmt::Debug for Cmd {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Cmd")
+            .field("command", &self.command)
+            .field("env", &self.env)
+            .field("pass_path", &self.pass_path)
+            .field("base_dir", &self.base_dir)
+            .field("scripts", &self.scripts)
+            .finish()
+    }
 }
 
 impl Cmd {
@@ -63,6 +98,8 @@ impl Cmd {
             pass_path: true,
             base_dir: None,
             scripts: Arc::new(IndexMap::new()),
+            compiled: Arc::new(Mutex::new(HashMap::new())),
+            compile_counts: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -143,6 +180,77 @@ impl Cmd {
             env.insert(k.clone(), v.clone());
         }
         env
+    }
+
+    /// Get (building on first use) the compiled engine + AST for the named
+    /// table's list script. Reused across calls.
+    pub(crate) fn compiled_list_script(&self, name: &str) -> Result<Arc<CompiledScript>> {
+        let spec = self.spec_for(name)?.clone();
+        self.compiled_for(name.to_string(), &spec, &spec.script)
+    }
+
+    /// Get the compiled detail script for the named table, or `None` if the
+    /// table has no detail script (single-pass). Reused across calls so a
+    /// per-row detail loop pays the parse/registration cost once.
+    pub(crate) fn compiled_detail_script(&self, name: &str) -> Result<Option<Arc<CompiledScript>>> {
+        let spec = self.spec_for(name)?.clone();
+        let Some(detail) = spec.detail.clone() else {
+            return Ok(None);
+        };
+        Ok(Some(self.compiled_for(
+            format!("{name}::detail"),
+            &spec,
+            &detail,
+        )?))
+    }
+
+    /// Compile (once) and memoize a script under `cache_key`, using the
+    /// spec's effective command + env. Shared across `Cmd` clones.
+    fn compiled_for(
+        &self,
+        cache_key: String,
+        spec: &CmdSpec,
+        script: &str,
+    ) -> Result<Arc<CompiledScript>> {
+        let mut cache = self.compiled.lock().unwrap();
+        if let Some(existing) = cache.get(&cache_key) {
+            return Ok(existing.clone());
+        }
+        let command = self.effective_command(spec);
+        let env = self.effective_env(spec);
+        let compiled = Arc::new(CompiledScript::compile(
+            command,
+            env,
+            self.pass_path(),
+            self.base_dir(),
+            script,
+        )?);
+        *self
+            .compile_counts
+            .lock()
+            .unwrap()
+            .entry(cache_key.clone())
+            .or_insert(0) += 1;
+        cache.insert(cache_key, compiled.clone());
+        Ok(compiled)
+    }
+
+    /// True if the named table has a detail script (two-pass loading).
+    pub(crate) fn has_detail_script(&self, name: &str) -> bool {
+        self.spec_for(name)
+            .map(|s| s.detail.is_some())
+            .unwrap_or(false)
+    }
+
+    /// How many times the named script has been compiled. Reuse means this
+    /// stays at 1 no matter how many reads run.
+    pub fn compile_count(&self, name: &str) -> usize {
+        self.compile_counts
+            .lock()
+            .unwrap()
+            .get(name)
+            .copied()
+            .unwrap_or(0)
     }
 
     /// A Vista factory bound to this datasource.

--- a/vantage-cmd/src/rhai_engine.rs
+++ b/vantage-cmd/src/rhai_engine.rs
@@ -25,6 +25,9 @@ pub(crate) struct QueryContext {
     pub limit: Option<i64>,
     pub offset: Option<i64>,
     pub id_column: Option<String>,
+    /// The target id for a per-row detail fetch, seeded as the `id` scope
+    /// variable. `None` for list reads.
+    pub id: Option<String>,
 }
 
 fn runtime_err(msg: impl Into<String>) -> Box<EvalAltResult> {
@@ -42,87 +45,113 @@ fn dynamic_to_arg(d: Dynamic) -> String {
     }
 }
 
-/// Evaluate `script` with the locked `command` + declared `env` and the
-/// `ctx` variables in scope, returning the rows the script produced as
-/// JSON objects.
-pub(crate) fn eval_rows(
-    command: String,
-    env: IndexMap<String, String>,
-    pass_path: bool,
-    base_dir: Option<Arc<Path>>,
-    script: &str,
-    ctx: QueryContext,
-) -> Result<Vec<JsonValue>> {
-    let mut engine = Engine::new();
-    engine.set_max_expr_depths(256, 256);
+/// A rhai script with its `Engine` and parsed `AST` built once and reused
+/// for every evaluation. The locked `command`/`env` are baked into the
+/// engine's `run` binding at construction, so a [`CompiledScript`] is
+/// specific to one table's script + command + env.
+///
+/// Requires rhai's `sync` feature so `Engine`/`AST` are `Send + Sync` and
+/// the compiled script can be cached on the (clone-shared) [`Cmd`] and
+/// evaluated across `spawn_blocking` threads.
+pub(crate) struct CompiledScript {
+    engine: Engine,
+    ast: rhai::AST,
+}
 
-    // parse_json(string) -> Dynamic
-    engine.register_fn(
-        "parse_json",
-        |s: &str| -> std::result::Result<Dynamic, Box<EvalAltResult>> {
-            let v: JsonValue =
-                serde_json::from_str(s).map_err(|e| runtime_err(format!("parse_json: {e}")))?;
-            rhai::serde::to_dynamic(v)
-        },
-    );
+impl CompiledScript {
+    /// Build the engine (registering `run`/`parse_json`/`parse_jsonl`) and
+    /// compile `script` to an `AST`. Both are done once; [`eval`](Self::eval)
+    /// reuses them.
+    pub(crate) fn compile(
+        command: String,
+        env: IndexMap<String, String>,
+        pass_path: bool,
+        base_dir: Option<Arc<Path>>,
+        script: &str,
+    ) -> Result<Self> {
+        let mut engine = Engine::new();
+        engine.set_max_expr_depths(256, 256);
 
-    // parse_jsonl(string) -> array of Dynamic, one per non-empty line
-    engine.register_fn(
-        "parse_jsonl",
-        |s: &str| -> std::result::Result<Dynamic, Box<EvalAltResult>> {
-            let mut out = rhai::Array::new();
-            for line in s.lines().filter(|l| !l.trim().is_empty()) {
-                let v: JsonValue = serde_json::from_str(line)
-                    .map_err(|e| runtime_err(format!("parse_jsonl: {e}")))?;
-                out.push(rhai::serde::to_dynamic(v)?);
-            }
-            Ok(out.into())
-        },
-    );
+        // parse_json(string) -> Dynamic
+        engine.register_fn(
+            "parse_json",
+            |s: &str| -> std::result::Result<Dynamic, Box<EvalAltResult>> {
+                let v: JsonValue =
+                    serde_json::from_str(s).map_err(|e| runtime_err(format!("parse_json: {e}")))?;
+                rhai::serde::to_dynamic(v)
+            },
+        );
 
-    // run(args) -> #{ stdout, stderr, exit_code }. Command + env are
-    // captured here, NOT passed by the script — that's the security lock.
-    engine.register_fn(
-        "run",
-        move |args: rhai::Array| -> std::result::Result<Map, Box<EvalAltResult>> {
-            let argv: Vec<String> = args.into_iter().map(dynamic_to_arg).collect();
-            let out = run_command(&command, &argv, &env, pass_path, base_dir.as_deref())
-                .map_err(|e| runtime_err(e.to_string()))?;
-            let mut map = Map::new();
-            map.insert("stdout".into(), out.stdout.into());
-            map.insert("stderr".into(), out.stderr.into());
-            map.insert("exit_code".into(), (out.exit_code as i64).into());
-            Ok(map)
-        },
-    );
+        // parse_jsonl(string) -> array of Dynamic, one per non-empty line
+        engine.register_fn(
+            "parse_jsonl",
+            |s: &str| -> std::result::Result<Dynamic, Box<EvalAltResult>> {
+                let mut out = rhai::Array::new();
+                for line in s.lines().filter(|l| !l.trim().is_empty()) {
+                    let v: JsonValue = serde_json::from_str(line)
+                        .map_err(|e| runtime_err(format!("parse_jsonl: {e}")))?;
+                    out.push(rhai::serde::to_dynamic(v)?);
+                }
+                Ok(out.into())
+            },
+        );
 
-    let mut scope = Scope::new();
-    scope.push_dynamic("conditions", conditions_dynamic(&ctx.conditions)?);
-    scope.push_dynamic("columns", to_dynamic(&ctx.columns)?);
-    scope.push_dynamic("limit", opt_int(ctx.limit));
-    scope.push_dynamic("offset", opt_int(ctx.offset));
-    scope.push_dynamic("id_column", opt_string(ctx.id_column));
+        // run(args) -> #{ stdout, stderr, exit_code }. Command + env are
+        // captured here, NOT passed by the script — that's the security lock.
+        engine.register_fn(
+            "run",
+            move |args: rhai::Array| -> std::result::Result<Map, Box<EvalAltResult>> {
+                let argv: Vec<String> = args.into_iter().map(dynamic_to_arg).collect();
+                let out = run_command(&command, &argv, &env, pass_path, base_dir.as_deref())
+                    .map_err(|e| runtime_err(e.to_string()))?;
+                let mut map = Map::new();
+                map.insert("stdout".into(), out.stdout.into());
+                map.insert("stderr".into(), out.stderr.into());
+                map.insert("exit_code".into(), (out.exit_code as i64).into());
+                Ok(map)
+            },
+        );
 
-    let result: Dynamic = engine
-        .eval_with_scope(&mut scope, script)
-        .map_err(|e| error!("command rhai script failed", detail = e.to_string()))?;
+        let ast = engine
+            .compile(script)
+            .map_err(|e| error!("command rhai script failed to compile", detail = e.to_string()))?;
 
-    if !result.is_array() {
-        return Err(error!(
-            "command rhai script must return an array of rows",
-            got = result.type_name().to_string()
-        ));
+        Ok(Self { engine, ast })
     }
-    let arr = result
-        .into_array()
-        .map_err(|t| error!("expected array result", got = t.to_string()))?;
 
-    arr.into_iter()
-        .map(|row| {
-            serde_json::to_value(&row)
-                .map_err(|e| error!("failed to convert row to JSON", detail = e.to_string()))
-        })
-        .collect()
+    /// Evaluate the compiled script with the `ctx` variables seeded into a
+    /// fresh scope, returning the rows the script produced as JSON objects.
+    pub(crate) fn eval(&self, ctx: QueryContext) -> Result<Vec<JsonValue>> {
+        let mut scope = Scope::new();
+        scope.push_dynamic("conditions", conditions_dynamic(&ctx.conditions)?);
+        scope.push_dynamic("columns", to_dynamic(&ctx.columns)?);
+        scope.push_dynamic("limit", opt_int(ctx.limit));
+        scope.push_dynamic("offset", opt_int(ctx.offset));
+        scope.push_dynamic("id_column", opt_string(ctx.id_column));
+        scope.push_dynamic("id", opt_string(ctx.id));
+
+        let result: Dynamic = self
+            .engine
+            .eval_ast_with_scope(&mut scope, &self.ast)
+            .map_err(|e| error!("command rhai script failed", detail = e.to_string()))?;
+
+        if !result.is_array() {
+            return Err(error!(
+                "command rhai script must return an array of rows",
+                got = result.type_name().to_string()
+            ));
+        }
+        let arr = result
+            .into_array()
+            .map_err(|t| error!("expected array result", got = t.to_string()))?;
+
+        arr.into_iter()
+            .map(|row| {
+                serde_json::to_value(&row)
+                    .map_err(|e| error!("failed to convert row to JSON", detail = e.to_string()))
+            })
+            .collect()
+    }
 }
 
 fn opt_int(v: Option<i64>) -> Dynamic {

--- a/vantage-cmd/src/rhai_engine.rs
+++ b/vantage-cmd/src/rhai_engine.rs
@@ -139,9 +139,12 @@ impl CompiledScript {
             },
         );
 
-        let ast = engine
-            .compile(script)
-            .map_err(|e| error!("command rhai script failed to compile", detail = e.to_string()))?;
+        let ast = engine.compile(script).map_err(|e| {
+            error!(
+                "command rhai script failed to compile",
+                detail = e.to_string()
+            )
+        })?;
 
         Ok(Self { engine, ast })
     }

--- a/vantage-cmd/src/rhai_engine.rs
+++ b/vantage-cmd/src/rhai_engine.rs
@@ -28,6 +28,10 @@ pub(crate) struct QueryContext {
     /// The target id for a per-row detail fetch, seeded as the `id` scope
     /// variable. `None` for list reads.
     pub id: Option<String>,
+    /// The existing (list-pass) record for a detail fetch, seeded as the `row`
+    /// scope variable so the detail script can read cheap columns it carries.
+    /// An empty map for list reads and id-only detail reads.
+    pub row: ciborium::value::Value,
 }
 
 fn runtime_err(msg: impl Into<String>) -> Box<EvalAltResult> {
@@ -129,6 +133,7 @@ impl CompiledScript {
         scope.push_dynamic("offset", opt_int(ctx.offset));
         scope.push_dynamic("id_column", opt_string(ctx.id_column));
         scope.push_dynamic("id", opt_string(ctx.id));
+        scope.push_dynamic("row", to_dynamic(&ctx.row)?);
 
         let result: Dynamic = self
             .engine

--- a/vantage-cmd/src/rhai_engine.rs
+++ b/vantage-cmd/src/rhai_engine.rs
@@ -108,6 +108,29 @@ impl CompiledScript {
                 let argv: Vec<String> = args.into_iter().map(dynamic_to_arg).collect();
                 let out = run_command(&command, &argv, &env, pass_path, base_dir.as_deref())
                     .map_err(|e| runtime_err(e.to_string()))?;
+                // Surface the child's stderr into the host app's log so tool
+                // diagnostics (e.g. "stats requires both step lists", "HTTP
+                // 410") are visible. Non-zero exits log at WARN (visible by
+                // default); chatter on success logs at DEBUG.
+                let err = out.stderr.trim();
+                if !err.is_empty() {
+                    if out.exit_code != 0 {
+                        tracing::warn!(
+                            target: "vantage_cmd",
+                            command = %command,
+                            args = ?argv,
+                            exit_code = out.exit_code,
+                            "command stderr: {err}",
+                        );
+                    } else {
+                        tracing::debug!(
+                            target: "vantage_cmd",
+                            command = %command,
+                            args = ?argv,
+                            "command stderr: {err}",
+                        );
+                    }
+                }
                 let mut map = Map::new();
                 map.insert("stdout".into(), out.stdout.into());
                 map.insert("stderr".into(), out.stderr.into());

--- a/vantage-cmd/src/table_source.rs
+++ b/vantage-cmd/src/table_source.rs
@@ -28,8 +28,37 @@ use vantage_types::{Entity, Record};
 
 use crate::cmd::Cmd;
 use crate::condition::CmdCondition;
-use crate::rhai_engine::{QueryContext, eval_rows};
+use crate::rhai_engine::QueryContext;
 use crate::types::{cbor_to_string, json_to_cbor};
+
+/// Convert script-produced JSON rows into id-keyed records. The id comes
+/// from the `id_field` value on each row, falling back to the row index.
+fn rows_to_records(
+    rows: Vec<JsonValue>,
+    id_field: Option<&str>,
+) -> IndexMap<String, Record<CborValue>> {
+    let mut records: IndexMap<String, Record<CborValue>> = IndexMap::new();
+    for (idx, row) in rows.into_iter().enumerate() {
+        let mut record = Record::new();
+        match row {
+            JsonValue::Object(map) => {
+                for (k, v) in map {
+                    record.insert(k, json_to_cbor(&v));
+                }
+            }
+            other => {
+                record.insert("value".to_string(), json_to_cbor(&other));
+            }
+        }
+        let id = id_field
+            .and_then(|f| record.get(f))
+            .map(cbor_to_string)
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| idx.to_string());
+        records.insert(id, record);
+    }
+    records
+}
 
 #[async_trait]
 impl TableSource for Cmd {
@@ -100,12 +129,6 @@ impl TableSource for Cmd {
         Self: Sized,
     {
         let table_name = table.table_name().to_string();
-        let spec = self.spec_for(&table_name)?.clone();
-        let command = self.effective_command(&spec);
-        let env = self.effective_env(&spec);
-        let pass_path = self.pass_path();
-        let base_dir = self.base_dir();
-        let script = spec.script.clone();
 
         let id_field = table.id_field().map(|c| c.name().to_string());
 
@@ -142,35 +165,18 @@ impl TableSource for Cmd {
             limit,
             offset,
             id_column: id_field.clone(),
+            id: None,
         };
 
+        let cmd = self.clone();
         let rows: Vec<JsonValue> = tokio::task::spawn_blocking(move || {
-            eval_rows(command, env, pass_path, base_dir, &script, ctx)
+            let compiled = cmd.compiled_list_script(&table_name)?;
+            compiled.eval(ctx)
         })
         .await
         .map_err(|e| error!("command task failed to join", detail = e.to_string()))??;
 
-        let mut records: IndexMap<String, Record<CborValue>> = IndexMap::new();
-        for (idx, row) in rows.into_iter().enumerate() {
-            let mut record = Record::new();
-            match row {
-                JsonValue::Object(map) => {
-                    for (k, v) in map {
-                        record.insert(k, json_to_cbor(&v));
-                    }
-                }
-                other => {
-                    record.insert("value".to_string(), json_to_cbor(&other));
-                }
-            }
-            let id = id_field
-                .as_ref()
-                .and_then(|f| record.get(f))
-                .map(cbor_to_string)
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| idx.to_string());
-            records.insert(id, record);
-        }
+        let mut records = rows_to_records(rows, id_field.as_deref());
 
         // Client-side safety net: re-apply `Eq` conditions naming real
         // record fields. Fields the script consumed as request flags won't
@@ -197,6 +203,39 @@ impl TableSource for Cmd {
         E: Entity<Self::Value>,
         Self: Sized,
     {
+        let table_name = table.table_name().to_string();
+
+        // Two-pass tables hydrate one record at a time via the detail script
+        // (with `id` in scope) instead of re-listing every row.
+        if self.has_detail_script(&table_name) {
+            let id_field = table.id_field().map(|c| c.name().to_string());
+            let columns: Vec<String> = table.columns().keys().cloned().collect();
+            let ctx = QueryContext {
+                conditions: Vec::new(),
+                columns,
+                limit: None,
+                offset: None,
+                id_column: id_field.clone(),
+                id: Some(id.clone()),
+            };
+            let cmd = self.clone();
+            let name = table_name.clone();
+            let rows: Vec<JsonValue> = tokio::task::spawn_blocking(move || {
+                let compiled = cmd
+                    .compiled_detail_script(&name)?
+                    .ok_or_else(|| error!("detail script vanished"))?;
+                compiled.eval(ctx)
+            })
+            .await
+            .map_err(|e| error!("command task failed to join", detail = e.to_string()))??;
+
+            let mut records = rows_to_records(rows, id_field.as_deref());
+            // Prefer the row matching the requested id; else the first row.
+            return Ok(records
+                .shift_remove(id)
+                .or_else(|| records.into_iter().next().map(|(_, r)| r)));
+        }
+
         let mut all = self.list_table_values(table).await?;
         Ok(all.shift_remove(id))
     }

--- a/vantage-cmd/src/table_source.rs
+++ b/vantage-cmd/src/table_source.rs
@@ -166,6 +166,7 @@ impl TableSource for Cmd {
             offset,
             id_column: id_field.clone(),
             id: None,
+            row: ciborium::value::Value::Map(vec![]),
         };
 
         let cmd = self.clone();
@@ -217,6 +218,7 @@ impl TableSource for Cmd {
                 offset: None,
                 id_column: id_field.clone(),
                 id: Some(id.clone()),
+                row: ciborium::value::Value::Map(vec![]),
             };
             let cmd = self.clone();
             let name = table_name.clone();

--- a/vantage-cmd/src/table_source.rs
+++ b/vantage-cmd/src/table_source.rs
@@ -60,6 +60,61 @@ fn rows_to_records(
     records
 }
 
+impl Cmd {
+    /// Detail-script hydration for one id, with the existing list-pass `row`
+    /// injected into the script scope as `row`. Falls back to the normal
+    /// list-and-pick path when the table has no detail script.
+    pub async fn get_table_value_with_row<E>(
+        &self,
+        table: &Table<Self, E>,
+        id: &String,
+        row: &Record<CborValue>,
+    ) -> Result<Option<Record<CborValue>>>
+    where
+        E: Entity<CborValue>,
+        Self: Sized,
+    {
+        let table_name = table.table_name().to_string();
+        if !self.has_detail_script(&table_name) {
+            let mut all = self.list_table_values(table).await?;
+            return Ok(all.shift_remove(id));
+        }
+
+        let id_field = table.id_field().map(|c| c.name().to_string());
+        let columns: Vec<String> = table.columns().keys().cloned().collect();
+        let row_map = ciborium::value::Value::Map(
+            row.iter()
+                .map(|(k, v)| (ciborium::value::Value::Text(k.clone()), v.clone()))
+                .collect(),
+        );
+        let ctx = QueryContext {
+            conditions: Vec::new(),
+            columns,
+            limit: None,
+            offset: None,
+            id_column: id_field.clone(),
+            id: Some(id.clone()),
+            row: row_map,
+        };
+        let cmd = self.clone();
+        let name = table_name.clone();
+        let rows: Vec<JsonValue> = tokio::task::spawn_blocking(move || {
+            let compiled = cmd
+                .compiled_detail_script(&name)?
+                .ok_or_else(|| error!("detail script vanished"))?;
+            compiled.eval(ctx)
+        })
+        .await
+        .map_err(|e| error!("command task failed to join", detail = e.to_string()))??;
+
+        let mut records = rows_to_records(rows, id_field.as_deref());
+        // Prefer the row matching the requested id; else the first row.
+        Ok(records
+            .shift_remove(id)
+            .or_else(|| records.into_iter().next().map(|(_, r)| r)))
+    }
+}
+
 #[async_trait]
 impl TableSource for Cmd {
     type Column<Type>
@@ -204,42 +259,9 @@ impl TableSource for Cmd {
         E: Entity<Self::Value>,
         Self: Sized,
     {
-        let table_name = table.table_name().to_string();
-
-        // Two-pass tables hydrate one record at a time via the detail script
-        // (with `id` in scope) instead of re-listing every row.
-        if self.has_detail_script(&table_name) {
-            let id_field = table.id_field().map(|c| c.name().to_string());
-            let columns: Vec<String> = table.columns().keys().cloned().collect();
-            let ctx = QueryContext {
-                conditions: Vec::new(),
-                columns,
-                limit: None,
-                offset: None,
-                id_column: id_field.clone(),
-                id: Some(id.clone()),
-                row: ciborium::value::Value::Map(vec![]),
-            };
-            let cmd = self.clone();
-            let name = table_name.clone();
-            let rows: Vec<JsonValue> = tokio::task::spawn_blocking(move || {
-                let compiled = cmd
-                    .compiled_detail_script(&name)?
-                    .ok_or_else(|| error!("detail script vanished"))?;
-                compiled.eval(ctx)
-            })
-            .await
-            .map_err(|e| error!("command task failed to join", detail = e.to_string()))??;
-
-            let mut records = rows_to_records(rows, id_field.as_deref());
-            // Prefer the row matching the requested id; else the first row.
-            return Ok(records
-                .shift_remove(id)
-                .or_else(|| records.into_iter().next().map(|(_, r)| r)));
-        }
-
-        let mut all = self.list_table_values(table).await?;
-        Ok(all.shift_remove(id))
+        // Detail hydration with no caller-supplied row (id-only path).
+        let empty: Record<CborValue> = Record::new();
+        self.get_table_value_with_row(table, id, &empty).await
     }
 
     async fn get_table_some_value<E>(

--- a/vantage-cmd/src/vista/factory.rs
+++ b/vantage-cmd/src/vista/factory.rs
@@ -59,6 +59,7 @@ impl CmdVistaFactory {
             let mut cs = CmdSpec::new(spec.driver.cmd.rhai.clone());
             cs.command = spec.driver.cmd.command.clone();
             cs.env = spec.driver.cmd.env.clone();
+            cs.detail = spec.driver.cmd.detail.clone().map(Into::into);
             cs
         };
         let cmd = self.cmd.clone().with_table(&spec.name, cmd_spec);

--- a/vantage-cmd/src/vista/source.rs
+++ b/vantage-cmd/src/vista/source.rs
@@ -74,6 +74,21 @@ impl TableShell for CmdTableShell {
         self.table.get_value(id).await
     }
 
+    async fn get_vista_value_with_row(
+        &self,
+        _vista: &Vista,
+        id: &String,
+        row: &Record<CborValue>,
+    ) -> Result<Option<Record<CborValue>>> {
+        // The detail pass hands us the cheap list-pass row so the detail script
+        // can read columns it carries (e.g. step numbers painted from the
+        // reference conditions).
+        self.table
+            .data_source()
+            .get_table_value_with_row(&self.table, id, row)
+            .await
+    }
+
     async fn get_vista_some_value(
         &self,
         _vista: &Vista,

--- a/vantage-cmd/src/vista/source.rs
+++ b/vantage-cmd/src/vista/source.rs
@@ -69,8 +69,9 @@ impl TableShell for CmdTableShell {
         _vista: &Vista,
         id: &String,
     ) -> Result<Option<Record<CborValue>>> {
-        let mut data = self.table.list_values().await?;
-        Ok(data.shift_remove(id))
+        // Route through the typed table so detail-script tables hydrate via
+        // the DETAIL script (Cmd::get_table_value), not the list script.
+        self.table.get_value(id).await
     }
 
     async fn get_vista_some_value(

--- a/vantage-cmd/src/vista/spec.rs
+++ b/vantage-cmd/src/vista/spec.rs
@@ -26,6 +26,10 @@ pub struct CmdBlock {
     pub env: IndexMap<String, String>,
     /// The Rhai script: builds the argv, calls `run(args)`, parses output.
     pub rhai: String,
+    /// Optional per-row detail script (opt into two-pass loading). Runs the
+    /// same locked command with `id` in scope to hydrate one record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/vantage-cmd/tests/fixtures/role.sh
+++ b/vantage-cmd/tests/fixtures/role.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Test stub for two-role (list + detail) scripts. Same locked command,
+# different argv built by each role's script:
+#   $1 = "list"            -> id-only stub rows
+#   $1 = "detail", $2 = id -> the full record for that id
+case "$1" in
+  list)   printf '[{"id":"a"},{"id":"b"}]' ;;
+  detail) printf '[{"id":"%s","detail":"full-%s"}]' "$2" "$2" ;;
+  *)      printf '[]' ;;
+esac

--- a/vantage-cmd/tests/fixtures/role.sh
+++ b/vantage-cmd/tests/fixtures/role.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # Test stub for two-role (list + detail) scripts. Same locked command,
 # different argv built by each role's script:
-#   $1 = "list"            -> id-only stub rows
-#   $1 = "detail", $2 = id -> the full record for that id
+#   $1 = "list"                    -> id-only stub rows
+#   $1 = "detail", $2 = id, $3 = x -> the full record for that id, echoing x
 case "$1" in
   list)   printf '[{"id":"a"},{"id":"b"}]' ;;
-  detail) printf '[{"id":"%s","detail":"full-%s"}]' "$2" "$2" ;;
+  detail) printf '[{"id":"%s","detail":"full-%s","echoed":"%s"}]' "$2" "$2" "$3" ;;
   *)      printf '[]' ;;
 esac

--- a/vantage-cmd/tests/rhai_table.rs
+++ b/vantage-cmd/tests/rhai_table.rs
@@ -229,3 +229,28 @@ cmd:
         "Vista::get_value must run the detail script"
     );
 }
+
+#[tokio::test]
+async fn detail_script_reads_the_injected_row() {
+    // The detail pass injects the existing (list-pass) row. The detail script
+    // reads a field off `row` and passes it through; the fixture echoes it.
+    const LIST: &str = r#"parse_json(run(["list"]).stdout)"#;
+    const DETAIL: &str = r#"parse_json(run(["detail", id, row.extra]).stdout)"#;
+    let cmd = Cmd::new(format!("{}/role.sh", fixtures_dir()))
+        .with_table("items", CmdSpec::new(LIST).with_detail(DETAIL));
+    let table = Table::<Cmd, EmptyEntity>::new("items", cmd.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("detail")
+        .with_column_of::<String>("echoed");
+
+    let mut row: Record<CborValue> = Record::new();
+    row.insert("extra".to_string(), CborValue::from("XYZ"));
+
+    let rec = cmd
+        .get_table_value_with_row(&table, &"a".to_string(), &row)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(rec.get("echoed"), Some(&CborValue::from("XYZ")));
+    assert_eq!(rec.get("detail"), Some(&CborValue::from("full-a")));
+}

--- a/vantage-cmd/tests/rhai_table.rs
+++ b/vantage-cmd/tests/rhai_table.rs
@@ -200,3 +200,32 @@ cmd:
     let vista = cmd.vista_factory().from_yaml(yaml).unwrap();
     assert_eq!(vista.get_id_column(), Some("id"));
 }
+
+#[tokio::test]
+async fn vista_get_value_runs_the_detail_script() {
+    // Regression: `Vista::get_value(id)` (used by the two-pass detail pass)
+    // must route through the cmd DETAIL script, not re-run the list script.
+    let yaml = r#"
+name: items
+columns:
+  id:
+    type: string
+    flags: [id, title]
+  detail:
+    type: string
+cmd:
+  rhai: |
+    parse_json(run(["list"]).stdout)
+  detail: |
+    parse_json(run(["detail", id]).stdout)
+"#;
+    let cmd = Cmd::new(format!("{}/role.sh", fixtures_dir()));
+    let vista = cmd.vista_factory().from_yaml(yaml).unwrap();
+
+    let rec = vista.get_value(&"a".to_string()).await.unwrap().unwrap();
+    assert_eq!(
+        rec.get("detail"),
+        Some(&CborValue::from("full-a")),
+        "Vista::get_value must run the detail script"
+    );
+}

--- a/vantage-cmd/tests/rhai_table.rs
+++ b/vantage-cmd/tests/rhai_table.rs
@@ -254,3 +254,37 @@ async fn detail_script_reads_the_injected_row() {
     assert_eq!(rec.get("echoed"), Some(&CborValue::from("XYZ")));
     assert_eq!(rec.get("detail"), Some(&CborValue::from("full-a")));
 }
+
+#[tokio::test]
+async fn vista_get_value_with_row_feeds_the_detail_script() {
+    // The path the two-pass lens uses: Vista::get_value_with_row → cmd override
+    // → detail script with `row` in scope.
+    let yaml = r#"
+name: items
+columns:
+  id:
+    type: string
+    flags: [id, title]
+  detail:
+    type: string
+  echoed:
+    type: string
+cmd:
+  rhai: |
+    parse_json(run(["list"]).stdout)
+  detail: |
+    parse_json(run(["detail", id, row.extra]).stdout)
+"#;
+    let cmd = Cmd::new(format!("{}/role.sh", fixtures_dir()));
+    let vista = cmd.vista_factory().from_yaml(yaml).unwrap();
+
+    let mut row: Record<CborValue> = Record::new();
+    row.insert("extra".to_string(), CborValue::from("PQR"));
+
+    let rec = vista
+        .get_value_with_row(&"a".to_string(), &row)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(rec.get("echoed"), Some(&CborValue::from("PQR")));
+}

--- a/vantage-cmd/tests/rhai_table.rs
+++ b/vantage-cmd/tests/rhai_table.rs
@@ -3,7 +3,7 @@
 //! parse → records) is exercised deterministically.
 
 use ciborium::Value as CborValue;
-use vantage_cmd::{Cmd, eq};
+use vantage_cmd::{Cmd, CmdSpec, eq};
 use vantage_dataset::prelude::{ReadableValueSet, WritableValueSet};
 use vantage_table::table::Table;
 use vantage_types::{EmptyEntity, Record};
@@ -96,6 +96,59 @@ async fn client_side_eq_filter_narrows_rows() {
 }
 
 #[tokio::test]
+async fn script_is_compiled_once_across_repeated_reads() {
+    // The rhai engine + compiled AST for a script are built on first use and
+    // reused for every subsequent read, so a per-row detail loop doesn't pay
+    // the parse/registration cost each time.
+    let script = r#"
+        let out = run([]);
+        if out.exit_code != 0 { throw out.stderr; }
+        parse_json(out.stdout).items
+    "#;
+    let cmd = Cmd::new(format!("{}/echo_json.sh", fixtures_dir())).with_script("items", script);
+    let table = Table::<Cmd, EmptyEntity>::new("items", cmd.clone())
+        .with_id_column("name")
+        .with_column_of::<i64>("size");
+
+    for _ in 0..3 {
+        table.list_values().await.unwrap();
+    }
+
+    assert_eq!(
+        cmd.compile_count("items"),
+        1,
+        "script should compile once and be reused across reads"
+    );
+}
+
+#[tokio::test]
+async fn detail_script_hydrates_a_single_record_by_id() {
+    // The list script returns id-only stubs; the detail script returns the
+    // full record for one id. `get_value(id)` must run the DETAIL script with
+    // `id` in scope — not re-run the list script.
+    const LIST: &str = r#"parse_json(run(["list"]).stdout)"#;
+    const DETAIL: &str = r#"parse_json(run(["detail", id]).stdout)"#;
+    let cmd = Cmd::new(format!("{}/role.sh", fixtures_dir()))
+        .with_table("items", CmdSpec::new(LIST).with_detail(DETAIL));
+    let table = Table::<Cmd, EmptyEntity>::new("items", cmd)
+        .with_id_column("id")
+        .with_column_of::<String>("detail");
+
+    // List pass: stubs only, no detail column.
+    let rows = table.list_values().await.unwrap();
+    assert_eq!(rows.len(), 2);
+    assert!(
+        rows["a"].get("detail").is_none(),
+        "list pass should return id stubs without detail"
+    );
+
+    // Detail pass: the detail script runs with `id` in scope and returns the
+    // full record.
+    let rec = table.get_value(&"a".to_string()).await.unwrap().unwrap();
+    assert_eq!(rec.get("detail"), Some(&CborValue::from("full-a")));
+}
+
+#[tokio::test]
 async fn writes_are_rejected() {
     let cmd = Cmd::new(format!("{}/echo_json.sh", fixtures_dir())).with_script("items", "[]");
     let table = Table::<Cmd, EmptyEntity>::new("items", cmd);
@@ -125,4 +178,25 @@ cmd:
     let vista = cmd.vista_factory().from_yaml(yaml).unwrap();
     assert_eq!(vista.get_id_column(), Some("id"));
     assert!(vista.get_column_names().contains(&"size"));
+}
+
+#[tokio::test]
+async fn yaml_cmd_block_accepts_detail_script() {
+    // A table opts into two-pass loading by declaring `cmd.detail` alongside
+    // `cmd.rhai`. The block must deserialize and build a valid vista.
+    let yaml = r#"
+name: things
+columns:
+  id:
+    type: string
+    flags: [id, title]
+cmd:
+  rhai: |
+    parse_json(run(["list"]).stdout)
+  detail: |
+    parse_json(run(["detail", id]).stdout)
+"#;
+    let cmd = Cmd::new("true");
+    let vista = cmd.vista_factory().from_yaml(yaml).unwrap();
+    assert_eq!(vista.get_id_column(), Some("id"));
 }

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.5.7 — 2026-06-07
+
+Two-pass progressive loading for slow data sources: a cheap **list pass** renders
+immediately and expensive per-row **detail** hydrates lazily as rows scroll into
+view, without blocking the UI. Engages only when a `detail` callback exists —
+SQL/CSV/single-pass paths are unchanged.
+
+- Persist `RowStatus` in the detail cache (envelope of `status + cbor body`) and
+  add the `Incomplete` variant. The detail table is keyed by Vista name and shared
+  across all filter/sort variants, so hydration resumes after restart and a
+  `Fresh` id is never re-fetched.
+- Per-query ordered index built by the list pass, keyed by `Vista::index_key`,
+  decoupled from the detail store; cached per-key on the `Dio` and shared across
+  its sceneries.
+- Viewport-driven detail pass hydrates absent/`Incomplete` ids per id, merges the
+  detail onto the cached list row (list columns survive), flips it to `Fresh`, and
+  bumps the generation; ids already `Fresh` are skipped.
+- Sequential no-total paging: pages until a short or empty page, which ends paging
+  and freezes the estimated total.
+- `QueryDescriptor` carries conditions/sort/pagination into the load callback, so a
+  server-side filtered/ordered list pass works.
+
 ## 0.5.6 — 2026-06-07
 
 - Pass the new `VistaCapabilities::can_build_ref_via_script` flag through the `Dio` cache

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -29,6 +29,7 @@ tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "test-util", "sync", "time"] }
 vantage-csv = { path = "../vantage-csv", features = ["vista"] }
 vantage-sql = { path = "../vantage-sql", features = ["sqlite", "vista"] }
+vantage-cmd = { path = "../vantage-cmd" }
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite"] }
 cucumber = { version = "0.21", default-features = false, features = ["macros"] }
 insta = { version = "1.41", features = ["yaml", "filters"] }

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -76,10 +76,7 @@ impl DioInner {
     /// Fetch (or lazily create) the [`QueryIndex`](crate::dio::query_index::QueryIndex)
     /// for `key`. Repeated calls with the same key return the same `Arc`, so
     /// all sceneries on a query variant share one ordered index.
-    pub(crate) fn query_index(
-        &self,
-        key: &str,
-    ) -> Arc<crate::dio::query_index::QueryIndex> {
+    pub(crate) fn query_index(&self, key: &str) -> Arc<crate::dio::query_index::QueryIndex> {
         let mut guard = self.query_indexes.lock().unwrap();
         guard
             .entry(key.to_string())

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -1,6 +1,7 @@
 pub mod event_bus;
 pub mod hot_tier;
 pub mod impls;
+pub(crate) mod query_index;
 pub mod refresh;
 pub mod shell;
 pub mod worker;
@@ -63,6 +64,28 @@ pub(crate) struct DioInner {
     pub(crate) refresh_task: Mutex<Option<JoinHandle<()>>>,
     pub(crate) write_worker: Mutex<Option<JoinHandle<()>>>,
     pub(crate) hot_tier: Arc<HotTier>,
+    /// Per-query ordered indexes, keyed by [`Vista::index_key`]. Shared across
+    /// every two-pass scenery of this Dio so reopening the same filter/sort
+    /// reuses the already-built index. Not persisted — re-listing rebuilds it.
+    pub(crate) query_indexes: std::sync::Mutex<
+        std::collections::HashMap<String, Arc<crate::dio::query_index::QueryIndex>>,
+    >,
+}
+
+impl DioInner {
+    /// Fetch (or lazily create) the [`QueryIndex`](crate::dio::query_index::QueryIndex)
+    /// for `key`. Repeated calls with the same key return the same `Arc`, so
+    /// all sceneries on a query variant share one ordered index.
+    pub(crate) fn query_index(
+        &self,
+        key: &str,
+    ) -> Arc<crate::dio::query_index::QueryIndex> {
+        let mut guard = self.query_indexes.lock().unwrap();
+        guard
+            .entry(key.to_string())
+            .or_insert_with(|| Arc::new(crate::dio::query_index::QueryIndex::new()))
+            .clone()
+    }
 }
 
 impl Dio {

--- a/vantage-diorama/src/dio/query_index.rs
+++ b/vantage-diorama/src/dio/query_index.rs
@@ -57,7 +57,11 @@ impl QueryIndex {
     /// that a page was fetched. `page_len` is the number of rows the source
     /// returned; a page shorter than `requested_limit` (including empty) marks
     /// the index [`complete`](Self::is_complete) — there is no next page.
-    pub(crate) fn append_page(&self, ids: impl IntoIterator<Item = String>, requested_limit: usize) {
+    pub(crate) fn append_page(
+        &self,
+        ids: impl IntoIterator<Item = String>,
+        requested_limit: usize,
+    ) {
         let mut guard = self.ids.write().unwrap();
         let before = guard.len();
         guard.extend(ids);

--- a/vantage-diorama/src/dio/query_index.rs
+++ b/vantage-diorama/src/dio/query_index.rs
@@ -1,0 +1,120 @@
+//! Per-query ordered index of record ids.
+//!
+//! Two-pass loading separates *ordering* from *detail*. The detail table
+//! (id→record, shared by Vista name) holds the records; a `QueryIndex` holds
+//! the ordered list of ids for **one** query variant — a specific combination
+//! of conditions + sort, identified by
+//! [`Vista::index_key`](vantage_vista::Vista::index_key).
+//!
+//! The Dio caches one `QueryIndex` per key (see
+//! [`DioInner::query_index`](crate::dio::DioInner::query_index)) and shares it
+//! across every scenery that opens with the same conditions/sort. Switching a
+//! filter on and off therefore reuses the already-built index — zero list
+//! calls — while the shared detail table means already-hydrated records are
+//! never re-fetched.
+
+use std::sync::RwLock;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+/// Ordered ids for one query variant, plus the bookkeeping the sequential
+/// (no-total) list pass needs: whether paging is exhausted and how many list
+/// pages have been fetched.
+#[derive(Debug, Default)]
+pub(crate) struct QueryIndex {
+    ids: RwLock<Vec<String>>,
+    /// Set once the list pass sees a short/empty page — no more pages exist.
+    complete: AtomicBool,
+    /// Number of list-page fetches that have populated this index. Drives
+    /// diagnostics and the BDD invocation-count assertions.
+    list_pages_fetched: AtomicUsize,
+}
+
+impl QueryIndex {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of ids currently indexed.
+    pub(crate) fn len(&self) -> usize {
+        self.ids.read().unwrap().len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Id at ordered position `idx`, if present.
+    pub(crate) fn id_at(&self, idx: usize) -> Option<String> {
+        self.ids.read().unwrap().get(idx).cloned()
+    }
+
+    /// Snapshot of all ids in order.
+    pub(crate) fn ids(&self) -> Vec<String> {
+        self.ids.read().unwrap().clone()
+    }
+
+    /// Append one list page's worth of ids to the end of the index and record
+    /// that a page was fetched. `page_len` is the number of rows the source
+    /// returned; a page shorter than `requested_limit` (including empty) marks
+    /// the index [`complete`](Self::is_complete) — there is no next page.
+    pub(crate) fn append_page(&self, ids: impl IntoIterator<Item = String>, requested_limit: usize) {
+        let mut guard = self.ids.write().unwrap();
+        let before = guard.len();
+        guard.extend(ids);
+        let page_len = guard.len() - before;
+        drop(guard);
+        self.list_pages_fetched.fetch_add(1, Ordering::SeqCst);
+        if page_len < requested_limit {
+            self.complete.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// True once a short/empty page has been seen — the list pass is done.
+    pub(crate) fn is_complete(&self) -> bool {
+        self.complete.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn list_pages_fetched(&self) -> usize {
+        self.list_pages_fetched.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn append_page_grows_index_and_preserves_order() {
+        let idx = QueryIndex::new();
+        assert!(idx.is_empty());
+        idx.append_page(["a".into(), "b".into(), "c".into()], 3);
+        assert_eq!(idx.len(), 3);
+        assert_eq!(idx.id_at(0).as_deref(), Some("a"));
+        assert_eq!(idx.id_at(2).as_deref(), Some("c"));
+        assert_eq!(idx.ids(), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn full_page_does_not_complete_short_page_does() {
+        let idx = QueryIndex::new();
+        // A full page (page_len == requested_limit) leaves room for more.
+        idx.append_page(["a".into(), "b".into()], 2);
+        assert!(!idx.is_complete(), "a full page must not end paging");
+        assert_eq!(idx.list_pages_fetched(), 1);
+
+        // A short page ends paging.
+        idx.append_page(["c".into()], 2);
+        assert!(idx.is_complete(), "a short page must end paging");
+        assert_eq!(idx.len(), 3);
+        assert_eq!(idx.list_pages_fetched(), 2);
+    }
+
+    #[test]
+    fn empty_page_completes() {
+        let idx = QueryIndex::new();
+        idx.append_page(Vec::<String>::new(), 50);
+        assert!(idx.is_complete(), "an empty page must end paging");
+        assert_eq!(idx.len(), 0);
+        assert_eq!(idx.list_pages_fetched(), 1);
+    }
+}

--- a/vantage-diorama/src/lens/build.rs
+++ b/vantage-diorama/src/lens/build.rs
@@ -31,6 +31,8 @@ impl LensBuilder {
             on_query: self.on_query,
             total_provider: self.total_provider,
             on_load_chunk: self.on_load_chunk,
+            on_list_page: self.on_list_page,
+            on_load_detail: self.on_load_detail,
         };
 
         Ok(Lens {

--- a/vantage-diorama/src/lens/cache_backend.rs
+++ b/vantage-diorama/src/lens/cache_backend.rs
@@ -23,12 +23,30 @@ pub trait CacheBackend: Send + Sync + 'static {
     }
 }
 
-/// Per-Dio cache handle. Stores `id -> Record<CborValue>` rows.
+/// Persisted completeness of a cached record. Two-pass loading writes
+/// [`Incomplete`](CacheStatus::Incomplete) rows from the list pass (id +
+/// cheap columns) and flips them to [`Complete`](CacheStatus::Complete)
+/// once the detail pass hydrates them. Persisting this lets hydration
+/// resume across restarts and skip records that are already complete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CacheStatus {
+    /// Fully hydrated — no further detail fetch needed.
+    #[default]
+    Complete,
+    /// Only partially loaded (list pass) — awaiting detail hydration.
+    Incomplete,
+}
+
+/// Per-Dio cache handle. Stores `id -> (status, Record<CborValue>)` rows.
 ///
 /// Intentionally narrow — no conditions, no sort, no search. The cache
 /// is dumb storage; query planning lives on the Dio side. Capability
 /// flags on the facade Vista flip according to whether the cache or
 /// the master answers a given operation.
+///
+/// The status-agnostic methods (`get_value`, `insert_value`, …) treat
+/// every record as [`CacheStatus::Complete`]; two-pass callers use the
+/// `*_with_status` variants to read/write completeness.
 #[async_trait]
 pub trait CacheTable: Send + Sync + 'static {
     async fn list_values(&self) -> Result<IndexMap<String, Record<CborValue>>>;
@@ -46,4 +64,41 @@ pub trait CacheTable: Send + Sync + 'static {
     async fn clear(&self) -> Result<()>;
 
     async fn count(&self) -> Result<i64>;
+
+    /// Read a record together with its persisted [`CacheStatus`]. The
+    /// default treats any stored record as `Complete`; persisting backends
+    /// override this.
+    async fn get_value_with_status(
+        &self,
+        id: &str,
+    ) -> Result<Option<(Record<CborValue>, CacheStatus)>> {
+        Ok(self
+            .get_value(id)
+            .await?
+            .map(|r| (r, CacheStatus::Complete)))
+    }
+
+    /// Write a record with an explicit [`CacheStatus`]. The default drops
+    /// the status (writes a plain record); persisting backends override.
+    async fn insert_value_with_status(
+        &self,
+        id: &str,
+        record: &Record<CborValue>,
+        _status: CacheStatus,
+    ) -> Result<()> {
+        self.insert_value(id, record).await
+    }
+
+    /// List records together with their persisted statuses. The default
+    /// reports every record as `Complete`.
+    async fn list_values_with_status(
+        &self,
+    ) -> Result<IndexMap<String, (Record<CborValue>, CacheStatus)>> {
+        Ok(self
+            .list_values()
+            .await?
+            .into_iter()
+            .map(|(id, r)| (id, (r, CacheStatus::Complete)))
+            .collect())
+    }
 }

--- a/vantage-diorama/src/lens/callbacks.rs
+++ b/vantage-diorama/src/lens/callbacks.rs
@@ -2,7 +2,9 @@ use std::future::Future;
 use std::ops::Range;
 use std::pin::Pin;
 
+use ciborium::Value as CborValue;
 use vantage_core::Result;
+use vantage_types::Record;
 
 use crate::dio::Dio;
 use crate::lens::chunk_sink::ChunkSink;
@@ -44,6 +46,33 @@ pub type DioLoadChunkCallback = Box<
         + 'static,
 >;
 
+/// Future returned by a [`DioListPageCallback`]. Yields one page of
+/// `(id, cheap-record)` rows for the two-pass list pass.
+pub type DioListPageFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Vec<(String, Record<CborValue>)>>> + Send + 'a>>;
+
+/// Two-pass **list pass**. Given a [`QueryDescriptor`] (conditions, sort, and
+/// the `offset`/`limit` window), fetch one page of rows carrying only the
+/// cheap/list columns and return them in order. The scenery writes them to the
+/// detail table as [`Incomplete`](crate::lens::CacheStatus::Incomplete) and
+/// appends their ids to the per-query index. A page shorter than `limit` ends
+/// sequential paging.
+pub type DioListPageCallback = Box<
+    dyn for<'a> Fn(&'a Dio, QueryDescriptor) -> DioListPageFuture<'a> + Send + Sync + 'static,
+>;
+
+/// Future returned by a [`DioLoadDetailCallback`]. Yields the fully-hydrated
+/// record for a single id.
+pub type DioLoadDetailFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Record<CborValue>>> + Send + 'a>>;
+
+/// Two-pass **detail pass**. Given one id, fetch its expensive detail columns
+/// and return the complete record. The scenery merges it into the detail table
+/// as [`Complete`](crate::lens::CacheStatus::Complete) and flips the row to
+/// `Fresh`. Registering this callback is what opts a Dio into two-pass loading.
+pub type DioLoadDetailCallback =
+    Box<dyn for<'a> Fn(&'a Dio, String) -> DioLoadDetailFuture<'a> + Send + Sync + 'static>;
+
 /// The callback slots a Lens may hold. Each is independently
 /// optional; the Lens treats absent slots as "use the default path"
 /// (read from cache, write to master, etc.).
@@ -56,6 +85,8 @@ pub struct LensCallbacks {
     pub on_query: Option<DioQueryCallback>,
     pub total_provider: Option<DioTotalProviderCallback>,
     pub on_load_chunk: Option<DioLoadChunkCallback>,
+    pub on_list_page: Option<DioListPageCallback>,
+    pub on_load_detail: Option<DioLoadDetailCallback>,
 }
 
 /// Wrap a user closure into a [`DioCallback`].
@@ -116,4 +147,22 @@ where
     Fut: Future<Output = Result<()>> + Send + 'static,
 {
     Box::new(move |dio, range, sink| Box::pin(f(dio, range, sink)))
+}
+
+/// Wrap a user closure into a [`DioListPageCallback`].
+pub fn boxed_list_page_callback<F, Fut>(f: F) -> DioListPageCallback
+where
+    F: for<'a> Fn(&'a Dio, QueryDescriptor) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Vec<(String, Record<CborValue>)>>> + Send + 'static,
+{
+    Box::new(move |dio, q| Box::pin(f(dio, q)))
+}
+
+/// Wrap a user closure into a [`DioLoadDetailCallback`].
+pub fn boxed_load_detail_callback<F, Fut>(f: F) -> DioLoadDetailCallback
+where
+    F: for<'a> Fn(&'a Dio, String) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Record<CborValue>>> + Send + 'static,
+{
+    Box::new(move |dio, id| Box::pin(f(dio, id)))
 }

--- a/vantage-diorama/src/lens/callbacks.rs
+++ b/vantage-diorama/src/lens/callbacks.rs
@@ -57,9 +57,8 @@ pub type DioListPageFuture<'a> =
 /// detail table as [`Incomplete`](crate::lens::CacheStatus::Incomplete) and
 /// appends their ids to the per-query index. A page shorter than `limit` ends
 /// sequential paging.
-pub type DioListPageCallback = Box<
-    dyn for<'a> Fn(&'a Dio, QueryDescriptor) -> DioListPageFuture<'a> + Send + Sync + 'static,
->;
+pub type DioListPageCallback =
+    Box<dyn for<'a> Fn(&'a Dio, QueryDescriptor) -> DioListPageFuture<'a> + Send + Sync + 'static>;
 
 /// Future returned by a [`DioLoadDetailCallback`]. Yields the fully-hydrated
 /// record for a single id.

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -37,6 +37,7 @@ impl Lens {
             refresh_task: Mutex::new(None),
             write_worker: Mutex::new(None),
             hot_tier: Arc::new(HotTier::new()),
+            query_indexes: std::sync::Mutex::new(std::collections::HashMap::new()),
         });
         let dio = Dio { inner };
 

--- a/vantage-diorama/src/lens/mod.rs
+++ b/vantage-diorama/src/lens/mod.rs
@@ -19,12 +19,13 @@ use crate::dio::Dio;
 use crate::error::LensBuildError;
 use crate::ops::{ChangeEvent, QueryDescriptor, WriteOp};
 
-pub use cache_backend::{CacheBackend, CacheTable};
+pub use cache_backend::{CacheBackend, CacheStatus, CacheTable};
 pub use callbacks::{
-    DioCallback, DioEventCallback, DioLoadChunkCallback, DioQueryCallback,
-    DioTotalProviderCallback, DioWriteCallback, LensCallbacks, boxed_dio_callback,
-    boxed_dio_event_callback, boxed_dio_query_callback, boxed_dio_write_callback,
-    boxed_load_chunk_callback, boxed_total_provider_callback,
+    DioCallback, DioEventCallback, DioListPageCallback, DioLoadChunkCallback,
+    DioLoadDetailCallback, DioQueryCallback, DioTotalProviderCallback, DioWriteCallback,
+    LensCallbacks, boxed_dio_callback, boxed_dio_event_callback, boxed_dio_query_callback,
+    boxed_dio_write_callback, boxed_list_page_callback, boxed_load_chunk_callback,
+    boxed_load_detail_callback, boxed_total_provider_callback,
 };
 pub use chunk_sink::{ChunkRow, ChunkSink, SceneryChunkTarget};
 pub use defaults::LensDefaults;
@@ -80,6 +81,8 @@ pub struct LensBuilder {
     pub(crate) on_query: Option<DioQueryCallback>,
     pub(crate) total_provider: Option<DioTotalProviderCallback>,
     pub(crate) on_load_chunk: Option<DioLoadChunkCallback>,
+    pub(crate) on_list_page: Option<DioListPageCallback>,
+    pub(crate) on_load_detail: Option<DioLoadDetailCallback>,
     pub(crate) defaults: LensDefaults,
     pub(crate) runtime: Option<Handle>,
 }
@@ -102,6 +105,8 @@ impl LensBuilder {
             on_query: None,
             total_provider: None,
             on_load_chunk: None,
+            on_list_page: None,
+            on_load_detail: None,
             defaults: LensDefaults::default(),
             runtime: None,
         }
@@ -217,6 +222,39 @@ impl LensBuilder {
         Fut: Future<Output = Result<()>> + Send + 'static,
     {
         self.on_load_chunk = Some(callbacks::boxed_load_chunk_callback(f));
+        self
+    }
+
+    /// Register the two-pass **list pass**. The Scenery calls this to fetch one
+    /// page of cheap/list rows for its query variant (conditions + sort +
+    /// `offset`/`limit` arrive via the [`QueryDescriptor`]). Returned rows are
+    /// written to the detail table as `Incomplete` and their ids appended to
+    /// the per-query index. A page shorter than `limit` ends paging.
+    ///
+    /// Pairs with [`on_load_detail`](Self::on_load_detail); registering
+    /// `on_load_detail` is what engages two-pass loading.
+    pub fn on_list_page<F, Fut>(mut self, f: F) -> Self
+    where
+        F: for<'a> Fn(&'a Dio, QueryDescriptor) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Vec<(String, vantage_types::Record<ciborium::Value>)>>>
+            + Send
+            + 'static,
+    {
+        self.on_list_page = Some(callbacks::boxed_list_page_callback(f));
+        self
+    }
+
+    /// Register the two-pass **detail pass**. The Scenery calls this once per
+    /// visible `Incomplete` row to fetch its expensive columns; the returned
+    /// record is merged into the detail table as `Complete` and the row flips
+    /// to `Fresh`. **Registering this callback opts the Dio into two-pass
+    /// loading** — without it, sceneries use the legacy single-pass path.
+    pub fn on_load_detail<F, Fut>(mut self, f: F) -> Self
+    where
+        F: for<'a> Fn(&'a Dio, String) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<vantage_types::Record<ciborium::Value>>> + Send + 'static,
+    {
+        self.on_load_detail = Some(callbacks::boxed_load_detail_callback(f));
         self
     }
 

--- a/vantage-diorama/src/lens/redb_cache.rs
+++ b/vantage-diorama/src/lens/redb_cache.rs
@@ -18,7 +18,7 @@ use redb::{Database, ReadableTable, ReadableTableMetadata, TableDefinition};
 use vantage_core::{Result, error};
 use vantage_types::Record;
 
-use super::cache_backend::{CacheBackend, CacheTable};
+use super::cache_backend::{CacheBackend, CacheStatus, CacheTable};
 
 /// `RedbCache` opens (or creates) a redb database at the configured
 /// path. Each Dio under the owning Lens claims a named table within it.
@@ -81,20 +81,49 @@ impl RedbCacheTable {
     }
 }
 
+// Stored row layout: a one-byte status tag followed by the CBOR-encoded
+// record map. The tag bytes (0/1) are distinct from a CBOR map's leading
+// byte (major type 5, 0xA0..=0xBF), so a legacy raw-CBOR row written before
+// status tagging is detected on read and treated as `Complete`.
+const TAG_COMPLETE: u8 = 0;
+const TAG_INCOMPLETE: u8 = 1;
+
+fn status_tag(status: CacheStatus) -> u8 {
+    match status {
+        CacheStatus::Complete => TAG_COMPLETE,
+        CacheStatus::Incomplete => TAG_INCOMPLETE,
+    }
+}
+
 fn encode(record: &Record<CborValue>) -> Result<Vec<u8>> {
+    encode_with_status(record, CacheStatus::Complete)
+}
+
+fn encode_with_status(record: &Record<CborValue>, status: CacheStatus) -> Result<Vec<u8>> {
     let map: Vec<(CborValue, CborValue)> = record
         .iter()
         .map(|(k, v)| (CborValue::Text(k.clone()), v.clone()))
         .collect();
     let value = CborValue::Map(map);
     let mut buf = Vec::with_capacity(64);
+    buf.push(status_tag(status));
     ciborium::into_writer(&value, &mut buf)
         .map_err(|e| error!("Failed to encode cache row", detail = e.to_string()))?;
     Ok(buf)
 }
 
 fn decode(bytes: &[u8]) -> Result<Record<CborValue>> {
-    let value: CborValue = ciborium::from_reader(bytes)
+    Ok(decode_with_status(bytes)?.0)
+}
+
+fn decode_with_status(bytes: &[u8]) -> Result<(Record<CborValue>, CacheStatus)> {
+    let (status, body) = match bytes.first() {
+        Some(&TAG_COMPLETE) => (CacheStatus::Complete, &bytes[1..]),
+        Some(&TAG_INCOMPLETE) => (CacheStatus::Incomplete, &bytes[1..]),
+        // Legacy untagged row (raw CBOR map) — treat as complete.
+        _ => (CacheStatus::Complete, bytes),
+    };
+    let value: CborValue = ciborium::from_reader(body)
         .map_err(|e| error!("Failed to decode cache row", detail = e.to_string()))?;
     match value {
         CborValue::Map(entries) => {
@@ -105,7 +134,7 @@ fn decode(bytes: &[u8]) -> Result<Record<CborValue>> {
                 };
                 record.insert(key, v);
             }
-            Ok(record)
+            Ok((record, status))
         }
         other => Err(error!(
             "cache row not a cbor map",
@@ -318,6 +347,117 @@ impl CacheTable for RedbCacheTable {
                 .map_err(|e| error!("redb len failed", detail = e.to_string()))?
                 as i64)
         })
+        .await
+        .map_err(|e| error!("blocking task panicked", detail = e.to_string()))?
+    }
+
+    async fn insert_value_with_status(
+        &self,
+        id: &str,
+        record: &Record<CborValue>,
+        status: CacheStatus,
+    ) -> Result<()> {
+        let db = self.db.clone();
+        let name = self.name.clone();
+        let id = id.to_string();
+        let bytes = encode_with_status(record, status)?;
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let txn = db
+                .begin_write()
+                .map_err(|e| error!("redb begin_write failed", detail = e.to_string()))?;
+            {
+                let mut table = txn
+                    .open_table(TableDefinition::<&'static str, &'static [u8]>::new(&name))
+                    .map_err(|e| {
+                        error!(
+                            "redb open_table failed",
+                            table = name,
+                            detail = e.to_string()
+                        )
+                    })?;
+                table
+                    .insert(id.as_str(), bytes.as_slice())
+                    .map_err(|e| error!("redb insert failed", detail = e.to_string()))?;
+            }
+            txn.commit()
+                .map_err(|e| error!("redb commit failed", detail = e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| error!("blocking task panicked", detail = e.to_string()))?
+    }
+
+    async fn get_value_with_status(
+        &self,
+        id: &str,
+    ) -> Result<Option<(Record<CborValue>, CacheStatus)>> {
+        let db = self.db.clone();
+        let name = self.name.clone();
+        let id = id.to_string();
+        tokio::task::spawn_blocking(
+            move || -> Result<Option<(Record<CborValue>, CacheStatus)>> {
+                let txn = db
+                    .begin_read()
+                    .map_err(|e| error!("redb begin_read failed", detail = e.to_string()))?;
+                let table = match txn
+                    .open_table(TableDefinition::<&'static str, &'static [u8]>::new(&name))
+                {
+                    Ok(t) => t,
+                    Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+                    Err(e) => {
+                        return Err(error!(
+                            "redb open_table failed",
+                            table = name,
+                            detail = e.to_string()
+                        ));
+                    }
+                };
+                let row = table
+                    .get(id.as_str())
+                    .map_err(|e| error!("redb get failed", detail = e.to_string()))?;
+                row.map(|v| decode_with_status(v.value())).transpose()
+            },
+        )
+        .await
+        .map_err(|e| error!("blocking task panicked", detail = e.to_string()))?
+    }
+
+    async fn list_values_with_status(
+        &self,
+    ) -> Result<IndexMap<String, (Record<CborValue>, CacheStatus)>> {
+        let db = self.db.clone();
+        let name = self.name.clone();
+        tokio::task::spawn_blocking(
+            move || -> Result<IndexMap<String, (Record<CborValue>, CacheStatus)>> {
+                let txn = db
+                    .begin_read()
+                    .map_err(|e| error!("redb begin_read failed", detail = e.to_string()))?;
+                let table = match txn
+                    .open_table(TableDefinition::<&'static str, &'static [u8]>::new(&name))
+                {
+                    Ok(t) => t,
+                    Err(redb::TableError::TableDoesNotExist(_)) => return Ok(IndexMap::new()),
+                    Err(e) => {
+                        return Err(error!(
+                            "redb open_table failed",
+                            table = name,
+                            detail = e.to_string()
+                        ));
+                    }
+                };
+                let mut out = IndexMap::new();
+                let iter = table
+                    .iter()
+                    .map_err(|e| error!("redb iter failed", detail = e.to_string()))?;
+                for entry in iter {
+                    let (k, v) = entry
+                        .map_err(|e| error!("redb iter entry failed", detail = e.to_string()))?;
+                    let id = k.value().to_string();
+                    out.insert(id, decode_with_status(v.value())?);
+                }
+                Ok(out)
+            },
+        )
         .await
         .map_err(|e| error!("blocking task panicked", detail = e.to_string()))?
     }

--- a/vantage-diorama/src/ops/query_descriptor.rs
+++ b/vantage-diorama/src/ops/query_descriptor.rs
@@ -1,17 +1,85 @@
-/// Opaque description of a query a Scenery (or the Dio's vista facade) is
-/// about to run against the cache. Used by `on_query` callbacks to opt
-/// into eager fetches before the cache read happens.
+use ciborium::Value as CborValue;
+use vantage_vista::SortDirection;
+
+/// Description of the query a Scenery's list pass is about to run against the
+/// master. Carries the scenery's conditions, sort, search, and the pagination
+/// window (`offset`/`limit`) so a server-side list script can filter and order
+/// the page it returns.
 ///
-/// Stage 1 is a placeholder newtype. Stage 5 fills the concrete fields
-/// (conditions, sort, search, pagination) once Sceneries actually issue
-/// queries.
+/// A two-pass `on_list_page` callback reads these fields to fetch the right
+/// slice; the resulting ids feed the per-query index (keyed by
+/// [`Vista::index_key`](vantage_vista::Vista::index_key) over the same
+/// conditions + sort).
 #[derive(Debug, Clone, Default)]
 pub struct QueryDescriptor {
-    _private: (),
+    pub conditions: Vec<(String, CborValue)>,
+    pub sort: Option<(String, SortDirection)>,
+    pub search: Option<String>,
+    pub offset: usize,
+    pub limit: usize,
 }
 
 impl QueryDescriptor {
+    /// An empty descriptor — no conditions, no sort, no search, window `0..0`.
     pub fn new() -> Self {
-        Self { _private: () }
+        Self::default()
+    }
+
+    /// Set the pagination window for this page request.
+    pub fn with_window(mut self, offset: usize, limit: usize) -> Self {
+        self.offset = offset;
+        self.limit = limit;
+        self
+    }
+
+    /// Attach the scenery's conditions.
+    pub fn with_conditions(mut self, conditions: Vec<(String, CborValue)>) -> Self {
+        self.conditions = conditions;
+        self
+    }
+
+    /// Attach the scenery's sort.
+    pub fn with_sort(mut self, sort: Option<(String, SortDirection)>) -> Self {
+        self.sort = sort;
+        self
+    }
+
+    /// Attach the scenery's search string.
+    pub fn with_search(mut self, search: Option<String>) -> Self {
+        self.search = search;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(s: &str) -> CborValue {
+        CborValue::Text(s.into())
+    }
+
+    #[test]
+    fn carries_conditions_sort_search_and_window() {
+        let q = QueryDescriptor::new()
+            .with_conditions(vec![("branch".into(), t("main"))])
+            .with_sort(Some(("status".into(), SortDirection::Descending)))
+            .with_search(Some("flux".into()))
+            .with_window(50, 25);
+
+        assert_eq!(q.conditions, vec![("branch".to_string(), t("main"))]);
+        assert_eq!(q.sort, Some(("status".to_string(), SortDirection::Descending)));
+        assert_eq!(q.search.as_deref(), Some("flux"));
+        assert_eq!(q.offset, 50);
+        assert_eq!(q.limit, 25);
+    }
+
+    #[test]
+    fn default_is_empty_zero_window() {
+        let q = QueryDescriptor::new();
+        assert!(q.conditions.is_empty());
+        assert!(q.sort.is_none());
+        assert!(q.search.is_none());
+        assert_eq!((q.offset, q.limit), (0, 0));
     }
 }

--- a/vantage-diorama/src/ops/query_descriptor.rs
+++ b/vantage-diorama/src/ops/query_descriptor.rs
@@ -68,7 +68,10 @@ mod tests {
             .with_window(50, 25);
 
         assert_eq!(q.conditions, vec![("branch".to_string(), t("main"))]);
-        assert_eq!(q.sort, Some(("status".to_string(), SortDirection::Descending)));
+        assert_eq!(
+            q.sort,
+            Some(("status".to_string(), SortDirection::Descending))
+        );
         assert_eq!(q.search.as_deref(), Some("flux"));
         assert_eq!(q.offset, 50);
         assert_eq!(q.limit, 25);

--- a/vantage-diorama/src/scenery/enriched_record.rs
+++ b/vantage-diorama/src/scenery/enriched_record.rs
@@ -43,7 +43,11 @@ impl EnrichedRecord {
     /// Mark a row whose detail pass failed. Keeps the partial (list-pass)
     /// `record` so the row stays visible, but records the error so the UI can
     /// surface it. Carries over the previous `fetched_at`.
-    pub fn detail_failed(record: Record<CborValue>, error: String, fetched_at: Option<SystemTime>) -> Self {
+    pub fn detail_failed(
+        record: Record<CborValue>,
+        error: String,
+        fetched_at: Option<SystemTime>,
+    ) -> Self {
         Self {
             record,
             status: RowStatus::LoadFailed { error },
@@ -62,10 +66,14 @@ pub enum RowStatus {
     Stale,
     Loading,
     PendingWrite,
-    WriteFailed { error: String },
+    WriteFailed {
+        error: String,
+    },
     /// The two-pass detail fetch for this row failed; the partial list-pass
     /// columns remain visible. Distinct from [`WriteFailed`](RowStatus::WriteFailed),
     /// which is a write-back error.
-    LoadFailed { error: String },
+    LoadFailed {
+        error: String,
+    },
     NotFound,
 }

--- a/vantage-diorama/src/scenery/enriched_record.rs
+++ b/vantage-diorama/src/scenery/enriched_record.rs
@@ -27,14 +27,45 @@ impl EnrichedRecord {
             fetched_at: Some(SystemTime::now()),
         }
     }
+
+    /// Wrap a row that has only been partially loaded by the list pass —
+    /// its id and cheap columns are present, but the expensive detail
+    /// columns are still pending hydration.
+    pub fn incomplete(record: Record<CborValue>) -> Self {
+        Self {
+            record,
+            status: RowStatus::Incomplete,
+            dirty_fields: None,
+            fetched_at: Some(SystemTime::now()),
+        }
+    }
+
+    /// Mark a row whose detail pass failed. Keeps the partial (list-pass)
+    /// `record` so the row stays visible, but records the error so the UI can
+    /// surface it. Carries over the previous `fetched_at`.
+    pub fn detail_failed(record: Record<CborValue>, error: String, fetched_at: Option<SystemTime>) -> Self {
+        Self {
+            record,
+            status: RowStatus::LoadFailed { error },
+            dirty_fields: None,
+            fetched_at,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
 pub enum RowStatus {
     Fresh,
+    /// Only the list pass has run — cheap columns present, detail columns
+    /// awaiting hydration by the detail pass.
+    Incomplete,
     Stale,
     Loading,
     PendingWrite,
     WriteFailed { error: String },
+    /// The two-pass detail fetch for this row failed; the partial list-pass
+    /// columns remain visible. Distinct from [`WriteFailed`](RowStatus::WriteFailed),
+    /// which is a write-back error.
+    LoadFailed { error: String },
     NotFound,
 }

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -92,6 +92,26 @@ impl TableSceneryBuilder {
         let (viewport_tx, viewport_rx) = mpsc::unbounded_channel();
 
         let master_capabilities = dio.master.capabilities().clone();
+
+        // Two-pass engages only when the Lens registers an `on_load_detail`
+        // callback. The shared per-query index is keyed by the master Vista's
+        // index_key over the scenery's conditions + sort, so reopening the same
+        // variant reuses the already-built index.
+        let two_pass = dio.lens.callbacks.on_load_detail.is_some();
+        let index = if two_pass {
+            let vista_sort = sort.as_ref().map(|(col, dir)| {
+                let dir = match dir {
+                    SortDir::Asc => vantage_vista::SortDirection::Ascending,
+                    SortDir::Desc => vantage_vista::SortDirection::Descending,
+                };
+                (col.as_str(), dir)
+            });
+            let key = dio.master.index_key(&conditions, vista_sort);
+            Some(dio.query_index(&key))
+        } else {
+            None
+        };
+
         let state = Arc::new(TableSceneryState {
             dio_weak: Arc::downgrade(&dio),
             conditions: RwLock::new(conditions),
@@ -108,6 +128,10 @@ impl TableSceneryBuilder {
             viewport_queue_depth: AtomicUsize::new(0),
             load_in_flight: Mutex::new(None),
             master_capabilities,
+            two_pass,
+            index,
+            detail_in_flight: Mutex::new(std::collections::HashSet::new()),
+            list_in_flight: Mutex::new(false),
         });
 
         // 1. total_provider runs once per open, result cached.
@@ -117,9 +141,24 @@ impl TableSceneryBuilder {
             *state.total.write().unwrap() = Some(total);
         }
 
-        // 2. Seed the sparse map from whatever's in the cache.
-        state.reseed_from_cache().await?;
-        state.bump_generation();
+        // 2. Seed the sparse map.
+        if state.two_pass {
+            // Two-pass: seed from the shared per-query index if it is already
+            // populated (reused variant — no list call); otherwise run the
+            // first list page. The detail pass stays dormant until a viewport
+            // is set, so opening yields `Incomplete` rows with zero detail
+            // calls.
+            let index_empty = state.index.as_ref().map(|i| i.is_empty()).unwrap_or(true);
+            if index_empty {
+                super::two_pass::run_list_page(state.clone()).await;
+            } else {
+                super::two_pass::seed_from_index(&state).await;
+                state.bump_generation();
+            }
+        } else {
+            state.reseed_from_cache().await?;
+            state.bump_generation();
+        }
 
         // 3. Spawn reactor.
         let bus_rx = dio.event_bus.subscribe();
@@ -137,8 +176,13 @@ impl TableSceneryBuilder {
 
         // 5. Optional refresh-on-open: schedule a viewport for the
         //    initial range so the configured on_load_chunk re-fetches
-        //    the first page in the background.
-        if dio.lens.defaults.refresh_on_open && dio.lens.callbacks.on_load_chunk.is_some() {
+        //    the first page in the background. Skipped for two-pass — its
+        //    detail pass must wait for an explicit viewport so that opening
+        //    never triggers detail fetches.
+        if !two_pass
+            && dio.lens.defaults.refresh_on_open
+            && dio.lens.callbacks.on_load_chunk.is_some()
+        {
             let range = initial_range.unwrap_or(0..page_size);
             enqueue_viewport(
                 &state,

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -161,6 +161,14 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
         range: visible.clone(),
     });
 
+    // Two-pass: a viewport drives the detail pass over the visible rows, not a
+    // random-access chunk load. Hydration dedups against already-`Complete`
+    // ids, so re-entering the same viewport is a no-op.
+    if state.two_pass {
+        super::two_pass::run_detail_for_range(state.clone(), visible).await;
+        return;
+    }
+
     let total = *state.total.read().unwrap();
     let visible_len = visible.end.saturating_sub(visible.start);
     let visible_cached = {

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -22,6 +22,7 @@ mod helpers;
 mod loader;
 mod reactor;
 mod state;
+mod two_pass;
 
 use std::ops::Range;
 use std::sync::Arc;
@@ -82,6 +83,9 @@ pub(crate) struct TableSceneryImpl {
 
 impl TableScenery for TableSceneryImpl {
     fn row_count(&self) -> usize {
+        if let Some(index) = self.inner.index.as_ref() {
+            return index.len();
+        }
         if let Some(t) = *self.inner.total.read().unwrap() {
             return t;
         }
@@ -89,6 +93,11 @@ impl TableScenery for TableSceneryImpl {
     }
 
     fn has_more(&self) -> bool {
+        // Two-pass / sequential no-total: more pages exist until the list pass
+        // sees a short or empty page.
+        if let Some(index) = self.inner.index.as_ref() {
+            return !index.is_complete();
+        }
         let total = *self.inner.total.read().unwrap();
         let loaded = self.inner.rows.read().unwrap().len();
         match total {
@@ -98,6 +107,11 @@ impl TableScenery for TableSceneryImpl {
     }
 
     fn estimated_total(&self) -> Option<usize> {
+        // Two-pass: the running index length is the best estimate; it grows as
+        // pages load and freezes once the list pass completes.
+        if let Some(index) = self.inner.index.as_ref() {
+            return Some(index.len());
+        }
         let stored = *self.inner.total.read().unwrap();
         stored.or_else(|| Some(self.inner.rows.read().unwrap().len()))
     }
@@ -122,6 +136,19 @@ impl TableScenery for TableSceneryImpl {
     }
 
     fn request_load_more(&self) {
+        // Two-pass: load the next *list* page (append cheap rows to the index).
+        // Detail hydration is driven separately by `set_viewport`.
+        if self.inner.two_pass {
+            let Some(dio_inner) = self.inner.dio_weak.upgrade() else {
+                return;
+            };
+            let state = self.inner.clone();
+            dio_inner.lens.runtime.spawn(async move {
+                two_pass::run_list_page(state).await;
+            });
+            return;
+        }
+
         let start = self.inner.next_load_more_start();
         let mut end = start + self.inner.page_size;
         if let Some(t) = *self.inner.total.read().unwrap() {

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -53,6 +53,23 @@ pub(crate) struct TableSceneryState {
     /// page requests through the right primitive (`set_viewport` for
     /// `can_fetch_page`, `request_load_more` for `can_fetch_next`).
     pub(crate) master_capabilities: VistaCapabilities,
+
+    // ---- two-pass loading -------------------------------------------------
+    //
+    // Populated only when the Lens registers an `on_load_detail` callback.
+    // `two_pass == false` leaves every field below inert and the scenery on
+    // the legacy single-pass path.
+    /// Whether this scenery drives two-pass (list + detail) loading.
+    pub(crate) two_pass: bool,
+    /// The shared per-query ordered index for this scenery's conditions/sort,
+    /// keyed by [`Vista::index_key`]. `None` in single-pass mode.
+    pub(crate) index: Option<Arc<crate::dio::query_index::QueryIndex>>,
+    /// Ids whose detail fetch is currently dispatched — guards against
+    /// re-hydrating the same row while a fetch is in flight.
+    pub(crate) detail_in_flight: Mutex<std::collections::HashSet<String>>,
+    /// True while a list-page fetch is dispatched, so overlapping
+    /// `request_load_more` calls don't double-page.
+    pub(crate) list_in_flight: Mutex<bool>,
 }
 
 impl TableSceneryState {

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -62,7 +62,7 @@ pub(crate) struct TableSceneryState {
     /// Whether this scenery drives two-pass (list + detail) loading.
     pub(crate) two_pass: bool,
     /// The shared per-query ordered index for this scenery's conditions/sort,
-    /// keyed by [`Vista::index_key`]. `None` in single-pass mode.
+    /// keyed by [`Vista::index_key`](vantage_vista::Vista::index_key). `None` in single-pass mode.
     pub(crate) index: Option<Arc<crate::dio::query_index::QueryIndex>>,
     /// Ids whose detail fetch is currently dispatched — guards against
     /// re-hydrating the same row while a fetch is in flight.

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -123,7 +123,12 @@ pub(crate) async fn run_list_page(state: Arc<TableSceneryState>) {
             for (id, rec) in &rows {
                 // Never demote a record the detail pass already completed.
                 let already_complete = matches!(
-                    dio_inner.cache.get_value_with_status(id).await.ok().flatten(),
+                    dio_inner
+                        .cache
+                        .get_value_with_status(id)
+                        .await
+                        .ok()
+                        .flatten(),
                     Some((_, CacheStatus::Complete))
                 );
                 if !already_complete {

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -83,7 +83,7 @@ pub(crate) async fn seed_from_index(state: &Arc<TableSceneryState>) {
 /// append their ids to the index, and seed the new sparse-map slots.
 ///
 /// Sequential / no-total: a page shorter than the requested limit marks the
-/// index complete (see [`QueryIndex::append_page`]).
+/// index complete (see [`QueryIndex::append_page`](crate::dio::query_index::QueryIndex::append_page)).
 pub(crate) async fn run_list_page(state: Arc<TableSceneryState>) {
     let Some(dio_inner) = state.dio_weak.upgrade() else {
         return;

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -1,0 +1,252 @@
+//! Two-pass loading: a sequential **list pass** that builds the per-query
+//! index from cheap rows, and a viewport-driven **detail pass** that hydrates
+//! expensive columns one id at a time.
+//!
+//! Engaged only when the Lens registers an `on_load_detail` callback (see
+//! [`TableSceneryBuilder::open`](super::builder::TableSceneryBuilder::open)).
+//! In single-pass mode none of this runs.
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use vantage_vista::SortDirection;
+
+use crate::dio::{Dio, DioEvent};
+use crate::lens::CacheStatus;
+use crate::ops::QueryDescriptor;
+use crate::scenery::enriched_record::EnrichedRecord;
+
+use super::SortDir;
+use super::state::TableSceneryState;
+
+/// Build a [`QueryDescriptor`] for the page `offset..offset+limit` from the
+/// scenery's current conditions/sort/search.
+fn descriptor(state: &TableSceneryState, offset: usize, limit: usize) -> QueryDescriptor {
+    let conditions = state.conditions.read().unwrap().clone();
+    let sort = state.sort.read().unwrap().clone().map(|(col, dir)| {
+        let dir = match dir {
+            SortDir::Asc => SortDirection::Ascending,
+            SortDir::Desc => SortDirection::Descending,
+        };
+        (col, dir)
+    });
+    let search = state.search.read().unwrap().clone();
+    QueryDescriptor::new()
+        .with_conditions(conditions)
+        .with_sort(sort)
+        .with_search(search)
+        .with_window(offset, limit)
+}
+
+/// Seed the sparse map for `ids` starting at row index `base`, reading each
+/// id's current status from the detail cache. `Complete` rows show `Fresh`,
+/// everything else shows `Incomplete`.
+async fn seed_rows(
+    state: &Arc<TableSceneryState>,
+    dio_inner: &Arc<crate::dio::DioInner>,
+    base: usize,
+    ids: &[String],
+) {
+    for (i, id) in ids.iter().enumerate() {
+        let idx = base + i;
+        let entry = dio_inner
+            .cache
+            .get_value_with_status(id)
+            .await
+            .ok()
+            .flatten();
+        let enriched = match entry {
+            Some((rec, CacheStatus::Complete)) => EnrichedRecord::fresh(rec),
+            Some((rec, CacheStatus::Incomplete)) => EnrichedRecord::incomplete(rec),
+            None => continue,
+        };
+        state.rows.write().unwrap().insert(idx, Arc::new(enriched));
+        state.id_to_idx.write().unwrap().insert(id.clone(), idx);
+    }
+}
+
+/// Seed the scenery's sparse map from an already-populated shared index
+/// (reused across filter switches) without issuing any list call.
+pub(crate) async fn seed_from_index(state: &Arc<TableSceneryState>) {
+    let Some(dio_inner) = state.dio_weak.upgrade() else {
+        return;
+    };
+    let Some(index) = state.index.as_ref() else {
+        return;
+    };
+    let ids = index.ids();
+    seed_rows(state, &dio_inner, 0, &ids).await;
+}
+
+/// Run one list page: fetch `page_size` cheap rows at the current index tail,
+/// write them to the detail table as `Incomplete` (unless already `Complete`),
+/// append their ids to the index, and seed the new sparse-map slots.
+///
+/// Sequential / no-total: a page shorter than the requested limit marks the
+/// index complete (see [`QueryIndex::append_page`]).
+pub(crate) async fn run_list_page(state: Arc<TableSceneryState>) {
+    let Some(dio_inner) = state.dio_weak.upgrade() else {
+        return;
+    };
+    let Some(index) = state.index.clone() else {
+        return;
+    };
+    let Some(cb) = dio_inner.lens.callbacks.on_list_page.as_ref() else {
+        return;
+    };
+    if index.is_complete() {
+        return;
+    }
+
+    // Single-flight: don't let overlapping load-more calls double-page.
+    {
+        let mut guard = state.list_in_flight.lock().unwrap();
+        if *guard {
+            return;
+        }
+        *guard = true;
+    }
+
+    let limit = state.page_size.max(1);
+    let offset = index.len();
+    let q = descriptor(&state, offset, limit);
+    let dio = Dio {
+        inner: dio_inner.clone(),
+    };
+    let result = cb(&dio, q).await;
+
+    *state.list_in_flight.lock().unwrap() = false;
+
+    match result {
+        Ok(rows) => {
+            let mut new_ids = Vec::with_capacity(rows.len());
+            for (id, rec) in &rows {
+                // Never demote a record the detail pass already completed.
+                let already_complete = matches!(
+                    dio_inner.cache.get_value_with_status(id).await.ok().flatten(),
+                    Some((_, CacheStatus::Complete))
+                );
+                if !already_complete {
+                    let _ = dio_inner
+                        .cache
+                        .insert_value_with_status(id, rec, CacheStatus::Incomplete)
+                        .await;
+                }
+                new_ids.push(id.clone());
+            }
+            let base = index.len();
+            index.append_page(new_ids.clone(), limit);
+            seed_rows(&state, &dio_inner, base, &new_ids).await;
+            state.bump_generation();
+            let _ = dio_inner.event_bus.send(DioEvent::RangeLoaded {
+                range: base..index.len(),
+            });
+        }
+        Err(e) => {
+            let _ = dio_inner.event_bus.send(DioEvent::LoadFailed {
+                range: offset..offset,
+                error: e.to_string(),
+            });
+        }
+    }
+}
+
+/// Run the detail pass for `range`: for each indexed id in the range that is
+/// not already `Complete` (and not in flight), fetch its detail, merge it into
+/// the cache as `Complete`, and flip the row to `Fresh`. Skips ids already
+/// hydrated, so re-entering the same viewport — or switching to a variant whose
+/// rows are already `Fresh` — issues zero detail calls.
+pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: Range<usize>) {
+    let Some(dio_inner) = state.dio_weak.upgrade() else {
+        return;
+    };
+    let Some(index) = state.index.clone() else {
+        return;
+    };
+    let Some(cb) = dio_inner.lens.callbacks.on_load_detail.as_ref() else {
+        return;
+    };
+    let dio = Dio {
+        inner: dio_inner.clone(),
+    };
+    let mut changed = false;
+
+    for idx in range {
+        let Some(id) = index.id_at(idx) else {
+            continue;
+        };
+
+        let status = dio_inner
+            .cache
+            .get_value_with_status(&id)
+            .await
+            .ok()
+            .flatten()
+            .map(|(_, s)| s);
+        if status == Some(CacheStatus::Complete) {
+            continue;
+        }
+
+        // Claim the id; skip if another detail fetch already owns it.
+        {
+            let mut inflight = state.detail_in_flight.lock().unwrap();
+            if !inflight.insert(id.clone()) {
+                continue;
+            }
+        }
+
+        let result = cb(&dio, id.clone()).await;
+        state.detail_in_flight.lock().unwrap().remove(&id);
+
+        match result {
+            Ok(detail) => {
+                // Merge the detail columns onto the cheap list-pass row so the
+                // list columns survive hydration, then mark the row Complete.
+                let mut merged = dio_inner
+                    .cache
+                    .get_value(&id)
+                    .await
+                    .ok()
+                    .flatten()
+                    .unwrap_or_default();
+                for (k, v) in detail {
+                    merged.insert(k, v);
+                }
+                let _ = dio_inner
+                    .cache
+                    .insert_value_with_status(&id, &merged, CacheStatus::Complete)
+                    .await;
+                if let Some(i) = state.id_to_idx.read().unwrap().get(&id).copied() {
+                    state
+                        .rows
+                        .write()
+                        .unwrap()
+                        .insert(i, Arc::new(EnrichedRecord::fresh(merged)));
+                }
+                changed = true;
+            }
+            Err(e) => {
+                if let Some(i) = state.id_to_idx.read().unwrap().get(&id).copied() {
+                    let prev = state.rows.read().unwrap().get(&i).cloned();
+                    if let Some(prev) = prev {
+                        let failed = EnrichedRecord::detail_failed(
+                            prev.record.clone(),
+                            e.to_string(),
+                            prev.fetched_at,
+                        );
+                        state.rows.write().unwrap().insert(i, Arc::new(failed));
+                    }
+                }
+                let _ = dio_inner.event_bus.send(DioEvent::LoadFailed {
+                    range: idx..idx + 1,
+                    error: e.to_string(),
+                });
+                changed = true;
+            }
+        }
+    }
+
+    if changed {
+        state.bump_generation();
+    }
+}

--- a/vantage-diorama/tests/cache_status.rs
+++ b/vantage-diorama/tests/cache_status.rs
@@ -1,0 +1,54 @@
+//! The detail cache persists each record's completeness status so two-pass
+//! hydration can resume across restarts and skip already-complete records.
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_diorama::lens::{CacheBackend, CacheStatus, RedbCache};
+use vantage_types::Record;
+
+fn rec(v: &str) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("v".to_string(), CborValue::Text(v.to_string()));
+    r
+}
+
+#[tokio::test]
+async fn status_persists_across_reopen() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("cache.redb");
+
+    {
+        let cache = RedbCache::open(&path).unwrap();
+        let table = cache.open_table("items").await.unwrap();
+        table
+            .insert_value_with_status("a", &rec("a"), CacheStatus::Incomplete)
+            .await
+            .unwrap();
+        // The status-agnostic write defaults to Complete.
+        table.insert_value("b", &rec("b")).await.unwrap();
+
+        assert_eq!(
+            table.get_value_with_status("a").await.unwrap().unwrap().1,
+            CacheStatus::Incomplete
+        );
+        assert_eq!(
+            table.get_value_with_status("b").await.unwrap().unwrap().1,
+            CacheStatus::Complete
+        );
+    }
+
+    // Reopen the same file: the persisted status survives.
+    let cache = RedbCache::open(&path).unwrap();
+    let table = cache.open_table("items").await.unwrap();
+
+    let (rec_a, status_a) = table.get_value_with_status("a").await.unwrap().unwrap();
+    assert_eq!(status_a, CacheStatus::Incomplete);
+    assert_eq!(rec_a.get("v"), Some(&CborValue::Text("a".to_string())));
+    assert_eq!(
+        table.get_value_with_status("b").await.unwrap().unwrap().1,
+        CacheStatus::Complete
+    );
+
+    // The status-agnostic read still returns the record.
+    assert!(table.get_value("a").await.unwrap().is_some());
+}

--- a/vantage-diorama/tests/fixtures/two_pass_runs.sh
+++ b/vantage-diorama/tests/fixtures/two_pass_runs.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Dummy two-pass data source for the diorama BDD/integration suite.
+#
+#   list  <offset> <limit> [branch]  -> JSON array of {id, branch} for the
+#                                        (optionally branch-filtered) window
+#   detail <id>                      -> [{id, detail:"full-<id>"}]
+#
+# Every invocation appends a line to $RUNS_LOG so the test can assert the exact
+# sequence and count of list/detail calls the two-pass machinery issued.
+set -euo pipefail
+
+mode="${1:-}"
+log="${RUNS_LOG:-}"
+
+# Fixed dataset: five runs across two branches.
+ids=(r0 r1 r2 r3 r4)
+branches=(main dev main dev main)
+
+case "$mode" in
+  list)
+    offset="${2:-0}"
+    limit="${3:-50}"
+    branch="${4:-}"
+    [ -n "$log" ] && echo "list offset=$offset limit=$limit branch=${branch}" >> "$log"
+
+    # Apply the branch filter first, then the offset/limit window.
+    fids=()
+    fbr=()
+    for i in "${!ids[@]}"; do
+      if [ -z "$branch" ] || [ "${branches[$i]}" = "$branch" ]; then
+        fids+=("${ids[$i]}")
+        fbr+=("${branches[$i]}")
+      fi
+    done
+
+    n=${#fids[@]}
+    end=$((offset + limit))
+    out="["
+    first=1
+    j=$offset
+    while [ "$j" -lt "$end" ] && [ "$j" -lt "$n" ]; do
+      [ "$first" -eq 0 ] && out+=","
+      out+="{\"id\":\"${fids[$j]}\",\"branch\":\"${fbr[$j]}\"}"
+      first=0
+      j=$((j + 1))
+    done
+    out+="]"
+    printf '%s' "$out"
+    ;;
+  detail)
+    id="${2:-}"
+    [ -n "$log" ] && echo "detail id=$id" >> "$log"
+    # A configured FAIL_ID emits invalid JSON so the detail pass sees an error
+    # for exactly that id.
+    if [ -n "${FAIL_ID:-}" ] && [ "$id" = "$FAIL_ID" ]; then
+      printf 'BOOM-not-json'
+      exit 0
+    fi
+    printf '[{"id":"%s","detail":"full-%s"}]' "$id" "$id"
+    ;;
+  *)
+    printf '[]'
+    ;;
+esac

--- a/vantage-diorama/tests/two_pass.rs
+++ b/vantage-diorama/tests/two_pass.rs
@@ -38,7 +38,10 @@ const LIST: &str = r#"
 const DETAIL: &str = r#"parse_json(run(["detail", id]).stdout)"#;
 
 fn fixture() -> String {
-    format!("{}/tests/fixtures/two_pass_runs.sh", env!("CARGO_MANIFEST_DIR"))
+    format!(
+        "{}/tests/fixtures/two_pass_runs.sh",
+        env!("CARGO_MANIFEST_DIR")
+    )
 }
 
 /// A `Cmd` over the fixture, with the list + detail scripts and the log path
@@ -174,12 +177,23 @@ async fn list_pass_creates_incomplete_rows_and_no_detail_calls() {
     // First list page already ran (open awaits it): r0, r1 as Incomplete.
     assert_eq!(scenery.estimated_total(), Some(2));
     assert!(scenery.has_more(), "a full first page implies more pages");
-    assert_eq!(status_of(&scenery, 0).map(|s| matches!(s, RowStatus::Incomplete)), Some(true));
+    assert_eq!(
+        status_of(&scenery, 0).map(|s| matches!(s, RowStatus::Incomplete)),
+        Some(true)
+    );
     assert_eq!(branch_of(&scenery, 0).as_deref(), Some("main"));
-    assert!(detail_of(&scenery, 0).is_none(), "no detail before the detail pass");
+    assert!(
+        detail_of(&scenery, 0).is_none(),
+        "no detail before the detail pass"
+    );
 
     // Exactly one list call, no detail calls.
-    assert_eq!(count_with_prefix(&log, "list"), 1, "log: {:?}", log_lines(&log));
+    assert_eq!(
+        count_with_prefix(&log, "list"),
+        1,
+        "log: {:?}",
+        log_lines(&log)
+    );
     assert_eq!(count_with_prefix(&log, "detail"), 0);
 }
 
@@ -203,7 +217,11 @@ async fn detail_pass_hydrates_visible_rows_once_in_order() {
 
     assert_eq!(detail_of(&scenery, 0).as_deref(), Some("full-r0"));
     assert_eq!(detail_of(&scenery, 1).as_deref(), Some("full-r1"));
-    assert_eq!(branch_of(&scenery, 0).as_deref(), Some("main"), "merge keeps cheap cols");
+    assert_eq!(
+        branch_of(&scenery, 0).as_deref(),
+        Some("main"),
+        "merge keeps cheap cols"
+    );
 
     // Two detail calls, in row order.
     let details: Vec<String> = log_lines(&log)
@@ -246,9 +264,17 @@ async fn sequential_paging_stops_on_short_page() {
     let lists_before = count_with_prefix(&log, "list");
     scenery.request_load_more();
     tokio::time::sleep(Duration::from_millis(20)).await;
-    assert_eq!(count_with_prefix(&log, "list"), lists_before, "no paging past the end");
+    assert_eq!(
+        count_with_prefix(&log, "list"),
+        lists_before,
+        "no paging past the end"
+    );
     assert_eq!(scenery.estimated_total(), Some(5));
-    assert_eq!(count_with_prefix(&log, "detail"), 0, "paging never triggers detail");
+    assert_eq!(
+        count_with_prefix(&log, "detail"),
+        0,
+        "paging never triggers detail"
+    );
 }
 
 /// Switching filter variants reuses the shared detail cache: a filtered variant
@@ -272,7 +298,11 @@ async fn shared_detail_across_filter_variants() {
         (0..5).all(|i| matches!(status_of(&all, i), Some(RowStatus::Fresh)))
     })
     .await;
-    assert_eq!(count_with_prefix(&log, "detail"), 5, "five rows hydrated once each");
+    assert_eq!(
+        count_with_prefix(&log, "detail"),
+        5,
+        "five rows hydrated once each"
+    );
     let lists_after_unfiltered = count_with_prefix(&log, "list");
 
     // Filtered to branch=main: a new index (list runs for the main variant),
@@ -292,7 +322,11 @@ async fn shared_detail_across_filter_variants() {
         "filtered rows reuse the shared detail cache"
     );
     assert_eq!(detail_of(&main, 0).as_deref(), Some("full-r0"));
-    assert_eq!(count_with_prefix(&log, "detail"), 5, "no detail re-fetch across variants");
+    assert_eq!(
+        count_with_prefix(&log, "detail"),
+        5,
+        "no detail re-fetch across variants"
+    );
     assert!(
         count_with_prefix(&log, "list") > lists_after_unfiltered,
         "filtered variant builds its own index"
@@ -311,7 +345,11 @@ async fn shared_detail_across_filter_variants() {
         lists_before_switchback,
         "reused index ⇒ zero list calls"
     );
-    assert_eq!(count_with_prefix(&log, "detail"), 5, "reused index ⇒ zero detail calls");
+    assert_eq!(
+        count_with_prefix(&log, "detail"),
+        5,
+        "reused index ⇒ zero detail calls"
+    );
 }
 
 /// Persisted completeness survives a restart: reopening against the same cache
@@ -459,5 +497,9 @@ async fn no_detail_callback_uses_single_pass() {
             "row {i} should be Fresh in single-pass mode"
         );
     }
-    assert_eq!(count_with_prefix(&log, "detail"), 0, "no detail script in single-pass");
+    assert_eq!(
+        count_with_prefix(&log, "detail"),
+        0,
+        "no detail script in single-pass"
+    );
 }

--- a/vantage-diorama/tests/two_pass.rs
+++ b/vantage-diorama/tests/two_pass.rs
@@ -1,0 +1,463 @@
+//! Two-pass (progressive) loading, end-to-end, wired to **real** vantage-cmd
+//! list + detail scripts (a shell fixture — no mocked records).
+//!
+//! These tests assert the things that matter for progressive loading:
+//! invocation **count**, invocation **order**, and async correctness. They do
+//! NOT simulate slow loads or advance a paused clock (the cucumber suite's
+//! flakiness comes from clock-advance); instead they run on a real clock with a
+//! tiny viewport debounce and a bounded poll helper.
+//!
+//! The fixture (`fixtures/two_pass_runs.sh`) logs every invocation to
+//! `$RUNS_LOG`, so a test reads that file back to assert the exact sequence of
+//! `list`/`detail` calls the machinery issued.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_cmd::{Cmd, CmdSpec, eq};
+use vantage_dataset::prelude::ReadableValueSet;
+use vantage_diorama::{Dio, Lens, RowStatus, TableScenery};
+use vantage_table::pagination::Pagination;
+use vantage_table::table::Table;
+use vantage_types::EmptyEntity;
+
+const ENTITY: &str = "gh-workflow-runs";
+
+/// List script: build `["list", offset, limit, <branch?>]` from scope and parse
+/// the JSON the fixture emits.
+const LIST: &str = r#"
+    let args = ["list", offset, limit];
+    for c in conditions { args += [c.value]; }
+    parse_json(run(args).stdout)
+"#;
+
+/// Detail script: run the fixture with `id` in scope.
+const DETAIL: &str = r#"parse_json(run(["detail", id]).stdout)"#;
+
+fn fixture() -> String {
+    format!("{}/tests/fixtures/two_pass_runs.sh", env!("CARGO_MANIFEST_DIR"))
+}
+
+/// A `Cmd` over the fixture, with the list + detail scripts and the log path
+/// baked into the environment.
+fn make_cmd(log: &Path) -> Cmd {
+    Cmd::new(fixture())
+        .with_env("RUNS_LOG", log.to_string_lossy().to_string())
+        .with_table(ENTITY, CmdSpec::new(LIST).with_detail(DETAIL))
+}
+
+/// Build a master `Vista` over the cmd source — used by the Dio only for its
+/// name (cache table key) and `index_key`.
+fn master(cmd: &Cmd) -> vantage_vista::Vista {
+    let table = Table::<Cmd, EmptyEntity>::new(ENTITY, cmd.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("branch")
+        .with_column_of::<String>("detail");
+    cmd.vista_factory().from_table(table).expect("master vista")
+}
+
+fn cbor_text(v: &CborValue) -> Option<String> {
+    match v {
+        CborValue::Text(s) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Build a two-pass Lens: `on_list_page` runs the cmd list script for the
+/// requested window/conditions; `on_load_detail` runs the cmd detail script for
+/// one id. Registering `on_load_detail` is what opts the Dio into two-pass.
+fn two_pass_lens(cache_dir: &Path, log: &Path) -> Arc<Lens> {
+    let list_cmd = make_cmd(log);
+    let detail_cmd = make_cmd(log);
+    let lens = Lens::new()
+        .cache_at(cache_dir.join("cache.redb"))
+        .viewport_debounce(Duration::from_millis(1))
+        .on_list_page(move |_dio, q| {
+            let cmd = list_cmd.clone();
+            async move {
+                let mut table = Table::<Cmd, EmptyEntity>::new(ENTITY, cmd)
+                    .with_id_column("id")
+                    .with_column_of::<String>("branch");
+                for (field, value) in &q.conditions {
+                    table.add_condition(eq(field.clone(), value.clone()));
+                }
+                let limit = q.limit.max(1) as i64;
+                let page = (q.offset as i64 / limit) + 1;
+                table.set_pagination(Some(Pagination::new(page, limit)));
+                let rows = table.list_values().await?;
+                Ok(rows.into_iter().collect::<Vec<_>>())
+            }
+        })
+        .on_load_detail(move |_dio, id| {
+            let cmd = detail_cmd.clone();
+            async move {
+                let table = Table::<Cmd, EmptyEntity>::new(ENTITY, cmd)
+                    .with_id_column("id")
+                    .with_column_of::<String>("branch")
+                    .with_column_of::<String>("detail");
+                table
+                    .get_value(&id)
+                    .await?
+                    .ok_or_else(|| vantage_core::error!("detail: no record for id"))
+            }
+        })
+        .build()
+        .expect("lens builds");
+    Arc::new(lens)
+}
+
+/// Read the fixture's invocation log back as lines.
+fn log_lines(log: &Path) -> Vec<String> {
+    std::fs::read_to_string(log)
+        .unwrap_or_default()
+        .lines()
+        .map(|l| l.to_string())
+        .collect()
+}
+
+fn count_with_prefix(log: &Path, prefix: &str) -> usize {
+    log_lines(log)
+        .iter()
+        .filter(|l| l.starts_with(prefix))
+        .count()
+}
+
+/// Poll until `f` holds, or panic after ~1s. Real clock; small sleeps yield to
+/// the spawned viewport / list tasks.
+async fn eventually(label: &str, f: impl Fn() -> bool) {
+    for _ in 0..200 {
+        if f() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("condition '{label}' not met within timeout");
+}
+
+fn status_of(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<RowStatus> {
+    scenery.row(idx).map(|r| r.status.clone())
+}
+
+fn detail_of(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
+    scenery
+        .row(idx)
+        .and_then(|r| r.record.get("detail").and_then(cbor_text))
+}
+
+fn branch_of(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
+    scenery
+        .row(idx)
+        .and_then(|r| r.record.get("branch").and_then(cbor_text))
+}
+
+async fn open_dio(lens: &Arc<Lens>, cmd: &Cmd) -> Dio {
+    lens.make_dio(master(cmd)).await.expect("make_dio")
+}
+
+// ---------------------------------------------------------------------------
+
+/// Opening a two-pass scenery runs the list pass exactly once and yields
+/// `Incomplete` rows carrying the cheap columns — and issues **zero** detail
+/// calls until a viewport asks for them.
+#[tokio::test]
+async fn list_pass_creates_incomplete_rows_and_no_detail_calls() {
+    let tmp = TempDir::new().unwrap();
+    let log = tmp.path().join("calls.log");
+    let lens = two_pass_lens(tmp.path(), &log);
+    let dio = open_dio(&lens, &make_cmd(&log)).await;
+
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+
+    // First list page already ran (open awaits it): r0, r1 as Incomplete.
+    assert_eq!(scenery.estimated_total(), Some(2));
+    assert!(scenery.has_more(), "a full first page implies more pages");
+    assert_eq!(status_of(&scenery, 0).map(|s| matches!(s, RowStatus::Incomplete)), Some(true));
+    assert_eq!(branch_of(&scenery, 0).as_deref(), Some("main"));
+    assert!(detail_of(&scenery, 0).is_none(), "no detail before the detail pass");
+
+    // Exactly one list call, no detail calls.
+    assert_eq!(count_with_prefix(&log, "list"), 1, "log: {:?}", log_lines(&log));
+    assert_eq!(count_with_prefix(&log, "detail"), 0);
+}
+
+/// A viewport hydrates each visible `Incomplete` row exactly once, in order,
+/// flipping it to `Fresh`. Re-entering the same viewport hydrates nothing.
+#[tokio::test]
+async fn detail_pass_hydrates_visible_rows_once_in_order() {
+    let tmp = TempDir::new().unwrap();
+    let log = tmp.path().join("calls.log");
+    let lens = two_pass_lens(tmp.path(), &log);
+    let dio = open_dio(&lens, &make_cmd(&log)).await;
+
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    scenery.set_viewport(0..2);
+
+    eventually("rows hydrated", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+            && matches!(status_of(&scenery, 1), Some(RowStatus::Fresh))
+    })
+    .await;
+
+    assert_eq!(detail_of(&scenery, 0).as_deref(), Some("full-r0"));
+    assert_eq!(detail_of(&scenery, 1).as_deref(), Some("full-r1"));
+    assert_eq!(branch_of(&scenery, 0).as_deref(), Some("main"), "merge keeps cheap cols");
+
+    // Two detail calls, in row order.
+    let details: Vec<String> = log_lines(&log)
+        .into_iter()
+        .filter(|l| l.starts_with("detail"))
+        .collect();
+    assert_eq!(details, vec!["detail id=r0", "detail id=r1"]);
+
+    // Re-entering the same viewport must not re-hydrate.
+    scenery.set_viewport(0..2);
+    eventually("debounce settles", || true).await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(count_with_prefix(&log, "detail"), 2, "no re-hydration");
+}
+
+/// Sequential, no-total paging: each `request_load_more` fetches the next list
+/// page; a short final page flips `has_more` false and freezes the estimate.
+#[tokio::test]
+async fn sequential_paging_stops_on_short_page() {
+    let tmp = TempDir::new().unwrap();
+    let log = tmp.path().join("calls.log");
+    let lens = two_pass_lens(tmp.path(), &log);
+    let dio = open_dio(&lens, &make_cmd(&log)).await;
+
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    assert_eq!(scenery.estimated_total(), Some(2));
+    assert!(scenery.has_more());
+
+    // Page 2: r2, r3 (full page) — still more.
+    scenery.request_load_more();
+    eventually("page 2 loaded", || scenery.estimated_total() == Some(4)).await;
+    assert!(scenery.has_more());
+
+    // Page 3: r4 only (short page) — paging ends, estimate freezes at 5.
+    scenery.request_load_more();
+    eventually("page 3 loaded", || scenery.estimated_total() == Some(5)).await;
+    assert!(!scenery.has_more(), "short page ends paging");
+
+    // A further load_more must not issue another list call.
+    let lists_before = count_with_prefix(&log, "list");
+    scenery.request_load_more();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(count_with_prefix(&log, "list"), lists_before, "no paging past the end");
+    assert_eq!(scenery.estimated_total(), Some(5));
+    assert_eq!(count_with_prefix(&log, "detail"), 0, "paging never triggers detail");
+}
+
+/// Switching filter variants reuses the shared detail cache: a filtered variant
+/// finds already-hydrated rows `Fresh` (no detail re-fetch), and switching back
+/// to a previously-built variant reuses its cached index (no list re-fetch).
+#[tokio::test]
+async fn shared_detail_across_filter_variants() {
+    let tmp = TempDir::new().unwrap();
+    let log = tmp.path().join("calls.log");
+    let lens = two_pass_lens(tmp.path(), &log);
+    let dio = open_dio(&lens, &make_cmd(&log)).await;
+
+    // Unfiltered: page through all 5 and hydrate them.
+    let all = dio.table_scenery().page_size(2).open().await.unwrap();
+    all.request_load_more();
+    eventually("page2", || all.estimated_total() == Some(4)).await;
+    all.request_load_more();
+    eventually("page3", || all.estimated_total() == Some(5)).await;
+    all.set_viewport(0..5);
+    eventually("all hydrated", || {
+        (0..5).all(|i| matches!(status_of(&all, i), Some(RowStatus::Fresh)))
+    })
+    .await;
+    assert_eq!(count_with_prefix(&log, "detail"), 5, "five rows hydrated once each");
+    let lists_after_unfiltered = count_with_prefix(&log, "list");
+
+    // Filtered to branch=main: a new index (list runs for the main variant),
+    // but its rows are already Fresh in the shared detail cache → no detail.
+    let main = dio
+        .table_scenery()
+        .where_eq("branch", "main")
+        .page_size(2)
+        .open()
+        .await
+        .unwrap();
+    main.set_viewport(0..2);
+    eventually("filtered rows present", || status_of(&main, 0).is_some()).await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(
+        matches!(status_of(&main, 0), Some(RowStatus::Fresh)),
+        "filtered rows reuse the shared detail cache"
+    );
+    assert_eq!(detail_of(&main, 0).as_deref(), Some("full-r0"));
+    assert_eq!(count_with_prefix(&log, "detail"), 5, "no detail re-fetch across variants");
+    assert!(
+        count_with_prefix(&log, "list") > lists_after_unfiltered,
+        "filtered variant builds its own index"
+    );
+
+    // Switch back to unfiltered: same index_key → cached index reused, so
+    // opening issues zero list calls and zero detail calls.
+    let lists_before_switchback = count_with_prefix(&log, "list");
+    let again = dio.table_scenery().page_size(2).open().await.unwrap();
+    again.set_viewport(0..5);
+    eventually("switchback rows present", || status_of(&again, 4).is_some()).await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(again.estimated_total(), Some(5), "reused index is complete");
+    assert_eq!(
+        count_with_prefix(&log, "list"),
+        lists_before_switchback,
+        "reused index ⇒ zero list calls"
+    );
+    assert_eq!(count_with_prefix(&log, "detail"), 5, "reused index ⇒ zero detail calls");
+}
+
+/// Persisted completeness survives a restart: reopening against the same cache
+/// file resumes the detail pass only for rows that are not already `Complete`.
+#[tokio::test]
+async fn reopen_resumes_without_refetching_complete_rows() {
+    let tmp = TempDir::new().unwrap();
+    let cache_dir = tmp.path().to_path_buf();
+
+    // First run: hydrate the first page, then drop everything.
+    {
+        let log = cache_dir.join("run1.log");
+        let lens = two_pass_lens(&cache_dir, &log);
+        let dio = open_dio(&lens, &make_cmd(&log)).await;
+        let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+        scenery.set_viewport(0..2);
+        eventually("run1 hydrated", || {
+            matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+                && matches!(status_of(&scenery, 1), Some(RowStatus::Fresh))
+        })
+        .await;
+    }
+
+    // Second run: a fresh log against the SAME cache file. The list pass rebuilds
+    // the index, but the persisted `Complete` rows mean zero detail calls.
+    let log2 = cache_dir.join("run2.log");
+    let lens2 = two_pass_lens(&cache_dir, &log2);
+    let dio2 = open_dio(&lens2, &make_cmd(&log2)).await;
+    let scenery2 = dio2.table_scenery().page_size(2).open().await.unwrap();
+
+    // Rows come back `Fresh` straight from the persisted cache.
+    eventually("run2 rows present", || status_of(&scenery2, 0).is_some()).await;
+    assert!(matches!(status_of(&scenery2, 0), Some(RowStatus::Fresh)));
+    assert_eq!(detail_of(&scenery2, 0).as_deref(), Some("full-r0"));
+
+    scenery2.set_viewport(0..2);
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(
+        count_with_prefix(&log2, "detail"),
+        0,
+        "already-complete rows are never re-fetched after restart"
+    );
+}
+
+/// A detail-pass failure for one id marks only that row failed; the others
+/// hydrate normally.
+#[tokio::test]
+async fn detail_failure_marks_only_that_row() {
+    let tmp = TempDir::new().unwrap();
+    let log = tmp.path().join("calls.log");
+
+    // Reuse the two-pass lens but bake FAIL_ID into the detail cmd so r1 errors.
+    let list_cmd = make_cmd(&log);
+    let detail_cmd = make_cmd(&log)
+        .with_env("FAIL_ID", "r1")
+        .with_table(ENTITY, CmdSpec::new(LIST).with_detail(DETAIL));
+    let lens = Arc::new(
+        Lens::new()
+            .cache_at(tmp.path().join("cache.redb"))
+            .viewport_debounce(Duration::from_millis(1))
+            .on_list_page(move |_dio, q| {
+                let cmd = list_cmd.clone();
+                async move {
+                    let mut table = Table::<Cmd, EmptyEntity>::new(ENTITY, cmd)
+                        .with_id_column("id")
+                        .with_column_of::<String>("branch");
+                    for (field, value) in &q.conditions {
+                        table.add_condition(eq(field.clone(), value.clone()));
+                    }
+                    let limit = q.limit.max(1) as i64;
+                    let page = (q.offset as i64 / limit) + 1;
+                    table.set_pagination(Some(Pagination::new(page, limit)));
+                    Ok(table.list_values().await?.into_iter().collect::<Vec<_>>())
+                }
+            })
+            .on_load_detail(move |_dio, id| {
+                let cmd = detail_cmd.clone();
+                async move {
+                    let table = Table::<Cmd, EmptyEntity>::new(ENTITY, cmd)
+                        .with_id_column("id")
+                        .with_column_of::<String>("branch")
+                        .with_column_of::<String>("detail");
+                    table
+                        .get_value(&id)
+                        .await?
+                        .ok_or_else(|| vantage_core::error!("detail: no record"))
+                }
+            })
+            .build()
+            .expect("lens"),
+    );
+
+    let dio = open_dio(&lens, &make_cmd(&log)).await;
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    scenery.set_viewport(0..2);
+
+    eventually("r0 fresh, r1 failed", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+            && matches!(status_of(&scenery, 1), Some(RowStatus::LoadFailed { .. }))
+    })
+    .await;
+
+    assert_eq!(detail_of(&scenery, 0).as_deref(), Some("full-r0"));
+    // The failed row keeps its cheap list column and is not Fresh.
+    assert_eq!(branch_of(&scenery, 1).as_deref(), Some("dev"));
+}
+
+/// Opt-in guard: with no `on_load_detail`, the scenery uses the legacy
+/// single-pass path — rows are `Fresh` immediately and no index is built.
+#[tokio::test]
+async fn no_detail_callback_uses_single_pass() {
+    use vantage_dataset::prelude::ReadableValueSet as _;
+
+    let tmp = TempDir::new().unwrap();
+    let log = tmp.path().join("calls.log");
+    let load_cmd = make_cmd(&log);
+
+    // Legacy lens: on_start copies the full list into the cache; no detail.
+    let lens = Arc::new(
+        Lens::new()
+            .cache_at(tmp.path().join("cache.redb"))
+            .on_start(move |dio| {
+                let dio = dio.clone();
+                let cmd = load_cmd.clone();
+                async move {
+                    let table = Table::<Cmd, EmptyEntity>::new(ENTITY, cmd)
+                        .with_id_column("id")
+                        .with_column_of::<String>("branch");
+                    let rows = table.list_values().await?;
+                    dio.cache().insert_values(rows).await
+                }
+            })
+            .build()
+            .expect("lens"),
+    );
+
+    let dio = open_dio(&lens, &make_cmd(&log)).await;
+    let scenery = dio.table_scenery().page_size(50).open().await.unwrap();
+
+    // Single-pass: every cached row is Fresh, no Incomplete stubs.
+    assert_eq!(scenery.row_count(), 5);
+    for i in 0..5 {
+        assert!(
+            matches!(status_of(&scenery, i), Some(RowStatus::Fresh)),
+            "row {i} should be Fresh in single-pass mode"
+        );
+    }
+    assert_eq!(count_with_prefix(&log, "detail"), 0, "no detail script in single-pass");
+}

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.5 — 2026-06-07
+
+### Added
+
+- `Vista::index_key(conditions, sort)` — a stable per-query identity string
+  (name + normalized conditions + sort). Two-pass loading keys its ordered index
+  by this, so filter/sort variants of the same entity get distinct indexes while
+  sharing the name-keyed detail store.
+
 ## 0.5.4 — 2026-06-07
 
 ### Added

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/mocks/mock_shell.rs
+++ b/vantage-vista/src/mocks/mock_shell.rs
@@ -524,6 +524,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn default_get_value_with_row_ignores_row_and_delegates() {
+        // A driver that does not override `get_vista_value_with_row` must behave
+        // exactly like `get_value` — the extra `row` is ignored.
+        let source = MockShell::new().with_record(
+            "x",
+            record(&[("id", cbor_text("x")), ("name", cbor_text("Xavier"))]),
+        );
+        let vista = build_user_vista(source);
+
+        let mut row: Record<CborValue> = Record::new();
+        row.insert("extra".into(), cbor_text("ignored"));
+
+        let got = vista
+            .get_value_with_row(&"x".to_string(), &row)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(got.get("name"), Some(&cbor_text("Xavier")));
+    }
+
+    #[tokio::test]
     async fn insertable_value_set_assigns_ids() {
         let vista = build_user_vista(MockShell::new());
 

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -57,6 +57,20 @@ pub trait TableShell: Send + Sync + 'static {
         id: &String,
     ) -> Result<Option<Record<CborValue>>>;
 
+    /// Fetch one record by id, with the caller's existing (cheap) record
+    /// available to drivers that can use it (e.g. a cmd detail script reading
+    /// list-pass columns). The default ignores `row` and delegates to
+    /// [`get_vista_value`](Self::get_vista_value); only drivers that benefit
+    /// override it.
+    async fn get_vista_value_with_row(
+        &self,
+        vista: &Vista,
+        id: &String,
+        _row: &Record<CborValue>,
+    ) -> Result<Option<Record<CborValue>>> {
+        self.get_vista_value(vista, id).await
+    }
+
     async fn get_vista_some_value(
         &self,
         vista: &Vista,

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -174,7 +174,7 @@ impl Vista {
     /// driver. Pairs with the two-pass detail pass, which holds the cheap
     /// list-pass row and lets the detail script read its columns. Drivers that
     /// don't use it fall back to plain id lookup (see
-    /// [`TableShell::get_vista_value_with_row`](crate::TableShell::get_vista_value_with_row)).
+    /// [`TableShell::get_vista_value_with_row`]).
     pub async fn get_value_with_row(
         &self,
         id: &String,

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -131,6 +131,39 @@ impl Vista {
         Ok(self)
     }
 
+    // ---- index key ---------------------------------------------------------
+
+    /// Stable string identifying one query variant — the vista's name plus the
+    /// given conditions and sort. Two variants with the same name, the same set
+    /// of conditions (order-insensitive), and the same sort produce the same
+    /// key; any difference produces a different key.
+    ///
+    /// Diorama uses this to cache one ordered index per variant: switching
+    /// filters/sort selects (or builds) the matching index, while the
+    /// id→record detail table is shared across all variants by vista name.
+    /// Deliberately simple — a readable, deterministic rendering rather than a
+    /// hash; collision-resistance is not a goal at this layer.
+    pub fn index_key(
+        &self,
+        conditions: &[(String, CborValue)],
+        sort: Option<(&str, SortDirection)>,
+    ) -> String {
+        let mut conds: Vec<String> = conditions
+            .iter()
+            .map(|(field, value)| format!("{}={}", field, cbor_repr(value)))
+            .collect();
+        // Normalize away condition order so the key is set-stable.
+        conds.sort();
+
+        let sort_repr = match sort {
+            Some((col, SortDirection::Ascending)) => format!("{}:asc", col),
+            Some((col, SortDirection::Descending)) => format!("{}:desc", col),
+            None => String::new(),
+        };
+
+        format!("{}|c:{}|s:{}", self.name, conds.join(";"), sort_repr)
+    }
+
     // ---- aggregates (not part of ValueSet) ---------------------------------
 
     pub async fn get_count(&self) -> Result<i64> {
@@ -278,5 +311,44 @@ impl Vista {
     /// [`TableShell::get_ref_target`].
     pub fn get_ref_target(&self, relation: &str) -> Result<Vista> {
         self.source.get_ref_target(relation)
+    }
+}
+
+/// Deterministic, type-tagged rendering of a [`CborValue`] for
+/// [`Vista::index_key`]. The type tag prevents collisions between values that
+/// stringify alike (e.g. the text `"1"` vs the integer `1`). Containers recurse
+/// so nested condition values stay distinguishable.
+fn cbor_repr(value: &CborValue) -> String {
+    match value {
+        CborValue::Null => "nul".to_string(),
+        CborValue::Bool(b) => format!("b:{b}"),
+        CborValue::Integer(n) => {
+            let n: i128 = (*n).into();
+            format!("i:{n}")
+        }
+        CborValue::Float(f) => format!("f:{f}"),
+        CborValue::Text(s) => format!("t:{s}"),
+        CborValue::Bytes(bytes) => {
+            use std::fmt::Write;
+            let mut s = String::from("x:");
+            for byte in bytes {
+                let _ = write!(s, "{byte:02x}");
+            }
+            s
+        }
+        CborValue::Array(items) => {
+            let inner: Vec<String> = items.iter().map(cbor_repr).collect();
+            format!("a:[{}]", inner.join(","))
+        }
+        CborValue::Map(pairs) => {
+            // Sort by rendered key so map ordering never affects the result.
+            let mut inner: Vec<String> = pairs
+                .iter()
+                .map(|(k, v)| format!("{}={}", cbor_repr(k), cbor_repr(v)))
+                .collect();
+            inner.sort();
+            format!("m:{{{}}}", inner.join(","))
+        }
+        other => format!("?:{other:?}"),
     }
 }

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -170,6 +170,19 @@ impl Vista {
         self.source.get_vista_count(self).await
     }
 
+    /// Fetch one record by id, passing the caller's existing record down to the
+    /// driver. Pairs with the two-pass detail pass, which holds the cheap
+    /// list-pass row and lets the detail script read its columns. Drivers that
+    /// don't use it fall back to plain id lookup (see
+    /// [`TableShell::get_vista_value_with_row`](crate::TableShell::get_vista_value_with_row)).
+    pub async fn get_value_with_row(
+        &self,
+        id: &String,
+        row: &Record<CborValue>,
+    ) -> Result<Option<Record<CborValue>>> {
+        self.source.get_vista_value_with_row(self, id, row).await
+    }
+
     /// Push a driver-native condition into the wrapped table. The
     /// boxed value must match the driver's `T::Condition`. Used by
     /// YAML-driven relation factories that need to inject deferred

--- a/vantage-vista/tests/index_key.rs
+++ b/vantage-vista/tests/index_key.rs
@@ -1,0 +1,95 @@
+//! `Vista::index_key` produces a stable string identifying a query variant
+//! (conditions + sort) so Diorama can cache one ordered index per variant and
+//! reuse it when the same conditions/sort recur.
+
+use ciborium::Value as CborValue;
+use vantage_vista::{Column, SortDirection, Vista, VistaMetadata, mocks::mock_shell::MockShell};
+
+fn t(s: &str) -> CborValue {
+    CborValue::Text(s.into())
+}
+fn i(n: i64) -> CborValue {
+    CborValue::Integer(n.into())
+}
+
+fn runs_vista() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("branch", "String"))
+        .with_column(Column::new("status", "String"))
+        .with_id_column("id");
+    let shell = MockShell::new().with_metadata(metadata);
+    Vista::new("gh-workflow-runs", Box::new(shell))
+}
+
+fn other_vista() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_id_column("id");
+    let shell = MockShell::new().with_metadata(metadata);
+    Vista::new("gh-workflows", Box::new(shell))
+}
+
+#[test]
+fn same_conditions_and_sort_yield_same_key() {
+    let v = runs_vista();
+    let conds = vec![("branch".to_string(), t("main"))];
+    let sort = Some(("status", SortDirection::Ascending));
+    assert_eq!(
+        v.index_key(&conds, sort),
+        v.index_key(&conds, sort),
+        "identical query must produce identical key"
+    );
+}
+
+#[test]
+fn different_conditions_yield_different_keys() {
+    let v = runs_vista();
+    let a = v.index_key(&[("branch".to_string(), t("main"))], None);
+    let b = v.index_key(&[("branch".to_string(), t("dev"))], None);
+    assert_ne!(a, b, "different condition value must change the key");
+
+    let none = v.index_key(&[], None);
+    assert_ne!(a, none, "adding a condition must change the key");
+}
+
+#[test]
+fn different_sort_yields_different_key() {
+    let v = runs_vista();
+    let asc = v.index_key(&[], Some(("status", SortDirection::Ascending)));
+    let desc = v.index_key(&[], Some(("status", SortDirection::Descending)));
+    let unsorted = v.index_key(&[], None);
+    assert_ne!(asc, desc, "sort direction must change the key");
+    assert_ne!(asc, unsorted, "presence of a sort must change the key");
+}
+
+#[test]
+fn condition_order_does_not_change_key() {
+    let v = runs_vista();
+    let ab = v.index_key(
+        &[
+            ("branch".to_string(), t("main")),
+            ("status".to_string(), i(1)),
+        ],
+        None,
+    );
+    let ba = v.index_key(
+        &[
+            ("status".to_string(), i(1)),
+            ("branch".to_string(), t("main")),
+        ],
+        None,
+    );
+    assert_eq!(ab, ba, "condition order must be normalized away");
+}
+
+#[test]
+fn different_vista_name_yields_different_key() {
+    let runs = runs_vista();
+    let workflows = other_vista();
+    assert_ne!(
+        runs.index_key(&[], None),
+        workflows.index_key(&[], None),
+        "the same empty query on two entities must not collide"
+    );
+}


### PR DESCRIPTION
## Two-pass progressive loading + cmd detail scripts

Adds the framework capability for slow data sources to render a cheap **list pass** immediately and hydrate expensive per-row **detail** lazily as rows come into view, without blocking the UI.

### vantage-cmd
- Reuse the rhai `Engine` + compiled `AST` across calls instead of rebuilding per call.
- A table can declare two scripts: a `list` script (default) and a `detail` script. `get_table_value(id)` runs the detail script with the id — and the existing list-pass row — injected into scope (`row` map in `QueryContext`), so the detail script can read cheap columns already fetched.
- `Vista::get_value` routes through the detail script; `get_table_value_with_row` / `get_vista_value_with_row` feed the cached row down.
- Surface child-process stderr into the tracing log (WARN on non-zero exit, DEBUG otherwise) so tool diagnostics are visible to the host app.

### vantage-diorama
- Persist `RowStatus` in the detail cache (adds `Incomplete`); detail table is keyed by Vista name and shared across filter/sort variants.
- Per-query index built by the list pass (keyed by `Vista::index_key(conditions, sort)`), decoupled from the detail store.
- Viewport-driven detail pass hydrates absent/`Incomplete` ids per-id, merges detail onto the list row (list columns survive), flips to `Fresh`, bumps the generation; skips ids already `Fresh`.
- Sequential no-total paging (short/empty page ends paging).
- All of the above engages only when a `detail` callback exists; SQL/CSV/single-pass paths are unchanged.

### vantage-vista
- `Vista::index_key(conditions, sort)` for per-query index identity.

### Tests
- `vantage-cmd`: list vs detail dispatch, engine/AST reuse, row injection.
- `vantage-diorama`: cmd-script-backed BDD suite for list pass, detail pass, shared detail across variants, resume, opt-in guard, failure — assertion-based, no timing/clock advance.

**Merge order:** base for `vantage-ui#feature/scripted-tables` (which patches these crates to local paths until released).
