### PR TITLE
Add security review form fable

### DIFF
--- a/agent/review/INDEX.md
+++ b/agent/review/INDEX.md
@@ -1,0 +1,94 @@
+# Code Review Findings — vantage
+
+Generated 2026-06-10 by an automated multi-agent review. Each file contains a snippet, severity, and recommendation.
+
+**Total: 59** (security: 11 · bugs: 18 · inconsistencies: 14 · omissions: 11 · performance: 3 · suggestions: 2)
+
+## Security (11)
+
+| Severity | Finding | Location |
+|---|---|---|
+| critical | [SurrealQL injection via Thing/record-id rendered into query text](security/data-surreal-thing-injection.md) | `vantage-surrealdb/src/thing.rs:132` |
+| high | [DebugEngine prints all RPC params and responses (incl. secrets) to stdout](security/data-surreal-debug-logging.md) | `surreal-client/src/engines/debug.rs:21` |
+| high | [SurrealDB Identifier escaping is incomplete and bypassable](security/data-surreal-identifier-escaping.md) | `vantage-surrealdb/src/identifier.rs:49` |
+| high | [SurrealQL injection in inline single-quoted primitives (similarity / time_group)](security/data-surreal-inline-string-injection.md) | `vantage-surrealdb/src/primitives.rs:219` |
+| high | [API auth tokens exposed via derived Debug on RestApi/GraphqlApi](security/infra-auth-header-in-debug.md) | `vantage-api-client/src/rest/api.rs:103` |
+| medium | [search_table_condition embeds parameter placeholder inside a quoted SQL literal](security/core-search-condition-placeholder-in-literal.md) | `vantage-table/src/mocks/mock_table_source.rs:159-168` |
+| medium | [MySQL JSON_TABLE inlines name/type/path without escaping](security/data-mysql-jsontable-escaping.md) | `vantage-sql/src/mysql/statements/primitives/json_table.rs:57` |
+| medium | [vantage-sql Identifier does not escape embedded quote characters](security/data-sql-identifier-quote-escaping.md) | `vantage-sql/src/primitives/identifier.rs:67` |
+| medium | [Plaintext credentials exposed through derived Debug on connection/auth types](security/data-surreal-credentials-in-debug-derive.md) | `surreal-client/src/connection.rs:31` |
+| medium | [Cmd/CmdSpec Debug output includes declared env (often credentials)](security/infra-cmd-debug-env-secrets.md) | `vantage-cmd/src/cmd.rs:80` |
+| low | [LogWriter table name joins into the path unchecked (traversal out of base_dir)](security/infra-log-writer-path-traversal.md) | `vantage-log-writer/src/log_writer.rs:56` |
+
+## Bugs (18)
+
+| Severity | Finding | Location |
+|---|---|---|
+| high | [ImDataSource read-modify-write race loses concurrent updates](bugs/core-im-datasource-lost-update-race.md) | `vantage-dataset/src/im/mod.rs:50-58` |
+| high | [LICENSE carries someone else's copyright; Apache-2.0 file missing despite dual-license claim](bugs/docs-license-wrong-copyright.md) | `LICENSE:3` |
+| high | [Failed pool requests are dropped, leaving callers awaiting forever](bugs/infra-pool-error-request-hangs-caller.md) | `vantage-api-pool/src/client_pool/http.rs:101` |
+| medium | [IntoValue for f64 panics on NaN/Infinity](bugs/core-f64-into-value-panic.md) | `vantage-expressions/src/value.rs:31` |
+| medium | [IntoRecord blanket impls panic on entity serialization failure](bugs/core-into-record-expect-panic.md) | `vantage-types/src/record.rs:237` |
+| medium | [get_table_count_expr calls Handle::block_on inside the runtime — guaranteed panic](bugs/core-mock-count-block-on-panic.md) | `vantage-table/src/mocks/mock_table_source.rs:492-520` |
+| medium | [Table::select_column unwraps column lookup — panics on unknown field name](bugs/core-select-column-unwrap.md) | `vantage-table/src/table/impls/selectable.rs:135` |
+| medium | [CSV search filter is silently a no-op (returns all rows)](bugs/data-csv-search-noop.md) | `vantage-csv/src/table_source.rs:65` |
+| medium | [bakery_model3 README documents a `cli` example that doesn't exist and outdated sources/version](bugs/docs-bakery3-readme-cli-example.md) | `bakery_model3/README.md:43` |
+| medium | [README references crates and an example file that don't exist (vantage-config, bakery_api, bakery_model/examples)](bugs/docs-readme-nonexistent-crates-and-example.md) | `README.md:84` |
+| medium | [Unbounded retries and uncapped server-controlled Retry-After sleep](bugs/infra-pool-unbounded-retries.md) | `vantage-api-pool/src/eventual_request/mod.rs:117` |
+| medium | [RestApi get_table_value/get_table_count only see the current page](bugs/infra-rest-get-value-page-scoped.md) | `vantage-api-client/src/rest/table_source.rs:131` |
+| medium | [RestApi search condition is silently dropped — search returns all rows](bugs/infra-rest-search-silent-noop.md) | `vantage-api-client/src/rest/table_source.rs:103` |
+| low | [Expression::preview() corrupts output when parameter values contain `{}`](bugs/core-preview-replacen-corruption.md) | `vantage-expressions/src/expression/core.rs:168-175` |
+| low | [SurrealDB get_table_value ignores the table's id field name](bugs/data-surreal-get-value-id-field.md) | `vantage-surrealdb/src/surrealdb/impls/table_source.rs:216` |
+| low | [Broken links: book step8 link, vantage-table → expressions README, rustdoc-only link in crates.io README](bugs/docs-broken-doc-links.md) | `docs4/src/new-persistence.md:121` |
+| low | [README code snippets contain Rust syntax errors and typos](bugs/docs-readme-snippet-syntax-errors.md) | `README.md:35` |
+| low | [HttpClientPool::with_rate_limit silently does nothing when pool was built without one](bugs/infra-rate-limit-silent-noop.md) | `vantage-api-pool/src/client_pool/http.rs:109` |
+
+## Inconsistencies (14)
+
+| Severity | Finding | Location |
+|---|---|---|
+| high | [insert/delete idempotency contracts contradicted by the framework's own implementations](inconsistencies/core-insert-delete-idempotency-contract.md) | `vantage-dataset/src/traits/dataset.rs:179-189` |
+| high | [vantage-config.schema.json is the old-prototype schema; doesn't match what code parses](inconsistencies/docs-config-schema-stale.md) | `vantage-config.schema.json:1` |
+| high | [README documents type-erasure API (AnyTable, AnyDataSet) that does not exist in code](inconsistencies/docs-readme-anytable-anydataset-fiction.md) | `README.md:99` |
+| high | [README DataSet/Pagination examples use method names that don't exist](inconsistencies/docs-readme-dataset-api-names.md) | `README.md:241-283` |
+| high | [README and book claim "0.4" while all crates are 0.5.x; install snippet pins "0.4"](inconsistencies/docs-version-04-vs-05-crates.md) | `README.md:90` |
+| medium | [ActiveEntity::save() replaces, ActiveRecord::save() patches — same API name, different semantics](inconsistencies/core-active-save-semantics-diverge.md) | `vantage-dataset/src/record.rs:32-34` |
+| medium | [`search_table_condition` has wildly different semantics per engine](inconsistencies/data-search-semantics-divergence.md) | `vantage-sql/src/sqlite/impls/table_source.rs:110` |
+| medium | [SQL backends disagree on placeholder/param-count validation](inconsistencies/data-sql-placeholder-validation-divergence.md) | `vantage-sql/src/sqlite/impls/expr_data_source.rs:89` |
+| medium | [README says PostgreSQL/MySQL are "coming next" but vantage-sql already implements them](inconsistencies/docs-readme-postgres-mysql-status.md) | `README.md:665` |
+| medium | [README flips Table generic parameter order and shows outdated with_many closure shape](inconsistencies/docs-readme-table-generics-flip.md) | `README.md:293-297` |
+| medium | ["vantage-ui-adapters" is actually package `dataset-ui-adapters`, unpublished, with unusable Quick Start](inconsistencies/docs-ui-adapters-crate-name.md) | `vantage-ui-adapters/README.md:22` |
+| medium | [AWS_ENDPOINT_URL override honoured only by json1/json10 transports](inconsistencies/infra-aws-endpoint-override-ignored.md) | `vantage-aws/src/restjson/transport.rs:30` |
+| low | [Mixed id-parameter conventions across dataset traits, and trait docs showing outdated signatures](inconsistencies/core-id-param-conventions-and-doc-drift.md) | `vantage-dataset/src/traits/dataset.rs:125,189` |
+| low | [README backend-status table step numbers don't match the Persistence Guide it cites](inconsistencies/docs-readme-status-table-step-numbers.md) | `README.md:709-716` |
+
+## Omissions (11)
+
+| Severity | Finding | Location |
+|---|---|---|
+| medium | [get_count_via_query returns Ok(0) for unrecognized result shapes](omissions/core-count-query-silent-zero.md) | `vantage-table/src/table/impls/selectable.rs:209-221` |
+| medium | [Stale source files outside the module tree (would not compile if re-enabled)](omissions/core-dead-source-files.md) | `vantage-table/src/with_columns.rs:1` |
+| medium | [Flatten::resolve_deferred is a documented no-op — flatten() silently skips deferred parameters](omissions/core-resolve-deferred-noop.md) | `vantage-expressions/src/expression/flatten.rs:65-70` |
+| medium | [redb panics (not Err) on unsupported search — reachable from generic code](omissions/data-redb-csv-panic-on-unsupported.md) | `vantage-redb/src/redb/impls/table_source.rs:72` |
+| medium | [Root README omits Vista, Diorama and other shipped crates that the book headlines](omissions/docs-readme-missing-vista-diorama.md) | `README.md:64-88` |
+| medium | [Root CHANGELOG.md ends at 0.2.0 (2025-02-16) — three releases behind](omissions/docs-root-changelog-stale.md) | `CHANGELOG.md:5` |
+| medium | [AwwPool caches the first auth token forever — no expiry or refresh](omissions/infra-awwpool-token-never-refreshed.md) | `vantage-api-pool/src/aww_pool.rs:110` |
+| medium | [vantage-cmd subprocesses have no timeout and unbounded output capture](omissions/infra-cmd-run-no-timeout.md) | `vantage-cmd/src/exec.rs:66` |
+| medium | [No timeouts on any HTTP client (RestApi, GraphqlApi, AwsAccount, pool workers)](omissions/infra-no-http-timeouts.md) | `vantage-api-client/src/rest/api.rs:536` |
+| medium | [unimplemented!() panics reachable through normal TableSource API](omissions/infra-unimplemented-panics-reachable.md) | `vantage-api-pool/src/pool_api.rs:371` |
+| low | [MockTableSource::with_data silently drops rows without "id" — count and list disagree](omissions/core-mock-with-data-drops-idless-rows.md) | `vantage-table/src/mocks/mock_table_source.rs:50-77` |
+
+## Performance (3)
+
+| Severity | Finding | Location |
+|---|---|---|
+| medium | [Every ImTable operation clones the entire table](performance/core-im-table-full-clone-per-op.md) | `vantage-dataset/src/im/mod.rs:50-53` |
+| low | [CSV backend re-reads and re-parses the whole file on every operation](performance/data-csv-full-file-rescan.md) | `vantage-csv/src/table_source.rs:93` |
+| low | [AwwPool::get builds a fresh reqwest::Client per call](performance/infra-awwpool-new-client-per-get.md) | `vantage-api-pool/src/aww_pool.rs:75` |
+
+## Suggestions (2)
+
+| Severity | Finding | Location |
+|---|---|---|
+| low | [VantageError `is_*` methods are builders, not predicates](suggestions/core-errorkind-is-naming.md) | `vantage-core/src/util/error.rs:236-256` |
+| low | [Unify the two divergent SurrealDB identifier-escaping implementations](suggestions/data-unify-surreal-identifier-escaping.md) | `vantage-surrealdb/src/identifier.rs:49` |

--- a/agent/review/bugs/core-f64-into-value-panic.md
+++ b/agent/review/bugs/core-f64-into-value-panic.md
@@ -1,0 +1,21 @@
+# IntoValue for f64 panics on NaN/Infinity
+
+- **Severity:** medium
+- **Category:** bugs
+- **Location:** `vantage-expressions/src/value.rs:31`
+
+The `IntoValue` impl for `f64` unwraps `serde_json::Number::from_f64`, which returns `None` for `NaN`, `+Infinity` and `-Infinity`. Any value that flows from user data or a computation (e.g. a division by zero producing `inf`) into an expression parameter will panic the process instead of returning an error or `Value::Null`.
+
+```rust
+impl_into_value! {
+    i32 => |v| Value::Number(serde_json::Number::from(v)),
+    i64 => |v| Value::Number(serde_json::Number::from(v)),
+    u64 => |v| Value::Number(serde_json::Number::from(v)),
+    f64 => |v| Value::Number(serde_json::Number::from_f64(v).unwrap()),
+    bool => Value::Bool,
+    String => Value::String,
+    ...
+}
+```
+
+**Recommendation:** Map non-finite floats to `Value::Null` (`Number::from_f64(v).map(Value::Number).unwrap_or(Value::Null)`) or make `into_value` fallible; never `unwrap()` on data-derived floats.

--- a/agent/review/bugs/core-im-datasource-lost-update-race.md
+++ b/agent/review/bugs/core-im-datasource-lost-update-race.md
@@ -1,0 +1,21 @@
+# ImDataSource read-modify-write race loses concurrent updates
+
+- **Severity:** high
+- **Category:** bugs
+- **Location:** `vantage-dataset/src/im/mod.rs:50-58`
+
+Every `ImTable` operation calls `get_or_create_table` (which clones the whole table out of the mutex and releases the lock), mutates the clone, then calls `update_table` (which re-acquires the lock and overwrites the whole table). Two concurrent writers on the same table will each clone the same snapshot and the second `update_table` silently discards the first writer's changes. The idempotency check in `insert_value`/`insert` (`if table.get(id).is_some()`) is also race-prone: two concurrent inserts of the same id can both succeed and the later one overwrites. `ImDataSource` is `Clone` over an `Arc` and the API is async, so concurrent use is the expected mode.
+
+```rust
+pub(super) fn get_or_create_table(&self, table_name: &str) -> IndexMap<String, Record<V>> {
+    let mut tables = self.tables.lock().unwrap();
+    tables.entry(table_name.to_string()).or_default().clone()
+}
+
+pub(super) fn update_table(&self, table_name: &str, table: IndexMap<String, Record<V>>) {
+    let mut tables = self.tables.lock().unwrap();
+    tables.insert(table_name.to_string(), table);
+}
+```
+
+**Recommendation:** Mutate in place under a single lock acquisition (e.g. expose `with_table_mut(&self, name, impl FnOnce(&mut IndexMap<...>) -> R)`), so each operation is atomic with respect to the shared map.

--- a/agent/review/bugs/core-into-record-expect-panic.md
+++ b/agent/review/bugs/core-into-record-expect-panic.md
@@ -1,0 +1,23 @@
+# IntoRecord blanket impls panic on entity serialization failure
+
+- **Severity:** medium
+- **Category:** bugs
+- **Location:** `vantage-types/src/record.rs:237` (also `record.rs:281`)
+
+The blanket `IntoRecord<serde_json::Value>` and `IntoRecord<ciborium::Value>` impls — the path every serde-derived entity takes on `insert`/`replace`/`patch` — use `.expect()` on serialization. Serialization of user-defined entities can legitimately fail (e.g. a `HashMap` with non-string keys for JSON, or a custom `Serialize` impl returning an error), turning a recoverable error into a process abort deep inside `Table::insert`. The trait itself is infallible (`fn into_record(self) -> Record<T>`), so implementations have no error channel.
+
+```rust
+impl<T> IntoRecord<serde_json::Value> for T
+where
+    T: serde::Serialize,
+{
+    fn into_record(self) -> Record<serde_json::Value> {
+        let json_value = serde_json::to_value(self).expect("Failed to serialize to JSON");
+        ...
+    }
+}
+// CBOR twin:
+let cbor_value = ciborium::Value::serialized(&self).expect("Failed to serialize entity to CBOR");
+```
+
+**Recommendation:** Make the conversion fallible (`TryIntoRecord` / `fn into_record(self) -> Result<Record<T>>`) mirroring `TryFromRecord`, or document the panic contract prominently. Note the CBOR impl additionally drops map entries with non-text keys silently (`filter_map`), which is silent data loss on the same path.

--- a/agent/review/bugs/core-mock-count-block-on-panic.md
+++ b/agent/review/bugs/core-mock-count-block-on-panic.md
@@ -1,0 +1,20 @@
+# get_table_count_expr calls Handle::block_on inside the runtime — guaranteed panic
+
+- **Severity:** medium
+- **Category:** bugs
+- **Location:** `vantage-table/src/mocks/mock_table_source.rs:492-520`
+
+`TableExprSource::get_table_count_expr` is a sync method that grabs the current Tokio handle with `Handle::try_current()` and immediately calls `handle.block_on(...)`. `Handle::block_on` panics with "Cannot block the current thread from within a runtime" when invoked from a runtime worker thread — which is exactly the case in which `try_current()` succeeds. So whenever this is called from async code (the normal case for table operations), it panics; when called outside a runtime it silently returns 0. A TODO in the code acknowledges this, and the only test exercising the path is commented out.
+
+```rust
+let count = tokio::runtime::Handle::try_current()
+    .map(|handle| {
+        // TODO: we shouldn't use block_on here
+        handle.block_on(async {
+            self.data.lock().await.get(table_name).map(|data| data.len()).unwrap_or(0)
+        })
+    })
+    .unwrap_or_else(|_| 0);
+```
+
+**Recommendation:** Replace `tokio::sync::Mutex` with `std::sync::Mutex` for `data` (no await is needed under the lock) so the count can be read synchronously, or register the mock answer lazily via a `DeferredFn` instead of pre-computing it.

--- a/agent/review/bugs/core-preview-replacen-corruption.md
+++ b/agent/review/bugs/core-preview-replacen-corruption.md
@@ -1,0 +1,20 @@
+# Expression::preview() corrupts output when parameter values contain `{}`
+
+- **Severity:** low
+- **Category:** bugs
+- **Location:** `vantage-expressions/src/expression/core.rs:168-175`
+
+`preview()` substitutes parameters with `replacen("{}", ..., 1)` sequentially. If an earlier parameter's rendered value itself contains `{}` (a JSON object/string like `"x{}y"` or `{}`), subsequent replacements target the `{}` *inside the already-substituted value* instead of the next template placeholder, producing a scrambled preview. `preview()` is also the `Debug` impl and is what `MockBuilder::on_exact_select` matches against, so mocks and error messages can mis-resolve for such values.
+
+```rust
+pub fn preview(&self) -> String {
+    let mut preview = self.template.clone();
+    for param in &self.parameters {
+        let param_str = param.preview();
+        preview = preview.replacen("{}", &param_str, 1);
+    }
+    preview
+}
+```
+
+**Recommendation:** Build the preview in one pass by splitting the template on `{}` and interleaving parameter strings (as `flatten_nested` does), so substituted values are never re-scanned.

--- a/agent/review/bugs/core-select-column-unwrap.md
+++ b/agent/review/bugs/core-select-column-unwrap.md
@@ -1,0 +1,21 @@
+# Table::select_column unwraps column lookup — panics on unknown field name
+
+- **Severity:** medium
+- **Category:** bugs
+- **Location:** `vantage-table/src/table/impls/selectable.rs:135`
+
+`select_column(&self, field: &str)` calls `self.get_column_expr(field).unwrap()`. The field name is a plain string that in Vantage UI typically originates from YAML/Rhai config, so a typo in a config file panics the process instead of surfacing a config error. The sibling lookup APIs (`column()`, `get_ref_as`, `lookup_ref`) all return `Option`/`Result` for the same situation, so this is also internally inconsistent.
+
+```rust
+pub fn select_column(&self, field: &str) -> Expression<T::Value>
+where
+    T::Column<T::AnyType>: Expressive<T::Value>,
+    T::Select: Expressive<T::Value>,
+{
+    let expr = self.get_column_expr(field).unwrap();
+    let mut select = self.select_empty();
+    ...
+}
+```
+
+**Recommendation:** Return `Result<Expression<T::Value>>` and propagate a "column not found" `VantageError` (with the table and field in context), matching `lookup_ref`'s behavior.

--- a/agent/review/bugs/data-csv-search-noop.md
+++ b/agent/review/bugs/data-csv-search-noop.md
@@ -1,0 +1,16 @@
+# CSV search filter is silently a no-op (returns all rows)
+
+- **Severity:** medium
+- **Category:** bugs
+- **Location:** `vantage-csv/src/table_source.rs:65`
+
+`Csv::search_table_condition` returns `Expression::new(format!("SEARCH '{}'", search_value), vec![])` — a template with **zero parameters**. When that condition reaches `apply_condition`, the first guard `if params.len() < 2 { return Ok(records); }` (`condition.rs:26`) matches, so the records pass through **unfiltered**. A user searching a CSV-backed table silently gets every row instead of the matching subset — a correctness and data-exposure bug (the UI presents it as a filtered result). The interpolated, unescaped `'{}'` is also dead/misleading code.
+
+```rust
+fn search_table_condition<E>(&self, _table: &Table<Self, E>, search_value: &str)
+    -> Expression<Self::Value> {
+    Expression::new(format!("SEARCH '{}'", search_value), vec![])  // 0 params → ignored downstream
+}
+```
+
+**Recommendation:** Either implement a real substring filter over the table's columns (matching the SQL/Surreal/Mongo backends) or return an explicit "search unsupported" error so the no-op cannot masquerade as a filtered result.

--- a/agent/review/bugs/data-surreal-get-value-id-field.md
+++ b/agent/review/bugs/data-surreal-get-value-id-field.md
@@ -1,0 +1,14 @@
+# SurrealDB get_table_value ignores the table's id field name
+
+- **Severity:** low
+- **Category:** bugs
+- **Location:** `vantage-surrealdb/src/surrealdb/impls/table_source.rs:216`
+
+`get_table_value` hard-codes the literal `"id"` when parsing the returned row, while the sibling methods `list_table_values` and `get_table_some_value` correctly derive `id_field_name` from `table.id_field()`. For a table whose id column is named anything other than `id`, `parse_cbor_row` will fail to extract the `Thing` (it is discarded anyway here, so the record still returns), but the divergence is a latent inconsistency: the same table source resolves the id field three different ways across three read paths.
+
+```rust
+let (_thing, record) = parse_cbor_row(map, "id");  // should be table.id_field() name
+Ok(Some(record))
+```
+
+**Recommendation:** Compute `id_field_name` from `table.id_field()` as the other read methods do, and pass it to `parse_cbor_row` for consistency.

--- a/agent/review/bugs/docs-bakery3-readme-cli-example.md
+++ b/agent/review/bugs/docs-bakery3-readme-cli-example.md
@@ -1,0 +1,17 @@
+# bakery_model3 README documents a `cli` example that doesn't exist and outdated sources/version
+
+- **Severity:** medium
+- **Category:** bugs
+- **Location:** `bakery_model3/README.md:43` (also lines 3, 28)
+
+Every CLI invocation in the README uses `cargo run -p bakery_model3 --example cli -- ...`, but the examples directory contains only `0-intro.rs`, `cli-vista.rs`, `contained-surreal.rs` and `dynamo-smoke.rs` — `cargo` errors with "no example target named `cli`". The README also says sources are "`csv`, `surreal`" while `cli-vista.rs` actually supports `csv, sqlite, postgres, mongo, surreal` (and the sibling `CLI_WALKTHROUGH.md` correctly uses `--example cli-vista -- sqlite ...`). Line 3 still labels the crate as "demonstrating Vantage 0.3" although the workspace is at 0.5.x.
+
+```
+# List products from CSV files
+cargo run -p bakery_model3 --example cli -- csv product list
+
+# List clients from SurrealDB
+cargo run -p bakery_model3 --example cli -- surreal client list
+```
+
+**Recommendation:** Replace `--example cli` with `--example cli-vista` throughout, update the sources table to the five actually supported backends (matching CLI_WALKTHROUGH.md), and fix the "Vantage 0.3" label.

--- a/agent/review/bugs/docs-broken-doc-links.md
+++ b/agent/review/bugs/docs-broken-doc-links.md
@@ -1,0 +1,17 @@
+# Broken links: book step8 link, vantage-table → expressions README, rustdoc-only link in crates.io README
+
+- **Severity:** low
+- **Category:** bugs
+- **Location:** `docs4/src/new-persistence.md:121` (also `vantage-table/README.md:293`, `vantage-expressions/README.md:21`)
+
+Three dead links verified by resolving every relative markdown link: (1) the persistence guide links "Read Step 8" to `./new-persistence/step8-vista.md`, but the file is named `step8-vista-integration.md` (per SUMMARY.md), so the rendered book yields a 404; (2) `vantage-table/README.md:293` links `[vantage-expressions README](vantage-expressions/README.md)` — relative to the vantage-table directory this resolves to `vantage-table/vantage-expressions/README.md`, which doesn't exist (missing `../`); (3) `vantage-expressions/README.md:21` uses a rustdoc intra-doc path `[expression module documentation](crate::expression::core)` which is a literal broken href on GitHub and crates.io where this README is the crate landing page.
+
+```
+**[Read Step 8 →](./new-persistence/step8-vista.md)**
+...
+[vantage-expressions README](vantage-expressions/README.md) for details on `DeferredFn` and
+...
+[expression module documentation](crate::expression::core).
+```
+
+**Recommendation:** Fix the step8 filename, prefix `../` on the vantage-table link, and replace the intra-doc link with a docs.rs URL; consider adding a link-checker (e.g. lychee or mdbook-linkcheck) to CI.

--- a/agent/review/bugs/docs-license-wrong-copyright.md
+++ b/agent/review/bugs/docs-license-wrong-copyright.md
@@ -1,0 +1,19 @@
+# LICENSE carries someone else's copyright; Apache-2.0 file missing despite dual-license claim
+
+- **Severity:** high
+- **Category:** bugs
+- **Location:** `LICENSE:3`
+
+The repo's only license file is MIT with "Copyright (c) 2015 Sean Griffin" — Sean Griffin is the Diesel author, so this file appears copied verbatim from another project and assigns copyright to the wrong person/year. Meanwhile all 21 publishable crates declare `license = "MIT OR Apache-2.0"` in Cargo.toml, but no Apache-2.0 license text exists anywhere in the repo, and no per-crate license files are packaged. The website (vantage-web2/positioning.md) leans on "open-source, MIT-licensed Vantage Framework" as a trust signal, so a wrong copyright holder directly undermines a headline claim.
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Sean Griffin
+```
+```
+# */Cargo.toml (21 crates)
+license = "MIT OR Apache-2.0"
+```
+
+**Recommendation:** Replace the copyright line with the actual author (Romans Malinovskis) and current year, add a LICENSE-APACHE file (or change crate metadata to `license = "MIT"` to match the website), and ensure license files are included in published packages.

--- a/agent/review/bugs/docs-readme-nonexistent-crates-and-example.md
+++ b/agent/review/bugs/docs-readme-nonexistent-crates-and-example.md
@@ -1,0 +1,18 @@
+# README references crates and an example file that don't exist (vantage-config, bakery_api, bakery_model/examples)
+
+- **Severity:** medium
+- **Category:** bugs
+- **Location:** `README.md:84` (also `README.md:531-532,613`)
+
+Three referents in the README don't exist: (1) line 84 lists a `vantage-config` crate ("Reads Entity definitions from yaml, creating type-erased AnyTables") — no such crate exists in this repo or on the workspace member list (the YAML loader is `vantage_inventory` in the vantage-ui repo); (2) lines 531-532 link to `https://github.com/romaninsh/vantage/blob/main/bakery_model/examples/3-query-builder.rs`, but `bakery_model/` contains only `src/` — no `examples/` directory, so the link 404s; (3) line 613 says "there is integration with Axum (see `bakery_api` crate)" — no `bakery_api` directory or crate exists anywhere in the repo (the Axum demo is `learn-3/src/vantage_axum.rs`).
+
+```
+- vantage-config - Reads Entity definitions from `yaml` file, creating type-erased `AnyTable`s.
+...
+(Full example:
+<https://github.com/romaninsh/vantage/blob/main/bakery_model/examples/3-query-builder.rs>)
+...
+there is integration with Axum (see `bakery_api` crate)
+```
+
+**Recommendation:** Drop or rename the `vantage-config` bullet, point the query-builder link at an existing example (e.g. `bakery_model3/examples/` or `learn-1`), and point the Axum mention at `learn-3` / the book's "A Standalone Axum Server" chapter.

--- a/agent/review/bugs/docs-readme-snippet-syntax-errors.md
+++ b/agent/review/bugs/docs-readme-snippet-syntax-errors.md
@@ -1,0 +1,15 @@
+# README code snippets contain Rust syntax errors and typos
+
+- **Severity:** low
+- **Category:** bugs
+- **Location:** `README.md:35` (also lines 130, 230, 416, 452, 470-471)
+
+Several README snippets are not valid Rust even as pseudo-code: line 35 `email: Email(String),` is not a legal field type; line 130 `fn new(){ /* ... */};` has a stray semicolon and missing signature; line 230 `let entities: = vec![clients, orders, ..];` has an empty type ascription; line 416 `let now = if Some(date) = cutoff_date` is missing `let` in the `if let`; lines 470-471 have unbalanced parens and a string opened with `"` but closed with `'`, plus typos `postgrs` and (line 452) `eu_countires`. For a crate whose pitch is type-safety and ergonomics, the front-page examples failing to even parse undermines credibility.
+
+```
+    .with_expression(expr!("SUM(vat)", Some("total_vat".to_string()))
+    .with_condition(expr!("country_code in {}', postgrs.defer(&eu_countries)))
+    .get().await?; // <-- single await!
+```
+
+**Recommendation:** Run the snippets through `rustfmt`/a doctest-style compile pass (or source them from the compiled `learn-*` crates as the book does) and fix the typos.

--- a/agent/review/bugs/infra-pool-error-request-hangs-caller.md
+++ b/agent/review/bugs/infra-pool-error-request-hangs-caller.md
@@ -1,0 +1,15 @@
+# Failed pool requests are dropped, leaving callers awaiting forever
+
+- **Severity:** high
+- **Category:** bugs
+- **Location:** `vantage-api-pool/src/client_pool/http.rs:101`
+
+When a worker gets `EventualRequestResult::Error` (any non-success, non-429, non-5xx status — including 401/403/404 — or a missing/un-clonable request body), it only logs and drops the `EventualRequest`. The matching `oneshot::Sender` stays in `EventualRequestMatcher::pending_requests` forever, so the caller blocked on `receiver.await` in `matcher/mod.rs:76` (`AwwPool::request`/`get`) never resolves — every 4xx response turns into a permanent hang plus a map-entry leak.
+
+```rust
+EventualRequestResult::Error(e) => {
+    error!(error = %e, worker = w, "http request failed in worker");
+}
+```
+
+**Recommendation:** Route errored requests back through the response channel (the matcher already delivers the `EventualRequest`; `send()` can surface `Error` from it), or remove and drop the pending oneshot sender so `receiver.await` fails fast with `RecvError`.

--- a/agent/review/bugs/infra-pool-unbounded-retries.md
+++ b/agent/review/bugs/infra-pool-unbounded-retries.md
@@ -1,0 +1,21 @@
+# Unbounded retries and uncapped server-controlled Retry-After sleep
+
+- **Severity:** medium
+- **Category:** bugs
+- **Location:** `vantage-api-pool/src/eventual_request/mod.rs:117`
+
+`EventualRequest::execute` returns `Retry` for every 429, 5xx, and network error, and the worker loop (`client_pool/http.rs:97`) re-runs the same request with no maximum attempt count — a permanently failing endpoint pins a worker forever and the caller never gets an answer. Additionally `extract_retry_delay` honours the server's `Retry-After` header with no upper bound, so a hostile or misconfigured server can park a worker with `retry-after: 99999999` (the sleep happens inside `execute`, occupying the worker for the whole duration).
+
+```rust
+Ok(response) if response.status() == 429 => {
+    self.retries += 1;
+    let delay = self
+        .extract_retry_delay(&response)        // uncapped, server-controlled
+        .unwrap_or_else(|| self.calculate_backoff_delay());
+    ...
+    sleep(delay).await;
+    EventualRequestResult::Retry
+}
+```
+
+**Recommendation:** Add a max-retries cap (e.g. 5–10, after which return `Error`), and clamp `Retry-After` to a sane ceiling (e.g. 60s).

--- a/agent/review/bugs/infra-rate-limit-silent-noop.md
+++ b/agent/review/bugs/infra-rate-limit-silent-noop.md
@@ -1,0 +1,20 @@
+# HttpClientPool::with_rate_limit silently does nothing when pool was built without one
+
+- **Severity:** low
+- **Category:** bugs
+- **Location:** `vantage-api-pool/src/client_pool/http.rs:109`
+
+`with_rate_limit` only adjusts an *existing* `KeyedRateLimiter`; if the pool was constructed with `rate_limit: None`, the call is a silent no-op and the pool runs unthrottled despite the caller explicitly requesting a cap. Additionally, `RateLimiter::set_desired_rate` computes `Decimal::ONE / rate` (`rate_limit/rate_limiter.rs:21`), which panics on a zero rate, and `Decimal::from_usize(self.workers).unwrap()` divides by the worker count with no zero-guard.
+
+```rust
+/// Cap at rate_limit requests per second
+pub fn with_rate_limit(mut self, rate_limit: Decimal) -> Self {
+    let desired_rate = rate_limit / Decimal::from_usize(self.workers).unwrap();
+    if let Some(rl) = self.rate_limit.as_mut() {
+        rl.set_desired_rate(desired_rate);
+    }
+    self
+}
+```
+
+**Recommendation:** Create the limiter when absent (it is already behind an `Option<Arc<_>>`), or return an error; validate `rate > 0` and `workers > 0` at construction.

--- a/agent/review/bugs/infra-rest-get-value-page-scoped.md
+++ b/agent/review/bugs/infra-rest-get-value-page-scoped.md
@@ -1,0 +1,21 @@
+# RestApi get_table_value/get_table_count only see the current page
+
+- **Severity:** medium
+- **Category:** bugs
+- **Location:** `vantage-api-client/src/rest/table_source.rs:131`
+
+`get_table_value` fetches the table's list (with the table's pagination applied) and then looks the id up in the returned map. If the requested record is on any other page — or beyond the API's default page size — the lookup returns `Ok(None)` even though the record exists, with no error to distinguish "not found" from "not on this page". `get_table_count` (line 170) likewise returns the size of the fetched page, not the dataset's total. PoolApi at least fetches all pages, but pays a full-table scan per `get_table_value` call.
+
+```rust
+let records = self
+    .fetch_records(
+        table.table_name(),
+        id_field_name(table).as_deref(),
+        table.pagination(),
+        table.conditions(),
+    )
+    .await?;
+Ok(records.get(id).cloned())
+```
+
+**Recommendation:** Issue an id-targeted request instead (`GET {base}/{table}/{id}` or `?{id_field}={id}` plus the existing conditions), and for count use the API's total field when the response shape carries one, otherwise document the page-scoped semantics.

--- a/agent/review/bugs/infra-rest-search-silent-noop.md
+++ b/agent/review/bugs/infra-rest-search-silent-noop.md
@@ -1,0 +1,20 @@
+# RestApi search condition is silently dropped — search returns all rows
+
+- **Severity:** medium
+- **Category:** bugs
+- **Location:** `vantage-api-client/src/rest/table_source.rs:103`
+
+`search_table_condition` builds an expression with template `SEARCH '<value>'`, but the only consumer of conditions, `condition_to_query_param` (`rest/operation.rs:38`), requires template `"{} = {}"` and returns `None` otherwise. The search condition is therefore never sent as a query param and never applied client-side — a user typing a search in the UI gets the full, unfiltered result set presented as if every row matched. The same dead `SEARCH '...'` shape exists in `vantage-api-pool/src/pool_api.rs:132`.
+
+```rust
+fn search_table_condition<E>(
+    &self,
+    _table: &Table<Self, E>,
+    search_value: &str,
+) -> Expression<Self::Value>
+{
+    Expression::new(format!("SEARCH '{}'", search_value), vec![])
+}
+```
+
+**Recommendation:** Either implement search (map to a configurable query param like `q`/`search`, or filter rows in memory across columns) or return an error/`Unsupported` so the UI can disable the search box instead of showing wrong results.

--- a/agent/review/inconsistencies/core-active-save-semantics-diverge.md
+++ b/agent/review/inconsistencies/core-active-save-semantics-diverge.md
@@ -1,0 +1,21 @@
+# ActiveEntity::save() replaces, ActiveRecord::save() patches — same API name, different semantics
+
+- **Severity:** medium
+- **Category:** inconsistencies
+- **Location:** `vantage-dataset/src/record.rs:32-34` vs `vantage-dataset/src/record.rs:114-116`
+
+The two change-tracking wrappers expose an identical `save()` method with different persistence semantics: `ActiveEntity::save()` calls `replace` (idempotent full overwrite, creates if missing, removes absent fields), while `ActiveRecord::save()` calls `patch_value` (fails if the row was deleted, merges fields and never removes any). So deleting a key from an `ActiveRecord` and calling `save()` silently leaves the key in storage, and saving after a concurrent delete errors for records but resurrects the row for entities. Neither doc comment mentions the difference; both just say "Save the current state of the record back to the dataset."
+
+```rust
+// ActiveEntity
+pub async fn save(&self) -> Result<E> {
+    self.dataset.replace(&self.id, &self.data).await
+}
+...
+// ActiveRecord
+pub async fn save(&self) -> Result<Record<D::Value>> {
+    self.dataset.patch_value(&self.id, &self.data).await
+}
+```
+
+**Recommendation:** Use the same operation for both (replace is the natural "save full state" choice since both wrappers hold the complete value), or rename/document one of them explicitly (e.g. `save_patch()`).

--- a/agent/review/inconsistencies/core-id-param-conventions-and-doc-drift.md
+++ b/agent/review/inconsistencies/core-id-param-conventions-and-doc-drift.md
@@ -1,0 +1,18 @@
+# Mixed id-parameter conventions across dataset traits, and trait docs showing outdated signatures
+
+- **Severity:** low
+- **Category:** inconsistencies
+- **Location:** `vantage-dataset/src/traits/dataset.rs:125,189` and `vantage-dataset/src/traits/valueset.rs:46-60`
+
+Within the same trait family, `ReadableDataSet::get` takes `id: impl Into<Self::Id> + Send` while `WritableDataSet::insert/replace/patch` and all `ValueSet` methods take `id: &Self::Id`. Callers must write `table.get("1".to_string())` but `table.insert(&"1".to_string(), ...)` — two conventions for the same concept. Additionally, the `ValueSet` doc example shows `get_value` returning `Result<Self::Value>` while the real signature is `Result<Option<Record<Self::Value>>>` (and `get_some_value` returning `Result<Option<(Self::Id, Self::Value)>>` instead of the `Record`-wrapped form), so the primary implementation example no longer compiles conceptually against the trait.
+
+```rust
+// dataset.rs — Into-style
+async fn get(&self, id: impl Into<Self::Id> + Send) -> Result<Option<E>>;
+async fn insert(&self, id: &Self::Id, entity: &E) -> Result<E>;
+
+// valueset.rs doc example — stale signature
+/// async fn get_value(&self, id: &Self::Id) -> Result<Self::Value> {
+```
+
+**Recommendation:** Standardize on one id-passing convention (either `&Self::Id` everywhere or `impl Into<Self::Id>` everywhere) across Readable/Writable/Insertable traits, and update the `ValueSet` doc example to the current `Option<Record<...>>` signatures.

--- a/agent/review/inconsistencies/core-insert-delete-idempotency-contract.md
+++ b/agent/review/inconsistencies/core-insert-delete-idempotency-contract.md
@@ -1,0 +1,20 @@
+# insert/delete idempotency contracts contradicted by the framework's own implementations
+
+- **Severity:** high
+- **Category:** inconsistencies
+- **Location:** `vantage-dataset/src/traits/dataset.rs:179-189` (contract) vs `vantage-table/src/mocks/mock_table_source.rs:273-279,328-331` (violations)
+
+`WritableDataSet::insert` is documented "**Idempotent**: ... If entity already exists, must return success without overwriting data, returning original data", and `WritableValueSet::delete` is documented "**Idempotent**: Always succeeds, even if the record doesn't exist." `ImTable` implements exactly that. But `MockTableSource` (which backs `Table`'s dataset impls) does the opposite — `insert_table_value` errors on an existing id and `delete_table_value` errors on a missing id — and `vantage-table/src/table/sets/writable_dataset.rs:92-99,153-155` has tests *asserting* the error behavior ("Test insert with existing ID should fail", "Test delete non-existing ID should fail"). Callers cannot rely on the documented retry-safety semantics; behavior depends on which backend they happen to use.
+
+```rust
+// MockTableSource::insert_table_value — contradicts the trait contract
+if im_table.get_value(id).await?.is_some() {
+    return Err(vantage_core::error!("Record with ID already exists", id = id));
+}
+// MockTableSource::delete_table_value — contradicts "always succeeds"
+if im_table.get_value(id).await?.is_none() {
+    return Err(vantage_core::error!("Record not found", id = id));
+}
+```
+
+**Recommendation:** Pick one contract per operation and enforce it everywhere: either fix the trait docs (insert fails on duplicate, delete fails on missing) or fix `MockTableSource` and the tests to match the documented idempotent semantics. Driver crates should be audited against the chosen contract.

--- a/agent/review/inconsistencies/data-search-semantics-divergence.md
+++ b/agent/review/inconsistencies/data-search-semantics-divergence.md
@@ -1,0 +1,15 @@
+# `search_table_condition` has wildly different semantics per engine
+
+- **Severity:** medium
+- **Category:** inconsistencies
+- **Location:** `vantage-sql/src/sqlite/impls/table_source.rs:110`, `vantage-surrealdb/src/surrealdb/impls/table_source.rs:122`, `vantage-mongodb/src/mongodb/impls/table_source.rs:115`, `vantage-csv/src/table_source.rs:65`, `vantage-redb/src/redb/impls/table_source.rs:64`
+
+The same trait method behaves incompatibly across the six data engines, so identical UI search input yields different results (or failures) depending on backend:
+
+- SQLite/Postgres/MySQL: `LIKE %v% ESCAPE '$'` over all columns, case-sensitivity backend-dependent (Postgres casts `::text`, others don't).
+- SurrealDB: `string::contains(string::lowercase(...))` — case-insensitive, no wildcard escaping needed.
+- MongoDB: case-insensitive `$regex` with metacharacter escaping.
+- CSV: returns a 0-param `SEARCH '...'` expression that is silently ignored downstream (returns all rows).
+- redb: `panic!("full-table search is not supported")` — a panic, not a `Result::Err`.
+
+**Recommendation:** Define the contract (case sensitivity, which columns, empty-table result) in the trait doc and conform each backend; redb and CSV should return `Result::Err`, never panic or silently no-op.

--- a/agent/review/inconsistencies/data-sql-placeholder-validation-divergence.md
+++ b/agent/review/inconsistencies/data-sql-placeholder-validation-divergence.md
@@ -1,0 +1,15 @@
+# SQL backends disagree on placeholder/param-count validation
+
+- **Severity:** medium
+- **Category:** inconsistencies
+- **Location:** `vantage-sql/src/sqlite/impls/expr_data_source.rs:89`, `vantage-sql/src/postgres/impls/expr_data_source.rs:108`, `vantage-sql/src/mysql/expr_data_source.rs:104`
+
+The three `prepare_typed_query` implementations are near-identical but handle a placeholder/parameter mismatch three different ways. Postgres and MySQL `assert_eq!` the counts — a mismatch **panics** the whole process (a query-builder bug becomes a hard crash / DoS). SQLite has no assertion: on mismatch it silently emits trailing `?N` placeholders with no separator, producing malformed SQL that fails at the driver instead. Same trait, same invariant, three behaviors (panic vs. silent corruption).
+
+```rust
+// postgres / mysql:
+assert_eq!(template_parts.len(), flattened.parameters.len() + 1, /* … */);
+// sqlite: no such check — relies on the driver to reject the bad SQL
+```
+
+**Recommendation:** Pick one strategy for all three — return a `Result::Err` (not `assert!`) on mismatch so a builder bug surfaces as a recoverable error rather than a panic or corrupt SQL.

--- a/agent/review/inconsistencies/docs-config-schema-stale.md
+++ b/agent/review/inconsistencies/docs-config-schema-stale.md
@@ -1,0 +1,23 @@
+# vantage-config.schema.json is the old-prototype schema; doesn't match what code parses
+
+- **Severity:** high
+- **Category:** inconsistencies
+- **Location:** `vantage-config.schema.json:1`
+
+The schema shipped at the repo root is byte-identical to `vantage-ui-old-prototype/vantage-config.schema.json` (last touched 2025-10-30, "Rewrote README for 0.3"). The current parser — `vantage-ui/crates/inventory/src/config.rs` (`Inventory`) and `table.rs` (`TableConfig`), whose `bin/generate-schema.rs` is the designated generator for this exact filename — accepts `datasource`, `id_column`, `expressions`, `params`, `graphql`, `has_many`, `references`, `surreal`, `cmd`, and VistaSpec map-style columns. None of these appear in the schema; instead the schema's `EntityConfig` requires `table` and `columns` (array-only) which the code no longer requires. Anyone validating YAML against this schema gets false errors on every modern config and no completion for real fields.
+
+```
+"EntityConfig": { ... "required": ["columns", "table"], ... }
+// vs vantage-ui/crates/inventory/src/table.rs:
+pub struct TableConfig {
+    pub name: Option<String>,
+    pub datasource: Option<String>,
+    ...
+    pub expressions: HashMap<String, ExpressionDef>,
+    pub references: IndexMap<String, ReferenceFull>,
+    pub surreal: Option<SurrealDriverBlock>,
+    pub cmd: Option<CmdDriverBlock>,
+}
+```
+
+**Recommendation:** Regenerate the file with `vantage-ui/crates/inventory/bin/generate-schema.rs` (which writes `vantage-config.schema.json` from the live `Inventory` struct) and add that step to CI, or delete the stale copy from this repo if the schema now lives with vantage-ui.

--- a/agent/review/inconsistencies/docs-readme-anytable-anydataset-fiction.md
+++ b/agent/review/inconsistencies/docs-readme-anytable-anydataset-fiction.md
@@ -1,0 +1,18 @@
+# README documents type-erasure API (AnyTable, AnyDataSet) that does not exist in code
+
+- **Severity:** high
+- **Category:** inconsistencies
+- **Location:** `README.md:99` (also `README.md:213,224-231`)
+
+The README's "0.4 key additions" claims `AnyTable::from_table()` wraps any datasource, the feature list claims "Type-erased structs for all major traits (AnyTable, AnyExpression)", and the "Type erasure support" section shows `AnyDataSet::new(clients)`. Neither `AnyTable` nor `AnyDataSet` exists anywhere in the workspace crates (`grep -r AnyTable vantage-*/src` only matches doc comments in vantage-aws). The actual erasure layer is `Vista` (`vantage-vista`, `T::vista_factory().from_table(...)` per `vantage-table/src/lib.rs:8`). Users following the README will look for types that were never published.
+
+```
+- **Cross-database integration** - `AnyTable::from_table()` wraps any datasource for generic code
+...
+let clients = Client::admin_api(); // impl DataSet<Client>
+let clients = AnyDataSet::new(clients); // AnyDataSet - types erased.
+
+let entities: = vec![clients, orders, ..];
+```
+
+**Recommendation:** Rewrite the type-erasure sections around `Vista`/`vantage-vista-factory` (the real API), or remove the `AnyTable`/`AnyDataSet` claims until such types exist. `AnyExpression` does exist and can stay.

--- a/agent/review/inconsistencies/docs-readme-dataset-api-names.md
+++ b/agent/review/inconsistencies/docs-readme-dataset-api-names.md
@@ -1,0 +1,20 @@
+# README DataSet/Pagination examples use method names that don't exist
+
+- **Severity:** high
+- **Category:** inconsistencies
+- **Location:** `README.md:241-283` (also `README.md:314`)
+
+The "DataSet operations" and "Type casting" sections call `load_some()`, `delete_id(&id)`, `insert_id(id, client)`, `get_id_as::<T>(id)` and `get_id_value(id)`. None of these methods exist in `vantage-dataset` — the actual trait (`vantage-dataset/src/traits/dataset.rs` and `valueset.rs`) exposes `get_some()`, `get(id)`, `insert(&id, &entity)`, `delete(&id)`, `replace`, `patch`, `insert_return_id`. Likewise `Pagination::ipp(25)` (README.md:314) does not exist; `vantage-table/src/pagination.rs` only has `Pagination::new(page, items_per_page)` and `set_ipp`. Copy-pasting any of these snippets fails to compile.
+
+```
+// Basic loading operation - load one client record
+let (id, client) = clients.load_some().await?;
+// Next - delete it from memory
+clients.delete_id(&id).await?;
+// Insert it back
+clients.insert_id(id, client).await?;
+...
+order.set_pagination(Pagination::ipp(25));
+```
+
+**Recommendation:** Update the snippets to the real API (`get_some`, `delete`, `insert`, `get_as`/value accessors as they actually exist, `Pagination::new(0, 25)`), ideally by extracting them from a compiled example (the `learn-*` crates pattern used by the book).

--- a/agent/review/inconsistencies/docs-readme-postgres-mysql-status.md
+++ b/agent/review/inconsistencies/docs-readme-postgres-mysql-status.md
@@ -1,0 +1,18 @@
+# README says PostgreSQL/MySQL are "coming next" but vantage-sql already implements them
+
+- **Severity:** medium
+- **Category:** inconsistencies
+- **Location:** `README.md:665` (also `README.md:70-71,713`)
+
+The "What's Coming Next" section lists "PostgreSQL / MySQL — Extend `vantage-sql` beyond SQLite", and the crate bullet describes `vantage-sql` as "SQLite implementation (via sqlx)". In reality `vantage-sql/src/` already ships `postgres/` (with `PostgresDB`, `PostgresSelect`) and `mysql/` modules behind cargo features, `bakery_model3/examples/cli-vista.rs` accepts `postgres` as a source, the book's history table credits 0.4 with "SurrealDB, SQLite, Postgres, MySQL, MongoDB, CSV, REST API", and the README's own install snippet says `# also: "postgres", "mysql"`. The README's status table (line 713) likewise scores the SQL column as "SQLite" only. The README contradicts both the code and itself.
+
+```
+## What's Coming Next
+...
+- **PostgreSQL / MySQL** - Extend `vantage-sql` beyond SQLite using sqlx's multi-database support.
+```
+```
+- [`vantage-sql`](vantage-sql/README.md) - SQLite implementation (via sqlx) with full CRUD,
+```
+
+**Recommendation:** Move PostgreSQL/MySQL out of the roadmap, describe vantage-sql as SQLite/PostgreSQL/MySQL via sqlx feature flags, and relabel the status-table column accordingly (noting any backend-specific gaps if Postgres/MySQL coverage is partial).

--- a/agent/review/inconsistencies/docs-readme-status-table-step-numbers.md
+++ b/agent/review/inconsistencies/docs-readme-status-table-step-numbers.md
@@ -1,0 +1,16 @@
+# README backend-status table step numbers don't match the Persistence Guide it cites
+
+- **Severity:** low
+- **Category:** inconsistencies
+- **Location:** `README.md:709-716`
+
+The "Current status" table says it measures progress "against the steps in the [Persistence Guide](docs4/src/new-persistence.md)" and lists 6 steps: 1 Type system, 2 Expressions, 3 Query builder, 4 Table, 5 Relationships, 6 Multi-backend. The actual guide has 9 steps with different numbering — Step 3 is Operators, Step 4 is Query Builder, Step 5 is Table & CRUD, Step 6 is Relationships, Step 7 is Multi-Backend, plus Step 8 Vista Integration and Step 9 Contained Relations which the table omits entirely. Anyone cross-referencing a row to the named guide chapter lands on the wrong step.
+
+```
+| Step | Feature                                                 | SurrealDB | ...
+| 3    | Query builder (`Selectable`, `SelectableDataSource`)    | Full      | ...
+| 4    | Table abstraction (`TableSource`, CRUD, aggregates)     | Full      | ...
+| 6    | Multi-backend (`AnyTable`, CLI)                          | Full      | ...
+```
+
+**Recommendation:** Renumber the table to match the guide's 9 steps (adding Vista Integration and Contained Relations rows), and replace the `AnyTable` mention in row 6 with the real multi-backend mechanism (Vista/CLI).

--- a/agent/review/inconsistencies/docs-readme-table-generics-flip.md
+++ b/agent/review/inconsistencies/docs-readme-table-generics-flip.md
@@ -1,0 +1,20 @@
+# README flips Table generic parameter order and shows outdated with_many closure shape
+
+- **Severity:** medium
+- **Category:** inconsistencies
+- **Location:** `README.md:293-297` (also `README.md:137,146,540-547`)
+
+The code defines `Table<T, E>` with the datasource first (`vantage-table/src/table/base.rs:18`), and the README's first example correctly writes `Table<SurrealDB, Client>` (line 137). But the "Table" and "Table References" sections then use the opposite order — `Table<Client, Oracle>`, `Table<Order, MongoDB>`, `Table<Order, SurrealDB>`, `Table<Client, SurrealDB>` — which won't type-check and confuses readers about which parameter is the entity. Additionally, line 540 shows `with_many("orders", "client_id", || Box::new(Order::table()))`, but the actual signature takes `impl Fn(T) -> Table<T, E2>` (no `Box`, closure receives the datasource: `.with_many("orders", "client_id", Order::postgres_table)` per the method's own doc example).
+
+```
+impl Client {
+    fn table() -> Table<Client, Oracle>;
+}
+impl Order {
+    fn table() -> Table<Order, MongoDB>;
+}
+...
+let client = client.with_many("orders", "client_id", || Box::new(Order::table()));
+```
+
+**Recommendation:** Normalize all README examples to `Table<Source, Entity>` order and update `with_many`/`with_one` calls to the current `Fn(T) -> Table<T, E2>` closure form.

--- a/agent/review/inconsistencies/docs-ui-adapters-crate-name.md
+++ b/agent/review/inconsistencies/docs-ui-adapters-crate-name.md
@@ -1,0 +1,21 @@
+# "vantage-ui-adapters" is actually package `dataset-ui-adapters`, unpublished, with unusable Quick Start
+
+- **Severity:** medium
+- **Category:** inconsistencies
+- **Location:** `vantage-ui-adapters/README.md:22` (also `vantage-ui-adapters/Cargo.toml:2-5`, `README.md:81-82`)
+
+The root README and the crate's own README/Quick Start refer to the crate as `vantage-ui-adapters` and the example imports `use vantage_ui_adapters::...`, but the package is actually named `dataset-ui-adapters` (so the import path is `dataset_ui_adapters`) and it is `publish = false` — it is not on crates.io at all. The Quick Start additionally tells users to depend on it via `path = "."` and on `bakery_model3 = { path = "../bakery_model3" }`, which only works from inside this repository's directory layout. A reader who follows the root README bullet ("Implement DataGrid for Tauri, EGui, Cursive, GPUI, RatatUI and Slint") cannot install or import the crate as documented.
+
+```
+[dependencies]
+vantage-ui-adapters = { path = ".", features = ["egui"] }
+bakery_model3 = { path = "../bakery_model3" }
+```
+```
+[package]
+name = "dataset-ui-adapters"
+...
+publish = false
+```
+
+**Recommendation:** Rename the package to `vantage-ui-adapters` (or fix all docs to `dataset_ui_adapters`), state clearly that it is an in-repo reference implementation rather than a published crate, and make the Quick Start use git/clone instructions that actually work.

--- a/agent/review/inconsistencies/docs-version-04-vs-05-crates.md
+++ b/agent/review/inconsistencies/docs-version-04-vs-05-crates.md
@@ -1,0 +1,19 @@
+# README and book claim "0.4" while all crates are 0.5.x; install snippet pins "0.4"
+
+- **Severity:** high
+- **Category:** inconsistencies
+- **Location:** `README.md:90` (also `README.md:682-697`, `docs4/book.toml:5`, `docs4/src/introduction.md:10`)
+
+README (refreshed 2026-06-07) states "Vantage `0.4` is the current version" and the Installation section tells users to add `vantage-core = "0.4"` etc. Actual workspace versions are 0.5.x (vantage-core 0.5.0, vantage-table 0.5.7, vantage-sql 0.5.9, vantage-surrealdb 0.5.9, vantage-csv 0.5.3), bumped in commits like "Bump versions and changelogs: vista 0.5.3, table 0.5.7, sql 0.5.8". Because these are 0.x crates, semver `"0.4"` resolves to `>=0.4, <0.5`, so the documented install pulls outdated crates whose APIs differ from everything else the README/book describe. The book title ("Vantage 0.4 Framework") and `introduction.md` carry the same stale version.
+
+```
+Vantage `0.4` is the current version — a global rewrite starting with the type system.
+...
+# Core crates
+vantage-core = "0.4"
+vantage-types = "0.4"
+...
+vantage-sql = { version = "0.4", features = ["sqlite"] }  # also: "postgres", "mysql"
+```
+
+**Recommendation:** Bump every version mention to 0.5 (or use unpinned guidance like `cargo add vantage-sql --features sqlite`, as the book already does), and update the book title/introduction or state explicitly that 0.4 docs also cover 0.5.

--- a/agent/review/inconsistencies/infra-aws-endpoint-override-ignored.md
+++ b/agent/review/inconsistencies/infra-aws-endpoint-override-ignored.md
@@ -1,0 +1,15 @@
+# AWS_ENDPOINT_URL override honoured only by json1/json10 transports
+
+- **Severity:** medium
+- **Category:** inconsistencies
+- **Location:** `vantage-aws/src/restjson/transport.rs:30`
+
+`AwsAccount` documents that the endpoint override (set via `with_endpoint` or `AWS_ENDPOINT_URL`, "picked up automatically by every constructor") redirects requests to DynamoDB Local/LocalStack. But only the JSON transports route through `account.endpoint_for(service)`. The REST-JSON, REST-XML (`restxml/transport.rs:166`), and Query (`query/transport.rs:39-42`) transports hard-code `{service}.{region}.amazonaws.com`, so with an endpoint override configured, Lambda/S3/IAM tables silently send real AWS requests — signed with whatever (possibly dummy LocalStack) credentials are loaded — instead of hitting the local endpoint.
+
+```rust
+// restjson/transport.rs
+let host = format!("{service}.{region}.amazonaws.com");
+let url = build_url(&host, path, query);
+```
+
+**Recommendation:** Route all transports through `endpoint_for()` (it already returns `(url, host)`), or return a hard error from the non-JSON transports when an endpoint override is configured so the mismatch is loud instead of silent.

--- a/agent/review/omissions/core-count-query-silent-zero.md
+++ b/agent/review/omissions/core-count-query-silent-zero.md
@@ -1,0 +1,25 @@
+# get_count_via_query returns Ok(0) for unrecognized result shapes
+
+- **Severity:** medium
+- **Category:** omissions
+- **Location:** `vantage-table/src/table/impls/selectable.rs:209-221`
+
+If the driver's count query returns anything other than `{"count": n}` or a bare integer (e.g. SurrealDB-style `[{"count": 42}]` arrays, a string-typed number, or an unexpected error payload), `get_count_via_query` silently reports `Ok(0)`. A wrong-but-successful zero is the worst failure mode for a count used in pagination or "is empty" checks — the table appears empty and the bug is invisible.
+
+```rust
+pub async fn get_count_via_query(&self) -> Result<i64> {
+    let count_query = self.get_count_query();
+    let result = self.data_source.execute(&count_query).await?;
+
+    // Extract count from result - could be {"count": 42} or just 42
+    if let Some(count) = result.get("count").and_then(|v| v.as_i64()) {
+        Ok(count)
+    } else if let Some(count) = result.as_i64() {
+        Ok(count)
+    } else {
+        Ok(0)
+    }
+}
+```
+
+**Recommendation:** Return `Err(error!("unexpected count result shape", result = result))` in the fallback arm (and consider also handling the single-element-array shape explicitly).

--- a/agent/review/omissions/core-dead-source-files.md
+++ b/agent/review/omissions/core-dead-source-files.md
@@ -1,0 +1,18 @@
+# Stale source files outside the module tree (would not compile if re-enabled)
+
+- **Severity:** medium
+- **Category:** omissions
+- **Location:** `vantage-table/src/with_columns.rs:1` (also `vantage-table/src/operation.rs`, `vantage-table/src/record.rs`, `vantage-table/src/column/any.rs`, `vantage-dataset/src/datasetsource.rs`)
+
+Several `.rs` files ship in the crates' src directories but are not declared in any `mod` tree, so they are silently skipped by the compiler and have rotted: `with_columns.rs` references a nonexistent `crate::with_ordering` module and uses unimported types; `record.rs` imports `vantage_dataset::dataset` (the module is now `traits`) and `crate::Entity` (not exported); `column/any.rs` is commented out in `column/mod.rs` and imports `crate::column::column`; `datasetsource.rs` is commented out in `vantage-dataset/src/lib.rs` and imports `vantage_core::Entity`, which is itself commented out in `vantage-core/src/lib.rs:14-23`. These mislead readers/contributors (and AI tools) about the real API and will produce confusing breakage if anyone re-enables them.
+
+```rust
+// vantage-table/src/lib.rs declares: traits, mocks, cbor_ext, conditions,
+// pagination, prelude, references, sorting, column, source, table
+// — but src/ also contains with_columns.rs, operation.rs, record.rs:
+use crate::with_ordering::OrderByExt;          // with_columns.rs test — module doesn't exist
+use vantage_dataset::dataset::{Result, WritableDataSet}; // record.rs — module renamed to `traits`
+use vantage_core::Entity;                       // datasetsource.rs — Entity is commented out
+```
+
+**Recommendation:** Delete the dead files (git history preserves them) or move them under a feature-gated/experimental module that is actually compiled in CI.

--- a/agent/review/omissions/core-mock-with-data-drops-idless-rows.md
+++ b/agent/review/omissions/core-mock-with-data-drops-idless-rows.md
@@ -1,0 +1,24 @@
+# MockTableSource::with_data silently drops rows without "id" — count and list disagree
+
+- **Severity:** low
+- **Category:** omissions
+- **Location:** `vantage-table/src/mocks/mock_table_source.rs:50-77`
+
+`with_data` stores all rows in the `data` HashMap (used by `get_table_count`) but only copies rows that have an `"id"` field into the `ImDataSource` (used by `list_table_values`/`get_table_value`). Seed data without ids is silently dropped from reads while still being counted, so `get_count()` and `list().len()` disagree — a confusing trap for anyone writing tests against the mock. Rows whose id is neither string nor number `panic!` with a leftover `[DEBUG]` message instead of returning an error.
+
+```rust
+for value in data.iter() {
+    if let Some(id_value) = value.get("id") {
+        let id_str = match id_value {
+            Value::String(s) => s.clone(),
+            Value::Number(n) => n.to_string(),
+            _ => {
+                panic!("[DEBUG] ID field is not a string or number: {:?}", id_value);
+            }
+        };
+        ...
+    } // else: row silently skipped
+}
+```
+
+**Recommendation:** Generate an id for id-less rows (the `ImTable::generate_id` helper exists) or panic/error loudly on them, and derive `get_table_count` from the same `ImDataSource` store so the two views can't diverge.

--- a/agent/review/omissions/core-resolve-deferred-noop.md
+++ b/agent/review/omissions/core-resolve-deferred-noop.md
@@ -1,0 +1,18 @@
+# Flatten::resolve_deferred is a documented no-op — flatten() silently skips deferred parameters
+
+- **Severity:** medium
+- **Category:** omissions
+- **Location:** `vantage-expressions/src/expression/flatten.rs:65-70`
+
+The `Flatten` trait promises "Flatten an expression by resolving all deferred parameters and nested expressions", and the module docs sell flattening as the step that makes parameter binding safe. But the only implementation, `ExpressionFlattener::resolve_deferred`, just clones the expression and leaves `ExpressiveEnum::Deferred` parameters untouched (an internal comment admits it is for testing). Any consumer that calls `flattener.flatten(&expr)` and then binds parameters will pass unresolved `DeferredFn` values through, with no error or warning — the API contract and behavior disagree, and being sync, this method can never fulfil the contract for async deferreds.
+
+```rust
+fn resolve_deferred(&self, expr: &Expression<T>) -> Expression<T> {
+    // Note: This is a sync implementation that doesn't actually execute deferred closures
+    // For testing purposes, deferred parameters are left as-is
+    // In real usage, this would be handled by the DataSource execute method
+    expr.clone()
+}
+```
+
+**Recommendation:** Remove `resolve_deferred` from the trait (flattening and deferred resolution are different phases — resolution is async and belongs to the DataSource), or make `flatten` return an error when deferred parameters remain.

--- a/agent/review/omissions/data-redb-csv-panic-on-unsupported.md
+++ b/agent/review/omissions/data-redb-csv-panic-on-unsupported.md
@@ -1,0 +1,16 @@
+# redb panics (not Err) on unsupported search — reachable from generic code
+
+- **Severity:** medium
+- **Category:** omissions
+- **Location:** `vantage-redb/src/redb/impls/table_source.rs:72`
+
+`Redb::search_table_condition` unconditionally `panic!`s. Because `search_table_condition` is a trait method on `TableSource`, generic UI/table code that offers a search box and calls it on whatever backend is configured will abort the process when that backend happens to be redb. A backend declaring "feature not supported" must do so via the `Result`/error channel the rest of the trait uses, not by panicking — otherwise any code path that can route to redb is a latent crash.
+
+```rust
+fn search_table_condition<E>(&self, _table: &Table<Self, E>, _search_value: &str)
+    -> Self::Condition {
+    panic!("vantage-redb: full-table search is not supported — use indexed eq() instead")
+}
+```
+
+**Recommendation:** Return a `RedbCondition` that resolves to an error (or change the trait to return `Result`), mirroring how redb's `get_table_sum/max/min` already return `Err(...)` instead of panicking.

--- a/agent/review/omissions/docs-readme-missing-vista-diorama.md
+++ b/agent/review/omissions/docs-readme-missing-vista-diorama.md
@@ -1,0 +1,20 @@
+# Root README omits Vista, Diorama and other shipped crates that the book headlines
+
+- **Severity:** medium
+- **Category:** omissions
+- **Location:** `README.md:64-88`
+
+The book's introduction dedicates three of six tutorial chapters to `Vista` ("the Universal Data Handle"), `Dio & Lens`, and `Scenery — Reactive Views`, and the persistence guide has a "Step 8: Vista Integration" — yet the root README never mentions `vantage-vista`, `vantage-vista-factory` or `vantage-diorama` in its crate list, feature list, or installation section. Other shipped crates are also undocumented at the top level: `vantage-redb`, `vantage-cmd`, `vantage-aws`, `vantage-log-writer`, `vantage-cli-util`. Several of these also lack crate READMEs (`vantage-redb`, `vantage-vista-factory`, `vantage-log-writer`, and `vantage-core` — the only core crate without one), which matters since READMEs become the crates.io landing pages.
+
+```
+With all of the fundamental blocks and interfaces in place, Vantage can be extended in several ways.
+First - persistence implementation:
+
+- [`vantage-surrealdb`](vantage-surrealdb/README.md) ...
+- [`vantage-sql`](vantage-sql/README.md) ...
+- `vantage-csv` ...
+- [`vantage-api-pool`](vantage-api-pool/README.md) ...
+- `vantage-api-client` ...
+```
+
+**Recommendation:** Add a "generic/UI layer" bullet group for vantage-vista, vantage-vista-factory and vantage-diorama (they are the actual basis of the AnyTable claims elsewhere in the README), list the remaining backends (redb, cmd, aws), and add minimal READMEs to vantage-core, vantage-redb, vantage-vista-factory and vantage-log-writer.

--- a/agent/review/omissions/docs-root-changelog-stale.md
+++ b/agent/review/omissions/docs-root-changelog-stale.md
@@ -1,0 +1,17 @@
+# Root CHANGELOG.md ends at 0.2.0 (2025-02-16) — three releases behind
+
+- **Severity:** medium
+- **Category:** omissions
+- **Location:** `CHANGELOG.md:5`
+
+The repository-level changelog's newest entry is `[0.2.0] - 2025-02-16` and it was last committed on that date. Since then the project shipped 0.3 (tag v0.3.0), the 0.4 rewrite the README/book advertise, and 0.5.x crate releases (vantage-table 0.5.7, vantage-sql 0.5.9, etc.). Per-crate changelogs exist (e.g. `vantage-table/CHANGELOG.md` documents 0.5.7), so the root file is not just incomplete — it actively misrepresents project activity to anyone who opens it from GitHub's front page.
+
+```
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.2.0] - 2025-02-16
+```
+
+**Recommendation:** Either bring the root changelog up to date with 0.3/0.4/0.5 milestone summaries (the book's `history.md` already has this content), or replace its body with a pointer to the per-crate CHANGELOG.md files and the book's Historical Timeline.

--- a/agent/review/omissions/infra-awwpool-token-never-refreshed.md
+++ b/agent/review/omissions/infra-awwpool-token-never-refreshed.md
@@ -1,0 +1,21 @@
+# AwwPool caches the first auth token forever — no expiry or refresh
+
+- **Severity:** medium
+- **Category:** omissions
+- **Location:** `vantage-api-pool/src/aww_pool.rs:110`
+
+`get_auth_token` acquires a token once via the configured callback and caches it in `auth_tokens`; nothing ever removes or refreshes it. When the token expires, every subsequent request gets a 401/403, which the worker classifies as `EventualRequestResult::Error` — it is neither retried with a fresh token nor surfaced to the caller (see the dropped-request hang). A long-running Vantage UI session with OAuth-style short-lived tokens goes permanently stale after the first expiry.
+
+```rust
+// Check if we already have a cached token
+{
+    let tokens = self.auth_tokens.lock().unwrap();
+    if !tokens.is_empty() {
+        return Ok(tokens[0].clone());
+    }
+}
+// No cached token, acquire a new one
+let token = acquire_fn().await?;
+```
+
+**Recommendation:** Invalidate the cached token on 401/403 responses and re-run the acquire callback (with single-flight to avoid a stampede), or store an expiry alongside the token and refresh proactively.

--- a/agent/review/omissions/infra-cmd-run-no-timeout.md
+++ b/agent/review/omissions/infra-cmd-run-no-timeout.md
@@ -1,0 +1,19 @@
+# vantage-cmd subprocesses have no timeout and unbounded output capture
+
+- **Severity:** medium
+- **Category:** omissions
+- **Location:** `vantage-cmd/src/exec.rs:66`
+
+`run_command` uses `std::process::Command::output()` with no deadline: a wrapped CLI that hangs (e.g. `gh` waiting on an interactive prompt or a stuck network call with a cleared env) blocks the `spawn_blocking` thread forever, and the table read in Vantage UI never completes. There is also no cap on captured output — `output()` buffers all of stdout/stderr in memory, so a command that streams gigabytes (e.g. a log dump) grows the host process unboundedly before the Rhai script ever sees it.
+
+```rust
+let output = cmd.output().map_err(|e| {
+    error!(
+        "failed to execute command",
+        command = command.to_string(),
+        detail = e.to_string()
+    )
+})?;
+```
+
+**Recommendation:** Spawn with piped stdio and enforce a configurable timeout (kill the child on expiry) plus a max-output-bytes cap; also set `stdin(Stdio::null())` so child tools cannot block waiting for input.

--- a/agent/review/omissions/infra-no-http-timeouts.md
+++ b/agent/review/omissions/infra-no-http-timeouts.md
@@ -1,0 +1,19 @@
+# No timeouts on any HTTP client (RestApi, GraphqlApi, AwsAccount, pool workers)
+
+- **Severity:** medium
+- **Category:** omissions
+- **Location:** `vantage-api-client/src/rest/api.rs:536`
+
+Every HTTP client in the API/infra crates is built with `reqwest::Client::new()`, which has no total-request timeout (only a connect-phase default). Affected: `RestApi` (`rest/api.rs:536`), `AwsAccount` (`vantage-aws/src/account.rs:53,77,121,138`), and the pool workers (`vantage-api-pool/src/client_pool/http.rs:37`). A stalled endpoint (or a slow-loris AWS-endpoint override) hangs the table read indefinitely; in Vantage UI that means a grid that never resolves, and in the pool it permanently occupies a worker.
+
+```rust
+pub fn build(self) -> RestApi {
+    RestApi {
+        base_url: self.base_url,
+        client: reqwest::Client::new(),
+        ...
+    }
+}
+```
+
+**Recommendation:** Build clients with `reqwest::Client::builder().timeout(...).connect_timeout(...)` (e.g. 30s/10s), optionally overridable per datasource.

--- a/agent/review/omissions/infra-unimplemented-panics-reachable.md
+++ b/agent/review/omissions/infra-unimplemented-panics-reachable.md
@@ -1,0 +1,21 @@
+# unimplemented!() panics reachable through normal TableSource API
+
+- **Severity:** medium
+- **Category:** omissions
+- **Location:** `vantage-api-pool/src/pool_api.rs:371`
+
+`PoolApi::related_in_condition` and `PoolApi::column_table_values_expr` are `unimplemented!()`, and `RestApi::column_table_values_expr` (`vantage-api-client/src/rest/table_source.rs:377`) likewise. These are ordinary `TableSource` trait methods invoked by relation traversal (`with_many`/`with_one` style references); on these backends a config that declares a reference panics the process instead of returning an error. Every other backend in scope (vantage-cmd, vantage-aws) returns a structured `error!(...)` for unsupported operations — these are the only hard panics on the trait surface.
+
+```rust
+fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(
+    &self,
+    _target_field: &str,
+    _source_table: &Table<Self, SourceE>,
+    _source_column: &str,
+) -> Self::Condition
+{
+    unimplemented!("related_in_condition not yet supported for API pool")
+}
+```
+
+**Recommendation:** Return a sentinel/error-bearing condition (or restructure the trait to allow `Result`) so unsupported traversal surfaces as a recoverable error like the read-only write paths do, rather than aborting an admin-console session.

--- a/agent/review/performance/core-im-table-full-clone-per-op.md
+++ b/agent/review/performance/core-im-table-full-clone-per-op.md
@@ -1,0 +1,16 @@
+# Every ImTable operation clones the entire table
+
+- **Severity:** medium
+- **Category:** performance
+- **Location:** `vantage-dataset/src/im/mod.rs:50-53`
+
+`get_or_create_table` deep-clones the whole `IndexMap<String, Record<V>>` (every row, every value) on *every* operation — including single-row reads like `get_value` and `get_some_value`, and writes additionally write the full clone back via `update_table`. A point lookup is O(table size) in time and memory instead of O(1). `ImDataSource` is the backing store for `MockTableSource` and in-memory datasets, so test suites and any in-memory production use pay quadratic cost as tables grow (n operations × n rows).
+
+```rust
+pub(super) fn get_or_create_table(&self, table_name: &str) -> IndexMap<String, Record<V>> {
+    let mut tables = self.tables.lock().unwrap();
+    tables.entry(table_name.to_string()).or_default().clone()
+}
+```
+
+**Recommendation:** Operate on the map in place under the lock (closure-based accessor like `with_table(&self, name, |t| ...)`), cloning only the rows actually returned. This also fixes the lost-update race reported separately.

--- a/agent/review/performance/data-csv-full-file-rescan.md
+++ b/agent/review/performance/data-csv-full-file-rescan.md
@@ -1,0 +1,16 @@
+# CSV backend re-reads and re-parses the whole file on every operation
+
+- **Severity:** low
+- **Category:** performance
+- **Location:** `vantage-csv/src/table_source.rs:93`, `vantage-csv/src/csv.rs:53`
+
+Every `TableSource` read on the CSV backend calls `read_csv`, which opens the file from disk and parses all rows into an `IndexMap` from scratch. `get_table_value` parses the entire file just to `records.get(id)`; `get_table_count` parses everything to call `.len()`; `get_some_value` parses everything to take `.next()`. For a related-records resolution that calls `get_value` per id, this is O(rows × lookups) full re-parses. There is no caching of the parsed table even within a single logical operation.
+
+```rust
+async fn get_table_value<E>(&self, table: &Table<Self, E>, id: &Self::Id) -> Result<Option<Record<Self::Value>>> {
+    let records = self.read_csv(table.table_name(), table.columns())?; // full parse
+    Ok(records.get(id).cloned())
+}
+```
+
+**Recommendation:** Cache the parsed table (keyed by path + mtime) behind the `Csv` handle, or at least reuse one parse across a batch operation; for `get_table_value`, stop scanning once the id is found.

--- a/agent/review/performance/infra-awwpool-new-client-per-get.md
+++ b/agent/review/performance/infra-awwpool-new-client-per-get.md
@@ -1,0 +1,19 @@
+# AwwPool::get builds a fresh reqwest::Client per call
+
+- **Severity:** low
+- **Category:** performance
+- **Location:** `vantage-api-pool/src/aww_pool.rs:75`
+
+Every `AwwPool::get` constructs a brand-new `reqwest::Client` (connection pool, TLS config, resolver state) just to build a `Request` object; the request is then executed by the workers' own clients. Client construction is one of the more expensive reqwest operations and is explicitly recommended to be done once and reused. On a pool meant for high-volume paginated streaming (`PaginatedStream` calls `get` per page), this is per-page overhead for no benefit.
+
+```rust
+pub async fn get(&self, path: &str) -> anyhow::Result<Response> {
+    let full_url = if path.starts_with('/') {
+        format!("{}{}", self.base_url, path)
+    } else {
+        format!("{}/{}", self.base_url, path)
+    };
+    let mut request = Client::builder().build()?.get(&full_url).build()?;
+```
+
+**Recommendation:** Store one `reqwest::Client` on `AwwPool` (or use `Request::new(Method::GET, url.parse()?)`) instead of building a client per request.

--- a/agent/review/security/core-search-condition-placeholder-in-literal.md
+++ b/agent/review/security/core-search-condition-placeholder-in-literal.md
@@ -1,0 +1,22 @@
+# search_table_condition embeds parameter placeholder inside a quoted SQL literal
+
+- **Severity:** medium
+- **Category:** security
+- **Location:** `vantage-table/src/mocks/mock_table_source.rs:159-168`
+
+The reference implementation of `TableSource::search_table_condition` builds `name LIKE '%{}%'` — the `{}` parameter placeholder sits *inside* a single-quoted string literal. Real parameter binding cannot bind into the middle of a literal, so any driver copying this canonical pattern either produces broken SQL or falls back to string interpolation of the raw user search value (which is what `preview()`-based execution does in the mocks) — a textbook SQL/LIKE injection shape. The search value also isn't escaped for LIKE metacharacters (`%`, `_`).
+
+```rust
+fn search_table_condition<E>(
+    &self,
+    _table: &Table<Self, E>,
+    search_value: &str,
+) -> Expression<Self::Value>
+where
+    E: Entity<Self::Value>,
+{
+    expr_any!("name LIKE '%{}%'", search_value)
+}
+```
+
+**Recommendation:** Bind the whole pattern as one parameter: build `format!("%{}%", escape_like(search_value))` as the scalar and use `expr_any!("name LIKE {}", pattern)`. Audit driver crates for copies of this template.

--- a/agent/review/security/data-mysql-jsontable-escaping.md
+++ b/agent/review/security/data-mysql-jsontable-escaping.md
@@ -1,0 +1,16 @@
+# MySQL JSON_TABLE inlines name/type/path without escaping
+
+- **Severity:** medium
+- **Category:** security
+- **Location:** `vantage-sql/src/mysql/statements/primitives/json_table.rs:57`
+
+`JsonTableColumn::render` carefully escapes the `DEFAULT '...'` literal (`def.replace('\'', "''")`) but interpolates `name`, `col_type`, and the JSON `path` (which is itself inside single quotes `PATH '{}'`) with no escaping at all. The same applies to `JsonTable`'s `root_path` (`json_table.rs:130`). A `path` or `root_path` containing `'` closes the literal and injects SQL. The inconsistency (one field escaped, the adjacent quoted field not) shows the escaping was an afterthought.
+
+```rust
+let mut s = format!("{} {} PATH '{}'", self.name, self.col_type, self.path); // path unescaped
+if let Some(ref def) = self.default {
+    s.push_str(&format!(" DEFAULT '{}' ", def.replace('\'', "''")));         // but this is escaped
+}
+```
+
+**Recommendation:** Escape `'` in `path`/`root_path` and validate `name`/`col_type` against an identifier/type allowlist before rendering.

--- a/agent/review/security/data-sql-identifier-quote-escaping.md
+++ b/agent/review/security/data-sql-identifier-quote-escaping.md
@@ -1,0 +1,18 @@
+# vantage-sql Identifier does not escape embedded quote characters
+
+- **Severity:** medium
+- **Category:** security
+- **Location:** `vantage-sql/src/primitives/identifier.rs:67`
+
+`Identifier::render_with` wraps each part in the backend quote char but never doubles an embedded quote. `ident("a\"b")` renders `"a"b"` on Postgres/SQLite (and the backtick variant on MySQL), breaking out of the quoted identifier. The doc comment explicitly warns "do not pass untrusted user input," yet the Rhai engine exposes `ident()`, `table()`, and `from(name)` taking arbitrary config strings (`rhai_engine/constructors.rs`, `select_methods.rs`), so config-as-code authored by a less-trusted source can inject. The correct, cheap fix is to double the quote — the standard SQL identifier escaping.
+
+```rust
+fn render_with(&self, q: char) -> String {
+    let base = self.parts.iter()
+        .map(|p| format!("{q}{p}{q}"))  // embedded `q` not doubled
+        .collect::<Vec<_>>().join(".");
+    // …
+}
+```
+
+**Recommendation:** Escape by doubling: `format!("{q}{}{q}", p.replace(q, &format!("{q}{q}")))`. Reject identifiers containing NUL.

--- a/agent/review/security/data-surreal-credentials-in-debug-derive.md
+++ b/agent/review/security/data-surreal-credentials-in-debug-derive.md
@@ -1,0 +1,20 @@
+# Plaintext credentials exposed through derived Debug on connection/auth types
+
+- **Severity:** medium
+- **Category:** security
+- **Location:** `surreal-client/src/connection.rs:31`
+
+`AuthParams` derives `Debug` and holds `username`/`password`/JWT `Token` as plain `String`s; `SurrealConnection` also derives `Debug` and embeds an `Option<AuthParams>`. Any `{:?}` formatting of a connection or auth value — a `tracing` span field, an `.expect()`/`anyhow` context, a panic message — prints the password/token in clear text. Credential-bearing structs should never carry a naive derived `Debug`.
+
+```rust
+#[derive(Debug, Clone)]
+pub enum AuthParams {
+    Root { username: String, password: String },
+    // …
+    Token(String),
+}
+#[derive(Default, Debug, Clone)]
+pub struct SurrealConnection { /* … */ auth: Option<AuthParams>, /* … */ }
+```
+
+**Recommendation:** Hand-implement `Debug` to redact secret fields (`password: "***"`), or wrap secrets in a `Secret<String>` newtype whose `Debug` masks the value.

--- a/agent/review/security/data-surreal-debug-logging.md
+++ b/agent/review/security/data-surreal-debug-logging.md
@@ -1,0 +1,18 @@
+# DebugEngine prints all RPC params and responses (incl. secrets) to stdout
+
+- **Severity:** high
+- **Category:** security
+- **Location:** `surreal-client/src/engines/debug.rs:21`
+
+When debug mode is enabled (`SurrealConnection::with_debug(true)`), `DebugEngine` wraps the transport and `println!`s every RPC method, its full params, and the full response to stdout. This includes any `signin`/`authenticate` calls (username + password), `let_var` values, and entire result sets — i.e. raw user-database rows. For a product positioned as "local-first / private" that connects to user databases, dumping credentials and PII to stdout (which commonly lands in shell history, CI logs, journald) is a meaningful exposure.
+
+```rust
+fn log_request(&self, method: &str, params: &Value) {
+    let params_str = serde_json::to_string(params).unwrap_or_default();
+    println!("🔍 Surreal RPC: {} {}", method, params_str);  // logs signin {user,pass}
+}
+async fn send_message_cbor(&mut self, method: &str, params: CborValue) -> Result<CborValue> {
+    println!("🔍 Surreal CBOR RPC: {} {:?}", method, params);
+```
+
+**Recommendation:** Redact auth methods (`signin`/`signup`/`authenticate`) and truncate/redact result bodies; route through `tracing` at `trace` level rather than unconditional `println!`.

--- a/agent/review/security/data-surreal-identifier-escaping.md
+++ b/agent/review/security/data-surreal-identifier-escaping.md
@@ -1,0 +1,17 @@
+# SurrealDB Identifier escaping is incomplete and bypassable
+
+- **Severity:** high
+- **Category:** security
+- **Location:** `vantage-surrealdb/src/identifier.rs:49`
+
+`Identifier::needs_escaping` only flags identifiers that contain a space or match a hard-coded 11-word keyword list. Identifiers containing other SurrealQL-significant characters (`:`, `-`, `(`, `;`, `.`, leading digits, etc.) are emitted **raw** into the query. Worse, even when it does escape it wraps with `⟨{}⟩` without escaping an embedded `⟩`, so an identifier containing `⟩` breaks out of the brackets. Identifiers flow from column names / Rhai `ident()`/`table()` config strings into query text (they render as `Nested`, never parameterized), so a crafted field name injects SurrealQL.
+
+```rust
+fn needs_escaping(&self) -> bool {
+    let reserved_keywords = ["DEFINE","CREATE","SELECT", /* …11 total… */ "TABLE"];
+    self.identifier.contains(' ') || reserved_keywords.contains(&upper.as_str())
+}
+// expr(): Expression::new(format!("⟨{}⟩", self.identifier), vec![])  // embedded ⟩ not escaped
+```
+
+**Recommendation:** Always escape identifiers using `⟨…⟩` with `⟩` → `\⟩` replacement (as `surreal-client::record::escape_identifier` already does), instead of a keyword allowlist. Share one implementation across the crates.

--- a/agent/review/security/data-surreal-inline-string-injection.md
+++ b/agent/review/security/data-surreal-inline-string-injection.md
@@ -1,0 +1,18 @@
+# SurrealQL injection in inline single-quoted primitives (similarity / time_group)
+
+- **Severity:** high
+- **Category:** security
+- **Location:** `vantage-surrealdb/src/primitives.rs:219`, `vantage-surrealdb/src/primitives.rs:210`
+
+`similarity(expr, term)` and `time_group(expr, unit)` build the query by interpolating the caller string directly inside a single-quoted SurrealQL literal with no escaping. A `term`/`unit` containing a `'` closes the literal and injects arbitrary SurrealQL. Both are exposed to the Rhai config layer (`rhai_engine/constructors.rs: fn_similarity`/`fn_time_group`), and `similarity` is exactly the kind of helper fed a runtime user search term.
+
+```rust
+pub fn similarity(expr: impl Expressive<AnySurrealType>, term: &str) -> Expr {
+    Expression::new(
+        format!("string::similarity::jaro_winkler({{}}, '{term}')"),  // term unescaped
+        vec![ExpressiveEnum::Nested(expr.expr())],
+    )
+}
+```
+
+**Recommendation:** Pass `term`/`unit` as a bound `Scalar` parameter (`{}` placeholder) instead of inlining, or at minimum escape `'` → `\'`. Same applies to `time_group`'s `unit`.

--- a/agent/review/security/data-surreal-thing-injection.md
+++ b/agent/review/security/data-surreal-thing-injection.md
@@ -1,0 +1,19 @@
+# SurrealQL injection via Thing/record-id rendered into query text
+
+- **Severity:** critical
+- **Category:** security
+- **Location:** `vantage-surrealdb/src/thing.rs:132`, `vantage-surrealdb/src/surrealdb/impls/table_source.rs:199`
+
+`Thing::expr()` renders a record id straight into the SurrealQL template with no escaping or parameterization. The query preparer only parameterizes `Scalar` params; `Nested` expressions (which is what `Thing` and `Identifier` become) are flattened directly into the query string (`surrealdb/impls/base.rs:34-52`). So `get_table_value` builds `SELECT * FROM ONLY <table>:<id>` from caller-supplied id. In an admin console that fetches a record by a user-supplied id, an id like `user:1 OR true` (parsed into `Thing{table:"user", id:"1 OR true"}`) is concatenated verbatim, allowing query manipulation / data exfiltration.
+
+```rust
+impl Expressive<AnySurrealType> for Thing {
+    fn expr(&self) -> Expression<AnySurrealType> {
+        surreal_expr!(format!("{}:{}", self.table, self.id))  // no escaping
+    }
+}
+// table_source.rs
+let query = crate::surreal_expr!("SELECT * FROM ONLY {}", (id.clone()));
+```
+
+**Recommendation:** Bind record ids as real CBOR `$param` values (Tag(8) record-id), or escape both table and id with the `⟨…⟩` form (reuse `surreal-client`'s `escape_identifier`). Never interpolate untrusted ids into the template.

--- a/agent/review/security/infra-auth-header-in-debug.md
+++ b/agent/review/security/infra-auth-header-in-debug.md
@@ -1,0 +1,19 @@
+# API auth tokens exposed via derived Debug on RestApi/GraphqlApi
+
+- **Severity:** high
+- **Category:** security
+- **Location:** `vantage-api-client/src/rest/api.rs:103`
+
+`RestApi` (and `GraphqlApi` at `src/graphql/api.rs:24`) derive `Debug` while holding the raw `Authorization` header value (e.g. `Bearer <token>`). Any `{:?}` log line, error context, or panic message that includes the datasource prints the credential in plaintext. This is inconsistent with `AwsAccount` in vantage-aws, which hand-implements `Debug` and redacts `access_key`/`secret_key`/`session_token`.
+
+```rust
+#[derive(Clone, Debug)]
+pub struct RestApi {
+    base_url: String,
+    client: reqwest::Client,
+    pub(crate) auth_header: Option<String>,
+    ...
+}
+```
+
+**Recommendation:** Implement `Debug` manually for `RestApi`, `RestApiBuilder`, `GraphqlApi`, and `GraphqlApiBuilder`, printing `auth_header: Some("<redacted>")`, following the existing `AwsAccount` pattern.

--- a/agent/review/security/infra-cmd-debug-env-secrets.md
+++ b/agent/review/security/infra-cmd-debug-env-secrets.md
@@ -1,0 +1,22 @@
+# Cmd/CmdSpec Debug output includes declared env (often credentials)
+
+- **Severity:** medium
+- **Category:** security
+- **Location:** `vantage-cmd/src/cmd.rs:80`
+
+The declared env of a `Cmd` datasource is exactly where credentials for wrapped CLI tools live (`GH_TOKEN`, `AWS_SECRET_ACCESS_KEY`, etc. — that is the point of `with_env`). The manual `Debug` impl for `Cmd` prints `env` values verbatim, and `CmdSpec` (`cmd.rs:16`) derives `Debug` including its per-table `env`. Any tracing/error path that debug-formats the datasource or spec leaks those secrets into logs.
+
+```rust
+impl std::fmt::Debug for Cmd {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Cmd")
+            .field("command", &self.command)
+            .field("env", &self.env)
+            ...
+            .field("scripts", &self.scripts) // CmdSpec also derives Debug with env
+            .finish()
+    }
+}
+```
+
+**Recommendation:** Print env keys only (or `<redacted>` values) in both `Cmd`'s and `CmdSpec`'s `Debug` output, mirroring `AwsAccount`'s redaction.

--- a/agent/review/security/infra-log-writer-path-traversal.md
+++ b/agent/review/security/infra-log-writer-path-traversal.md
@@ -1,0 +1,15 @@
+# LogWriter table name joins into the path unchecked (traversal out of base_dir)
+
+- **Severity:** low
+- **Category:** security
+- **Location:** `vantage-log-writer/src/log_writer.rs:56`
+
+`file_path` builds the target file by joining `base_dir` with the raw table name. A table named `../../../tmp/evil` (table names come from YAML/Rhai config, which in an AI-native config-as-code product may be generated or third-party) escapes `base_dir` and appends records to an arbitrary path ending in `.jsonl`; the writer task even runs `create_dir_all` on the parent (`writer_task.rs:55`), creating directories anywhere the process can write.
+
+```rust
+pub(crate) fn file_path(&self, table_name: &str) -> PathBuf {
+    self.inner.base_dir.join(format!("{}.jsonl", table_name))
+}
+```
+
+**Recommendation:** Reject table names containing path separators or `..` (or canonicalise the joined path and verify it stays under `base_dir`) before queueing a write.

--- a/agent/review/suggestions/core-errorkind-is-naming.md
+++ b/agent/review/suggestions/core-errorkind-is-naming.md
@@ -1,0 +1,19 @@
+# VantageError `is_*` methods are builders, not predicates
+
+- **Severity:** low
+- **Category:** suggestions
+- **Location:** `vantage-core/src/util/error.rs:236-256`
+
+`is_unsupported()`, `is_unimplemented()` and `is_incorrect_usage()` consume `self`, mutate the error kind, emit a `tracing::error!` event as a side effect, and return `Self`. In Rust, `is_*` universally signals a `&self -> bool` predicate; here `if err.is_unsupported()` doesn't even compile but reads as a check, and the hidden tracing side effect inside an innocuous-looking "getter" name is surprising. Code review of callsites (`error!(...).is_unsupported()`) is harder than it should be.
+
+```rust
+/// Mark as [`ErrorKind::Unsupported`] and emit a `tracing::error!`
+/// event with the error's message and context.
+pub fn is_unsupported(mut self) -> Self {
+    self.kind = ErrorKind::Unsupported;
+    self.emit_trace();
+    self
+}
+```
+
+**Recommendation:** Rename to builder-style names (`as_unsupported()` / `mark_unsupported()` / `with_kind(ErrorKind::Unsupported)`), keep `is_*` available as real `&self -> bool` predicates, and consider making the trace emission explicit (`.traced()`) so classification and logging aren't coupled.

--- a/agent/review/suggestions/data-unify-surreal-identifier-escaping.md
+++ b/agent/review/suggestions/data-unify-surreal-identifier-escaping.md
@@ -1,0 +1,16 @@
+# Unify the two divergent SurrealDB identifier-escaping implementations
+
+- **Severity:** low
+- **Category:** suggestions
+- **Location:** `vantage-surrealdb/src/identifier.rs:49`, `surreal-client/src/record.rs:353`
+
+There are two independent SurrealDB identifier escapers with different rigor. `surreal-client::record::escape_identifier` is the careful one: it escapes empty, numeric, leading-digit, and any non-`[A-Za-z0-9_]` identifier with `⟨…⟩` and replaces embedded `⟩` with `\⟩`. `vantage-surrealdb::identifier::Identifier::expr` is the weak one: a space/keyword allowlist and no embedded-`⟩` escaping (see the related security finding). Having two implementations guarantees they drift, and the weaker one is the one used to build queries.
+
+```rust
+// surreal-client (good):
+return format!("⟨{}⟩", ident.replace('⟩', "\\⟩"));
+// vantage-surrealdb (weak):
+Expression::new(format!("⟨{}⟩", self.identifier), vec![])
+```
+
+**Recommendation:** Extract one escaping function (the `surreal-client` version) into a shared location and have both `Identifier` and `Thing` rendering use it, so escaping rules live in exactly one place.


### PR DESCRIPTION
Automated multi-agent code review found **59 issues** across the codebase.

**Breakdown:** security (11) · bugs (18) · inconsistencies (14) · omissions (11) · performance (3) · suggestions (2)

---

### Security (11)

- **Critical:** SurrealQL injection via Thing/record-id rendered into query text (`vantage-surrealdb/src/thing.rs:132`)
- **High:** DebugEngine prints all RPC params and responses to stdout (`surreal-client/src/engines/debug.rs:21`)
- **High:** SurrealDB identifier escaping is incomplete and bypassable (`vantage-surrealdb/src/identifier.rs:49`)
- **High:** SurrealQL injection in inline single-quoted primitives (`vantage-surrealdb/src/primitives.rs:219`)
- **High:** API auth tokens exposed via derived Debug on RestApi/GraphqlApi (`vantage-api-client/src/rest/api.rs:103`)
- **Medium:** search_table_condition embeds placeholder inside quoted SQL literal (`vantage-table/src/mocks/mock_table_source.rs:159`)
- **Medium:** MySQL JSON_TABLE inlines name/type/path without escaping (`vantage-sql/src/mysql/statements/primitives/json_table.rs:57`)
- **Medium:** vantage-sql Identifier does not escape embedded quote characters (`vantage-sql/src/primitives/identifier.rs:67`)
- **Medium:** Plaintext credentials through derived Debug on connection/auth types (`surreal-client/src/connection.rs:31`)
- **Medium:** Cmd/CmdSpec Debug output includes declared env (often credentials) (`vantage-cmd/src/cmd.rs:80`)
- **Low:** LogWriter table name joins into path unchecked (path traversal) (`vantage-log-writer/src/log_writer.rs:56`)

### Bugs (18)

- **High:** ImDataSource read-modify-write race loses concurrent updates
- **High:** LICENSE carries wrong copyright; Apache-2.0 file missing despite dual-license claim
- **High:** Failed pool requests dropped, callers await forever
- **Medium:** IntoValue for f64 panics on NaN/Infinity
- **Medium:** IntoRecord blanket impls panic on entity serialization failure
- **Medium:** get_table_count_expr calls block_on inside runtime — guaranteed panic
- **Medium:** Table::select_column unwraps column lookup — panics on unknown field
- **Medium:** CSV search filter is silently a no-op (returns all rows)
- **Medium:** bakery_model3 README documents a non-existent `cli` example
- **Medium:** README references non-existent crates and examples
- **Medium:** Unbounded retries and uncapped Retry-After sleep
- **Medium:** RestApi get_table_value/get_table_count only see current page
- **Medium:** RestApi search condition silently dropped
- **Low:** Expression::preview() corrupts output on `{}` in parameter values
- **Low:** SurrealDB get_table_value ignores table's id field name
- **Low:** Broken doc links across book and READMEs
- **Low:** README code snippets have syntax errors
- **Low:** HttpClientPool::with_rate_limit silently does nothing without pool config

### Inconsistencies (14)

- **High:** insert/delete idempotency contracts contradicted by implementations
- **High:** vantage-config.schema.json is stale; doesn't match parsed code
- **High:** README documents AnyTable/AnyDataSet API that doesn't exist
- **High:** README DataSet/Pagination examples use non-existent method names
- **High:** README and book claim "0.4" while all crates are 0.5.x
- **Medium:** ActiveEntity::save() replaces vs ActiveRecord::save() patches — same name, different semantics
- **Medium:** search_table_condition has wildly different semantics per engine
- **Medium:** SQL backends disagree on placeholder/param-count validation
- **Medium:** README says PostgreSQL/MySQL "coming next" but vantage-sql already implements them
- **Medium:** README flips Table generic parameter order and shows outdated closure shape
- **Medium:** "vantage-ui-adapters" is actually package `dataset-ui-adapters`, unpublished
- **Medium:** AWS_ENDPOINT_URL override honoured only by json1/json10 transports
- **Low:** Mixed id-parameter conventions across dataset traits
- **Low:** README backend-status table step numbers don't match Persistence Guide

### Omissions (11)

- Medium: get_count_via_query returns Ok(0) for unrecognized result shapes
- Medium: Stale source files outside module tree (won't compile if re-enabled)
- Medium: Flatten::resolve_deferred is a documented no-op
- Medium: redb panics (not Err) on unsupported search
- Medium: Root README omits Vista, Diorama and other shipped crates
- Medium: Root CHANGELOG.md ends at 0.2.0 — three releases behind
- Medium: AwwPool caches first auth token forever — no expiry/refresh
- Medium: vantage-cmd subprocesses have no timeout, unbounded output capture
- Medium: No timeouts on any HTTP client
- Medium: unimplemented!() panics reachable through normal TableSource API
- Low: MockTableSource::with_data silently drops rows without "id"

### Performance (3)

- Medium: Every ImTable operation clones the entire table
- Low: CSV backend re-reads and re-parses whole file on every operation
- Low: AwwPool::get builds a fresh reqwest::Client per call

### Suggestions (2)

- Low: VantageError `is_*` methods are builders, not predicates (naming confusion)
- Low: Unify two divergent SurrealDB identifier-escaping implementations

---

Full details in `agent/review/` directory.