### PR TITLE
fix expr panics and silent count results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4800,7 +4800,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-expressions"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4943,7 +4943,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -20,8 +20,8 @@ urlencoding = "2.1"
 uuid = { version = "1", features = ["serde"] }
 vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
-vantage-table = { version = "0.5", path = "../vantage-table" }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
+vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.5", path = "../vantage-vista" }
 

--- a/vantage-api-pool/Cargo.toml
+++ b/vantage-api-pool/Cargo.toml
@@ -21,8 +21,8 @@ indexmap = { version = "2", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
-vantage-table = { version = "0.5", path = "../vantage-table" }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
+vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
 
 [dev-dependencies]

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 [dependencies]
 vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
-vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
-vantage-table = { version = "0.5", path = "../vantage-table" }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
+vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-vista = { version = "0.5", path = "../vantage-vista" }
 

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -16,7 +16,7 @@ owo-colors = "4"
 serde_json = "1"
 vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-table = { version = "0.5", path = "../vantage-table" }
+vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.5", path = "../vantage-types" }
 vantage-vista = { version = "0.5", path = "../vantage-vista" }
 

--- a/vantage-cmd/Cargo.toml
+++ b/vantage-cmd/Cargo.toml
@@ -18,8 +18,8 @@ readme = "README.md"
 [dependencies]
 vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
-vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
-vantage-table = { version = "0.5", path = "../vantage-table" }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
+vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-vista = { version = "0.5", path = "../vantage-vista" }
 

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -22,8 +22,8 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1", features = ["preserve_order"] }
 vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
-vantage-table = { version = "0.5", path = "../vantage-table" }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
+vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
 

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-types = { version = "0.5", path = "../vantage-types" }
 vantage-vista = { version = "0.5", path = "../vantage-vista" }
-vantage-table = { version = "0.5", path = "../vantage-table" }
+vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 
 async-trait = "0.1"

--- a/vantage-expressions/CHANGELOG.md
+++ b/vantage-expressions/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.0 — 2026-06-10
+
+- `IntoValue` for `f64` no longer panics on NaN/Infinity — non-finite floats degrade to
+  `Value::Null` instead (JSON has no NaN/Inf representation).
+- `Expression::preview()` uses single-pass interleaving instead of repeated `replacen`, so `{}`
+  inside a rendered parameter value can no longer corrupt the output.
+- Removed the no-op `Flatten::resolve_deferred` method (deferred-parameter resolution is an async
+  DataSource concern, not a sync flattener concern).
+
 ## 0.5.0 — 2026-05-23
 
 - Align all internal dependency versions to 0.5+. No public API changes.

--- a/vantage-expressions/Cargo.toml
+++ b/vantage-expressions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-expressions"
-version = "0.5.0"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Database agnostic expressions"

--- a/vantage-expressions/src/expression/core.rs
+++ b/vantage-expressions/src/expression/core.rs
@@ -166,10 +166,16 @@ impl<T: Clone> Expressive<T> for Expression<T> {
 
 impl<T: std::fmt::Display + std::fmt::Debug> Expression<T> {
     pub fn preview(&self) -> String {
-        let mut preview = self.template.clone();
+        // Single pass: split the template on `{}` and interleave rendered
+        // params between the segments. Rendering this way (rather than
+        // repeated `replacen`) means a `{}` *inside* a rendered value can
+        // never be mistaken for the next placeholder.
+        let mut parts = self.template.split("{}");
+        let mut preview = String::new();
+        preview.push_str(parts.next().unwrap_or(""));
         for param in &self.parameters {
-            let param_str = param.preview();
-            preview = preview.replacen("{}", &param_str, 1);
+            preview.push_str(&param.preview());
+            preview.push_str(parts.next().unwrap_or(""));
         }
         preview
     }
@@ -230,5 +236,20 @@ mod tests {
         assert_eq!(expr.template, "SELECT * FROM table WHERE id = {}");
         assert_eq!(expr.parameters.len(), 1);
         assert_eq!(expr.preview(), "SELECT * FROM table WHERE id = 42");
+    }
+
+    #[test]
+    fn test_preview_param_value_containing_placeholder() {
+        // A rendered value that itself contains `{}` must not swallow the
+        // following placeholder. Single-pass interleaving handles this;
+        // the old repeated-`replacen` approach produced "weird{x} = " here.
+        let expr = Expression::new(
+            "{} = {}",
+            vec![
+                ExpressiveEnum::Scalar("weird{}".to_string()),
+                ExpressiveEnum::Scalar("x".to_string()),
+            ],
+        );
+        assert_eq!(expr.preview(), "weird{} = x");
     }
 }

--- a/vantage-expressions/src/expression/flatten.rs
+++ b/vantage-expressions/src/expression/flatten.rs
@@ -33,9 +33,6 @@ pub trait Flatten<T> {
     /// Flatten an expression by resolving all deferred parameters and nested expressions
     fn flatten(&self, expr: &T) -> T;
 
-    /// Resolve deferred parameters in the expression
-    fn resolve_deferred(&self, expr: &T) -> T;
-
     /// Flatten nested expressions into the parent template
     fn flatten_nested(&self, expr: &T) -> T;
 }
@@ -58,15 +55,10 @@ impl Default for ExpressionFlattener {
 
 impl<T: Clone> Flatten<Expression<T>> for ExpressionFlattener {
     fn flatten(&self, expr: &Expression<T>) -> Expression<T> {
-        let resolved = self.resolve_deferred(expr);
-        self.flatten_nested(&resolved)
-    }
-
-    fn resolve_deferred(&self, expr: &Expression<T>) -> Expression<T> {
-        // Note: This is a sync implementation that doesn't actually execute deferred closures
-        // For testing purposes, deferred parameters are left as-is
-        // In real usage, this would be handled by the DataSource execute method
-        expr.clone()
+        // Deferred-parameter resolution is a separate, async phase owned by the
+        // DataSource execute path (see each backend's `resolve_deferred`); it
+        // cannot happen in this sync flattener, so we only flatten nesting here.
+        self.flatten_nested(expr)
     }
 
     fn flatten_nested(&self, expr: &Expression<T>) -> Expression<T> {

--- a/vantage-expressions/src/value.rs
+++ b/vantage-expressions/src/value.rs
@@ -28,7 +28,7 @@ impl_into_value! {
     i32 => |v| Value::Number(serde_json::Number::from(v)),
     i64 => |v| Value::Number(serde_json::Number::from(v)),
     u64 => |v| Value::Number(serde_json::Number::from(v)),
-    f64 => |v| Value::Number(serde_json::Number::from_f64(v).unwrap()),
+    f64 => |v| serde_json::Number::from_f64(v).map(Value::Number).unwrap_or(Value::Null),
     bool => Value::Bool,
     String => Value::String,
     &str => |v:&str| Value::String(v.to_string()),
@@ -74,5 +74,20 @@ mod tests {
         fx(());
         fx(["some", "slice"]);
         fx(vec!["some", "slice"]);
+    }
+
+    #[test]
+    fn test_finite_f64_into_value() {
+        let v = IntoValue::into_value(Box::new(1.5f64));
+        assert_eq!(v, Value::Number(serde_json::Number::from_f64(1.5).unwrap()));
+    }
+
+    #[test]
+    fn test_non_finite_f64_into_value_is_null() {
+        // `into_value` is infallible, and JSON has no NaN/Infinity, so
+        // non-finite floats degrade to Null rather than panicking.
+        for v in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert_eq!(IntoValue::into_value(Box::new(v)), Value::Null);
+        }
     }
 }

--- a/vantage-log-writer/Cargo.toml
+++ b/vantage-log-writer/Cargo.toml
@@ -24,8 +24,8 @@ tracing = "0.1"
 ulid = "1"
 vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
-vantage-table = { version = "0.5", path = "../vantage-table" }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
+vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
 

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -13,8 +13,8 @@ vista = ["dep:vantage-vista"]
 [dependencies]
 vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-types = { version = "0.5", path = "../vantage-types" }
-vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
-vantage-table = { version = "0.5", path = "../vantage-table" }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
+vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
 

--- a/vantage-redb/Cargo.toml
+++ b/vantage-redb/Cargo.toml
@@ -13,8 +13,8 @@ readme = "../README.md"
 [dependencies]
 vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-types = { version = "0.5", path = "../vantage-types" }
-vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
-vantage-table = { version = "0.5", path = "../vantage-table" }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
+vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 
 redb = "2.6"

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -20,11 +20,11 @@ rhai = ["dep:rhai"]
 [dependencies]
 vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
-vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 paste = "1.0"
 
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-table = { version = "0.5", path = "../vantage-table" }
+vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
 async-trait = "0.1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "rust_decimal", "uuid", "chrono"] }

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -22,8 +22,8 @@ rhai = ["dep:rhai", "vista", "vantage-vista/rhai"]
 [dependencies]
 async-trait = "0.1"
 vantage-core = { version = "0.5", path = "../vantage-core" }
-vantage-expressions = { version = "0.5", path = "../vantage-expressions", features = ["chrono"] }
-vantage-table = { version = "0.5", path = "../vantage-table" }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions", features = ["chrono"] }
+vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-types = { version = "0.5", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Changelog
 
+## 0.6.0 — 2026-06-10
+
+- `get_count_via_query` now unwraps single-element arrays (`[{"count": N}]`), matching how
+  SQL/Surreal count queries commonly return results.
+- Unrecognized result shapes are now surfaced as errors instead of silently returning 0.
+
 ## 0.5.7 — 2026-06-06
 
 ### Changed
 
 - Docs only: reference-traversal documentation now points to
-  [`vantage-vista-factory`](https://crates.io/crates/vantage-vista-factory)'s `VistaCatalog`
-  for cross-persistence traversal. No functional or API change.
+  [`vantage-vista-factory`](https://crates.io/crates/vantage-vista-factory)'s `VistaCatalog` for
+  cross-persistence traversal. No functional or API change.
 
 ## 0.5.6 — 2026-06-02
 
@@ -15,15 +21,15 @@
 - A table can now be sourced from an arbitrary sub-`SELECT`, not just a named table.
   [`Table::from_select(ds, alias, select)`](https://docs.rs/vantage-table/0.5.6/vantage_table/table/struct.Table.html)
   builds a derived table that renders `FROM (<select>) AS <alias>`.
-- [`SelectSource<S>`](https://docs.rs/vantage-table/0.5.6/vantage_table/source/enum.SelectSource.html) —
-  the source enum (`Name` or `Query { select, alias }`) that SQL/SurrealDB backends use for
-  their new `TableSource::Source` associated type. Other backends keep `String`.
+- [`SelectSource<S>`](https://docs.rs/vantage-table/0.5.6/vantage_table/source/enum.SelectSource.html)
+  — the source enum (`Name` or `Query { select, alias }`) that SQL/SurrealDB backends use for their
+  new `TableSource::Source` associated type. Other backends keep `String`.
 
 ### Changed
 
 - `TableSource` gains a required `type Source: TableSourceSpec`. Built-in backends are updated;
-  out-of-tree `TableSource` impls must add the associated type (use `String` for a plain
-  named source).
+  out-of-tree `TableSource` impls must add the associated type (use `String` for a plain named
+  source).
 
 ## 0.5.5 — 2026-05-31
 
@@ -32,26 +38,28 @@
 - `Table::with_contained_one` / `with_contained_many` — declare an embedded object/array column as a
   contained relation, surfaced through Vista as an editable sub-table. The closure builds the
   contained record's schema, reusing the normal `Table` column machinery.
-- `Table::get_contained_ref` — the generic, driver-agnostic resolution of a contained relation from a
-  parent row (each backend supplies only its host-column encode/decode pair).
+- `Table::get_contained_ref` — the generic, driver-agnostic resolution of a contained relation from
+  a parent row (each backend supplies only its host-column encode/decode pair).
 - `Table::with_contained_specs` — lowers a YAML `contained:` section into the same registrations,
   reusing the driver's existing column builder.
 - `ContainedRelation<T>`, plus `Table::vista_contained()` / `contained_relation()` for driver
-  factories. See the [contained relations guide](https://romaninsh.github.io/vantage/new-persistence/step9-contained-relations.html).
+  factories. See the
+  [contained relations guide](https://romaninsh.github.io/vantage/new-persistence/step9-contained-relations.html).
 
 ## 0.5.4 — 2026-05-30
 
-Support for [vantage-vista 0.5.1](https://docs.rs/vantage-vista/0.5.1/vantage_vista/)'s nested insert.
+Support for [vantage-vista 0.5.1](https://docs.rs/vantage-vista/0.5.1/vantage_vista/)'s nested
+insert.
 
 ### Added
 
 - `Table::get_ref_target::<E2>(relation)` — builds a relation's target table with **no** join
   condition (the bare table a new related row is inserted into), complementing the row-conditioned
   `get_ref_from_row` / `get_ref_as`.
-- `Table::vista_references()` — snapshots the table's relations as `vantage_vista::Reference`s (name,
-  target, cardinality, foreign key) for driver factories to fold into `VistaMetadata`.
-- `Reference::foreign_key()` on the `Reference` trait — exposes the relation's FK column. **Note:** a
-  new required trait method; external `Reference` impls (beyond the built-in `HasOne` / `HasMany`)
+- `Table::vista_references()` — snapshots the table's relations as `vantage_vista::Reference`s
+  (name, target, cardinality, foreign key) for driver factories to fold into `VistaMetadata`.
+- `Reference::foreign_key()` on the `Reference` trait — exposes the relation's FK column. **Note:**
+  a new required trait method; external `Reference` impls (beyond the built-in `HasOne` / `HasMany`)
   must add it.
 
 ## 0.5.3 — 2026-05-23

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.5.7"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"
@@ -18,7 +18,7 @@ doctest = false
 [dependencies]
 vantage-core = { version = "0.5", path = "../vantage-core" }
 vantage-types = { version = "0.5", path = "../vantage-types" }
-vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-vista = { version = "0.5", path = "../vantage-vista" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 async-stream = "0.3"
@@ -36,7 +36,7 @@ rust_decimal = { version = "1.42.0", features = ["macros", "serde"] }
 [dev-dependencies]
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "sync"] }
 serde_json = "1.0"
-vantage-expressions = { version = "0.5", path = "../vantage-expressions" }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 # vantage-surrealdb = { path = "../vantage-surrealdb" }
 surreal-client = { version = "0.5", path = "../surreal-client" }
 async-trait = "0.1"

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -210,13 +210,24 @@ where
         let count_query = self.get_count_query();
         let result = self.data_source.execute(&count_query).await?;
 
-        // Extract count from result - could be {"count": 42} or just 42
+        // Unwrap a single-element array, e.g. `[{"count": 42}]` or `[42]`,
+        // which is how SQL/Surreal count queries commonly come back.
+        let result = match result.as_array().map(Vec::as_slice) {
+            Some([single]) => single,
+            _ => &result,
+        };
+
+        // Extract count from result - could be {"count": 42} or just 42.
+        // Anything else is an unexpected shape: surface it rather than
+        // silently reporting zero rows.
         if let Some(count) = result.get("count").and_then(|v| v.as_i64()) {
             Ok(count)
         } else if let Some(count) = result.as_i64() {
             Ok(count)
         } else {
-            Ok(0)
+            Err(vantage_core::util::error::vantage_error!(
+                "count query returned an unexpected result shape: {result}"
+            ))
         }
     }
 }
@@ -273,6 +284,32 @@ mod tests {
         // Test actual count/sum methods - get_count should return 42 from mock query source
         let count = table.get_count_via_query().await.unwrap();
         assert_eq!(count, 42);
+    }
+
+    async fn count_table_returning(
+        count_result: serde_json::Value,
+    ) -> Table<MockTableSource, vantage_types::EmptyEntity> {
+        let mock_select_source = MockSelectableDataSource::new(json!([]));
+        let mock_query_source = vantage_expressions::mocks::mock_builder::new()
+            .on_exact_select("(SELECT COUNT(*) FROM \"users\")", count_result);
+        let source = MockTableSource::new()
+            .with_select_source(mock_select_source)
+            .with_query_source(mock_query_source);
+        Table::<_, vantage_types::EmptyEntity>::new("users", source)
+    }
+
+    #[tokio::test]
+    async fn test_count_unwraps_single_element_array() {
+        // SQL/Surreal count queries commonly return `[{"count": N}]`.
+        let table = count_table_returning(json!([{"count": 7}])).await;
+        assert_eq!(table.get_count_via_query().await.unwrap(), 7);
+    }
+
+    #[tokio::test]
+    async fn test_count_errors_on_unexpected_shape() {
+        // An unrecognized result must surface as an error, not a silent zero.
+        let table = count_table_returning(json!({"total": 5})).await;
+        assert!(table.get_count_via_query().await.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Hardens expression value conversions and table count handling against panics and silent failures.

**vantage-expressions 0.6.0**
- `IntoValue` for `f64` returns `Value::Null` on NaN/Infinity instead of panicking
- `Expression::preview()` uses single-pass interleaving — `{}` inside a param value no longer corrupts output
- Removed no-op `Flatten::resolve_deferred` (deferred resolution is an async DataSource concern)

**vantage-table 0.6.0**
- `get_count_via_query` unwraps single-element arrays (`[{"count": N}]`) from SQL/Surreal backends
- Unrecognized result shapes now return `Err` instead of silently reporting 0

All `vantage-expressions` and `vantage-table` dependency pins updated to `"0.6"` across the workspace.