### PR TITLE
fix surreal identifier bracket escaping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surreal-client"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "async-trait",
  "bakery_model3",

--- a/agent/review/security/data-surreal-identifier-escaping.md
+++ b/agent/review/security/data-surreal-identifier-escaping.md
@@ -11,10 +11,10 @@
     `\\` first, then `⟩` → `\u{27E9}`. Regression tests: `record::tests::test_escape_identifier`
     (surreal-client) and `identifier::tests::{embedded_close_bracket_cannot_break_out_of_quoting,
     crafted_backslash_bracket_cannot_break_out_of_quoting}` (vantage-surrealdb).
-- **Related regression found while fixing (NOT addressed here):** #297's quote-everything rule also
-  wraps the `$parent` *variable* (`Parent::identifier()`) as `⟨$parent⟩`, which is a literal field
-  name, not the parent-row variable — `vantage-surrealdb` test `select::query11` fails on the base
-  branch because of this. Variable-like identifiers (`$…`) should bypass quoting. Tracked separately.
+- **Related regression (already fixed on main, separately):** #297's quote-everything rule also
+  wrapped the `$parent` *variable* as `⟨$parent⟩` (a literal field name, not the parent-row variable).
+  Fixed by `4d20148e` — `Parent::dot()` now emits `$parent.<field>` verbatim, bypassing
+  `escape_identifier`. Noted here only because it was discovered while verifying this finding.
 - **Severity:** high
 - **Category:** security
 - **Location:** `vantage-surrealdb/src/identifier.rs:49`

--- a/agent/review/security/data-surreal-identifier-escaping.md
+++ b/agent/review/security/data-surreal-identifier-escaping.md
@@ -1,5 +1,20 @@
 # SurrealDB Identifier escaping is incomplete and bypassable
 
