### PR TITLE
add generic diorama augmentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4759,7 +4759,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4769,6 +4769,7 @@ dependencies = [
  "insta",
  "redb",
  "rstest",
+ "serde",
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",
@@ -4782,6 +4783,7 @@ dependencies = [
  "vantage-table",
  "vantage-types",
  "vantage-vista",
+ "vantage-vista-factory",
 ]
 
 [[package]]
@@ -4994,7 +4996,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/docs4/src/SUMMARY.md
+++ b/docs4/src/SUMMARY.md
@@ -23,6 +23,7 @@
   - [Step 7: Multi-Backend](./new-persistence/step7-multi-backend.md)
   - [Step 8: Vista Integration](./new-persistence/step8-vista-integration.md)
   - [Step 9: Contained Relations](./new-persistence/step9-contained-relations.md)
+- [Augmentation](./augmentation.md)
 - [Persistence-aligned Type System](./type-system.md)
   - [Adding Custom Types](./type-system/custom-types.md)
 - [SQL: PostgreSQL, MySQL & SQLite](./sql.md)

--- a/docs4/src/augmentation.md
+++ b/docs4/src/augmentation.md
@@ -1,0 +1,170 @@
+# Augmentation
+
+A `Vista` reads one table from one backend. But a row is often only half the
+story: an S3 bucket listing tells you a file's key and size, not how many
+resources the terraform state inside it declares. A REST list of repositories
+doesn't carry the CI status that lives behind a shell command. The data you want
+to show lives in a *second* source, keyed off the first.
+
+**Augmentation wires two Vistas into one `Dio`**: a *master* that is listed, and
+a *detail* source that is loaded one row at a time and merged on top. The two can
+be the same Vista (a backend whose list and detail are separate operations) or
+entirely different backends — a REST master enriched by a `cmd` detail, or the
+reverse. The detail source is resolved by name through the
+[`VistaCatalog`](./new-persistence/step8-vista-integration.md), so it is
+persistence-agnostic.
+
+## Why this lives in the Dio, not the Vista
+
+This is a join, and joins are governed by the capability contract. A SQL Vista
+can join its own tables; a REST Vista cannot; two *different* backends can never
+push a join down to either engine. Where the backend can't, the layer above fills
+the gap — that is the whole job of the Dio.
+
+So augmentation is deliberately a `Dio`-layer feature. A `Vista` honestly
+describes one backend and has no cache, no viewport, and no catalog; declaring
+"enrich from another Vista, loaded lazily and cached" on it would be a promise it
+can't keep. The `Dio` has all three, so it owns the augmentation: it lists the
+master cheaply, and for each row the user actually scrolls to, it fetches the
+detail and stitches the columns together. It is a per-row join, executed
+client-side, exactly where a push-down is impossible.
+
+```admonish note title="It reduces to the old two-pass"
+The previous progressive-loading path — a `cmd` table with a `detail` script —
+is just the special case where the detail source *is* the master and the key is
+the id. Expressed as augmentation it is `table: <self>, source: id, fetch:
+per_row`. Nothing about that behaviour changed; it stopped being a backend quirk.
+```
+
+## How it runs
+
+Augmentation engages the two-pass machinery:
+
+1. **List pass** — the master is listed cheaply (a page at a time). Each row is
+   written to the cache as `Incomplete`, carrying only the columns the list
+   returns. When the master can serve windows (`can_fetch_window`) the page is
+   pushed down; otherwise the set is listed and windowed locally.
+2. **Detail pass** — viewport-driven. For each visible `Incomplete` row, every
+   augmentation resolves its detail Vista, fetches the matching record, and
+   merges the chosen columns onto the cached row, which flips to `Fresh`. Rows
+   off-screen are never fetched; rows already hydrated are never re-fetched.
+
+A failed detail fetch marks only that row, leaving its cheap columns intact — the
+rest of the page hydrates normally.
+
+## Declaring it
+
+On the `Lens`, supply the catalog and one or more augmentations:
+
+```rust
+let lens = Lens::new()
+    .cache_at(cache_path)
+    .catalog(catalog)                       // resolves `table:` names
+    .augment(vec![augmentation])            // ≥1 engages two-pass
+    .build()?;
+```
+
+Each `Augmentation` has four parts:
+
+```rust
+Augmentation {
+    table:  "tfstate_detail".into(),  // catalog name of the detail Vista
+    source: Source::Column { from: "key".into(), to: None },
+    fetch:  Fetch::PerRow,
+    merge:  MergeRule { columns: vec!["resources".into(), "serial".into()] },
+}
+```
+
+`source` and `fetch` are two orthogonal axes:
+
+| `Source` | how a master row selects its detail |
+|---|---|
+| `Id` | `master.id → detail.id` |
+| `Column { from, to }` | `master[from] → detail[to` *or* `detail.id]` |
+| `Build(closure)` | arbitrary narrowing from the whole row — per-row only |
+
+| `Fetch` | how the detail is read |
+|---|---|
+| `PerRow` | one record per master row (`get_value`, or narrow-and-take-first) |
+| `Custom(closure)` | a caller-supplied async fetch |
+| `Batched` | one set query across the window's keys — *planned* |
+
+`Id` and id-keyed `Column` sources read by key through `get_value` — the uniform
+"one record by key" primitive (a `cmd` detail script, a SQL `WHERE id =`, a REST
+`GET /{id}`). They can name a target column, so they are the batchable shapes.
+`Build` returns an arbitrary narrowed Vista that can't be coalesced into a set, so
+it is per-row only — the type enforces what can and can't batch, rather than a
+runtime check.
+
+### From YAML
+
+The same declaration is data, lowered with `lower_augment`:
+
+```yaml
+augment:
+  - table: tfstate_detail
+    source: { kind: column, from: key }
+    fetch:  { kind: per_row }
+    merge:  [resources, serial, outputs]
+```
+
+### Rhai as a closure factory
+
+The runtime types carry **closures**, not script strings — `Source::Build` is a
+`Fn(&row, base) -> Vista`. Rhai is one factory that produces such a closure;
+hand-written Rust is another. A `{ kind: script, code: "..." }` source lowers (under
+the `rhai` feature) to a `Build` closure that narrows the base detail Vista using
+the master `row`:
+
+```rhai
+self.add_condition_eq("key", row.key)
+```
+
+This is the same machinery a reference build-script uses, pointed at a possibly
+different persistence. The diorama core never sees a script string; all engine
+assembly stays in `vantage-vista`.
+
+## Merging
+
+`merge.columns` lists the detail columns to lift; an empty list lifts all of
+them. The detail record is the authoritative hydration of the row, so on a name
+clash its value wins — it overwrites the cheap list-pass value and adds its new
+columns. (An empty list plus overwrite is exactly the old cmd two-pass: the
+detail script returns the full record, which replaces the stub.) The augmented
+`Dio` therefore advertises the union of the master's columns and the lifted
+detail columns — the "Dio advertises a superset" principle: below it, sources are
+partial; above it, the view is whole.
+
+## Anticipated objections
+
+**Why not model the detail as a foreign-key relation?** A relation resolves
+*within* one persistence and can be pushed down as a join. The detail here may be
+a different backend entirely; there is nothing to join on and no engine that could
+honour it. Augmentation is the cross-Vista form, stitched by the Dio.
+
+**Why one row at a time?** Because the expensive work should follow the user's
+attention. The list pass is cheap and immediate; only rows that reach the viewport
+pay for their detail, and they pay once.
+
+## What's next
+
+Three things are planned but not yet implemented; each fails honestly today rather
+than degrading silently:
+
+- **`Batched` fetch** — collect the window's distinct keys into one set query and
+  scatter the results back, for `Id`/`Column` sources.
+- **Detail-key cache** — dedupe fetches across master rows that share a key
+  (non-unique `Column` sources).
+- **Scripted fetch** — Rhai fetch verbs choosing how to pull.
+
+## Checklist
+
+To augment a master with a second source:
+
+1. **Register the detail model** in the `VistaCatalog` by name.
+2. **Build the `Augmentation`** — pick a `Source` (id, column, or a closure) and a
+   `Fetch` (`PerRow` for now), and list the `merge` columns.
+3. **Wire the Lens** — `.catalog(...)` then `.augment(vec![...])`; building it
+   engages the two-pass passes automatically.
+4. **Show the columns** — the lifted detail columns appear on hydrated rows
+   alongside the master's.

--- a/docs4/src/augmentation.md
+++ b/docs4/src/augmentation.md
@@ -168,3 +168,10 @@ To augment a master with a second source:
    engages the two-pass passes automatically.
 4. **Show the columns** — the lifted detail columns appear on hydrated rows
    alongside the master's.
+
+A runnable end-to-end example (two in-memory Vistas, list pass then detail pass)
+lives in `vantage-diorama/examples/augmentation.rs`:
+
+```console
+cargo run -p vantage-diorama --example augmentation
+```

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.6.2 — unreleased
+
+Generic augmentation: wire a **second** Vista into a `Dio` to enrich each master row,
+loaded one-at-a-time and merged on top. The master is listed cheaply; each visible row
+resolves a detail Vista from a `VistaCatalog`, fetches its record, and merges chosen
+columns. The detail source may be the same Vista (the former cmd two-pass) or a
+different backend entirely (REST master enriched by a cmd script, or vice versa).
+
+- New `augment` module: `Augmentation { table, source, fetch, merge }`, with
+  `Source::{Id, Column, Build}` (closures — Rhai is one factory via `lower_augment`) and
+  `Fetch::{PerRow, Batched, Custom}`. `AugmentSpec`/`SourceSpec`/`FetchSpec` are the serde
+  (YAML) forms; `lower_augment` lowers them.
+- `LensBuilder::augment(...)` + `.catalog(...)`. Registering augmentations engages two-pass
+  and synthesizes the list, detail, and refresh-reconciliation passes (the reconciliation
+  formerly hand-written in the vantage-ui app now lives here). Each pass is synthesized only
+  if the caller didn't supply one.
+- The synthesized list pass is capability-aware: it pushes the window down via
+  `fetch_window` when the master advertises `can_fetch_window`, else lists and windows
+  locally — no more whole-set over-fetch on every page where the backend can window.
+- Now depends on `vantage-vista-factory` (catalog resolution + per-row narrowing reuse) and
+  adds an optional `rhai` feature (forwards to `vantage-vista/rhai`).
+
 ## 0.6.1 — unreleased
 
 - The cache shell now passes `can_fetch_window` through from its master Vista, so a cached REST/SQL

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"
@@ -12,7 +12,8 @@ doctest = false
 [dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-vista = { version = "0.6.1", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.2", path = "../vantage-vista" }
+vantage-vista-factory = { version = "0.6", path = "../vantage-vista-factory" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 
@@ -20,9 +21,15 @@ async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }
 indexmap = "2"
 redb = "2.6"
+serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 tokio = { version = "1", features = ["sync", "rt", "time"] }
 tracing = "0.1"
+
+[features]
+# Rhai-scripted augmentation sources/fetches. Flips on `vantage-vista`'s rhai
+# vocabulary; all engine assembly stays in vantage-vista (see `augment::lower`).
+rhai = ["vantage-vista/rhai"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/vantage-diorama/examples/augmentation.rs
+++ b/vantage-diorama/examples/augmentation.rs
@@ -1,0 +1,161 @@
+//! Generic augmentation: a master Vista is listed cheaply, and each row is
+//! enriched one at a time from a *separate* detail Vista resolved through a
+//! [`VistaCatalog`]. The detail source can be any backend — here both are
+//! in-memory so the example is self-contained.
+//!
+//! Run with: `cargo run -p vantage-diorama --example augmentation`
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use vantage_diorama::{Augmentation, Fetch, Lens, MergeRule, RowStatus, Source};
+use vantage_types::Record;
+use vantage_vista::mocks::MockShell;
+use vantage_vista::{Column, Vista, VistaMetadata};
+use vantage_vista_factory::VistaCatalog;
+
+fn text(s: &str) -> CborValue {
+    CborValue::Text(s.into())
+}
+
+fn record(pairs: &[(&str, &str)]) -> Record<CborValue> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), text(v)))
+        .collect()
+}
+
+fn meta(columns: &[&str]) -> VistaMetadata {
+    let mut m = VistaMetadata::new();
+    for c in columns {
+        let col = if *c == "id" {
+            Column::new("id", "String").with_flag("id")
+        } else {
+            Column::new(*c, "String")
+        };
+        m = m.with_column(col);
+    }
+    m.with_id_column("id")
+}
+
+/// Master: a bucket listing — cheap columns only (id, size).
+fn master() -> Vista {
+    let shell = MockShell::new()
+        .with_record(
+            "us-east-1.tfstate",
+            record(&[("id", "us-east-1.tfstate"), ("size", "4kb")]),
+        )
+        .with_record(
+            "eu-west-1.tfstate",
+            record(&[("id", "eu-west-1.tfstate"), ("size", "7kb")]),
+        )
+        .with_metadata(meta(&["id", "size"]));
+    Vista::new("buckets", Box::new(shell))
+}
+
+/// Detail: the expensive per-file analysis (resources, serial), keyed by id.
+fn detail() -> Vista {
+    let shell = MockShell::new()
+        .with_record(
+            "us-east-1.tfstate",
+            record(&[
+                ("id", "us-east-1.tfstate"),
+                ("resources", "42"),
+                ("serial", "17"),
+            ]),
+        )
+        .with_record(
+            "eu-west-1.tfstate",
+            record(&[
+                ("id", "eu-west-1.tfstate"),
+                ("resources", "8"),
+                ("serial", "3"),
+            ]),
+        )
+        .with_metadata(meta(&["id", "resources", "serial"]));
+    Vista::new("tfstate-detail", Box::new(shell))
+}
+
+fn cell(scenery: &Arc<dyn vantage_diorama::TableScenery>, i: usize, key: &str) -> String {
+    scenery
+        .row(i)
+        .and_then(|r| match r.record.get(key) {
+            Some(CborValue::Text(t)) => Some(t.clone()),
+            _ => None,
+        })
+        .unwrap_or_else(|| "—".into())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cache = std::env::temp_dir().join("vantage-augmentation-example.redb");
+    let _ = std::fs::remove_file(&cache);
+
+    // The catalog resolves the detail source by name (any persistence).
+    let mut catalog = VistaCatalog::new();
+    catalog.register("tfstate-detail", Arc::new(|| Ok(detail())));
+
+    let lens = Arc::new(
+        Lens::new()
+            .cache_at(&cache)
+            .viewport_debounce(Duration::from_millis(1))
+            .catalog(Arc::new(catalog))
+            .augment(vec![Augmentation {
+                table: "tfstate-detail".into(), // catalog name of the detail Vista
+                source: Source::Id,             // master.id -> detail.id
+                fetch: Fetch::PerRow,           // one detail record per master row
+                merge: MergeRule {
+                    columns: vec!["resources".into(), "serial".into()],
+                },
+            }])
+            .build()?,
+    );
+
+    let dio = lens.make_dio(master()).await?;
+    let scenery = dio.table_scenery().page_size(10).open().await?;
+    let n = scenery.row_count();
+
+    println!("after list pass (cheap columns only, rows are Incomplete):");
+    for i in 0..n {
+        if let Some(r) = scenery.row(i) {
+            println!(
+                "  {:<18} size={:<4} resources={}  [{:?}]",
+                cell(&scenery, i, "id"),
+                cell(&scenery, i, "size"),
+                cell(&scenery, i, "resources"),
+                r.status,
+            );
+        }
+    }
+
+    // Bring the rows on screen → the detail pass hydrates each from the second
+    // Vista and merges its columns in place.
+    scenery.set_viewport(0..n);
+    for _ in 0..100 {
+        let all_fresh = (0..n).all(|i| {
+            matches!(
+                scenery.row(i).map(|r| r.status.clone()),
+                Some(RowStatus::Fresh)
+            )
+        });
+        if all_fresh {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    println!("\nafter detail pass (augmented from tfstate-detail):");
+    for i in 0..n {
+        println!(
+            "  {:<18} size={:<4} resources={:<3} serial={}",
+            cell(&scenery, i, "id"),
+            cell(&scenery, i, "size"),
+            cell(&scenery, i, "resources"),
+            cell(&scenery, i, "serial"),
+        );
+    }
+
+    let _ = std::fs::remove_file(&cache);
+    Ok(())
+}

--- a/vantage-diorama/src/augment/lower.rs
+++ b/vantage-diorama/src/augment/lower.rs
@@ -1,0 +1,54 @@
+//! Lowering: [`AugmentSpec`] (serde) → [`Augmentation`] (runtime closures). The
+//! only place Rhai is touched — and only behind the `rhai` feature.
+
+use std::sync::Arc;
+
+use vantage_core::{Result, error};
+use vantage_vista_factory::VistaCatalog;
+
+use super::spec::{AugmentSpec, FetchSpec, SourceSpec};
+use super::{Augmentation, Fetch, MergeRule, Source};
+
+/// Lower one declared augmentation into its runtime form. `catalog` backs the
+/// `table(name)` resolver used by scripted sources.
+pub fn lower_augment(spec: AugmentSpec, catalog: &Arc<VistaCatalog>) -> Result<Augmentation> {
+    let source = match spec.source {
+        SourceSpec::Id => Source::Id,
+        SourceSpec::Column { from, to } => Source::Column { from, to },
+        SourceSpec::Script { code } => lower_source_script(code, catalog)?,
+    };
+    let fetch = match spec.fetch {
+        FetchSpec::PerRow => Fetch::PerRow,
+        FetchSpec::Batched { op } => Fetch::Batched { op },
+        FetchSpec::Script { .. } => {
+            return Err(error!(
+                "augment: scripted fetch is not yet implemented (phase 2)"
+            ));
+        }
+    };
+    Ok(Augmentation {
+        table: spec.table,
+        source,
+        fetch,
+        merge: MergeRule {
+            columns: spec.merge,
+        },
+    })
+}
+
+#[cfg(feature = "rhai")]
+fn lower_source_script(code: String, catalog: &Arc<VistaCatalog>) -> Result<Source> {
+    let catalog = catalog.clone();
+    let resolver: vantage_vista::TargetResolver =
+        Arc::new(move |name: &str| catalog.build_vista(name));
+    Ok(Source::Build(vantage_vista::augment_source_closure(
+        resolver, code,
+    )))
+}
+
+#[cfg(not(feature = "rhai"))]
+fn lower_source_script(_code: String, _catalog: &Arc<VistaCatalog>) -> Result<Source> {
+    Err(error!(
+        "augment: source `script` requires the `rhai` feature"
+    ))
+}

--- a/vantage-diorama/src/augment/mod.rs
+++ b/vantage-diorama/src/augment/mod.rs
@@ -1,0 +1,338 @@
+//! Generic augmentation: enrich a master Vista's rows from a *second* Vista,
+//! loaded one row at a time and merged on top.
+//!
+//! The master is listed; for each visible row an [`Augmentation`] resolves a
+//! detail Vista (from the [`VistaCatalog`]), narrows it for that row, fetches a
+//! record, and merges chosen columns onto the master row. The detail source may
+//! be the same Vista as the master (today's cmd two-pass) or an entirely
+//! different backend (REST master enriched by a cmd script, or vice versa).
+//!
+//! This is the runtime, closure-based form. [`AugmentSpec`] is the serde/YAML
+//! form; [`lower_augment`] turns one into the other (the only place Rhai is
+//! touched). A consumer can also build [`Augmentation`] by hand — `Source::Build`
+//! and `Fetch::Custom` take plain Rust closures.
+
+mod lower;
+mod spec;
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use ciborium::Value as CborValue;
+use vantage_core::{Result, error};
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_types::Record;
+use vantage_vista::{ReferenceKind, Vista};
+use vantage_vista_factory::{Relation, VistaCatalog};
+
+pub use lower::lower_augment;
+pub use spec::{AugmentSpec, FetchSpec, SetOp, SourceSpec};
+
+/// Narrow a freshly resolved `base` detail Vista for one master `row`. Produced
+/// by hand or by Rhai (via [`vantage_vista::augment_source_closure`]).
+pub type BuildFn = Arc<dyn Fn(&Record<CborValue>, Vista) -> Result<Vista> + Send + Sync>;
+
+/// Pull records from a narrowed detail Vista.
+pub type FetchFn = Arc<
+    dyn Fn(Vista) -> Pin<Box<dyn Future<Output = Result<Vec<Record<CborValue>>>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// How a master row selects its detail record(s).
+pub enum Source {
+    /// `master.id → detail.id`.
+    Id,
+    /// `master[from] → detail[to | detail.id]`.
+    Column { from: String, to: Option<String> },
+    /// Arbitrary narrowing of the base detail Vista from the whole row.
+    /// Per-row only — a built Vista can't be coalesced into a set query.
+    Build(BuildFn),
+}
+
+/// How the narrowed detail Vista is read.
+pub enum Fetch {
+    /// One detail record per master row.
+    PerRow,
+    /// One set query across the window's distinct keys (phase 2).
+    Batched { op: SetOp },
+    /// Caller-supplied fetch.
+    Custom(FetchFn),
+}
+
+/// Which detail columns land on the master row.
+pub struct MergeRule {
+    /// Columns to lift. Empty = lift all detail columns.
+    pub columns: Vec<String>,
+}
+
+impl MergeRule {
+    fn wants(&self, key: &str) -> bool {
+        self.columns.is_empty() || self.columns.iter().any(|c| c == key)
+    }
+
+    /// Merge `detail`'s columns into `dest`. Detail values win on a name clash —
+    /// the detail record is the authoritative hydration of the row, so it
+    /// overwrites the cheap list-pass value (and adds its new columns).
+    pub fn apply(&self, dest: &mut Record<CborValue>, detail: &Record<CborValue>) {
+        for (k, v) in detail {
+            if self.wants(k) {
+                dest.insert(k.clone(), v.clone());
+            }
+        }
+    }
+}
+
+/// One declared augmentation in runtime form.
+pub struct Augmentation {
+    /// Catalog name of the detail model.
+    pub table: String,
+    pub source: Source,
+    pub fetch: Fetch,
+    pub merge: MergeRule,
+}
+
+impl Augmentation {
+    /// Resolve → fetch → merge the matching detail record onto `row` in place.
+    /// The per-row unit the two-pass detail pass drives.
+    pub async fn augment_row(
+        &self,
+        master_id_column: &str,
+        row: &mut Record<CborValue>,
+        catalog: &VistaCatalog,
+    ) -> Result<()> {
+        if let Some(detail) = self.fetch_one(master_id_column, row, catalog).await? {
+            self.merge.apply(row, &detail);
+        }
+        Ok(())
+    }
+
+    /// Fetch the single detail record for one master row, or `None` if there is
+    /// no match.
+    ///
+    /// `Id` and id-keyed `Column` sources read by key via
+    /// [`get_value`](vantage_dataset::traits::ReadableValueSet::get_value) — the
+    /// uniform "one record by key" primitive (cmd runs its detail script, SQL a
+    /// `WHERE id =`, REST a `GET /{id}`). Other-column and `Build` sources narrow
+    /// the detail vista and take the first record.
+    async fn fetch_one(
+        &self,
+        master_id_column: &str,
+        row: &Record<CborValue>,
+        catalog: &VistaCatalog,
+    ) -> Result<Option<Record<CborValue>>> {
+        let base = catalog.build_vista(&self.table)?;
+        match &self.fetch {
+            Fetch::PerRow => match &self.source {
+                // `get_value_with_row` hands the cheap master row to drivers that
+                // use it (a cmd detail script reads list-pass columns); other
+                // drivers fall through to `get_value` by default.
+                Source::Id => {
+                    base.get_value_with_row(&self.key(row, master_id_column)?, row)
+                        .await
+                }
+                Source::Column { from, to: None } => {
+                    base.get_value_with_row(&self.key(row, from)?, row).await
+                }
+                Source::Column {
+                    from,
+                    to: Some(col),
+                } => {
+                    let mut base = base;
+                    self.narrow_eq(&mut base, col, from, row)?;
+                    Ok(base.get_some_value().await?.map(|(_, r)| r))
+                }
+                Source::Build(f) => Ok(f(row, base)?.get_some_value().await?.map(|(_, r)| r)),
+            },
+            Fetch::Custom(f) => {
+                let detail = self.resolve_detail(master_id_column, row, catalog)?;
+                Ok(f(detail).await?.into_iter().next())
+            }
+            Fetch::Batched { .. } => Err(error!(
+                "augment: batched fetch is not yet implemented (phase 2)"
+            )),
+        }
+    }
+
+    /// Build the detail vista and narrow it per [`Source`] — the form a
+    /// [`Fetch::Custom`] closure receives.
+    fn resolve_detail(
+        &self,
+        master_id_column: &str,
+        row: &Record<CborValue>,
+        catalog: &VistaCatalog,
+    ) -> Result<Vista> {
+        let mut base = catalog.build_vista(&self.table)?;
+        match &self.source {
+            Source::Id => {
+                let detail_id = self.detail_id_column(&base)?;
+                self.narrow_eq(&mut base, &detail_id, master_id_column, row)?;
+                Ok(base)
+            }
+            Source::Column { from, to } => {
+                let fk = match to {
+                    Some(c) => c.clone(),
+                    None => self.detail_id_column(&base)?,
+                };
+                self.narrow_eq(&mut base, &fk, from, row)?;
+                Ok(base)
+            }
+            Source::Build(f) => f(row, base),
+        }
+    }
+
+    fn narrow_eq(
+        &self,
+        base: &mut Vista,
+        detail_column: &str,
+        master_field: &str,
+        row: &Record<CborValue>,
+    ) -> Result<()> {
+        Relation::single_key(
+            "augment",
+            &self.table,
+            ReferenceKind::HasOne,
+            detail_column.to_string(),
+            master_field.to_string(),
+        )
+        .narrow(base, row)
+    }
+
+    fn detail_id_column(&self, base: &Vista) -> Result<String> {
+        base.get_id_column().map(str::to_string).ok_or_else(|| {
+            error!(
+                "augment: detail vista has no id column",
+                table = self.table.as_str()
+            )
+        })
+    }
+
+    /// Read a master row field as a scalar key string.
+    fn key(&self, row: &Record<CborValue>, field: &str) -> Result<String> {
+        match row.get(field) {
+            Some(CborValue::Text(s)) => Ok(s.clone()),
+            Some(CborValue::Integer(i)) => Ok(i128::from(*i).to_string()),
+            Some(_) => Err(error!(
+                "augment: key field is not a string/int",
+                field = field
+            )),
+            None => Err(error!(
+                "augment: master row missing key field",
+                field = field
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_catalog() -> Arc<VistaCatalog> {
+        Arc::new(VistaCatalog::new())
+    }
+
+    fn spec(source: SourceSpec, fetch: FetchSpec) -> AugmentSpec {
+        AugmentSpec {
+            table: "detail".into(),
+            source,
+            fetch,
+            merge: vec![],
+        }
+    }
+
+    #[test]
+    fn lowers_id_source_with_default_per_row_fetch() {
+        let aug =
+            lower_augment(spec(SourceSpec::Id, FetchSpec::default()), &empty_catalog()).unwrap();
+        assert!(matches!(aug.source, Source::Id));
+        assert!(matches!(aug.fetch, Fetch::PerRow));
+    }
+
+    #[test]
+    fn lowers_column_source() {
+        let s = SourceSpec::Column {
+            from: "key".into(),
+            to: None,
+        };
+        let aug = lower_augment(spec(s, FetchSpec::default()), &empty_catalog()).unwrap();
+        match aug.source {
+            Source::Column { from, to } => {
+                assert_eq!(from, "key");
+                assert!(to.is_none());
+            }
+            _ => panic!("expected Column source"),
+        }
+    }
+
+    #[test]
+    fn scripted_fetch_is_rejected_for_now() {
+        let s = spec(SourceSpec::Id, FetchSpec::Script { code: "x".into() });
+        assert!(lower_augment(s, &empty_catalog()).is_err());
+    }
+
+    #[cfg(not(feature = "rhai"))]
+    #[test]
+    fn scripted_source_errors_without_rhai() {
+        let s = spec(
+            SourceSpec::Script {
+                code: "self".into(),
+            },
+            FetchSpec::default(),
+        );
+        assert!(lower_augment(s, &empty_catalog()).is_err());
+    }
+
+    #[cfg(feature = "rhai")]
+    #[test]
+    fn scripted_source_lowers_to_build_with_rhai() {
+        let s = spec(
+            SourceSpec::Script {
+                code: "self".into(),
+            },
+            FetchSpec::default(),
+        );
+        let aug = lower_augment(s, &empty_catalog()).unwrap();
+        assert!(matches!(aug.source, Source::Build(_)));
+    }
+
+    #[test]
+    fn merge_overwrites_master_columns_on_clash() {
+        let rule = MergeRule { columns: vec![] };
+        let mut dest: Record<CborValue> = [("id".to_string(), CborValue::Text("master".into()))]
+            .into_iter()
+            .collect();
+        let detail: Record<CborValue> = [
+            ("id".to_string(), CborValue::Text("detail".into())),
+            ("extra".to_string(), CborValue::Text("v".into())),
+        ]
+        .into_iter()
+        .collect();
+
+        rule.apply(&mut dest, &detail);
+
+        // Detail wins on a clash (it's the authoritative hydration); new columns add.
+        assert_eq!(dest.get("id"), Some(&CborValue::Text("detail".into())));
+        assert_eq!(dest.get("extra"), Some(&CborValue::Text("v".into())));
+    }
+
+    #[test]
+    fn merge_respects_explicit_column_list() {
+        let rule = MergeRule {
+            columns: vec!["extra".into()],
+        };
+        let mut dest: Record<CborValue> = Record::default();
+        let detail: Record<CborValue> = [
+            ("extra".to_string(), CborValue::Text("v".into())),
+            ("skipme".to_string(), CborValue::Text("no".into())),
+        ]
+        .into_iter()
+        .collect();
+
+        rule.apply(&mut dest, &detail);
+
+        assert_eq!(dest.get("extra"), Some(&CborValue::Text("v".into())));
+        assert!(dest.get("skipme").is_none());
+    }
+}

--- a/vantage-diorama/src/augment/mod.rs
+++ b/vantage-diorama/src/augment/mod.rs
@@ -30,7 +30,7 @@ pub use lower::lower_augment;
 pub use spec::{AugmentSpec, FetchSpec, SetOp, SourceSpec};
 
 /// Narrow a freshly resolved `base` detail Vista for one master `row`. Produced
-/// by hand or by Rhai (via [`vantage_vista::augment_source_closure`]).
+/// by hand or by Rhai (via `vantage_vista::augment_source_closure`, rhai feature).
 pub type BuildFn = Arc<dyn Fn(&Record<CborValue>, Vista) -> Result<Vista> + Send + Sync>;
 
 /// Pull records from a narrowed detail Vista.

--- a/vantage-diorama/src/augment/spec.rs
+++ b/vantage-diorama/src/augment/spec.rs
@@ -1,0 +1,71 @@
+//! Serde spec for declaring augmentations in config (YAML). Pure data — the
+//! runtime form (closures, in [`super`]) is produced by [`super::lower_augment`].
+//!
+//! ```yaml
+//! augment:
+//!   - table: tfstate_detail          # catalog name → base detail vista (any persistence)
+//!     source: { kind: column, from: key }
+//!     fetch:  { kind: per_row }
+//!     merge:  [resources, serial, outputs]
+//! ```
+
+use serde::Deserialize;
+
+/// One declared augmentation: enrich each master row from another `table`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AugmentSpec {
+    /// Catalog name of the detail model this augmentation reads from.
+    pub table: String,
+    /// How to narrow the detail vista for a given master row.
+    pub source: SourceSpec,
+    /// How to pull records from the narrowed detail vista.
+    #[serde(default)]
+    pub fetch: FetchSpec,
+    /// Detail columns to lift onto the master row. Empty = lift all.
+    #[serde(default)]
+    pub merge: Vec<String>,
+}
+
+/// Key derivation: how a master row selects its detail record(s). Internally
+/// tagged on `kind` so unit and struct variants coexist (`{kind: id}`,
+/// `{kind: column, from: x}`, `{kind: script, code: "..."}`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SourceSpec {
+    /// `master.id → detail.id`.
+    Id,
+    /// `master[from] → detail[to | detail.id]`.
+    Column {
+        from: String,
+        #[serde(default)]
+        to: Option<String>,
+    },
+    /// Rhai narrows the base detail vista in place using `row` (requires the
+    /// `rhai` feature). Per-row only — see [`super::Source::Build`].
+    Script { code: String },
+}
+
+/// Fetch mode: how the narrowed detail vista is read.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FetchSpec {
+    /// One detail record per master row.
+    #[default]
+    PerRow,
+    /// Collect distinct keys across the window into one set query (phase 2).
+    Batched {
+        #[serde(default)]
+        op: SetOp,
+    },
+    /// Rhai fetch verbs decide how to pull (phase 2).
+    Script { code: String },
+}
+
+/// Set operator for [`FetchSpec::Batched`].
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SetOp {
+    /// `detail[col] IN [keys]`.
+    #[default]
+    Contains,
+}

--- a/vantage-diorama/src/error.rs
+++ b/vantage-diorama/src/error.rs
@@ -6,6 +6,9 @@ pub enum LensBuildError {
     #[error("cache backend is required (call .cache_at(...) or .cache_source(...))")]
     MissingCacheSource,
 
+    #[error("augmentations were registered but no catalog was provided (call .catalog(...))")]
+    MissingCatalog,
+
     #[error(transparent)]
     Other(#[from] VantageError),
 }

--- a/vantage-diorama/src/lens/build.rs
+++ b/vantage-diorama/src/lens/build.rs
@@ -22,8 +22,8 @@ impl LensBuilder {
     ///
     /// When [`augment`](Self::augment) registered any augmentations and no
     /// explicit two-pass callbacks were supplied, this synthesizes them: a
-    /// capability-aware list pass and an augmentation detail pass (see
-    /// [`synth_list_page`] / [`synth_load_detail`]). Registering the detail pass
+    /// capability-aware list pass and an augmentation detail pass
+    /// (`synth_list_page` / `synth_load_detail`). Registering the detail pass
     /// is what engages two-pass loading downstream.
     pub fn build(self) -> Result<Lens, LensBuildError> {
         if let Some(err) = self.deferred_cache_error {

--- a/vantage-diorama/src/lens/build.rs
+++ b/vantage-diorama/src/lens/build.rs
@@ -1,17 +1,30 @@
 use std::sync::Arc;
 
+use ciborium::Value as CborValue;
 use tokio::runtime::Handle;
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_types::Record;
+use vantage_vista_factory::VistaCatalog;
 
+use crate::augment::Augmentation;
+use crate::dio::Dio;
 use crate::error::LensBuildError;
+use crate::lens::CacheStatus;
 
+use super::callbacks::{
+    DioCallback, DioListPageCallback, DioLoadDetailCallback, boxed_dio_callback,
+    boxed_list_page_callback, boxed_load_detail_callback,
+};
 use super::{Lens, LensBuilder, LensCallbacks};
 
 impl LensBuilder {
     /// Validate required state and produce the built [`Lens`].
     ///
-    /// Stage 1 only asserts a cache backend is present. The actual
-    /// runtime wiring (refresh task spawning, callback dispatch) lands
-    /// in stages 3+.
+    /// When [`augment`](Self::augment) registered any augmentations and no
+    /// explicit two-pass callbacks were supplied, this synthesizes them: a
+    /// capability-aware list pass and an augmentation detail pass (see
+    /// [`synth_list_page`] / [`synth_load_detail`]). Registering the detail pass
+    /// is what engages two-pass loading downstream.
     pub fn build(self) -> Result<Lens, LensBuildError> {
         if let Some(err) = self.deferred_cache_error {
             return Err(err);
@@ -23,16 +36,35 @@ impl LensBuilder {
             .runtime
             .unwrap_or_else(|| Handle::try_current().expect("LensBuilder::build called outside a tokio runtime; supply one with .runtime(handle)"));
 
+        let mut on_list_page = self.on_list_page;
+        let mut on_load_detail = self.on_load_detail;
+        let mut on_refresh = self.on_refresh;
+
+        if !self.augmentations.is_empty() && on_load_detail.is_none() {
+            let catalog = self.catalog.ok_or(LensBuildError::MissingCatalog)?;
+            let augmentations = Arc::new(self.augmentations);
+
+            // Each pass is synthesized only if the caller didn't supply one, so an
+            // app can still hand-roll any single pass while reusing the rest.
+            if on_list_page.is_none() {
+                on_list_page = Some(synth_list_page());
+            }
+            if on_refresh.is_none() {
+                on_refresh = Some(synth_refresh());
+            }
+            on_load_detail = Some(synth_load_detail(catalog, augmentations));
+        }
+
         let callbacks = LensCallbacks {
             on_start: self.on_start,
-            on_refresh: self.on_refresh,
+            on_refresh,
             on_write: self.on_write,
             on_event: self.on_event,
             on_query: self.on_query,
             total_provider: self.total_provider,
             on_load_chunk: self.on_load_chunk,
-            on_list_page: self.on_list_page,
-            on_load_detail: self.on_load_detail,
+            on_list_page,
+            on_load_detail,
         };
 
         Ok(Lens {
@@ -41,5 +73,171 @@ impl LensBuilder {
             defaults: self.defaults,
             runtime,
         })
+    }
+}
+
+/// Capability-aware list pass for an augmented Dio.
+///
+/// When the master advertises `can_fetch_window` the requested
+/// `[offset, offset+limit)` slice is pushed down to the driver; otherwise it
+/// falls back to a full `list_values` windowed locally so sequential paging
+/// still terminates. This is the generic form of what apps previously hand-rolled
+/// — and it stops over-fetching the whole set on every page where the backend can
+/// window.
+fn synth_list_page() -> DioListPageCallback {
+    boxed_list_page_callback(move |dio: &Dio, desc| {
+        let dio = dio.clone();
+        async move {
+            let master = dio.master();
+            if master.capabilities().can_fetch_window {
+                master.fetch_window(desc.offset, desc.limit).await
+            } else {
+                use vantage_dataset::traits::ReadableValueSet;
+                let rows = master.list_values().await?;
+                Ok(rows
+                    .into_iter()
+                    .skip(desc.offset)
+                    .take(desc.limit)
+                    .collect())
+            }
+        }
+    })
+}
+
+/// Augmentation detail pass: read the cheap list-pass row from the cache, run
+/// every [`Augmentation`] against it (resolve a detail Vista, fetch, merge), and
+/// return the enriched row.
+fn synth_load_detail(
+    catalog: Arc<VistaCatalog>,
+    augmentations: Arc<Vec<Augmentation>>,
+) -> DioLoadDetailCallback {
+    boxed_load_detail_callback(move |dio: &Dio, id| {
+        let dio = dio.clone();
+        let catalog = catalog.clone();
+        let augmentations = augmentations.clone();
+        async move {
+            let mut row = dio.cache().get_value(&id).await?.unwrap_or_default();
+            let master_id_column = dio.master().get_id_column().unwrap_or("id").to_string();
+            for aug in augmentations.iter() {
+                aug.augment_row(&master_id_column, &mut row, &catalog)
+                    .await?;
+            }
+            Ok(row)
+        }
+    })
+}
+
+/// Augmentation refresh: re-run the cheap **list pass** and reconcile it against
+/// the cache without throwing away augmentation that is still valid.
+///
+/// Per id, only the keys the list pass paints are compared (the *non-augmented*
+/// fields — the detail pass merges its columns on top). The verdict:
+///
+/// - **unchanged** list fields → leave the row as-is, keeping its hydrated detail
+///   columns and `Complete` status (no re-augmentation).
+/// - **changed** list fields → merge the fresh list values onto the cached record
+///   and demote it to `Incomplete`, so the detail pass re-runs when it's next
+///   visible.
+/// - **new** id → stub `Incomplete`.
+/// - **gone** (cached but no longer listed) → delete.
+///
+/// `dio.refresh()` (driven by an app's auto-refresh / change-probe) invokes this;
+/// demoting to `Incomplete` is what restarts hydration on the next viewport pass.
+fn synth_refresh() -> DioCallback {
+    boxed_dio_callback(move |dio: &Dio| {
+        let dio = dio.clone();
+        async move {
+            let fresh = dio.master().list_values().await?;
+            let cache = dio.cache();
+            let existing = cache.list_values_with_status().await?;
+
+            for (id, list_row) in &fresh {
+                match existing.get(id) {
+                    Some((old, _)) => {
+                        if !list_fields_changed(list_row, old) {
+                            continue;
+                        }
+                        let mut merged = old.clone();
+                        for (k, v) in list_row {
+                            merged.insert(k.clone(), v.clone());
+                        }
+                        cache
+                            .insert_value_with_status(id, &merged, CacheStatus::Incomplete)
+                            .await?;
+                    }
+                    None => {
+                        cache
+                            .insert_value_with_status(id, list_row, CacheStatus::Incomplete)
+                            .await?;
+                    }
+                }
+            }
+            for id in existing.keys() {
+                if !fresh.contains_key(id) {
+                    cache.delete_value(id).await?;
+                }
+            }
+            Ok(())
+        }
+    })
+}
+
+/// True when any field the list pass paints differs from the cached record. Only
+/// keys present in `list_row` are compared — the detail pass's own columns (which
+/// exist only in `cached`) are never inspected, so a row whose list fields are
+/// byte-for-byte equal is left untouched.
+fn list_fields_changed(list_row: &Record<CborValue>, cached: &Record<CborValue>) -> bool {
+    list_row.iter().any(|(k, v)| cached.get(k) != Some(v))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::list_fields_changed;
+    use ciborium::Value;
+    use vantage_types::Record;
+
+    fn rec(pairs: &[(&str, Value)]) -> Record<Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn unchanged_list_fields_ignore_augmented_columns() {
+        let list = rec(&[
+            ("status", Value::from("LIVE")),
+            ("updated_at", Value::from("t1")),
+        ]);
+        let cached = rec(&[
+            ("status", Value::from("LIVE")),
+            ("updated_at", Value::from("t1")),
+            ("subject_area", Value::from("finance")),
+        ]);
+        assert!(!list_fields_changed(&list, &cached));
+    }
+
+    #[test]
+    fn a_changed_non_augmented_field_is_detected() {
+        let list = rec(&[
+            ("status", Value::from("DECOMMISSIONED")),
+            ("updated_at", Value::from("t2")),
+        ]);
+        let cached = rec(&[
+            ("status", Value::from("LIVE")),
+            ("updated_at", Value::from("t1")),
+            ("subject_area", Value::from("finance")),
+        ]);
+        assert!(list_fields_changed(&list, &cached));
+    }
+
+    #[test]
+    fn a_new_list_key_absent_from_cache_counts_as_changed() {
+        let list = rec(&[
+            ("status", Value::from("LIVE")),
+            ("region", Value::from("eu")),
+        ]);
+        let cached = rec(&[("status", Value::from("LIVE"))]);
+        assert!(list_fields_changed(&list, &cached));
     }
 }

--- a/vantage-diorama/src/lens/mod.rs
+++ b/vantage-diorama/src/lens/mod.rs
@@ -83,6 +83,8 @@ pub struct LensBuilder {
     pub(crate) on_load_chunk: Option<DioLoadChunkCallback>,
     pub(crate) on_list_page: Option<DioListPageCallback>,
     pub(crate) on_load_detail: Option<DioLoadDetailCallback>,
+    pub(crate) augmentations: Vec<crate::augment::Augmentation>,
+    pub(crate) catalog: Option<std::sync::Arc<vantage_vista_factory::VistaCatalog>>,
     pub(crate) defaults: LensDefaults,
     pub(crate) runtime: Option<Handle>,
 }
@@ -107,6 +109,8 @@ impl LensBuilder {
             on_load_chunk: None,
             on_list_page: None,
             on_load_detail: None,
+            augmentations: Vec::new(),
+            catalog: None,
             defaults: LensDefaults::default(),
             runtime: None,
         }
@@ -293,6 +297,30 @@ impl LensBuilder {
 
     pub fn runtime(mut self, handle: Handle) -> Self {
         self.runtime = Some(handle);
+        self
+    }
+
+    /// Provide the cross-persistence [`VistaCatalog`](vantage_vista_factory::VistaCatalog)
+    /// used to resolve augmentation `table:` names into base detail Vistas.
+    /// Required whenever [`augment`](Self::augment) is used.
+    pub fn catalog(mut self, catalog: std::sync::Arc<vantage_vista_factory::VistaCatalog>) -> Self {
+        self.catalog = Some(catalog);
+        self
+    }
+
+    /// Register augmentations — detail sources merged onto each master row.
+    ///
+    /// Registering at least one engages two-pass loading: the master is listed
+    /// cheaply, then each visible row is augmented one at a time from its detail
+    /// source (the same Vista or a different backend, resolved via the
+    /// [`catalog`](Self::catalog)). [`build`](Self::build) synthesizes the list
+    /// and detail passes unless explicit `on_list_page`/`on_load_detail`
+    /// callbacks were supplied.
+    ///
+    /// Lower [`AugmentSpec`](crate::augment::AugmentSpec)s with
+    /// [`lower_augment`](crate::augment::lower_augment) first.
+    pub fn augment(mut self, augmentations: Vec<crate::augment::Augmentation>) -> Self {
+        self.augmentations = augmentations;
         self
     }
 }

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -2,6 +2,7 @@
 // Stage 1 is shape-only — fields/methods land their first callers in stages 2+.
 #![allow(dead_code)]
 
+pub mod augment;
 pub mod composition;
 pub mod dio;
 pub mod error;
@@ -9,6 +10,10 @@ pub mod lens;
 pub mod ops;
 pub mod scenery;
 
+pub use augment::{
+    AugmentSpec, Augmentation, BuildFn, Fetch, FetchFn, FetchSpec, MergeRule, SetOp, Source,
+    SourceSpec, lower_augment,
+};
 pub use composition::Diorama;
 pub use dio::{Dio, DioEvent, DioShell, Generation};
 pub use error::{DioError, LensBuildError};

--- a/vantage-diorama/tests/augment.rs
+++ b/vantage-diorama/tests/augment.rs
@@ -1,0 +1,317 @@
+//! Generic augmentation, end-to-end: a master Vista listed cheaply, each row
+//! enriched one-at-a-time from a *separate* detail Vista resolved through a
+//! [`VistaCatalog`]. Proves the `.augment(...)` wiring drives the two-pass
+//! machinery without any hand-written list/detail callbacks.
+//!
+//! Both vistas are in-memory `MockShell`s — independent handles resolved by
+//! name, which is exactly the "wire two generic Vistas into one Dio" shape (the
+//! same path serves a REST master + cmd detail, since the catalog is
+//! persistence-agnostic).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_diorama::{Augmentation, Dio, Fetch, Lens, MergeRule, RowStatus, Source, TableScenery};
+use vantage_types::Record;
+use vantage_vista::mocks::MockShell;
+use vantage_vista::{Column, Vista, VistaMetadata};
+use vantage_vista_factory::VistaCatalog;
+
+fn text(s: &str) -> CborValue {
+    CborValue::Text(s.into())
+}
+
+fn record(pairs: &[(&str, &str)]) -> Record<CborValue> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), text(v)))
+        .collect()
+}
+
+fn meta(columns: &[&str]) -> VistaMetadata {
+    let mut m = VistaMetadata::new();
+    for c in columns {
+        let col = if *c == "id" {
+            Column::new("id", "String").with_flag("id")
+        } else {
+            Column::new(*c, "String")
+        };
+        m = m.with_column(col);
+    }
+    m.with_id_column("id")
+}
+
+/// Master: two rows with cheap columns only (id, branch).
+fn master_vista() -> Vista {
+    let shell = MockShell::new()
+        .with_record("r0", record(&[("id", "r0"), ("branch", "main")]))
+        .with_record("r1", record(&[("id", "r1"), ("branch", "dev")]))
+        .with_metadata(meta(&["id", "branch"]));
+    Vista::new("runs", Box::new(shell))
+}
+
+/// Detail source #1: keyed by id, carries the expensive `detail` column.
+fn detail_vista() -> Vista {
+    let shell = MockShell::new()
+        .with_record("r0", record(&[("id", "r0"), ("detail", "full-r0")]))
+        .with_record("r1", record(&[("id", "r1"), ("detail", "full-r1")]))
+        .with_metadata(meta(&["id", "detail"]));
+    Vista::new("runs-detail", Box::new(shell))
+}
+
+/// Detail source #2: a *second* independent vista, carries `extra`.
+fn extra_vista() -> Vista {
+    let shell = MockShell::new()
+        .with_record("r0", record(&[("id", "r0"), ("extra", "x0")]))
+        .with_record("r1", record(&[("id", "r1"), ("extra", "x1")]))
+        .with_metadata(meta(&["id", "extra"]));
+    Vista::new("runs-extra", Box::new(shell))
+}
+
+fn catalog() -> Arc<VistaCatalog> {
+    let mut c = VistaCatalog::new();
+    c.register("runs-detail", Arc::new(|| Ok(detail_vista())));
+    c.register("runs-extra", Arc::new(|| Ok(extra_vista())));
+    Arc::new(c)
+}
+
+fn aug(table: &str, source: Source, merge: &[&str]) -> Augmentation {
+    Augmentation {
+        table: table.into(),
+        source,
+        fetch: Fetch::PerRow,
+        merge: MergeRule {
+            columns: merge.iter().map(|s| s.to_string()).collect(),
+        },
+    }
+}
+
+async fn open(tmp: &TempDir, augmentations: Vec<Augmentation>) -> Dio {
+    let lens = Arc::new(
+        Lens::new()
+            .cache_at(tmp.path().join("cache.redb"))
+            .viewport_debounce(Duration::from_millis(1))
+            .catalog(catalog())
+            .augment(augmentations)
+            .build()
+            .expect("lens builds"),
+    );
+    lens.make_dio(master_vista()).await.expect("make_dio")
+}
+
+fn status_of(s: &Arc<dyn TableScenery>, i: usize) -> Option<RowStatus> {
+    s.row(i).map(|r| r.status.clone())
+}
+
+fn col_of(s: &Arc<dyn TableScenery>, i: usize, c: &str) -> Option<String> {
+    s.row(i).and_then(|r| match r.record.get(c) {
+        Some(CborValue::Text(t)) => Some(t.clone()),
+        _ => None,
+    })
+}
+
+async fn eventually(label: &str, f: impl Fn() -> bool) {
+    for _ in 0..200 {
+        if f() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("condition '{label}' not met within timeout");
+}
+
+// ---------------------------------------------------------------------------
+
+/// The list pass stubs rows `Incomplete` with cheap columns; no detail fetched
+/// until a viewport asks. Then the detail pass merges the second vista's column
+/// and flips the row `Fresh`, keeping the cheap columns.
+#[tokio::test]
+async fn id_source_augments_from_a_separate_vista() {
+    let tmp = TempDir::new().unwrap();
+    let dio = open(&tmp, vec![aug("runs-detail", Source::Id, &["detail"])]).await;
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+
+    // List pass ran: cheap columns present, Incomplete, no augmented column yet.
+    assert!(matches!(
+        status_of(&scenery, 0),
+        Some(RowStatus::Incomplete)
+    ));
+    assert_eq!(col_of(&scenery, 0, "branch").as_deref(), Some("main"));
+    assert!(
+        col_of(&scenery, 0, "detail").is_none(),
+        "no detail before viewport"
+    );
+
+    scenery.set_viewport(0..2);
+    eventually("rows hydrated", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+            && matches!(status_of(&scenery, 1), Some(RowStatus::Fresh))
+    })
+    .await;
+
+    // Augmented column merged from runs-detail; cheap column survived.
+    assert_eq!(col_of(&scenery, 0, "detail").as_deref(), Some("full-r0"));
+    assert_eq!(col_of(&scenery, 1, "detail").as_deref(), Some("full-r1"));
+    assert_eq!(col_of(&scenery, 0, "branch").as_deref(), Some("main"));
+}
+
+/// A `Column` source keyed on an explicit master field resolves the same way.
+#[tokio::test]
+async fn column_source_keyed_by_field() {
+    let tmp = TempDir::new().unwrap();
+    let source = Source::Column {
+        from: "id".into(),
+        to: None,
+    };
+    let dio = open(&tmp, vec![aug("runs-detail", source, &["detail"])]).await;
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    scenery.set_viewport(0..2);
+
+    eventually("hydrated", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+    })
+    .await;
+    assert_eq!(col_of(&scenery, 0, "detail").as_deref(), Some("full-r0"));
+}
+
+/// Multiple augmentations compose: each merges its own column from its own vista.
+#[tokio::test]
+async fn multiple_augmentations_merge_independently() {
+    let tmp = TempDir::new().unwrap();
+    let dio = open(
+        &tmp,
+        vec![
+            aug("runs-detail", Source::Id, &["detail"]),
+            aug("runs-extra", Source::Id, &["extra"]),
+        ],
+    )
+    .await;
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    scenery.set_viewport(0..2);
+
+    eventually("hydrated", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+    })
+    .await;
+
+    assert_eq!(col_of(&scenery, 0, "detail").as_deref(), Some("full-r0"));
+    assert_eq!(col_of(&scenery, 0, "extra").as_deref(), Some("x0"));
+    assert_eq!(col_of(&scenery, 0, "branch").as_deref(), Some("main"));
+}
+
+/// Registering augmentations without a catalog is rejected at build time —
+/// honest failure, not a silent no-op.
+#[tokio::test]
+async fn augment_without_catalog_fails_to_build() {
+    let tmp = TempDir::new().unwrap();
+    let result = Lens::new()
+        .cache_at(tmp.path().join("cache.redb"))
+        .augment(vec![aug("runs-detail", Source::Id, &["detail"])])
+        .build();
+    assert!(matches!(
+        result,
+        Err(vantage_diorama::LensBuildError::MissingCatalog)
+    ));
+}
+
+/// A missing key field surfaces as a failed row — the detail pass error marks
+/// only that row `LoadFailed`, and its cheap columns survive.
+#[tokio::test]
+async fn missing_key_field_marks_row_failed() {
+    let tmp = TempDir::new().unwrap();
+    let source = Source::Column {
+        from: "nonexistent".into(),
+        to: None,
+    };
+    let dio = open(&tmp, vec![aug("runs-detail", source, &["detail"])]).await;
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    scenery.set_viewport(0..2);
+
+    eventually("row failed", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::LoadFailed { .. }))
+    })
+    .await;
+    assert_eq!(col_of(&scenery, 0, "branch").as_deref(), Some("main"));
+}
+
+/// Refresh re-runs the list pass and reconciles against the cache without
+/// discarding still-valid augmentation: an unchanged master leaves hydrated
+/// detail columns intact (the property that makes auto-refresh safe).
+#[tokio::test]
+async fn refresh_keeps_hydrated_detail_when_master_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    let dio = open(&tmp, vec![aug("runs-detail", Source::Id, &["detail"])]).await;
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    scenery.set_viewport(0..2);
+    eventually("hydrated", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+    })
+    .await;
+
+    dio.refresh().await.expect("refresh");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Reconciliation kept the row's augmented column rather than wiping it.
+    assert_eq!(col_of(&scenery, 0, "detail").as_deref(), Some("full-r0"));
+    assert_eq!(col_of(&scenery, 0, "branch").as_deref(), Some("main"));
+}
+
+/// A caller-supplied [`Fetch::Custom`] closure reads the narrowed detail vista.
+#[tokio::test]
+async fn custom_fetch_closure_reads_narrowed_detail() {
+    use vantage_dataset::prelude::ReadableValueSet;
+    use vantage_vista::Vista as V;
+
+    let tmp = TempDir::new().unwrap();
+    let augmentation = Augmentation {
+        table: "runs-detail".into(),
+        source: Source::Id,
+        fetch: Fetch::Custom(Arc::new(|detail: V| {
+            Box::pin(async move { Ok(detail.list_values().await?.into_values().collect()) })
+        })),
+        merge: MergeRule {
+            columns: vec!["detail".into()],
+        },
+    };
+    let dio = open(&tmp, vec![augmentation]).await;
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    scenery.set_viewport(0..2);
+
+    eventually("hydrated", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+    })
+    .await;
+    assert_eq!(col_of(&scenery, 0, "detail").as_deref(), Some("full-r0"));
+}
+
+/// End-to-end through the Rhai-scripted source path: a `script` spec lowers to a
+/// `Build` closure that narrows the detail vista using the master `row`.
+#[cfg(feature = "rhai")]
+#[tokio::test]
+async fn scripted_source_augments_via_rhai() {
+    use vantage_diorama::{AugmentSpec, FetchSpec, SourceSpec, lower_augment};
+
+    let tmp = TempDir::new().unwrap();
+    let spec = AugmentSpec {
+        table: "runs-detail".into(),
+        source: SourceSpec::Script {
+            code: r#"self.add_condition_eq("id", row.id)"#.into(),
+        },
+        fetch: FetchSpec::PerRow,
+        merge: vec!["detail".into()],
+    };
+    let augmentation = lower_augment(spec, &catalog()).expect("lowers with rhai");
+    let dio = open(&tmp, vec![augmentation]).await;
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    scenery.set_viewport(0..2);
+
+    eventually("both rows hydrated", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+            && matches!(status_of(&scenery, 1), Some(RowStatus::Fresh))
+    })
+    .await;
+    assert_eq!(col_of(&scenery, 0, "detail").as_deref(), Some("full-r0"));
+    assert_eq!(col_of(&scenery, 1, "detail").as_deref(), Some("full-r1"));
+}

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.2 — unreleased
+
+### Added
+
+- `augment_source_closure(resolver, code)` and `eval_augment_source(engine, code, base, row)` (rhai
+  feature): build a reusable closure that narrows a pre-built `base` Vista in place from a master
+  `row`, exposing the base as `self` and the row as `row`. Backs `vantage-diorama`'s scripted
+  augmentation sources — all Rhai engine assembly stays here, so consumers only flip the `rhai`
+  feature. Re-exported alongside the existing conventional/fetch vocabulary.
+
 ## 0.6.1 — unreleased
 
 - Folded the read-only Rhai data-fetch surface (formerly the standalone `vantage-data-script` crate)

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/lib.rs
+++ b/vantage-vista/src/lib.rs
@@ -29,8 +29,9 @@ pub use metadata::VistaMetadata;
 pub use reference::{ContainedKind, ContainedSpec, Reference, ReferenceKind};
 #[cfg(feature = "rhai")]
 pub use rhai::{
-    DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT, RhaiVista, TargetResolver, eval_modify_script,
-    eval_ref_script, register_conventional_onto, register_fetch_verbs, run_script,
+    AugmentSourceFn, DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT, RhaiVista, TargetResolver,
+    augment_source_closure, eval_augment_source, eval_modify_script, eval_ref_script,
+    register_conventional_onto, register_fetch_verbs, run_script,
 };
 pub use sort::SortDirection;
 pub use source::TableShell;

