### PR TITLE
release 0.6.0

### DIFF
--- a/.github/workflows/publish-on-merge.yaml
+++ b/.github/workflows/publish-on-merge.yaml
@@ -80,9 +80,11 @@ jobs:
           # not a substitute.
           PUBLISH_ORDER=(
             vantage-core
+            vantage-types-entity
             vantage-types
             vantage-dataset
             vantage-vista
+            vantage-vista-factory
             surreal-client
             vantage-expressions
             vantage-table

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4738,7 +4738,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4800,7 +4800,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-expressions"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4943,7 +4943,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ciborium",
  "csv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,7 +3850,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surreal-client"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -4589,7 +4589,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-pool"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4640,7 +4640,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cmd"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-log-writer"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bson",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-redb"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4885,7 +4885,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.5.11"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bakery_model3",
@@ -4984,7 +4984,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types-entity"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4993,7 +4993,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista-factory"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ciborium",
  "indexmap",

--- a/learn-1/Cargo.toml
+++ b/learn-1/Cargo.toml
@@ -9,5 +9,5 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.52.3", features = ["full"] }
 vantage-expressions = { path = "../vantage-expressions" }
-vantage-sql = { version = "0.5", path = "../vantage-sql", features = ["sqlite"] }
+vantage-sql = { version = "0.6", path = "../vantage-sql", features = ["sqlite"] }
 vantage-types = { path = "../vantage-types", features = ["serde"] }

--- a/learn-2/Cargo.toml
+++ b/learn-2/Cargo.toml
@@ -11,7 +11,7 @@ tokio = { version = "1.52.3", features = ["full"] }
 vantage-core = { path = "../vantage-core" }
 vantage-expressions = { path = "../vantage-expressions" }
 vantage-dataset = { path = "../vantage-dataset" }
-vantage-sql = { version = "0.5", path = "../vantage-sql", features = ["sqlite"] }
+vantage-sql = { version = "0.6", path = "../vantage-sql", features = ["sqlite"] }
 vantage-table = { path = "../vantage-table" }
 vantage-types = { path = "../vantage-types", features = ["serde"] }
 vantage-cli-util = { path = "../vantage-cli-util" }

--- a/surreal-client/CHANGELOG.md
+++ b/surreal-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No changes beyond 0.5.2.
+
 ## 0.5.2 — 2026-06-13
 
 - Fixed [`escape_identifier`](https://docs.rs/surreal-client/0.5.2/surreal_client/fn.escape_identifier.html)

--- a/surreal-client/Cargo.toml
+++ b/surreal-client/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "surreal-client"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "CBOR-based SurrealDB client for the Vantage data framework"
@@ -32,6 +32,6 @@ futures = "0.3.32"
 url = "2.5.8"
 uuid = { version = "1.23", features = ["v4"] }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 paste = "1.0"
 indexmap = "2.14"

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.7 — 2026-06-06
 
 ### Changed

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.5.7"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"
@@ -18,12 +18,12 @@ serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml_ng = "0.10"
 urlencoding = "2.1"
 uuid = { version = "1", features = ["serde"] }
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/vantage-api-pool/CHANGELOG.md
+++ b/vantage-api-pool/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.3 — 2026-06-02
 
 - Track `vantage-table`'s new `TableSource::Source` associated type (set to `String`; no

--- a/vantage-api-pool/Cargo.toml
+++ b/vantage-api-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "vantage-api-pool"
-version = "0.5.3"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 description = "Paginated REST API client pool for Vantage"
 
@@ -19,7 +19,7 @@ tracing = "0.1"
 async-trait = "0.1"
 indexmap = { version = "2", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.4 — 2026-06-02
 
 - Track `vantage-table`'s new `TableSource::Source` associated type (set to `String`; no

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "atty",
  "indexmap",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ciborium",
  "indexmap",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types-entity"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-expressions"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ciborium",
  "indexmap",

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -11,12 +11,12 @@ repository = "https://github.com/romaninsh/vantage"
 readme = "README.md"
 
 [dependencies]
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
 
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
@@ -42,8 +42,8 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 
 [dev-dependencies]
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-cli-util = { version = "0.5", path = "../vantage-cli-util" }
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-cli-util = { version = "0.6", path = "../vantage-cli-util" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
 
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }

--- a/vantage-cli-util/CHANGELOG.md
+++ b/vantage-cli-util/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.3 — 2026-05-23
 
 - Align all internal dependency versions to 0.5+. No public API changes.

--- a/vantage-cli-util/Cargo.toml
+++ b/vantage-cli-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-cli-util"
-version = "0.5.3"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "CLI utilities for Vantage data framework"
@@ -14,11 +14,11 @@ comfy-table = { version = "7", features = ["custom_styling"] }
 indexmap = "2"
 owo-colors = "4"
 serde_json = "1"
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/vantage-cmd/CHANGELOG.md
+++ b/vantage-cmd/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.2 — 2026-06-07
 
 - Reuse the rhai `Engine` and compiled `AST` across calls instead of rebuilding

--- a/vantage-cmd/Cargo.lock
+++ b/vantage-cmd/Cargo.lock
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-expressions"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ciborium",
  "indexmap",

--- a/vantage-cmd/Cargo.lock
+++ b/vantage-cmd/Cargo.lock
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cmd"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "atty",
  "indexmap",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "ciborium",
  "indexmap",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types-entity"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-cmd/Cargo.toml
+++ b/vantage-cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-cmd"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -16,12 +16,12 @@ readme = "README.md"
 [workspace]
 
 [dependencies]
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
 
 # Rhai builds the argv and parses the output. "serde" gives us the
 # serde_json::Value <-> Dynamic bridge used by `parse_json`.
@@ -44,7 +44,7 @@ tracing = "0.1"
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [dev-dependencies]
-vantage-cli-util = { version = "0.5", path = "../vantage-cli-util" }
+vantage-cli-util = { version = "0.6", path = "../vantage-cli-util" }
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }
 

--- a/vantage-core/Cargo.toml
+++ b/vantage-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Core error types and utilities for the Vantage data framework"

--- a/vantage-csv/CHANGELOG.md
+++ b/vantage-csv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.4 — 2026-06-13
 
 - Searching a CSV table now returns an `Unsupported` error instead of silently matching every row.

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.5.4"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"
@@ -20,15 +20,15 @@ paste = "1.0"
 indexmap = { version = "2", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1", features = ["preserve_order"] }
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.6", path = "../vantage-vista", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }

--- a/vantage-dataset/CHANGELOG.md
+++ b/vantage-dataset/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1 — unreleased
+
+- Internal dependency realignment for the coordinated 0.6 release; no public API changes.
+
 ## 0.6.0 — 2026-06-10
 
 - `ImTable` now supports mutability: `insert`, `update`, and `delete` operations through

--- a/vantage-dataset/Cargo.toml
+++ b/vantage-dataset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-dataset"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Dataset traits for the Vantage data framework"

--- a/vantage-dataset/Cargo.toml
+++ b/vantage-dataset/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0.18"
 uuid = { version = "1.23.1", features = ["v4"] }
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 
 [dev-dependencies]

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.7 — 2026-06-07
 
 Two-pass progressive loading for slow data sources: a cheap **list pass** renders

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.5.7"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"
@@ -10,9 +10,9 @@ repository = "https://github.com/romaninsh/vantage"
 doctest = false
 
 [dependencies]
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 

--- a/vantage-expressions/CHANGELOG.md
+++ b/vantage-expressions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1 — unreleased
+
+- Internal dependency realignment for the coordinated 0.6 release; no public API changes.
+
 ## 0.6.0 — 2026-06-10
 
 - `IntoValue` for `f64` no longer panics on NaN/Infinity — non-finite floats degrade to

--- a/vantage-expressions/Cargo.toml
+++ b/vantage-expressions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-expressions"
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Database agnostic expressions"

--- a/vantage-expressions/Cargo.toml
+++ b/vantage-expressions/Cargo.toml
@@ -14,9 +14,9 @@ chrono = { version = "0.4", features = ["serde"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["full"] }

--- a/vantage-log-writer/CHANGELOG.md
+++ b/vantage-log-writer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.3 — 2026-06-02
 
 - Track `vantage-table`'s new `TableSource::Source` associated type (set to `String`; no

--- a/vantage-log-writer/Cargo.toml
+++ b/vantage-log-writer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-log-writer"
-version = "0.5.3"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for append-only log files (JSONL)"
@@ -22,16 +22,16 @@ serde_json = { version = "1", features = ["preserve_order"] }
 tokio = { version = "1.48", features = ["rt", "fs", "sync", "io-util", "macros"] }
 tracing = "0.1"
 ulid = "1"
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.6", path = "../vantage-vista", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"
 tempfile = "3"
 tokio = { version = "1.48", features = ["full"] }
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }

--- a/vantage-mongodb/CHANGELOG.md
+++ b/vantage-mongodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.6 — 2026-06-02
 
 - Track `vantage-table`'s new `TableSource::Source` associated type (set to `String`; no

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"
@@ -11,12 +11,12 @@ default = []
 vista = ["dep:vantage-vista"]
 
 [dependencies]
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.6", path = "../vantage-vista", optional = true }
 
 bson = "2"
 ciborium = { version = "0.2", features = ["std"] }
@@ -33,4 +33,4 @@ futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
 pretty_assertions = "1"
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }

--- a/vantage-redb/CHANGELOG.md
+++ b/vantage-redb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.4 — 2026-06-13
 
 - Full-table search now reports the canonical `Unsupported` error kind, matching how the other

--- a/vantage-redb/Cargo.toml
+++ b/vantage-redb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-redb"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -11,7 +11,7 @@ repository = "https://github.com/romaninsh/vantage"
 readme = "../README.md"
 
 [dependencies]
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.9 — 2026-06-07
 
 ### Changed

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.5.9"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -18,14 +18,14 @@ vista = ["dep:vantage-vista"]
 rhai = ["dep:rhai"]
 
 [dependencies]
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 paste = "1.0"
 
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
-vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.6", path = "../vantage-vista", optional = true }
 async-trait = "0.1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "rust_decimal", "uuid", "chrono"] }
 rust_decimal = "1"
@@ -42,7 +42,7 @@ rhai = { version = "1.25", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
 sqlformat = "0.3"
 
 [[example]]

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No changes beyond 0.5.12.
+
 ## 0.5.12 — 2026-06-13
 
 - `Identifier` escaping is now correct on SurrealDB 3.x. It picks up the `surreal-client` 0.5.2 fix:

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.5.11"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"
@@ -21,13 +21,13 @@ rhai = ["dep:rhai", "vista", "vantage-vista/rhai"]
 
 [dependencies]
 async-trait = "0.1"
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions", features = ["chrono"] }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.5", path = "../vantage-vista", optional = true }
-surreal-client = { version = "0.5.1", path = "../surreal-client" }
+vantage-vista = { version = "0.6", path = "../vantage-vista", optional = true }
+surreal-client = { version = "0.6", path = "../surreal-client" }
 
 ciborium = "0.2"
 hex = "0.4"
@@ -90,7 +90,7 @@ test = false
 [dev-dependencies]
 bakery_model3 = { path = "../bakery_model3" }
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
 
 [[example]]
 name = "expr"

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.2 — unreleased
+
+- Internal dependency realignment for the coordinated 0.6 release; no public API changes.
+
 ## 0.6.1 — 2026-06-13
 
 - Documented the contract for `TableSource::search_table_condition`: search is a server-side

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -16,10 +16,10 @@ doctest = false
 
 
 [dependencies]
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 async-stream = "0.3"
 async-trait = "0.1"
@@ -38,7 +38,7 @@ tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "sync"] }
 serde_json = "1.0"
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 # vantage-surrealdb = { path = "../vantage-surrealdb" }
-surreal-client = { version = "0.5", path = "../surreal-client" }
+surreal-client = { version = "0.6", path = "../surreal-client" }
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }
 url = { version = "2.5", features = ["serde"] }

