### PR TITLE
fix publish-on-merge crate order

### DIFF
--- a/.github/workflows/publish-on-merge.yaml
+++ b/.github/workflows/publish-on-merge.yaml
@@ -70,17 +70,21 @@ jobs:
           CRATES: ${{ steps.detect.outputs.crates }}
         run: |
           set -euo pipefail
-          # Canonical topological publish order. `cargo publish` checks
-          # each crate's [dependencies] against crates.io at packaging
-          # time, so a downstream crate's bumped version must already be
-          # on the registry before its dependent publishes. Alphabetical
-          # iteration fails when api-client (depends on vista) runs
-          # before vista. New publishable crates must be appended here
-          # at the right layer; the unknown-crate tail is a safety net,
-          # not a substitute.
+          # Canonical topological publish order. `cargo publish` resolves
+          # each crate's full graph against crates.io at packaging time —
+          # including dev-dependencies — so every internal crate a package
+          # depends on (normal OR dev) must already be on the registry
+          # before that package publishes. Alphabetical iteration fails
+          # when api-client (depends on vista) runs before vista.
+          #
+          # Entries are DIRECTORY paths, matched against the dirs of
+          # changed Cargo.toml files — so nested crates use their path
+          # (e.g. vantage-types/entity, not vantage-types-entity). New
+          # publishable crates must be inserted here at the right layer;
+          # the unknown-crate tail is a safety net, not a substitute.
           PUBLISH_ORDER=(
             vantage-core
-            vantage-types-entity
+            vantage-types/entity
             vantage-types
             vantage-dataset
             vantage-vista
@@ -88,17 +92,17 @@ jobs:
             surreal-client
             vantage-expressions
             vantage-table
-            vantage-cmd
+            vantage-cli-util
             vantage-csv
-            vantage-surrealdb
-            vantage-sql
+            vantage-log-writer
             vantage-mongodb
             vantage-redb
-            vantage-cli-util
+            vantage-sql
+            vantage-surrealdb
             vantage-api-client
             vantage-api-pool
             vantage-aws
-            vantage-log-writer
+            vantage-cmd
             vantage-diorama
           )
 


### PR DESCRIPTION
The 0.6 release exposed two latent bugs in `publish-on-merge.yaml`'s `PUBLISH_ORDER`, both of which halted the auto-publish partway and required finishing the release by hand.

### Directory path vs crate name

The publish step iterates `PUBLISH_ORDER` and does `cd "$crate"`, matching entries against the *directories* of changed `Cargo.toml` files. `vantage-types-entity` lives in `vantage-types/entity/`, so the crate-name entry never matched — it fell through to the unknown-crate tail and published *after* `vantage-types`, which depends on it. `cargo publish` validates dependency versions against the index at package time, so `vantage-types` failed with `failed to select a version for the requirement vantage-types-entity = "^0.6"`. Entry is now the directory path `vantage-types/entity`, slotted before `vantage-types`.

### cli-util ordered after its dependents

`vantage-cmd`, `vantage-api-client`, `vantage-api-pool`, and `vantage-aws` all depend on `vantage-cli-util` (some via dev-dependencies, which `cargo publish` also resolves at package time), but it was listed *after* them — so `vantage-cmd` failed the same way. `vantage-cli-util` now precedes everything that needs it, and the order is a full topological sort over normal + dev dependencies.

The comment now spells out both gotchas: entries are directory paths, and dev-dependency targets must precede their dependents.