+- **Status:** FIXED (2026-06-13). Two parts:
+  - The keyword-allowlist bypass was closed earlier (#297, commit `e9d44ae4`): the allowlist is gone
+    and a single `surreal-client::escape_identifier` authority now quotes anything outside
+    `[A-Za-z0-9_]` / leading digit / reserved keyword / empty.
+  - That fix's *escaping* was itself broken and injectable on SurrealDB 3.x — it emitted `\⟩` for an
+    embedded `⟩`, but `\⟩` is an invalid escape inside `⟨…⟩` (verified live), and backslashes weren't
+    doubled, so a crafted `\⟩` collapsed and closed the quoting early (live-verified injection running
+    a smuggled `RETURN 999`). Fixed in surreal-client 0.5.2 / vantage-surrealdb 0.5.12: backslash →
+    `\\` first, then `⟩` → `\u{27E9}`. Regression tests: `record::tests::test_escape_identifier`
+    (surreal-client) and `identifier::tests::{embedded_close_bracket_cannot_break_out_of_quoting,
+    crafted_backslash_bracket_cannot_break_out_of_quoting}` (vantage-surrealdb).
+- **Related regression found while fixing (NOT addressed here):** #297's quote-everything rule also
+  wraps the `$parent` *variable* (`Parent::identifier()`) as `⟨$parent⟩`, which is a literal field
+  name, not the parent-row variable — `vantage-surrealdb` test `select::query11` fails on the base
+  branch because of this. Variable-like identifiers (`$…`) should bypass quoting. Tracked separately.
 - **Severity:** high
 - **Category:** security
 - **Location:** `vantage-surrealdb/src/identifier.rs:49`

--- a/surreal-client/CHANGELOG.md
+++ b/surreal-client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.2 — 2026-06-13
+
+- Fixed [`escape_identifier`](https://docs.rs/surreal-client/0.5.2/surreal_client/fn.escape_identifier.html)
+  emitting `\⟩` for an embedded closing bracket. On SurrealDB 3.x `\⟩` is an *invalid* escape inside
+  `⟨…⟩`, so that output failed to parse — and because backslashes weren't doubled, a crafted `\⟩`
+  collapsed and let the bracket close early, injecting arbitrary SurrealQL from an identifier (verified
+  live). Backslashes are now doubled and `⟩` is emitted as the `\u{27E9}` unicode escape, the only form
+  the lexer accepts. Identifier and record-id rendering both benefit, since they share this function.
+
 ## 0.5.1 — 2026-06-13
 
 - [`escape_identifier`](https://docs.rs/surreal-client/0.5.1/surreal_client/fn.escape_identifier.html)

--- a/surreal-client/Cargo.toml
+++ b/surreal-client/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "surreal-client"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "CBOR-based SurrealDB client for the Vantage data framework"

--- a/surreal-client/src/record.rs
+++ b/surreal-client/src/record.rs
@@ -364,8 +364,12 @@ const RESERVED_KEYWORDS: &[&str] = &[
 ///
 /// The identifier is wrapped in `⟨…⟩` when it is empty, numeric, starts with a
 /// digit, contains a character outside `[A-Za-z0-9_]`, or collides with a
-/// reserved keyword. Any embedded `⟩` is backslash-escaped so it cannot
-/// terminate the quoting early. Plain identifiers pass through unchanged.
+/// reserved keyword. Inside the brackets SurrealDB applies C-style escapes, so
+/// backslashes are doubled (otherwise `\b`/`\n` would become control chars, or
+/// a crafted `\⟩` would collapse and close the quoting early) and any `⟩` is
+/// emitted as `\u{27E9}` — `\⟩` is itself an invalid escape there, so the
+/// unicode escape is the only representation that survives. Plain identifiers
+/// pass through unchanged.
 pub fn escape_identifier(ident: &str) -> String {
     if ident.is_empty() {
         return "⟨⟩".to_string();
@@ -382,7 +386,9 @@ pub fn escape_identifier(ident: &str) -> String {
         || ident.chars().next().unwrap().is_ascii_digit()
         || ident.chars().any(|c| !c.is_alphanumeric() && c != '_')
     {
-        return format!("⟨{}⟩", ident.replace('⟩', "\\⟩"));
+        // Backslash first, so the `\u{27E9}` we emit for `⟩` isn't re-escaped.
+        let escaped = ident.replace('\\', "\\\\").replace('⟩', "\\u{27E9}");
+        return format!("⟨{}⟩", escaped);
     }
 
     ident.to_string()
@@ -435,8 +441,16 @@ mod tests {
         // Reserved keywords must be escaped even though they are alphanumeric.
         assert_eq!(escape_identifier("SELECT"), "⟨SELECT⟩");
         assert_eq!(escape_identifier("from"), "⟨from⟩");
-        // An embedded closing bracket cannot be allowed to terminate quoting.
-        assert_eq!(escape_identifier("a⟩b"), "⟨a\\⟩b⟩");
+        // `⟩` cannot be backslash-escaped inside ⟨…⟩ — SurrealDB treats `\⟩` as
+        // an invalid escape sequence — so it must be emitted as the `\u{27E9}`
+        // unicode escape, the only representation that survives the lexer.
+        assert_eq!(escape_identifier("a⟩b"), "⟨a\\u{27E9}b⟩");
+        // A backslash must be doubled. Left raw it would either form a control
+        // escape (`\b` → backspace, `\n` → newline) or, as `\⟩`, collapse so a
+        // following `⟩` closes the quoting early — an identifier-injection vector.
+        assert_eq!(escape_identifier("a\\b"), "⟨a\\\\b⟩");
+        // Combined: a crafted `\⟩` must stay inside the identifier, not break out.
+        assert_eq!(escape_identifier("a\\⟩b"), "⟨a\\\\\\u{27E9}b⟩");
     }
 
     #[test]

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.12 — 2026-06-13
+
+- `Identifier` escaping is now correct on SurrealDB 3.x. It picks up the `surreal-client` 0.5.2 fix:
+  a `⟩` inside a column/field name is emitted as `\u{27E9}` (the previous `\⟩` was an invalid escape
+  that failed to parse) and backslashes are doubled, closing an identifier-injection hole where a
+  crafted `\⟩` could break out of `⟨…⟩` quoting. Verified against a live SurrealDB.
+
 ## 0.5.11 — 2026-06-13
 
 - `similarity(expr, term)` and `time_group(expr, unit)` now bind their literal token as a query

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.5.11"
+version = "0.5.12"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"
@@ -27,7 +27,7 @@ vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
-surreal-client = { version = "0.5.1", path = "../surreal-client" }
+surreal-client = { version = "0.5.2", path = "../surreal-client" }
 
 ciborium = "0.2"
 hex = "0.4"

--- a/vantage-surrealdb/src/identifier.rs
+++ b/vantage-surrealdb/src/identifier.rs
@@ -114,10 +114,19 @@ mod tests {
 
     #[test]
     fn embedded_close_bracket_cannot_break_out_of_quoting() {
-        // An identifier carrying the ⟨…⟩ closing bracket must have it
-        // backslash-escaped, otherwise it could terminate the quoting early.
+        // `\⟩` is an invalid escape inside ⟨…⟩, so a `⟩` must be emitted as the
+        // `\u{27E9}` unicode escape — the only form the SurrealDB lexer accepts.
         let expr = Identifier::new("a⟩b").expr();
-        assert_eq!(expr.preview(), "⟨a\\⟩b⟩");
+        assert_eq!(expr.preview(), "⟨a\\u{27E9}b⟩");
+    }
+
+    #[test]
+    fn crafted_backslash_bracket_cannot_break_out_of_quoting() {
+        // A raw `\⟩` would collapse (via `\\`) and let the `⟩` close the
+        // identifier early, injecting whatever follows. The backslash must be
+        // doubled so the whole sequence stays one identifier.
+        let expr = Identifier::new("a\\⟩: 1 }; RETURN 999; x").expr();
+        assert_eq!(expr.preview(), "⟨a\\\\\\u{27E9}: 1 }; RETURN 999; x⟩");
     }
 
     #[test]


### PR DESCRIPTION
`Identifier` escaping was broken on SurrealDB 3.x — and exploitable. Field and column names route through `surreal-client::escape_identifier`, which wrapped them in `⟨…⟩` and escaped an embedded `⟩` by backslashing it:

```rust
// before
return format!("⟨{}⟩", ident.replace('⟩', "\\⟩"));
```

Two problems, both verified against a live SurrealDB 3.0.4:

**1. `\⟩` is an invalid escape on 3.x**, so any identifier containing a plain `⟩` produced an unparseable query:

```
> RETURN { ⟨a\⟩b⟩: 1 };
Parse error: Invalid escape sequence — not a valid escape character
```

**2. Backslashes weren't doubled**, so a crafted field name broke out of the quoting. SurrealDB reads `\\` as one literal backslash, which lets the `⟩` close the identifier early and spills the rest as live SurrealQL:

```rust
// attacker-controlled field name
let field = r"a\⟩: 1 }; RETURN 999; x";
// renders to:  ⟨a\\⟩: 1 }; RETURN 999; x⟩
```

```
> RETURN { ⟨a\\⟩: 1 }; RETURN 999; x⟩ ... };
[ { "a\\": 1 }, 999 ]          -- two results: the smuggled RETURN 999 ran
```

### The fix

Double backslashes **first**, then emit `⟩` as the `\u{27E9}` unicode escape — the only representation the 3.x lexer accepts inside `⟨…⟩`:

```rust
// after — backslash first, so the \u{27E9} we emit isn't re-escaped
let escaped = ident.replace('\\', "\\\\").replace('⟩', "\\u{27E9}");
return format!("⟨{}⟩", escaped);
```

The same payload is now fully contained as a single field name:

```
> RETURN { ⟨a\\\u{27E9}: 1 }; RETURN 999; x⟩: 1 };
[ { "a\\⟩: 1 }; RETURN 999; x": 1 } ]      -- one result, nothing executed
```

Both consumers of the shared function (`Identifier` and record-id rendering) are covered, with regression tests that drive the exact breakout payload. This corrects the escaping that landed in #297.