### PR TITLE
bind similarity/time_group literals as params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "async-trait",
  "bakery_model3",

--- a/agent/review/security/data-surreal-inline-string-injection.md
+++ b/agent/review/security/data-surreal-inline-string-injection.md
@@ -1,5 +1,11 @@
 # SurrealQL injection in inline single-quoted primitives (similarity / time_group)
 
+- **Status:** FIXED (2026-06-13, vantage-surrealdb 0.5.11) — both `similarity` and `time_group`
+  now bind their literal token as a `Scalar` parameter (the recommended fix), routed through
+  `prepare_query` → CBOR `$_arg`, so a quote can no longer break out of the literal. Verified
+  against a live SurrealDB: the payload `x') OR true OR ('` bypassed the filter inline but is
+  contained once bound. Regression tests: `primitives::tests::tier2_literal_tokens_cannot_break_out_of_query`
+  and `tier2_literal_tokens_are_bound_params`.
 - **Severity:** high
 - **Category:** security
 - **Location:** `vantage-surrealdb/src/primitives.rs:219`, `vantage-surrealdb/src/primitives.rs:210`

--- a/agent/review/security/data-surreal-thing-injection.md
+++ b/agent/review/security/data-surreal-thing-injection.md
@@ -1,5 +1,11 @@
 # SurrealQL injection via Thing/record-id rendered into query text
 
