### PR TITLE
Fold vantage-data-script into vantage-vista (rhai feature)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4589,7 +4589,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4602,6 +4602,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "tokio",
+ "tracing",
  "urlencoding",
  "uuid",
  "vantage-cli-util",
@@ -4758,7 +4759,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4943,7 +4944,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4993,7 +4994,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5002,6 +5003,7 @@ dependencies = [
  "indexmap",
  "rhai",
  "serde",
+ "serde_json",
  "serde_yaml_ng",
  "thiserror 2.0.18",
  "tokio",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.1 — unreleased
+
+- REST lazy-load: `RestApiBuilder::total_key`/`debug`, `RestApi::fetch_window_records`/`fetch_total`,
+  a `RestApiTableShell::fetch_window` impl + envelope-total count, and `can_fetch_window` advertised
+  when a `total_key` is configured. Windows map onto skip-based (raw offset) or page-based
+  (`offset/limit+1`) pagination.
+
 ## 0.6.0 — unreleased
 
 - Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"
@@ -16,6 +16,7 @@ reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml_ng = "0.10"
+tracing = "0.1"
 urlencoding = "2.1"
 uuid = { version = "1", features = ["serde"] }
 vantage-core = { version = "0.6", path = "../vantage-core" }

--- a/vantage-api-client/src/rest/api.rs
+++ b/vantage-api-client/src/rest/api.rs
@@ -117,6 +117,13 @@ pub struct RestApi {
     /// How non-path eq-conditions are applied — query params vs.
     /// in-memory post-fetch filtering. See [`FilterStrategy`].
     filter_strategy: FilterStrategy,
+    /// Response-envelope key carrying the grand total of matching rows
+    /// (e.g. `count`). When set, the shell reports an exact count and
+    /// advertises `can_fetch_window` for lazy/scroll loading; when `None`
+    /// it falls back to counting fetched rows.
+    total_key: Option<String>,
+    /// Emit `tracing` events for window/count requests.
+    debug: bool,
 }
 
 impl RestApi {
@@ -138,6 +145,12 @@ impl RestApi {
     pub fn with_auth(mut self, auth: impl Into<String>) -> Self {
         self.auth_header = Some(auth.into());
         self
+    }
+
+    /// The configured response-envelope total key, if any. When set, the
+    /// REST shell can report an exact count and serve `fetch_window`.
+    pub fn total_key(&self) -> Option<&str> {
+        self.total_key.as_deref()
     }
 
     /// Build the endpoint path for `table_name`, substituting any
@@ -199,7 +212,7 @@ impl RestApi {
     /// stance as before.
     fn build_query_string(
         &self,
-        pagination: Option<&Pagination>,
+        window: Option<(i64, i64)>,
         conditions: &[&Expression<CborValue>],
         consumed: &[usize],
     ) -> String {
@@ -209,16 +222,23 @@ impl RestApi {
         // When `no_pagination` is set the API doesn't accept page/limit
         // query params (and may treat them as strict filters that
         // return empty), so we leave them off.
+        //
+        // `window` is a half-open `[offset, offset+limit)` band. Skip-based
+        // APIs take the offset verbatim; page-based APIs are addressed by
+        // 1-based page, derived from the offset (the loader may hand
+        // non-page-aligned windows, so it rounds down to the containing page).
         if !self.no_pagination
-            && let Some(p) = pagination
+            && let Some((offset, limit)) = window
         {
+            let offset = offset.max(0);
+            let limit = limit.max(1);
             let page_value = if self.pagination.skip_based {
-                p.skip().to_string()
+                offset.to_string()
             } else {
-                p.get_page().to_string()
+                (offset / limit + 1).to_string()
             };
             params.push((self.pagination.page.clone(), page_value));
-            params.push((self.pagination.limit.clone(), p.limit().to_string()));
+            params.push((self.pagination.limit.clone(), limit.to_string()));
         }
 
         // Conditions: each `eq` becomes `?field=value`. Multiple
@@ -253,8 +273,9 @@ impl RestApi {
     /// Fetch data from the API endpoint and return parsed records.
     ///
     /// `id_field` selects which JSON field is treated as the record ID;
-    /// if `None`, row indices are used. `pagination` and `conditions`
-    /// are pushed into the URL query string — eq-conditions become
+    /// if `None`, row indices are used. The page-based `pagination` is
+    /// lowered to a `[offset, offset+limit)` window; `conditions` are
+    /// pushed into the URL query string — eq-conditions become
     /// `?field=value`. Conditions that can't be peeled into a simple
     /// eq are silently skipped (caller-side filtering still applies if
     /// needed).
@@ -265,23 +286,71 @@ impl RestApi {
         pagination: Option<&Pagination>,
         conditions: impl IntoIterator<Item = &'a Expression<CborValue>>,
     ) -> Result<IndexMap<String, Record<CborValue>>> {
-        // Non-paginating endpoints return the whole list on page 1; a
-        // page-2 fetch would just re-deliver the same rows and the
-        // perpetual grid would never mark itself exhausted. Short-
-        // circuit page > 1 to empty so the grid sees the chunk shrink
-        // and stops asking for more.
-        if self.no_pagination
-            && let Some(p) = pagination
-            && p.get_page() > 1
-        {
-            return Ok(IndexMap::new());
-        }
+        let window = pagination.map(|p| (p.skip(), p.limit()));
+        self.fetch_windowed(table_name, id_field, window, conditions)
+            .await
+    }
 
+    /// Fetch a single half-open row window `[offset, offset+limit)` — the
+    /// primitive a paged, lazily-loaded grid drives on scroll (offset is
+    /// an absolute row index, not a page number).
+    pub(crate) async fn fetch_window_records<'a>(
+        &self,
+        table_name: &str,
+        id_field: Option<&str>,
+        offset: i64,
+        limit: i64,
+        conditions: impl IntoIterator<Item = &'a Expression<CborValue>>,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        self.fetch_windowed(table_name, id_field, Some((offset, limit)), conditions)
+            .await
+    }
+
+    /// Read the grand total of matching rows from the response envelope's
+    /// configured `total_key` (e.g. `count`). Returns `None` when no
+    /// `total_key` is set — the caller then falls back to counting fetched
+    /// rows. Issues a cheap `limit=1` request so the body carries the count
+    /// without paying for the rows.
+    pub(crate) async fn fetch_total<'a>(
+        &self,
+        table_name: &str,
+        conditions: impl IntoIterator<Item = &'a Expression<CborValue>>,
+    ) -> Result<Option<i64>> {
+        let Some(total_key) = self.total_key.clone() else {
+            return Ok(None);
+        };
+        let (body, _client_filters) = self
+            .fetch_raw_body(table_name, Some((0, 1)), conditions)
+            .await?;
+        let total = body
+            .get(total_key.as_str())
+            .and_then(|v| v.as_i64())
+            .ok_or_else(|| {
+                error!(
+                    "total_key missing or not an integer in API response",
+                    total_key = total_key.as_str()
+                )
+            })?;
+        if self.debug {
+            tracing::info!(target: "vantage_api_client::rest", total, "REST count");
+        }
+        Ok(Some(total))
+    }
+
+    /// Resolve conditions, build the windowed request URL, GET it (with the
+    /// auth header if configured), and return the parsed JSON body together
+    /// with any client-side filters that still need applying (under
+    /// [`FilterStrategy::Client`]).
+    async fn fetch_raw_body<'a>(
+        &self,
+        table_name: &str,
+        window: Option<(i64, i64)>,
+        conditions: impl IntoIterator<Item = &'a Expression<CborValue>>,
+    ) -> Result<(serde_json::Value, Vec<(String, String)>)> {
         // Conditions may carry `DeferredFn` values — typically from
-        // `related_in_condition` for `with_one`-style traversals where
-        // the FK lives in a parent record we haven't fetched yet.
-        // Resolve them once, up front, so the rest of the pipeline
-        // sees only sync, peelable scalars.
+        // `related_in_condition` for `with_one`-style traversals where the FK
+        // lives in a parent record we haven't fetched yet. Resolve them once,
+        // up front, so the rest of the pipeline sees only sync scalars.
         let raw: Vec<&Expression<CborValue>> = conditions.into_iter().collect();
         let mut resolved: Vec<Expression<CborValue>> = Vec::with_capacity(raw.len());
         for cond in raw {
@@ -290,11 +359,10 @@ impl RestApi {
         let conds: Vec<&Expression<CborValue>> = resolved.iter().collect();
         let (endpoint, consumed) = self.endpoint_url(table_name, &conds)?;
 
-        // Under `FilterStrategy::Client`, non-path eq-conditions are
-        // applied to the fetched rows in memory rather than sent as query
-        // params (the API rejects/ignores unknown params). Collect them,
-        // and keep them out of the query string by marking every
-        // condition as consumed for query-building purposes.
+        // Under `FilterStrategy::Client`, non-path eq-conditions are applied
+        // to the fetched rows in memory rather than sent as query params (the
+        // API rejects/ignores unknown params). Collect them, and keep them out
+        // of the query string by marking every condition as consumed.
         let (query_consumed, client_filters): (Vec<usize>, Vec<(String, String)>) =
             if self.filter_strategy == FilterStrategy::Client {
                 let filters = conds
@@ -311,7 +379,7 @@ impl RestApi {
         let url = format!(
             "{}{}",
             endpoint,
-            self.build_query_string(pagination, &conds, &query_consumed)
+            self.build_query_string(window, &conds, &query_consumed)
         );
 
         let mut request = self.client.get(&url);
@@ -337,6 +405,26 @@ impl RestApi {
             .await
             .map_err(|e| error!("Failed to parse API response as JSON", detail = e))?;
 
+        Ok((body, client_filters))
+    }
+
+    async fn fetch_windowed<'a>(
+        &self,
+        table_name: &str,
+        id_field: Option<&str>,
+        window: Option<(i64, i64)>,
+        conditions: impl IntoIterator<Item = &'a Expression<CborValue>>,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        // Non-paginating endpoints return the whole list on the first
+        // window; a later window would just re-deliver the same rows and the
+        // perpetual grid would never mark itself exhausted. Short-circuit any
+        // window past the start to empty so the grid sees the chunk shrink
+        // and stops asking for more.
+        if self.no_pagination && window.is_some_and(|(offset, _)| offset > 0) {
+            return Ok(IndexMap::new());
+        }
+
+        let (body, client_filters) = self.fetch_raw_body(table_name, window, conditions).await?;
         let data = self.extract_array(&body, table_name)?;
 
         let mut records = IndexMap::new();
@@ -477,6 +565,8 @@ pub struct RestApiBuilder {
     pagination: PaginationParams,
     no_pagination: bool,
     filter_strategy: FilterStrategy,
+    total_key: Option<String>,
+    debug: bool,
 }
 
 impl RestApiBuilder {
@@ -488,6 +578,8 @@ impl RestApiBuilder {
             pagination: PaginationParams::default(),
             no_pagination: false,
             filter_strategy: FilterStrategy::default(),
+            total_key: None,
+            debug: false,
         }
     }
 
@@ -530,6 +622,20 @@ impl RestApiBuilder {
         self
     }
 
+    /// Name the response-envelope key carrying the grand total of matching
+    /// rows (e.g. `count`). Setting it lets the shell report an exact count
+    /// and advertise `can_fetch_window` for lazy/scroll loading.
+    pub fn total_key(mut self, key: impl Into<String>) -> Self {
+        self.total_key = Some(key.into());
+        self
+    }
+
+    /// Emit `tracing` events for window/count requests.
+    pub fn debug(mut self, debug: bool) -> Self {
+        self.debug = debug;
+        self
+    }
+
     pub fn build(self) -> RestApi {
         RestApi {
             base_url: self.base_url,
@@ -539,6 +645,46 @@ impl RestApiBuilder {
             pagination: self.pagination,
             no_pagination: self.no_pagination,
             filter_strategy: self.filter_strategy,
+            total_key: self.total_key,
+            debug: self.debug,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `build_query_string` with no conditions, exercising only the
+    /// window → pagination-param mapping.
+    fn qs(api: &RestApi, window: Option<(i64, i64)>) -> String {
+        api.build_query_string(window, &[], &[])
+    }
+
+    #[test]
+    fn skip_based_window_uses_offset_verbatim() {
+        let api = RestApi::builder("http://x")
+            .pagination_params(PaginationParams::skip_limit("skip", "limit"))
+            .build();
+        assert_eq!(qs(&api, Some((20, 10))), "?skip=20&limit=10");
+    }
+
+    #[test]
+    fn page_based_window_derives_one_based_page() {
+        let api = RestApi::builder("http://x").build(); // default _page/_limit
+        // offset 20 / limit 10 → page 3 (1-based).
+        assert_eq!(qs(&api, Some((20, 10))), "?_page=3&_limit=10");
+    }
+
+    #[test]
+    fn no_window_emits_no_pagination_params() {
+        let api = RestApi::builder("http://x").build();
+        assert_eq!(qs(&api, None), "");
+    }
+
+    #[test]
+    fn no_pagination_suppresses_window_params() {
+        let api = RestApi::builder("http://x").no_pagination().build();
+        assert_eq!(qs(&api, Some((20, 10))), "");
     }
 }

--- a/vantage-api-client/src/rest/vista/factory.rs
+++ b/vantage-api-client/src/rest/vista/factory.rs
@@ -97,6 +97,9 @@ impl RestApiVistaFactory {
     {
         let metadata = metadata_from_table(&table);
         let name = table.table_name().to_string();
+        // A configured `total_key` lets the shell serve absolute-offset
+        // windows (and an exact count) — advertise it before erasing the table.
+        let can_fetch_window = table.data_source().total_key().is_some();
         let any_table = table.into_entity::<EmptyEntity>();
 
         let source = RestApiTableShell::new(
@@ -104,6 +107,7 @@ impl RestApiVistaFactory {
             VistaCapabilities {
                 can_count: true,
                 can_traverse_to_record: true,
+                can_fetch_window,
                 ..VistaCapabilities::default()
             },
             metadata,
@@ -185,11 +189,13 @@ impl VistaFactory for RestApiVistaFactory {
             );
         }
 
+        let can_fetch_window = table.data_source().total_key().is_some();
         let source = RestApiTableShell::new(
             table,
             VistaCapabilities {
                 can_count: true,
                 can_traverse_to_record: true,
+                can_fetch_window,
                 ..VistaCapabilities::default()
             },
             metadata,

--- a/vantage-api-client/src/rest/vista/source.rs
+++ b/vantage-api-client/src/rest/vista/source.rs
@@ -124,7 +124,38 @@ impl TableShell for RestApiTableShell {
     }
 
     async fn get_vista_count(&self, _vista: &Vista) -> Result<i64> {
-        self.table.data_source().get_table_count(&self.table).await
+        let api = self.table.data_source();
+        // Prefer the envelope total (`total_key`) — one cheap request that
+        // reflects the active conditions. Falls back to counting fetched rows
+        // when no `total_key` is configured.
+        if let Some(total) = api
+            .fetch_total(self.table.table_name(), self.table.conditions())
+            .await?
+        {
+            return Ok(total);
+        }
+        api.get_table_count(&self.table).await
+    }
+
+    async fn fetch_window(
+        &self,
+        _vista: &Vista,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, Record<CborValue>)>> {
+        let id_field = self.table.id_field().map(|c| c.name().to_string());
+        let records = self
+            .table
+            .data_source()
+            .fetch_window_records(
+                self.table.table_name(),
+                id_field.as_deref(),
+                offset as i64,
+                limit as i64,
+                self.table.conditions(),
+            )
+            .await?;
+        Ok(records.into_iter().collect())
     }
 
     fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1 — unreleased
+
+- The cache shell now passes `can_fetch_window` through from its master Vista, so a cached REST/SQL
+  source still advertises random-access windowing.
+
 ## 0.6.0 — unreleased
 
 - Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.1", path = "../vantage-vista" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 

--- a/vantage-diorama/src/dio/shell.rs
+++ b/vantage-diorama/src/dio/shell.rs
@@ -41,6 +41,7 @@ impl DioShell {
             can_set_page_size: master_caps.can_set_page_size,
             can_fetch_page: master_caps.can_fetch_page,
             can_fetch_next: master_caps.can_fetch_next,
+            can_fetch_window: master_caps.can_fetch_window,
             // Traversal capabilities pass through from the master vista; the
             // Dio cache does not add or remove traversal modes.
             can_traverse_to_record: master_caps.can_traverse_to_record,

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.3 — unreleased
+
+- Added `ColumnFlag::Label` — hints a column is better shown as a small status tag attached to the
+  record's title than as its own column (e.g. a status/state field with a per-value color map).
+
 ## 0.6.2 — unreleased
 
 - Internal dependency realignment for the coordinated 0.6 release; no public API changes.

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/column/flags.rs
+++ b/vantage-table/src/column/flags.rs
@@ -13,4 +13,8 @@ pub enum ColumnFlag {
     Searchable,
     /// Indexed marks this column as cheap to sort or filter on, hinting to generic UIs that they can offer sort headers and filter inputs without a performance penalty
     Indexed,
+    /// Label hints to generic UIs that this column is better shown as a
+    /// small status tag attached to the record's title than as its own
+    /// column (e.g. a status / state field with a per-value color map)
+    Label,
 }

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.1 — unreleased
+
+- Folded the read-only Rhai data-fetch surface (formerly the standalone `vantage-data-script` crate)
+  into the `rhai` feature: terminal `list`/`get_some`/`count`/`capabilities`/`columns`/`references`
+  verbs plus a `run_script` runner, alongside the existing builder vocabulary. The feature now pulls
+  `serde_json` + `tokio` for the sync↔async bridge.
+- Added random-access pagination: `VistaCapabilities::can_fetch_window`, `Vista::fetch_window`, and
+  the `TableShell::fetch_window` default.
+
 ## 0.6.0 — unreleased
 
 - Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"
@@ -22,13 +22,19 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"
 thiserror = "2.0"
 rhai = { version = "1.25", optional = true }
+serde_json = { version = "1", optional = true }
+# `rt`/`rt-multi-thread` for the spawn_blocking + Handle::block_on bridge that
+# drives the async Vista fetches from the synchronous Rhai engine.
+tokio = { version = "1.52", features = ["rt", "rt-multi-thread"], optional = true }
 
 [features]
-# Conventional Rhai vocabulary over the type-erased `Vista` (the engine and
-# builder verbs that back scripted reference traversal). Backends opt in and
-# layer their vendor-specific expression vocabulary on top via
-# `TableShell::register_rhai_extensions`.
-rhai = ["dep:rhai"]
+# Rhai scripting over the type-erased `Vista`: the conventional builder verbs
+# (`table`/`add_condition_eq`/`add_order`/`get_ref`…) that back scripted
+# reference traversal, plus the read-only terminal fetch verbs
+# (`list`/`get_some`/`count`/`capabilities`/`columns`/`references`) and the
+# `run_script` runner. Backends layer their vendor expression vocabulary on top
+# via `TableShell::register_rhai_extensions`.
+rhai = ["dep:rhai", "dep:serde_json", "dep:tokio"]
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }

--- a/vantage-vista/src/capabilities.rs
+++ b/vantage-vista/src/capabilities.rs
@@ -36,6 +36,13 @@ pub struct VistaCapabilities {
     /// the weakest of the three pagination primitives. DynamoDB and
     /// most token-paginated REST APIs only support this.
     pub can_fetch_next: bool,
+    /// Random-access pagination via `fetch_window(offset, limit)` —
+    /// addressed by absolute row index rather than page number, so it
+    /// maps directly onto a diorama `on_load_chunk` `Range<usize>` (which
+    /// is not page-aligned). Distinct from [`can_fetch_page`](Self::can_fetch_page),
+    /// which is page-indexed. Offset-style REST APIs that also report a
+    /// grand total advertise this for true lazy/scroll loading.
+    pub can_fetch_window: bool,
     /// Record-level reference traversal via `get_ref(relation, row)` — read
     /// the join value out of a known row and narrow the target with a plain
     /// eq-condition. Every backend that can filter by equality supports this

--- a/vantage-vista/src/lib.rs
+++ b/vantage-vista/src/lib.rs
@@ -12,7 +12,7 @@ pub mod metadata;
 pub mod mocks;
 pub mod reference;
 #[cfg(feature = "rhai")]
-pub mod rhai_conventional;
+pub mod rhai;
 pub mod sort;
 pub mod source;
 pub mod spec;
@@ -28,8 +28,9 @@ pub use factory::VistaFactory;
 pub use metadata::VistaMetadata;
 pub use reference::{ContainedKind, ContainedSpec, Reference, ReferenceKind};
 #[cfg(feature = "rhai")]
-pub use rhai_conventional::{
-    RhaiVista, TargetResolver, eval_modify_script, eval_ref_script, register_conventional_onto,
+pub use rhai::{
+    DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT, RhaiVista, TargetResolver, eval_modify_script,
+    eval_ref_script, register_conventional_onto, register_fetch_verbs, run_script,
 };
 pub use sort::SortDirection;
 pub use source::TableShell;

--- a/vantage-vista/src/rhai.rs
+++ b/vantage-vista/src/rhai.rs
@@ -1,0 +1,29 @@
+//! Rhai scripting surface over the type-erased [`Vista`](crate::vista::Vista).
+//!
+//! vantage-vista owns Rhai engine construction with a *backend-agnostic*
+//! vocabulary, in two layers:
+//!
+//! - [`conventional`] — the chainable query *builder*: `table(name)` resolves a
+//!   fresh target through an injected [`TargetResolver`], and builder verbs
+//!   (`add_condition_eq`, `add_order`, `get_ref`…) narrow it in place. Backends
+//!   layer vendor-specific verbs on top via
+//!   [`TableShell::register_rhai_extensions`](crate::TableShell::register_rhai_extensions).
+//! - [`fetch`] — the read-only *terminal* verbs (`list`, `get_some`, `count`,
+//!   `capabilities`, `columns`, `references`) that actually read data, plus the
+//!   [`runtime::run_script`] runner that drives their async fetches from
+//!   synchronous Rhai.
+//!
+//! [`convert`] and [`introspect`] are shared internals (value round-tripping and
+//! schema/capability map building).
+
+mod conventional;
+mod convert;
+mod fetch;
+mod introspect;
+mod runtime;
+
+pub use conventional::{
+    RhaiVista, TargetResolver, eval_modify_script, eval_ref_script, register_conventional_onto,
+};
+pub use fetch::register_fetch_verbs;
+pub use runtime::{DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT, run_script};

--- a/vantage-vista/src/rhai/conventional.rs
+++ b/vantage-vista/src/rhai/conventional.rs
@@ -21,6 +21,7 @@ use rhai::{Dynamic, Engine, EvalAltResult, Map as RhaiMap, Scope};
 use vantage_core::{Result, error};
 use vantage_types::Record;
 
+use super::convert::{dynamic_to_cbor, map_to_record, record_to_dynamic};
 use crate::{sort::SortDirection, vista::Vista};
 
 /// A [`Vista`] handle usable from Rhai: `Clone + Send + Sync + 'static` via
@@ -245,74 +246,6 @@ fn parse_dir(dir: &str) -> std::result::Result<SortDirection, Box<EvalAltResult>
 
 fn to_rhai_err(e: vantage_core::VantageError) -> Box<EvalAltResult> {
     Box::<EvalAltResult>::from(e.to_string())
-}
-
-/// Convert a scalar Rhai value into the universal CBOR carrier.
-fn dynamic_to_cbor(d: Dynamic) -> std::result::Result<CborValue, Box<EvalAltResult>> {
-    if d.is_unit() {
-        Ok(CborValue::Null)
-    } else if d.is::<bool>() {
-        Ok(CborValue::Bool(d.cast::<bool>()))
-    } else if d.is::<i64>() {
-        Ok(CborValue::Integer(d.cast::<i64>().into()))
-    } else if d.is::<f64>() {
-        Ok(CborValue::Float(d.cast::<f64>()))
-    } else if d.is::<String>() {
-        Ok(CborValue::Text(d.cast::<String>()))
-    } else {
-        Err(format!(
-            "cannot convert rhai value of type '{}' into a condition value",
-            d.type_name()
-        )
-        .into())
-    }
-}
-
-/// Convert a CBOR value into a Rhai `Dynamic` (used when seeding the parent
-/// `row` map for the script).
-fn cbor_to_dynamic(v: &CborValue) -> Dynamic {
-    match v {
-        CborValue::Null => Dynamic::UNIT,
-        CborValue::Bool(b) => Dynamic::from_bool(*b),
-        CborValue::Integer(i) => {
-            let n: i128 = (*i).into();
-            Dynamic::from_int(n as i64)
-        }
-        CborValue::Float(f) => Dynamic::from_float(*f),
-        CborValue::Text(s) => Dynamic::from(s.clone()),
-        CborValue::Bytes(b) => Dynamic::from_blob(b.clone()),
-        CborValue::Array(a) => {
-            let arr: rhai::Array = a.iter().map(cbor_to_dynamic).collect();
-            Dynamic::from_array(arr)
-        }
-        CborValue::Map(m) => {
-            let mut map = RhaiMap::new();
-            for (k, val) in m {
-                if let CborValue::Text(key) = k {
-                    map.insert(key.as_str().into(), cbor_to_dynamic(val));
-                }
-            }
-            Dynamic::from_map(map)
-        }
-        // ciborium::Value is non-exhaustive (tags, etc.); unknowns become unit.
-        _ => Dynamic::UNIT,
-    }
-}
-
-fn record_to_dynamic(row: &Record<CborValue>) -> Dynamic {
-    let mut map = RhaiMap::new();
-    for (k, v) in row.iter() {
-        map.insert(k.as_str().into(), cbor_to_dynamic(v));
-    }
-    Dynamic::from_map(map)
-}
-
-fn map_to_record(map: RhaiMap) -> std::result::Result<Record<CborValue>, Box<EvalAltResult>> {
-    let mut out: Vec<(String, CborValue)> = Vec::with_capacity(map.len());
-    for (k, v) in map {
-        out.push((k.to_string(), dynamic_to_cbor(v)?));
-    }
-    Ok(out.into_iter().collect())
 }
 
 #[cfg(test)]

--- a/vantage-vista/src/rhai/convert.rs
+++ b/vantage-vista/src/rhai/convert.rs
@@ -1,0 +1,122 @@
+//! Value conversions between the CBOR carrier, Rhai `Dynamic`, and (for the
+//! fetch surface) `serde_json`.
+//!
+//! Shared by [`rhai_conventional`](crate::rhai_conventional) (which seeds the
+//! parent `row` map and lowers condition scalars) and
+//! [`rhai_fetch`](crate::rhai_fetch) (which materialises fetched records and
+//! renders a script's final value as JSON). Kept in one place so the two
+//! vocabularies can never drift in how they round-trip a value.
+
+use ciborium::Value as CborValue;
+use rhai::{Array, Dynamic, EvalAltResult, Map as RhaiMap};
+use vantage_types::Record;
+
+/// Convert a scalar Rhai value into the universal CBOR carrier. Non-scalar
+/// types (arrays, maps) are rejected — only condition/id values pass through.
+pub(crate) fn dynamic_to_cbor(d: Dynamic) -> Result<CborValue, Box<EvalAltResult>> {
+    if d.is_unit() {
+        Ok(CborValue::Null)
+    } else if d.is::<bool>() {
+        Ok(CborValue::Bool(d.cast::<bool>()))
+    } else if d.is::<i64>() {
+        Ok(CborValue::Integer(d.cast::<i64>().into()))
+    } else if d.is::<f64>() {
+        Ok(CborValue::Float(d.cast::<f64>()))
+    } else if d.is::<String>() {
+        Ok(CborValue::Text(d.cast::<String>()))
+    } else {
+        Err(format!(
+            "cannot convert rhai value of type '{}' into a condition value",
+            d.type_name()
+        )
+        .into())
+    }
+}
+
+/// CBOR → Rhai `Dynamic`. `ciborium::Value` is non-exhaustive (tags, etc.);
+/// unknown variants degrade to unit.
+pub(crate) fn cbor_to_dynamic(v: &CborValue) -> Dynamic {
+    match v {
+        CborValue::Null => Dynamic::UNIT,
+        CborValue::Bool(b) => Dynamic::from_bool(*b),
+        CborValue::Integer(i) => {
+            let n: i128 = (*i).into();
+            Dynamic::from_int(n as i64)
+        }
+        CborValue::Float(f) => Dynamic::from_float(*f),
+        CborValue::Text(s) => Dynamic::from(s.clone()),
+        CborValue::Bytes(b) => Dynamic::from_blob(b.clone()),
+        CborValue::Array(a) => {
+            let arr: Array = a.iter().map(cbor_to_dynamic).collect();
+            Dynamic::from_array(arr)
+        }
+        CborValue::Map(m) => {
+            let mut map = RhaiMap::new();
+            for (k, val) in m {
+                if let CborValue::Text(key) = k {
+                    map.insert(key.as_str().into(), cbor_to_dynamic(val));
+                }
+            }
+            Dynamic::from_map(map)
+        }
+        _ => Dynamic::UNIT,
+    }
+}
+
+/// A whole record as a Rhai map (used to seed `row` and to materialise rows).
+pub(crate) fn record_to_dynamic(rec: &Record<CborValue>) -> Dynamic {
+    let mut map = RhaiMap::new();
+    for (k, v) in rec.iter() {
+        map.insert(k.as_str().into(), cbor_to_dynamic(v));
+    }
+    Dynamic::from_map(map)
+}
+
+/// A Rhai map back into a record (used to pass a parent row to `get_ref`).
+pub(crate) fn map_to_record(map: RhaiMap) -> Result<Record<CborValue>, Box<EvalAltResult>> {
+    let mut out: Vec<(String, CborValue)> = Vec::with_capacity(map.len());
+    for (k, v) in map {
+        out.push((k.to_string(), dynamic_to_cbor(v)?));
+    }
+    Ok(out.into_iter().collect())
+}
+
+/// Rhai `Dynamic` → `serde_json::Value` for handing a script's result back to a
+/// caller (e.g. over MCP). `rhai` is built without its `serde` feature, so the
+/// conversion is explicit; unknown types fall back to their display string.
+pub(crate) fn dynamic_to_json(d: &Dynamic) -> serde_json::Value {
+    use serde_json::Value;
+    if d.is_unit() {
+        return Value::Null;
+    }
+    if d.is::<bool>() {
+        return Value::Bool(d.as_bool().unwrap_or(false));
+    }
+    if d.is::<i64>() {
+        return Value::from(d.as_int().unwrap_or(0));
+    }
+    if d.is::<f64>() {
+        return d
+            .as_float()
+            .ok()
+            .and_then(serde_json::Number::from_f64)
+            .map(Value::Number)
+            .unwrap_or(Value::Null);
+    }
+    if d.is::<String>() {
+        return Value::String(d.clone().into_string().unwrap_or_default());
+    }
+    if d.is::<Array>() {
+        let arr = d.clone().cast::<Array>();
+        return Value::Array(arr.iter().map(dynamic_to_json).collect());
+    }
+    if d.is::<RhaiMap>() {
+        let map = d.clone().cast::<RhaiMap>();
+        let obj = map
+            .iter()
+            .map(|(k, v)| (k.to_string(), dynamic_to_json(v)))
+            .collect();
+        return Value::Object(obj);
+    }
+    Value::String(d.to_string())
+}

--- a/vantage-vista/src/rhai/fetch.rs
+++ b/vantage-vista/src/rhai/fetch.rs
@@ -1,0 +1,128 @@
+//! Read-only **terminal** fetch verbs over a [`Vista`].
+//!
+//! [`register_conventional_onto`](crate::register_conventional_onto) gives Rhai
+//! a chainable *query builder* — `table(name)`, `add_condition_eq`, `add_order`,
+//! `add_search`, `set_page_size`, `get_ref(relation, row)` — but those verbs
+//! only *narrow* a [`RhaiVista`]; they never fetch. This module adds the missing
+//! terminal verbs that actually read data and hand it back to the script:
+//! `list()`, `get_some()`, `count()`, plus the introspection verbs
+//! `capabilities()`, `columns()`, `references()`.
+//!
+//! It stays backend-agnostic: it knows only [`Vista`] and the injected
+//! `TargetResolver`. Per-driver vocabulary (SurrealDB/SQL expression syntax) is
+//! layered inside Vista via `TableShell::register_rhai_extensions`, so nothing
+//! vendor-specific leaks here.
+//!
+//! Rhai is synchronous; the Vista fetch methods are async. The verbs bridge that
+//! with [`block_on`], which is only legal because [`run_script`](crate::run_script)
+//! evaluates inside `tokio::task::spawn_blocking` — see that runner for why.
+
+use ciborium::Value as CborValue;
+use rhai::{Array, Dynamic, Engine, EvalAltResult, Map as RhaiMap};
+use vantage_dataset::ReadableValueSet;
+use vantage_types::Record;
+
+use super::conventional::RhaiVista;
+use super::convert::record_to_dynamic;
+use super::introspect::{capabilities_map, columns_array, references_array};
+use crate::vista::Vista;
+
+type RhaiResult<T> = Result<T, Box<EvalAltResult>>;
+
+/// Register the terminal fetch + introspection verbs onto `engine`. The engine
+/// must already carry the conventional vocabulary (see
+/// [`register_conventional_onto`](crate::register_conventional_onto)). `limit`
+/// caps every `list()`. Each verb is read-only.
+pub fn register_fetch_verbs(engine: &mut Engine, limit: usize) {
+    // `list()` → array of record-maps, capped at `limit`.
+    engine.register_fn("list", move |v: &mut RhaiVista| -> RhaiResult<Array> {
+        read_vista(v, |vista| {
+            let rows = block_on(fetch_capped(vista, limit)).map_err(vantage_err)?;
+            Ok(rows
+                .iter()
+                .map(|(_id, rec)| record_to_dynamic(rec))
+                .collect())
+        })
+    });
+
+    // `get_some()` → one record-map, or `()` when the set is empty. This is the
+    // `load_some` half of the traversal idiom.
+    engine.register_fn("get_some", |v: &mut RhaiVista| -> RhaiResult<Dynamic> {
+        read_vista(v, |vista| {
+            match block_on(vista.get_some_value()).map_err(vantage_err)? {
+                Some((_id, rec)) => Ok(record_to_dynamic(&rec)),
+                None => Ok(Dynamic::UNIT),
+            }
+        })
+    });
+
+    // `count()` → grand total (i64). Errors when the backend can't count.
+    engine.register_fn("count", |v: &mut RhaiVista| -> RhaiResult<i64> {
+        read_vista(v, |vista| {
+            if !vista.capabilities().can_count {
+                return Err("count: this backend does not support counting".into());
+            }
+            block_on(vista.get_count()).map_err(vantage_err)
+        })
+    });
+
+    // `capabilities()` → map of the Vista's capability flags.
+    engine.register_fn("capabilities", |v: &mut RhaiVista| -> RhaiResult<RhaiMap> {
+        read_vista(v, |vista| Ok(capabilities_map(vista)))
+    });
+
+    // `columns()` → array of `{ name, type, flags }`.
+    engine.register_fn("columns", |v: &mut RhaiVista| -> RhaiResult<Array> {
+        read_vista(v, |vista| Ok(columns_array(vista)))
+    });
+
+    // `references()` → array of `{ name, kind, contained }`.
+    engine.register_fn("references", |v: &mut RhaiVista| -> RhaiResult<Array> {
+        read_vista(v, |vista| Ok(references_array(vista)))
+    });
+}
+
+/// Fetch at most `limit` rows. Prefers `fetch_window(0, limit)` when the driver
+/// advertises it (true random-access lazy loading — REST/SQL window); otherwise
+/// falls back to a full `list_values` truncated to `limit`. The truncation keeps
+/// the *returned* payload bounded even when the backend over-fetches; a script
+/// that wants the backend itself to limit can call `.set_page_size(n)` first.
+async fn fetch_capped(
+    vista: &Vista,
+    limit: usize,
+) -> vantage_core::Result<Vec<(String, Record<CborValue>)>> {
+    if vista.capabilities().can_fetch_window {
+        match vista.fetch_window(0, limit).await {
+            Ok(rows) => return Ok(rows),
+            // Some shells advertise the window capability but refuse it in
+            // practice (notably the diorama cache shell, which passes the
+            // flag through from its master). Fall back to a truncated list
+            // rather than failing the script.
+            Err(e) if e.is_unsupported() => {}
+            Err(e) => return Err(e),
+        }
+    }
+    let all = vista.list_values().await?;
+    Ok(all.into_iter().take(limit).collect())
+}
+
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Handle::current().block_on(fut)
+}
+
+/// Lock a [`RhaiVista`] and run `f` with the borrowed [`Vista`]. The lock is
+/// held across `f` (and thus across any `block_on` inside it) — fine, since the
+/// guard is a plain `std::sync::Mutex` and evaluation is single-threaded.
+fn read_vista<T>(v: &RhaiVista, f: impl FnOnce(&Vista) -> RhaiResult<T>) -> RhaiResult<T> {
+    let guard =
+        v.0.lock()
+            .map_err(|_| Box::<EvalAltResult>::from("RhaiVista mutex poisoned"))?;
+    let vista = guard
+        .as_ref()
+        .ok_or_else(|| Box::<EvalAltResult>::from("vista already consumed in script"))?;
+    f(vista)
+}
+
+fn vantage_err(e: vantage_core::VantageError) -> Box<EvalAltResult> {
+    Box::<EvalAltResult>::from(e.to_string())
+}

--- a/vantage-vista/src/rhai/introspect.rs
+++ b/vantage-vista/src/rhai/introspect.rs
@@ -1,0 +1,68 @@
+//! Schema/capability introspection builders backing the `capabilities()`,
+//! `columns()`, and `references()` fetch verbs. Each turns a [`Vista`]'s
+//! metadata into a plain Rhai value the script can read.
+
+use rhai::{Array, Dynamic, Map as RhaiMap};
+
+use crate::vista::Vista;
+
+/// `{ can_count, can_insert, … }` — every capability flag as a bool.
+pub(crate) fn capabilities_map(vista: &Vista) -> RhaiMap {
+    let c = vista.capabilities();
+    let mut m = RhaiMap::new();
+    let mut put = |k: &str, b: bool| {
+        m.insert(k.into(), b.into());
+    };
+    put("can_count", c.can_count);
+    put("can_insert", c.can_insert);
+    put("can_update", c.can_update);
+    put("can_delete", c.can_delete);
+    put("can_subscribe", c.can_subscribe);
+    put("can_invalidate", c.can_invalidate);
+    put("can_order", c.can_order);
+    put("can_search", c.can_search);
+    put("can_set_page_size", c.can_set_page_size);
+    put("can_fetch_page", c.can_fetch_page);
+    put("can_fetch_next", c.can_fetch_next);
+    put("can_fetch_window", c.can_fetch_window);
+    put("can_traverse_to_record", c.can_traverse_to_record);
+    put("can_traverse_to_set", c.can_traverse_to_set);
+    put("can_build_ref_via_script", c.can_build_ref_via_script);
+    m
+}
+
+/// `[{ name, type, flags }, …]` — one entry per column.
+pub(crate) fn columns_array(vista: &Vista) -> Array {
+    let mut arr = Array::new();
+    for name in vista.get_column_names() {
+        let mut m = RhaiMap::new();
+        m.insert("name".into(), name.to_string().into());
+        if let Some(col) = vista.get_column(name) {
+            m.insert("type".into(), col.original_type.clone().into());
+            let flags: Array = col.flags.iter().map(|f| f.clone().into()).collect();
+            m.insert("flags".into(), Dynamic::from_array(flags));
+        }
+        arr.push(Dynamic::from_map(m));
+    }
+    arr
+}
+
+/// `[{ name, kind, contained }, …]` — referenced and contained relations.
+pub(crate) fn references_array(vista: &Vista) -> Array {
+    let mut arr = Array::new();
+    for (name, kind) in vista.list_references() {
+        let mut m = RhaiMap::new();
+        m.insert("name".into(), name.into());
+        m.insert("kind".into(), format!("{kind:?}").into());
+        m.insert("contained".into(), false.into());
+        arr.push(Dynamic::from_map(m));
+    }
+    for (name, kind) in vista.list_contained() {
+        let mut m = RhaiMap::new();
+        m.insert("name".into(), name.into());
+        m.insert("kind".into(), format!("{kind:?}").into());
+        m.insert("contained".into(), true.into());
+        arr.push(Dynamic::from_map(m));
+    }
+    arr
+}

--- a/vantage-vista/src/rhai/runtime.rs
+++ b/vantage-vista/src/rhai/runtime.rs
@@ -1,0 +1,192 @@
+//! The `run_script` runner: evaluate a data-fetch script and return its final
+//! value as JSON.
+//!
+//! Rhai is synchronous; the Vista fetch methods are async. [`run_script`] runs
+//! the whole evaluation inside [`tokio::task::spawn_blocking`], which gives a
+//! thread with a runtime *context* but no async *frame* — so each terminal verb
+//! can legally `Handle::current().block_on(…)` its fetch (see
+//! [`super::fetch`]). Calling `block_on` directly from an async task (e.g. an
+//! MCP handler future) would instead panic, which is exactly why the
+//! `spawn_blocking` hop exists.
+//!
+//! ## Traversal idiom (load, then descend only if loaded)
+//!
+//! ```rhai
+//! let o = table("orders").get_some();          // load one record
+//! if o != () {                                 // only traverse if it loaded
+//!     table("orders").get_ref("client", o).get_some()
+//! }
+//! ```
+
+use rhai::{Dynamic, Engine};
+
+use super::conventional::{TargetResolver, register_conventional_onto};
+use super::convert::dynamic_to_json;
+use super::fetch::register_fetch_verbs;
+
+/// Lower bound applied to a requested row limit.
+pub const MIN_LIMIT: usize = 1;
+/// Hard ceiling on rows any single `list()` returns — this is a debug surface,
+/// not a bulk reader.
+pub const MAX_LIMIT: usize = 50;
+/// Limit used when a caller does not specify one.
+pub const DEFAULT_LIMIT: usize = 5;
+
+/// Evaluate a data-fetch script and return its final value as JSON.
+///
+/// `resolver` backs the `table(name)` constructor — pass a *direct* resolver
+/// (fresh master Vista) or a *cache* resolver (a live Dio's cache-backed Vista);
+/// this is indifferent to which. `limit` is clamped to `[MIN_LIMIT, MAX_LIMIT]`
+/// and caps every `list()` in the script.
+///
+/// Compile errors, runtime errors, and resolver/fetch failures all surface as
+/// `Err(String)` (the Rhai error message), so a caller can hand the agent a
+/// precise complaint instead of a generic failure.
+pub async fn run_script(
+    script: String,
+    resolver: TargetResolver,
+    limit: usize,
+) -> Result<serde_json::Value, String> {
+    let limit = limit.clamp(MIN_LIMIT, MAX_LIMIT);
+
+    tokio::task::spawn_blocking(move || -> Result<serde_json::Value, String> {
+        let mut engine = Engine::new();
+        // The conventional builder vocabulary (table/condition/order/get_ref…)…
+        register_conventional_onto(&mut engine, resolver);
+        // …plus the terminal fetch/introspection verbs.
+        register_fetch_verbs(&mut engine, limit);
+
+        let result: Dynamic = engine.eval::<Dynamic>(&script).map_err(|e| e.to_string())?;
+        Ok(dynamic_to_json(&result))
+    })
+    .await
+    .map_err(|e| format!("data-fetch script task failed to run: {e}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mocks::MockShell;
+    use crate::vista::Vista;
+    use crate::{Column, VistaMetadata};
+    use ciborium::Value as CborValue;
+    use std::sync::Arc;
+    use vantage_types::Record;
+
+    fn cbor_text(s: &str) -> CborValue {
+        CborValue::Text(s.into())
+    }
+
+    fn record(pairs: &[(&str, CborValue)]) -> Record<CborValue> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), v.clone()))
+            .collect()
+    }
+
+    /// Three users, rebuilt fresh on each `table("users")` call.
+    fn users_vista() -> Vista {
+        let source = MockShell::new()
+            .with_record(
+                "1",
+                record(&[("id", cbor_text("1")), ("name", cbor_text("Alice"))]),
+            )
+            .with_record(
+                "2",
+                record(&[("id", cbor_text("2")), ("name", cbor_text("Bob"))]),
+            )
+            .with_record(
+                "3",
+                record(&[("id", cbor_text("3")), ("name", cbor_text("Carol"))]),
+            );
+        let metadata = VistaMetadata::new()
+            .with_column(Column::new("id", "String").with_flag("id"))
+            .with_column(Column::new("name", "String").with_flag("title"))
+            .with_id_column("id");
+        Vista::new("users", Box::new(source.with_metadata(metadata)))
+    }
+
+    fn resolver() -> TargetResolver {
+        Arc::new(|name: &str| {
+            if name == "users" {
+                Ok(users_vista())
+            } else {
+                Err(vantage_core::error!("unknown table", table = name))
+            }
+        })
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn list_caps_rows_at_limit() {
+        let json = run_script(r#"table("users").list()"#.into(), resolver(), 2)
+            .await
+            .unwrap();
+        let rows = json.as_array().expect("array");
+        assert_eq!(rows.len(), 2, "limit caps the returned rows");
+        assert_eq!(rows[0]["name"], serde_json::json!("Alice"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn list_clamps_to_max() {
+        // Requesting 9999 must clamp to MAX_LIMIT, not return everything-unbounded.
+        let json = run_script(r#"table("users").list()"#.into(), resolver(), 9999)
+            .await
+            .unwrap();
+        // Only 3 rows exist, but the point is the clamp didn't error/over-cap.
+        assert_eq!(json.as_array().unwrap().len(), 3);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_some_returns_a_map() {
+        let json = run_script(r#"table("users").get_some()"#.into(), resolver(), 5)
+            .await
+            .unwrap();
+        assert!(json.get("id").is_some(), "get_some yields a record object");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn condition_then_get_some_narrows() {
+        let json = run_script(
+            r#"table("users").add_condition_eq("id", "3").get_some()"#.into(),
+            resolver(),
+            5,
+        )
+        .await
+        .unwrap();
+        assert_eq!(json["name"], serde_json::json!("Carol"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn capabilities_is_a_flag_map() {
+        let json = run_script(r#"table("users").capabilities()"#.into(), resolver(), 5)
+            .await
+            .unwrap();
+        assert!(json.get("can_fetch_window").is_some());
+        assert!(json["can_count"].is_boolean());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn columns_lists_schema() {
+        let json = run_script(r#"table("users").columns()"#.into(), resolver(), 5)
+            .await
+            .unwrap();
+        let cols = json.as_array().unwrap();
+        assert!(cols.iter().any(|c| c["name"] == serde_json::json!("name")));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unknown_table_is_an_error() {
+        let err = run_script(r#"table("ghosts").list()"#.into(), resolver(), 5)
+            .await
+            .unwrap_err();
+        assert!(err.contains("unknown table"), "got: {err}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn syntax_error_is_reported() {
+        let err = run_script("this is not rhai (".into(), resolver(), 5)
+            .await
+            .unwrap_err();
+        assert!(!err.is_empty());
+    }
+}

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -247,6 +247,26 @@ pub trait TableShell: Send + Sync + 'static {
         Err(self.default_error("fetch_next", "can_fetch_next"))
     }
 
+    /// Fetch the half-open row window `[offset, offset + limit)` in the
+    /// source's natural order. Offset-style like [`fetch_page`](Self::fetch_page)
+    /// but addressed by absolute row index rather than page number, so it
+    /// maps directly onto a diorama `on_load_chunk` `Range<usize>` — which
+    /// is *not* guaranteed page-aligned. This is the primitive a paged,
+    /// lazily-loaded grid drives on scroll.
+    ///
+    /// Drivers leave the default in place (producing `Unsupported`) until
+    /// they implement it; callers branch on
+    /// `vista.capabilities().can_fetch_window` first. Default returns
+    /// `default_error("fetch_window", "can_fetch_window")`.
+    async fn fetch_window(
+        &self,
+        _vista: &Vista,
+        _offset: usize,
+        _limit: usize,
+    ) -> Result<Vec<(String, Record<CborValue>)>> {
+        Err(self.default_error("fetch_window", "can_fetch_window"))
+    }
+
     // ---- Quicksearch -------------------------------------------------------
 
     /// Apply a quicksearch filter — a single string the driver fans out across

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -229,6 +229,19 @@ impl Vista {
         self.source.fetch_next(self, token).await
     }
 
+    /// Fetch the half-open row window `[offset, offset + limit)` in the
+    /// source's natural order. Addressed by absolute row index (unlike the
+    /// page-indexed [`fetch_page`](Self::fetch_page)), so it maps directly
+    /// onto a lazily-loaded grid's scroll range. Returns `Unsupported` when
+    /// the driver does not advertise `can_fetch_window`.
+    pub async fn fetch_window(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, Record<CborValue>)>> {
+        self.source.fetch_window(self, offset, limit).await
+    }
+
     // ---- quicksearch -------------------------------------------------------
 
     /// Apply a quicksearch filter. The driver decides which columns participate;


### PR DESCRIPTION
Moves the read-only Rhai data-fetch surface out of the standalone (unpublished) `vantage-data-script` crate and into `vantage-vista` under the existing `rhai` feature, then re-applies the `fetch_window` lazy-loading work it depended on.

## vantage-vista (0.6.0 → 0.6.1)
- `vantage-data-script` deleted; its logic now lives in `src/rhai/` split into focused modules: `conventional` (builder verbs, was `rhai_conventional.rs`), `convert` (shared value conversions, dedup'd from the conventional copies), `fetch` (terminal `list`/`get_some`/`count`/`capabilities`/`columns`/`references` verbs), `introspect` (capability/column/reference maps), `runtime` (`run_script` + tests).
- `rhai` feature now also pulls `serde_json` + `tokio` (the sync↔async `run_script` bridge).
- Re-applied `fetch_window`: `VistaCapabilities::can_fetch_window`, `Vista::fetch_window`, and the `TableShell::fetch_window` default.

## vantage-table (0.6.2 → 0.6.3)
- `ColumnFlag::Label` — hints a column renders as a status tag on the title.

## vantage-diorama (0.6.0 → 0.6.1)
- Cache shell passes `can_fetch_window` through from its master.

## vantage-api-client (0.6.0 → 0.6.1)
- REST lazy-load: `total_key`/`debug` builder options, `fetch_window_records`/`fetch_total`, `RestApiTableShell::fetch_window` + total-based count, and `can_fetch_window` advertised when `total_key` is set. +4 window-mapping unit tests.

`cargo test -p vantage-vista --features rhai` and `-p vantage-api-client` pass.