--- a/vantage-types/CHANGELOG.md
+++ b/vantage-types/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1 — unreleased
+
+- Internal dependency realignment for the coordinated 0.6 release; no public API changes.
+
 ## 0.6.0 — 2026-06-10
 
 - New `TryIntoRecord` trait, the fallible counterpart to `TryFromRecord`. Serializing a serde

--- a/vantage-types/Cargo.toml
+++ b/vantage-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-types"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Type system and Record types for the Vantage data framework"

--- a/vantage-types/Cargo.toml
+++ b/vantage-types/Cargo.toml
@@ -13,12 +13,12 @@ serde = ["dep:serde", "dep:serde_json", "vantage-types-entity/serde"]
 
 [dependencies]
 paste = "1.0"
-vantage-types-entity = { version = "0.5", path = "./entity" }
+vantage-types-entity = { version = "0.6", path = "./entity" }
 indexmap = "2.14"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0.149", optional = true }
 ciborium = { version = "0.2", features = ["std"] }
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 
 [dev-dependencies]
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-types/entity/CHANGELOG.md
+++ b/vantage-types/entity/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.

--- a/vantage-types/entity/Cargo.toml
+++ b/vantage-types/entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-types-entity"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Entity proc macro for the Vantage type system"

--- a/vantage-vista-factory/CHANGELOG.md
+++ b/vantage-vista-factory/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.1 — 2026-06-06
 
 ### Changed