+- **Status:** DISMISSED (2026-06-13) — no live attacker-controlled path. `Thing` ids
+  originate from internal construction (relationship traversal, typed record ids), not
+  from raw untrusted user input reaching `Thing::expr()`. The escaping divergence that
+  *did* matter (`Identifier`) is already fixed via the shared `escape_identifier`
+  (PR #297 / `data-surreal-identifier-escaping.md`). Re-open only if a code path is
+  added that builds a `Thing` directly from unvalidated external input.
 - **Severity:** critical
 - **Category:** security
 - **Location:** `vantage-surrealdb/src/thing.rs:132`, `vantage-surrealdb/src/surrealdb/impls/table_source.rs:199`

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.11 — 2026-06-13
+
+- `similarity(expr, term)` and `time_group(expr, unit)` now bind their literal token as a query
+  parameter instead of interpolating it into a single-quoted SurrealQL literal. A `term`/`unit`
+  containing a `'` previously broke out of the literal and could inject SurrealQL — relevant because
+  `similarity` is typically fed a runtime search term and both are exposed through the Rhai config
+  layer. The token is now routed through the same CBOR `$_arg` binding as every other scalar.
+
 ## 0.5.10 — 2026-06-13
 
 - `Identifier` escaping now routes through `surreal-client`'s shared `escape_identifier`, removing a

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.5.10"
+version = "0.5.11"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/primitives.rs
+++ b/vantage-surrealdb/src/primitives.rs
@@ -162,7 +162,7 @@ pub fn subquery(inner: impl Expressive<AnySurrealType>) -> Expr {
 // ── Tier 2: surreal-specific scalar/collection functions ────────────────────
 // Each mirrors a `math::`/`array::`/`object::`/`string::`/`time::` function under
 // a single-purpose name. The plain ones are `Fx` one-liners (like `avg`/`round`);
-// `time_group`/`similarity` inline a fixed config/search token single-quoted.
+// `time_group`/`similarity` bind their config/search token as a parameter.
 
 /// `first(expr)` → `array::first(expr)`.
 pub fn first(expr: impl Expressive<AnySurrealType>) -> Expr {
@@ -204,22 +204,29 @@ pub fn object_values(expr: impl Expressive<AnySurrealType>) -> Expr {
     Fx::new("object::values", vec![expr.expr()]).expr()
 }
 
-/// `time_group(expr, unit)` → `time::group(expr, 'unit')`. `unit` is a fixed
-/// bucket token (`'year'`/`'month'`/`'day'`/…), inlined single-quoted to match
-/// SurrealQL's literal form.
+/// `time_group(expr, unit)` → `time::group(expr, $unit)`. `unit` is the bucket
+/// token (`year`/`month`/`day`/…), bound as a parameter so it cannot break out of
+/// the SurrealQL string literal.
 pub fn time_group(expr: impl Expressive<AnySurrealType>, unit: &str) -> Expr {
     Expression::new(
-        format!("time::group({{}}, '{unit}')"),
-        vec![ExpressiveEnum::Nested(expr.expr())],
+        "time::group({}, {})",
+        vec![
+            ExpressiveEnum::Nested(expr.expr()),
+            ExpressiveEnum::Scalar(AnySurrealType::from(unit.to_string())),
+        ],
     )
 }
 
-/// `similarity(expr, term)` → `string::similarity::jaro_winkler(expr, 'term')`.
-/// `term` is the literal search string, inlined single-quoted.
+/// `similarity(expr, term)` → `string::similarity::jaro_winkler(expr, $term)`.
+/// `term` is the literal search string, bound as a parameter so an embedded quote
+/// cannot escape the literal and inject SurrealQL.
 pub fn similarity(expr: impl Expressive<AnySurrealType>, term: &str) -> Expr {
     Expression::new(
-        format!("string::similarity::jaro_winkler({{}}, '{term}')"),
-        vec![ExpressiveEnum::Nested(expr.expr())],
+        "string::similarity::jaro_winkler({}, {})",
+        vec![
+            ExpressiveEnum::Nested(expr.expr()),
+            ExpressiveEnum::Scalar(AnySurrealType::from(term.to_string())),
+        ],
     )
 }
 
@@ -580,15 +587,51 @@ mod tests {
     }
 
     #[test]
-    fn tier2_literal_tokens_are_single_quoted() {
-        // time unit and search term are inlined single-quoted to match SurrealQL.
+    fn tier2_literal_tokens_are_bound_params() {
+        // time unit and search term are bound parameters (rendered as double-quoted
+        // strings, routed through prepare_query → CBOR $_arg at execution), not
+        // interpolated into a single-quoted SurrealQL literal.
         assert_eq!(
             time_group(Identifier::new("created_at"), "month").preview(),
-            "time::group(created_at, 'month')"
+            r#"time::group(created_at, "month")"#
         );
         assert_eq!(
             similarity(lower(Identifier::new("name")), "marti mcfligh").preview(),
-            "string::similarity::jaro_winkler(string::lowercase(name), 'marti mcfligh')"
+            r#"string::similarity::jaro_winkler(string::lowercase(name), "marti mcfligh")"#
+        );
+    }
+
+    #[test]
+    fn tier2_literal_tokens_cannot_break_out_of_query() {
+        // Regression for SurrealQL injection: a term/unit containing a quote must not
+        // escape its literal. The token is carried as a bound Scalar parameter — never
+        // interpolated into the template — so it cannot alter query structure.
+        let evil = "x') OR true OR ('";
+
+        let s = similarity(Identifier::new("name"), evil);
+        assert!(
+            !s.template.contains(evil),
+            "term leaked into template (injectable): {}",
+            s.template
+        );
+        assert!(
+            s.parameters
+                .iter()
+                .any(|p| matches!(p, ExpressiveEnum::Scalar(v) if format!("{v}").contains(evil))),
+            "term must be a bound Scalar parameter"
+        );
+
+        let t = time_group(Identifier::new("created_at"), evil);
+        assert!(
+            !t.template.contains(evil),
+            "unit leaked into template (injectable): {}",
+            t.template
+        );
+        assert!(
+            t.parameters
+                .iter()
+                .any(|p| matches!(p, ExpressiveEnum::Scalar(v) if format!("{v}").contains(evil))),
+            "unit must be a bound Scalar parameter"
         );
     }
 }

--- a/vantage-surrealdb/src/rhai_engine/constructors.rs
+++ b/vantage-surrealdb/src/rhai_engine/constructors.rs
@@ -321,12 +321,12 @@ pub fn fn_object_values(arg: rhai::Dynamic) -> Result<RhaiExpr, Box<rhai::EvalAl
     Ok(RhaiExpr(primitives::object_values(unwrap_expr(arg)?)))
 }
 
-/// `time_group(expr, unit)` → `time::group(expr, 'unit')`.
+/// `time_group(expr, unit)` → `time::group(expr, $unit)` (unit bound as a parameter).
 pub fn fn_time_group(arg: rhai::Dynamic, unit: &str) -> Result<RhaiExpr, Box<rhai::EvalAltResult>> {
     Ok(RhaiExpr(primitives::time_group(unwrap_expr(arg)?, unit)))
 }
 
-/// `similarity(expr, term)` → `string::similarity::jaro_winkler(expr, 'term')`.
+/// `similarity(expr, term)` → `string::similarity::jaro_winkler(expr, $term)` (term bound).
 pub fn fn_similarity(arg: rhai::Dynamic, term: &str) -> Result<RhaiExpr, Box<rhai::EvalAltResult>> {
     Ok(RhaiExpr(primitives::similarity(unwrap_expr(arg)?, term)))
 }

--- a/vantage-surrealdb/tests/rhai-tests/v4_q08.rhai
+++ b/vantage-surrealdb/tests/rhai-tests/v4_q08.rhai
@@ -1,6 +1,6 @@
 // v4 Q8: fuzzy string matching
-// Tier 2: similarity (jaro_winkler), lower, words. The literal search term is inlined
-// single-quoted by similarity(). The order-by references the `similarity` output alias via ident().
+// Tier 2: similarity (jaro_winkler), lower, words. The literal search term is bound
+// as a parameter by similarity(). The order-by references the `similarity` output alias via ident().
 select()
     .from("client")
     .field("name")


### PR DESCRIPTION
`similarity(expr, term)` and `time_group(expr, unit)` built their SurrealQL by interpolating the caller's string straight into a single-quoted literal:

```rust
format!("string::similarity::jaro_winkler({{}}, '{term}')")
```

A `term` (or `unit`) containing a `'` closes that literal and injects arbitrary SurrealQL. This isn't theoretical for `similarity` — it's exactly the helper you feed a runtime search term, and both are reachable from the Rhai config layer (`fn_similarity` / `fn_time_group`). Verified against a live SurrealDB: a benign `term = "alice"` filtered to one row, while `term = "x') OR true OR ('"` broke out and returned the whole table.

Both now bind the token as a `Scalar` parameter — the same path `date_format` already used — so it flows through `prepare_query` into a CBOR `$_arg` and never touches query text. The escaping question disappears: the value can't alter query structure regardless of its contents.

`preview()` output for these two helpers changes from `'...'` to `"..."` (the value is now a bound scalar, not an inline literal); the executed query uses `$_arg`. No call-site API change.

Stacked on #297 — base retargets to `main` once that merges.