--- a/vantage-vista/src/rhai.rs
+++ b/vantage-vista/src/rhai.rs
@@ -23,7 +23,8 @@ mod introspect;
 mod runtime;
 
 pub use conventional::{
-    RhaiVista, TargetResolver, eval_modify_script, eval_ref_script, register_conventional_onto,
+    AugmentSourceFn, RhaiVista, TargetResolver, augment_source_closure, eval_augment_source,
+    eval_modify_script, eval_ref_script, register_conventional_onto,
 };
 pub use fetch::register_fetch_verbs;
 pub use runtime::{DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT, run_script};

--- a/vantage-vista/src/rhai/conventional.rs
+++ b/vantage-vista/src/rhai/conventional.rs
@@ -211,6 +211,65 @@ pub fn eval_modify_script(engine: &Engine, code: &str, vista: Vista) -> Result<V
         .ok_or_else(|| error!("rhai modify script consumed `self`"))
 }
 
+/// A diorama augmentation *source* closure: given a master `row` and a freshly
+/// resolved `base` detail [`Vista`], return the `base` narrowed for that row.
+/// Hand-written Rust and Rhai both produce this same shape.
+pub type AugmentSourceFn = Arc<dyn Fn(&Record<CborValue>, Vista) -> Result<Vista> + Send + Sync>;
+
+/// Evaluate an augmentation *source* script: narrow a pre-built `base` Vista in
+/// place using values from the master `row`, and return it. The base is exposed
+/// to the script as `self`, the master row as `row` — so a one-liner like
+///
+/// ```rhai
+/// self.add_condition_eq("key", row.key)
+/// ```
+///
+/// is the canonical form. Mirrors [`eval_modify_script`] but with the parent row
+/// in scope; the engine must already carry the conventional vocabulary (via
+/// [`register_conventional_onto`]) plus any vendor extensions.
+pub fn eval_augment_source(
+    engine: &Engine,
+    code: &str,
+    base: Vista,
+    row: &Record<CborValue>,
+) -> Result<Vista> {
+    let handle = RhaiVista::wrap(base);
+    let mut scope = Scope::new();
+    scope.push("self", handle.clone());
+    scope.push_dynamic("row", record_to_dynamic(row));
+
+    engine
+        .run_with_scope(&mut scope, code)
+        .map_err(|e| error!(format!("rhai augment source script failed: {e}")))?;
+
+    handle
+        .0
+        .lock()
+        .map_err(|_| error!("rhai augment source: result mutex poisoned"))?
+        .take()
+        .ok_or_else(|| error!("rhai augment source consumed `self`"))
+}
+
+/// Build a reusable [`AugmentSourceFn`] from a Rhai `code` string and a
+/// `resolver` for `table(name)`. Keeps all Rhai engine assembly inside
+/// vantage-vista: a consumer (diorama's augmentation lowering) only flips the
+/// `rhai` feature and calls this — it never touches the `rhai` crate directly.
+///
+/// The engine is rebuilt per call (cheap; `rhai`'s `sync` feature is not assumed,
+/// so an [`Engine`] cannot be stored in a `Send + Sync` closure). Vendor
+/// extensions come from the supplied `base`'s shell, so scripted narrowing can
+/// use a backend's expression syntax when present.
+pub fn augment_source_closure(resolver: TargetResolver, code: String) -> AugmentSourceFn {
+    Arc::new(
+        move |row: &Record<CborValue>, base: Vista| -> Result<Vista> {
+            let mut engine = Engine::new();
+            base.source.register_rhai_extensions(&mut engine);
+            register_conventional_onto(&mut engine, resolver.clone());
+            eval_augment_source(&engine, code.as_str(), base, row)
+        },
+    )
+}
+
 // ---- helpers --------------------------------------------------------------
 
 type Guard<'a> = std::sync::MutexGuard<'a, Option<Vista>>;


### PR DESCRIPTION
Augmenting a master row with data from a *second* source used to be impossible to express cleanly: the only progressive-loading path was hard-wired to `cmd` tables with a `detail` script, and the detail pass could only re-read the master Vista itself. There was no way to list an S3 bucket and enrich each file from a shell script, or list a REST endpoint and fill in fields from another backend.

### What this adds

Generic augmentation wires a second Vista into a `Dio`. The master is listed cheaply; each visible row resolves a detail Vista by name through a `VistaCatalog`, fetches its record, and merges chosen columns on top. The detail source can be the same Vista (the former cmd two-pass, now just `source: id`) or a different backend entirely.

`LensBuilder::augment(...)` + `.catalog(...)` engage two-pass and synthesize the list, detail, and refresh-reconciliation passes. The list pass is capability-aware — it pushes the window down via `fetch_window` when the master supports it instead of over-fetching the whole set. Rhai is a closure factory for scripted sources, with all engine assembly kept in `vantage-vista`.

### Notes

- Bumps `vantage-vista` and `vantage-diorama` to 0.6.2.
- `Batched` fetch, a detail-key dedup cache, and scripted fetch are scoped as follow-ups (they error explicitly rather than degrade).
- Docs: new `Augmentation` chapter in docs4.