--- a/vantage-vista-factory/Cargo.toml
+++ b/vantage-vista-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista-factory"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Multi-datasource Vista catalog and cross-persistence reference traversal for the Vantage data framework"
@@ -10,9 +10,9 @@ repository = "https://github.com/romaninsh/vantage"
 doctest = false
 
 [dependencies]
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-vista = { version = "0.5", path = "../vantage-vista" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
 ciborium = { version = "0.2", features = ["std"] }
 indexmap = { version = "2.14" }
 

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0 — unreleased
+
+- Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
+
 ## 0.5.5 — 2026-06-07
 
 ### Added

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.5.5"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"
@@ -10,7 +10,7 @@ repository = "https://github.com/romaninsh/vantage"
 doctest = false
 
 [dependencies]
-vantage-core = { version = "0.5", path = "../vantage-core" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 ciborium = { version = "0.2", features = ["std"] }


### PR DESCRIPTION
Coordinated 0.6 release. Every publishable internal crate moves to 0.6 (table to 0.6.1) and all internal dependency requirements cascade `0.5` -> `0.6`, keeping the graph consistent now that core/vista/surreal-client cross into 0.6.

### Publish-order fix

`publish-on-merge.yaml` auto-publishes version-bumped crates on merge using a hardcoded `PUBLISH_ORDER`. Two bumped crates were missing from it: `vantage-types-entity` and `vantage-vista-factory`. The workflow appends unknowns to the tail, so `vantage-types-entity` would have published *after* `vantage-types` that depends on it — and `cargo publish` validates deps against crates.io at package time, so the `vantage-types` 0.6.0 publish would have failed. Both are now slotted at the correct layer (entity before types, vista-factory after vista).

### Verification

- `cargo check --workspace --all-features` passes
- `vantage-aws` and `vantage-cmd` (workspace-excluded) check clean on their own
- All 21 publishable crates are currently behind crates.io (still on 0.5.x); merging this triggers their 0.6 publish in dependency order.